### PR TITLE
build: add typed marker for pecos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ where = ["python"]
 include = ["pecos*"]
 namespaces = true
 
+[tool.setuptools.package-data]
+"pecos" = ["py.typed"]
+
 # Linting and autorefactoring tools
 # ---------------------------------
 


### PR DESCRIPTION
This helps avoid mypy errors such as:
```py
pytket/phir/cli.py:17: error: Cannot find implementation or library stub for
module named "pecos.engines.hybrid_engine"  [import-not-found]
        from pecos.engines.hybrid_engine import HybridEngine
    ^
pytket/phir/cli.py:17: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
pytket/phir/cli.py:18: error: Cannot find implementation or library stub for
module named "pecos.foreign_objects.wasmtime"  [import-not-found]
        from pecos.foreign_objects.wasmtime import WasmtimeObj
    ^
```