### PR TITLE
fix argument to SlrConverter.generate

### DIFF
--- a/python/quantum-pecos/src/pecos/slr/slr_converter.py
+++ b/python/quantum-pecos/src/pecos/slr/slr_converter.py
@@ -42,7 +42,7 @@ class SlrConverter:
         generator.generate_block(self._block)
         return generator.get_output()
 
-    def qasm(self, skip_headers: False = False):
+    def qasm(self, *, skip_headers: bool = False):
         return self.generate(Language.QASM, skip_headers=skip_headers)
 
     def qir(self):

--- a/python/quantum-pecos/src/pecos/slr/slr_converter.py
+++ b/python/quantum-pecos/src/pecos/slr/slr_converter.py
@@ -43,7 +43,7 @@ class SlrConverter:
         return generator.get_output()
 
     def qasm(self, skip_headers: False = False):
-        return self.generate(Language.QASM, skip_headers)
+        return self.generate(Language.QASM, skip_headers=skip_headers)
 
     def qir(self):
         return self.generate(Language.QIR)


### PR DESCRIPTION
`skip_headers` is a positional argument to `SlrConverter.generate`, so currently calling `SlrConverter.qasm` simply fails.  While we're at it, this PR also makes `skip_headers` a positional argument to `SlrConverter.qasm` for consistency, and fixes what I think is a type hinting error(?).