### PR TITLE
Fix memory leak in custatevec

### DIFF
--- a/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
@@ -43,6 +43,7 @@ class CuStateVec(StateVector):
             num_qubits (int): Number of qubits being represented.
             seed (int): Seed for randomness.
         """
+        self.libhandle = None
         if not isinstance(num_qubits, int):
             msg = "``num_qubits`` should be of type ``int``."
             raise TypeError(msg)
@@ -59,6 +60,7 @@ class CuStateVec(StateVector):
         self.compute_type = ComputeType.COMPUTE_64F
 
         # Allocate the statevector in GPU and initialize it to |0>
+        self.cupy_vector = None
         self.reset()
 
         ####################################################
@@ -106,15 +108,20 @@ class CuStateVec(StateVector):
     def reset(self) -> Self:
         """Reset the quantum state for another run without reinitializing."""
         # Initialize all qubits in the zero state
-        self.cupy_vector = cp.zeros(shape=2**self.num_qubits, dtype=self.cp_type)
-        self.cupy_vector[0] = 1
+        if self.cupy_vector is not None:
+            self.cupy_vector[:] = 0
+            self.cupy_vector[0] = 1
+        else:
+            self.cupy_vector = cp.zeros(shape=2**self.num_qubits, dtype=self.cp_type)
+            self.cupy_vector[0] = 1
         return self
 
     def __del__(self) -> None:
         """Clean up GPU resources when the object is destroyed."""
         # CuPy will release GPU memory when the variable ``self.cupy_vector`` is no longer
         # reachable. However, we need to manually destroy the library handle.
-        cusv.destroy(self.libhandle)
+        if self.libhandle:
+            cusv.destroy(self.libhandle)
 
     @property
     def vector(self) -> ArrayLike:


### PR DESCRIPTION
Example stack-trace:

> multiprocessing.pool.RemoteTraceback:
> """
> Traceback (most recent call last):
>   File "/usr/lib/python3.12/multiprocessing/pool.py", line 125, in worker
>     result = (True, func(*args, **kwds))
>                     ^^^^^^^^^^^^^^^^^^^
>   File "/usr/lib/python3.12/multiprocessing/pool.py", line 48, in mapstar
>     return list(map(*args))
>            ^^^^^^^^^^^^^^^^
>   File "/gpu/lib/python3.12/site-packages/qemulator/job_wrappers/run_multisim.py", line 108, in multiproc_sim_wrapper
>     return run_sim(**kwargs), run_info
>            ^^^^^^^^^^^^^^^^^
>   File "/gpu/lib/python3.12/site-packages/qemulator/job_wrappers/run_sim.py", line 307, in run_sim
>     state = state.reset()
>             ^^^^^^^^^^^^^
>   File "/gpu/lib/python3.12/site-packages/pecos/simulators/custatevec/state.py", line 103, in reset
>     self.cupy_vector = cp.zeros(shape=2**self.num_qubits, dtype=self.cp_type)
>                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/gpu/lib/python3.12/site-packages/cupy/_creation/basic.py", line 250, in zeros
>     a = cupy.ndarray(shape, dtype, order=order)
>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "cupy/_core/core.pyx", line 151, in cupy._core.core.ndarray.__new__
>   File "cupy/_core/core.pyx", line 239, in cupy._core.core._ndarray_base._init
>   File "cupy/cuda/memory.pyx", line 738, in cupy.cuda.memory.alloc
>   File "cupy/cuda/memory.pyx", line 1424, in cupy.cuda.memory.MemoryPool.malloc
>   File "cupy/cuda/memory.pyx", line 1445, in cupy.cuda.memory.MemoryPool.malloc
>   File "cupy/cuda/memory.pyx", line 1116, in cupy.cuda.memory.SingleDeviceMemoryPool.malloc
>   File "cupy/cuda/memory.pyx", line 1137, in cupy.cuda.memory.SingleDeviceMemoryPool._malloc
>   File "cupy/cuda/memory.pyx", line 1382, in cupy.cuda.memory.SingleDeviceMemoryPool._try_malloc
>   File "cupy/cuda/memory.pyx", line 1385, in cupy.cuda.memory.SingleDeviceMemoryPool._try_malloc
> cupy.cuda.memory.OutOfMemoryError: Out of memory allocating 68,719,476,736 bytes (allocated so far: 68,719,476,736 bytes).
> """

