### PR TITLE
Allow passing ancillas to `Steane` class

### DIFF
--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -33,10 +33,10 @@ class Steane(Vars):
     This represents one particular choice of Steane protocols. For finer control construct your own class
     or utilize the library of Steane code protocols directly."""
 
-    def __init__(self, name: str, default_rus_limit: int = 3):
+    def __init__(self, name: str, default_rus_limit: int = 3, ancillas: QReg | None = None):
         super().__init__()
         self.d = QReg(f"{name}_d", 7)
-        self.a = QReg(f"{name}_a", 3)
+        self.a = ancillas or QReg(f"{name}_a", 3)
         self.c = CReg(f"{name}_c", 32)
 
         # TODO: Make it so I can put these in self.c... need to convert things like if(c) and c = a ^ b, a = 0;
@@ -59,7 +59,6 @@ class Steane(Vars):
 
         self.vars = [
             self.d,
-            self.a,
             self.c,
             self.syn_meas,
             self.last_raw_syn_x,
@@ -74,6 +73,8 @@ class Steane(Vars):
             self.syndromes,
             self.verify_prep,
         ]
+        if ancillas is None:
+            self.vars.append(self.a)
 
         # derived classical registers
         c = self.c

--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -62,6 +62,7 @@ class Steane(Vars):
 
         self.vars = [
             self.d,
+            self.a,
             self.c,
             self.syn_meas,
             self.last_raw_syn_x,
@@ -76,8 +77,6 @@ class Steane(Vars):
             self.syndromes,
             self.verify_prep,
         ]
-        if ancillas is None:
-            self.vars.append(self.a)
 
         # derived classical registers
         c = self.c

--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -62,7 +62,6 @@ class Steane(Vars):
 
         self.vars = [
             self.d,
-            self.a,
             self.c,
             self.syn_meas,
             self.last_raw_syn_x,
@@ -77,6 +76,8 @@ class Steane(Vars):
             self.syndromes,
             self.verify_prep,
         ]
+        if ancillas is None:
+            self.vars.append(self.a)
 
         # derived classical registers
         c = self.c

--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -39,6 +39,9 @@ class Steane(Vars):
         self.a = ancillas or QReg(f"{name}_a", 3)
         self.c = CReg(f"{name}_c", 32)
 
+        if self.a.size < 3:
+            raise ValueError(f"Steane ancilla registers must have >= 3 qubits (provided: {self.a.size})")
+
         # TODO: Make it so I can put these in self.c... need to convert things like if(c) and c = a ^ b, a = 0;
         #  to allow lists of bits
         self.syn_meas = CReg(f"{name}_syn_meas", 32)

--- a/python/pecos/slr/vars.py
+++ b/python/pecos/slr/vars.py
@@ -23,7 +23,9 @@ class Vars:
 
     def extend(self, vars_obj: "Vars"):
         if isinstance(vars_obj, Vars):
-            self.vars.extend(vars_obj.vars)
+            # identify and add only new variables
+            new_vars = [var for var in vars_obj.vars if var not in self]
+            self.vars.extend(new_vars)
         else:
             msg = f"Was expecting a Vars object. Instead got type: {type(vars_obj)}"
             raise TypeError(msg)
@@ -48,6 +50,9 @@ class Vars:
 
     def __iter__(self):
         return iter(self.vars)
+
+    def __contains__(self, var: object) -> bool:
+        return any(var is self_var for self_var in self.vars)
 
 
 class Var: ...

--- a/python/pecos/slr/vars.py
+++ b/python/pecos/slr/vars.py
@@ -23,9 +23,7 @@ class Vars:
 
     def extend(self, vars_obj: "Vars"):
         if isinstance(vars_obj, Vars):
-            # identify and add only new variables
-            new_vars = [var for var in vars_obj.vars if var not in self]
-            self.vars.extend(new_vars)
+            self.vars.extend(vars_obj.vars)
         else:
             msg = f"Was expecting a Vars object. Instead got type: {type(vars_obj)}"
             raise TypeError(msg)
@@ -50,9 +48,6 @@ class Vars:
 
     def __iter__(self):
         return iter(self.vars)
-
-    def __contains__(self, var: object) -> bool:
-        return any(var is self_var for self_var in self.vars)
 
 
 class Var: ...


### PR DESCRIPTION
This should allow different logical qubits to share ancillas, with something like
```python
program = pecos.slr.Main(
    ancillas := pecos.slr.QReg("ancillas", size=3),
    logical_qubit_0 := pecos.qeclib.steane.steane_class.Steane("lq_0", ancillas=ancillas),
    logical_qubit_1 := pecos.qeclib.steane.steane_class.Steane("lq_1", ancillas=ancillas),
    ...
)
```

Warning: I am not sure how to test for unintended side effects, so I'm not sure whether this breaks anything...

UPDATE: for what it's worth, I've played around with some simulations that do/don't use this PR, and (1) this PR runs without error, and (2) the results from both simulations look to be identical.