### PR TITLE
patch for bug fix regarding unrolling N gates within a global operation when performing SLR->QIR translation

### DIFF
--- a/python/quantum-pecos/src/pecos/slr/gen_codes/gen_qir.py
+++ b/python/quantum-pecos/src/pecos/slr/gen_codes/gen_qir.py
@@ -770,7 +770,6 @@ class QIRGenerator(Generator):
             return
         elif (
             isinstance(gate.qargs, tuple)
-            and len(gate.qargs) != gate.qsize
             and all(isinstance(e, tuple) for e in gate.qargs)
         ):
             for pair in gate.qargs:


### PR DESCRIPTION
Taking a look at issue https://github.com/PECOS-packages/PECOS/issues/132, the programs cannot be compiled when attempting to generate QIR due to the following error:
```python
return (qarg.reg.sym, qarg.index)
            ^^^^^^^^
AttributeError: 'tuple' object has no attribute 'reg'
```
which is a direct result of the _create_qgate_call function call. The reason for this is due to the conditional block not being satisfied
```python
elif (
            isinstance(gate.qargs, tuple)
            and len(gate.qargs) != gate.qsize
            and all(isinstance(e, tuple) for e in gate.qargs)
        ):
```

if we have a CX((q[0], q[1]), (q[2], q[3])) the gate.qsize is 2 as its a two qubit operation and the len(gate.qargs) is also 2. As they are the same, the condition is skipped and we are kept with a tuple type as it has never been unrolled. As the expression `all(isinstance(e, tuple) for e in gate.qargs)` already implicitly denotes the disconnect between the two types, we do not need the additional length check. This then allows us to unroll any length from the set of qargs even if the length is the same as gate.qsize 