### PR TITLE
Raise an error if a user tries to construct a `CReg` with more than 64 bits

### DIFF
--- a/python/quantum-pecos/src/pecos/slr/vars.py
+++ b/python/quantum-pecos/src/pecos/slr/vars.py
@@ -124,6 +124,9 @@ class CReg(Reg, PyCOp):
             result: Whether this register is a result register (default True)
         """
 
+        if size > 64:
+            raise ValueError(f"Classical registers are limited to storing 64 bits (requested: {size})")
+
         super().__init__(sym, size, elem_type=Bit)
         self.result = result
 


### PR DESCRIPTION
My understanding is that `CReg`s are implemented by 64-bit integers.  This PR adds a helpful error message as soon as a user tries to instantiate an invalid `CReg`.