### PR TITLE
Use `default_rus_limit` in `Steane` class

### DIFF
--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -241,6 +241,8 @@ class Steane(Vars):
 
     def prep_tdg_plus_state(self, reject: Bit, rus_limit: int | None = None):
         """Prepare logical Tdg|+X> in a fault tolerant manner."""
+        if rus_limit is None:
+            rus_limit = self.default_rus_limit
 
         return Block(
             self.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
@@ -294,6 +296,9 @@ class Steane(Vars):
 
     def t(self, aux: Steane, reject: Bit, rus_limit: int | None):
         """T gate via teleportation using fault-tolerant initialization of the T|+> state."""
+        if rus_limit is None:
+            rus_limit = self.default_rus_limit
+
         block = Block(
             aux.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
             self.cx(aux),
@@ -316,6 +321,9 @@ class Steane(Vars):
 
     def tdg(self, aux: Steane, reject: Bit, rus_limit: int | None):
         """Tdg gate via teleportation using fault-tolerant initialization of the Tdg|+> state."""
+        if rus_limit is None:
+            rus_limit = self.default_rus_limit
+
         block = Block(
             aux.prep_tdg_plus_state(reject=reject, rus_limit=rus_limit),
             self.cx(aux),
@@ -354,6 +362,10 @@ class Steane(Vars):
         This version teleports the logical qubit from the original qubit to the auxiliary logical qubit. For
         convenience, the qubits are relabeled, so you can continue to use the original Steane code logical qubit."""
         warn("Using experimental feature: t_tel", stacklevel=2)
+
+        if rus_limit is None:
+            rus_limit = self.default_rus_limit
+
         block = Block(
             aux.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
             aux.cx(self),
@@ -392,6 +404,10 @@ class Steane(Vars):
         This version teleports the logical qubit from the original qubit to the auxiliary logical qubit. For
         convenience, the qubits are relabeled, so you can continue to use the original Steane code logical qubit."""
         warn("Using experimental feature: tdg_tel", stacklevel=2)
+
+        if rus_limit is None:
+            rus_limit = self.default_rus_limit
+
         block = Block(
             aux.prep_tdg_plus_state(reject=reject, rus_limit=rus_limit),
             aux.cx(self),

--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -241,8 +241,6 @@ class Steane(Vars):
 
     def prep_tdg_plus_state(self, reject: Bit, rus_limit: int | None = None):
         """Prepare logical Tdg|+X> in a fault tolerant manner."""
-        if rus_limit is None:
-            rus_limit = self.default_rus_limit
 
         return Block(
             self.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
@@ -296,9 +294,6 @@ class Steane(Vars):
 
     def t(self, aux: Steane, reject: Bit, rus_limit: int | None):
         """T gate via teleportation using fault-tolerant initialization of the T|+> state."""
-        if rus_limit is None:
-            rus_limit = self.default_rus_limit
-
         block = Block(
             aux.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
             self.cx(aux),
@@ -321,9 +316,6 @@ class Steane(Vars):
 
     def tdg(self, aux: Steane, reject: Bit, rus_limit: int | None):
         """Tdg gate via teleportation using fault-tolerant initialization of the Tdg|+> state."""
-        if rus_limit is None:
-            rus_limit = self.default_rus_limit
-
         block = Block(
             aux.prep_tdg_plus_state(reject=reject, rus_limit=rus_limit),
             self.cx(aux),
@@ -362,10 +354,6 @@ class Steane(Vars):
         This version teleports the logical qubit from the original qubit to the auxiliary logical qubit. For
         convenience, the qubits are relabeled, so you can continue to use the original Steane code logical qubit."""
         warn("Using experimental feature: t_tel", stacklevel=2)
-
-        if rus_limit is None:
-            rus_limit = self.default_rus_limit
-
         block = Block(
             aux.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
             aux.cx(self),
@@ -404,10 +392,6 @@ class Steane(Vars):
         This version teleports the logical qubit from the original qubit to the auxiliary logical qubit. For
         convenience, the qubits are relabeled, so you can continue to use the original Steane code logical qubit."""
         warn("Using experimental feature: tdg_tel", stacklevel=2)
-
-        if rus_limit is None:
-            rus_limit = self.default_rus_limit
-
         block = Block(
             aux.prep_tdg_plus_state(reject=reject, rus_limit=rus_limit),
             aux.cx(self),

--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -292,7 +292,7 @@ class Steane(Vars):
             If(self.t_meas == 1).Then(self.sz()),
         )
 
-    def t(self, aux: Steane, reject: Bit, rus_limit: int | None):
+    def t(self, aux: Steane, reject: Bit, rus_limit: int | None = None):
         """T gate via teleportation using fault-tolerant initialization of the T|+> state."""
         block = Block(
             aux.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
@@ -314,7 +314,7 @@ class Steane(Vars):
             If(self.tdg_meas == 1).Then(self.szdg()),
         )
 
-    def tdg(self, aux: Steane, reject: Bit, rus_limit: int | None):
+    def tdg(self, aux: Steane, reject: Bit, rus_limit: int | None = None):
         """Tdg gate via teleportation using fault-tolerant initialization of the Tdg|+> state."""
         block = Block(
             aux.prep_tdg_plus_state(reject=reject, rus_limit=rus_limit),
@@ -345,7 +345,7 @@ class Steane(Vars):
             Permute(self.d, aux.d),
         )
 
-    def t_tel(self, aux: Steane, reject: Bit, rus_limit: int | None):
+    def t_tel(self, aux: Steane, reject: Bit, rus_limit: int | None = None):
         """Warning:
             This is experimental.
 
@@ -383,7 +383,7 @@ class Steane(Vars):
             Permute(self.d, aux.d),
         )
 
-    def tdg_tel(self, aux: Steane, reject: Bit, rus_limit: int | None):
+    def tdg_tel(self, aux: Steane, reject: Bit, rus_limit: int | None = None):
         """Warning:
             This is experimental.
 


### PR DESCRIPTION
Some `Steane` methods (such as [`Steane.pz`](https://github.com/PECOS-packages/PECOS/blob/feat-qeclib-steane/python/pecos/qeclib/steane/steane_class.py#L90-L93)) ask for an `rus_limit: int | None = None` argument (`rus` = repeat until success).  If `rus_limit is None`, these methods set `rus_limit = self.default_rus_limit`.

However, some of the newer `Steane` methods require an `rus_limit: int | None` argument, without setting a default.  This PR sets the default to `None`.