### PR TITLE
Fix bug in `Steane.prep_tdg_plus_state`

### DIFF
--- a/python/pecos/qeclib/steane/steane_class.py
+++ b/python/pecos/qeclib/steane/steane_class.py
@@ -254,7 +254,7 @@ class Steane(Vars):
 
         return Block(
             self.prep_t_plus_state(reject=reject, rus_limit=rus_limit),
-            self.z(),
+            self.szdg(),
         )
 
     def x(self):


### PR DESCRIPTION
`Tdg |+> = Sdg T |+>`