### PR TITLE
Bugfix/custatevec 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ simulators = [
     "projectq>=0.5.0,<0.9.0",
 ]
 cuda = [
-    "cuquantum-python>=23.6.0",
+    "cuquantum-python>=24.03.0",
+    "custatevec>=1.6.0",
     "cupy>=10.4.0",
 ]
 wasmtime = [

--- a/python/pecos/simulators/custatevec/gates_meas.py
+++ b/python/pecos/simulators/custatevec/gates_meas.py
@@ -41,7 +41,7 @@ def meas_z(state, qubit: int, **params: Any) -> int:
         n_index_bits=state.num_qubits,  # Number of qubits in the statevector
         basis_bits=[target],  # The index of the qubit being measured
         n_basis_bits=1,  # Number of qubits being measured
-        rand_num=np.random.random(),  # Source of randomness for the measurement
+        randnum=np.random.random(),  # Source of randomness for the measurement
         collapse=cusv.Collapse.NORMALIZE_AND_ZERO,  # Collapse and normalise
     )
     state.stream.synchronize()

--- a/python/pecos/simulators/custatevec/gates_one_qubit.py
+++ b/python/pecos/simulators/custatevec/gates_one_qubit.py
@@ -47,8 +47,8 @@ def _apply_one_qubit_matrix(state, qubit: int, matrix: cp.ndarray) -> None:
         control_bit_values=[],  # No value of control bit assigned
         n_controls=0,
         compute_type=state.compute_type,
-        workspace=0,  # Let cuQuantum use the mempool we configured
-        workspace_size=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace_size_in_bytes=0,  # Let cuQuantum use the mempool we configured
     )
     state.stream.synchronize()
 

--- a/python/pecos/simulators/custatevec/gates_two_qubit.py
+++ b/python/pecos/simulators/custatevec/gates_two_qubit.py
@@ -52,8 +52,8 @@ def _apply_controlled_matrix(state, control: int, target: int, matrix: cp.ndarra
         control_bit_values=[],  # No value of control bit assigned
         n_controls=1,
         compute_type=state.compute_type,
-        workspace=0,  # Let cuQuantum use the mempool we configured
-        workspace_size=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace_size_in_bytes=0,  # Let cuQuantum use the mempool we configured
     )
     state.stream.synchronize()
 
@@ -155,8 +155,8 @@ def _apply_two_qubit_matrix(state, qubits: tuple[int, int], matrix: cp.ndarray) 
         control_bit_values=[],  # No value of control bit assigned
         n_controls=0,
         compute_type=state.compute_type,
-        workspace=0,  # Let cuQuantum use the mempool we configured
-        workspace_size=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace_size_in_bytes=0,  # Let cuQuantum use the mempool we configured
     )
     state.stream.synchronize()
 
@@ -392,7 +392,7 @@ def SWAP(state, qubits: tuple[int, int], **params: Any) -> None:
         controls=[],
         control_bit_values=[],  # No value of control bit assigned
         n_controls=0,
-        workspace=0,  # Let cuQuantum use the mempool we configured
-        workspace_size=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace=0,  # Let cuQuantum use the mempool we configured
+        extra_workspace_size_in_bytes=0,  # Let cuQuantum use the mempool we configured
     )
     state.stream.synchronize()

--- a/tests/integration/state_sim_tests/test_statevec.py
+++ b/tests/integration/state_sim_tests/test_statevec.py
@@ -16,12 +16,13 @@ from importlib.metadata import version
 import numpy as np
 import pytest
 from packaging.version import parse as vparse
+
 from pecos.circuits import QuantumCircuit
 
 try:
     import cuquantum
 
-    imported_cuquantum = vparse(cuquantum._version.__version__) >= vparse("23.6.0")  # noqa: SLF001
+    imported_cuquantum = vparse(cuquantum._version.__version__) >= vparse("24.03.0")  # noqa: SLF001
     import cupy as cp
 
     imported_cupy = vparse(version("cupy")) >= vparse("10.4.0")

--- a/tests/integration/state_sim_tests/test_statevec.py
+++ b/tests/integration/state_sim_tests/test_statevec.py
@@ -16,7 +16,6 @@ from importlib.metadata import version
 import numpy as np
 import pytest
 from packaging.version import parse as vparse
-
 from pecos.circuits import QuantumCircuit
 
 try:


### PR DESCRIPTION
Some of the argument names for CuStateVec functions in version 1.6.0 have changed. I've updated this and bumped the version requirements to `custatevec>=1.6.0`.