### PR TITLE
feat: Crosstalk Payload

### DIFF
--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -147,11 +147,7 @@ impl GateType {
             | GateType::Prep => 0,
 
             // Gates with one parameter
-            GateType::RX
-            | GateType::RY
-            | GateType::RZ
-            | GateType::RZZ
-            | GateType::Idle => 1,
+            GateType::RX | GateType::RY | GateType::RZ | GateType::RZZ | GateType::Idle => 1,
 
             // Gates with two parameters
             GateType::R1XY => 2,
@@ -218,8 +214,7 @@ impl GateType {
     /// Returns whether this gate is a crosstalk payload gate
     pub const fn is_crosstalk_payload(self) -> bool {
         match self {
-            GateType::MeasCrosstalkGlobalPayload
-            | GateType::MeasCrosstalkLocalPayload => true,
+            GateType::MeasCrosstalkGlobalPayload | GateType::MeasCrosstalkLocalPayload => true,
             _ => false,
         }
     }

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -212,11 +212,12 @@ impl GateType {
     }
 
     /// Returns whether this gate is a crosstalk payload gate
+    #[must_use]
     pub const fn is_crosstalk_payload(self) -> bool {
-        match self {
-            GateType::MeasCrosstalkGlobalPayload | GateType::MeasCrosstalkLocalPayload => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            GateType::MeasCrosstalkGlobalPayload | GateType::MeasCrosstalkLocalPayload
+        )
     }
 }
 

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(GateType::from(36u8), GateType::R1XY);
         assert_eq!(GateType::from(104u8), GateType::Measure);
         assert_eq!(GateType::from(105u8), GateType::MeasureLeaked);
-        assert_eq!(GateType::from(105u8), GateType::Idle);
+        assert_eq!(GateType::from(200u8), GateType::Idle);
         assert_eq!(GateType::from(218u8), GateType::MeasCrosstalkGlobalPayload);
         assert_eq!(GateType::from(219u8), GateType::MeasCrosstalkLocalPayload);
     }

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -214,6 +214,15 @@ impl GateType {
     pub const fn is_two_qubit(self) -> bool {
         self.quantum_arity() == 2
     }
+
+    /// Returns whether this gate is a crosstalk payload gate
+    pub const fn is_crosstalk_payload(self) -> bool {
+        match self {
+            GateType::MeasCrosstalkGlobalPayload
+            | GateType::MeasCrosstalkLocalPayload => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for GateType {

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -82,6 +82,8 @@ pub enum GateType {
     Prep = 134,
     // PnZ
     Idle = 200,
+    MeasCrosstalkGlobalPayload = 218,
+    MeasCrosstalkLocalPayload = 219,
 }
 
 impl From<u8> for GateType {
@@ -107,6 +109,8 @@ impl From<u8> for GateType {
             82 => GateType::RZZ,
             104 => GateType::Measure,
             105 => GateType::MeasureLeaked,
+            218 => GateType::MeasCrosstalkGlobalPayload,
+            219 => GateType::MeasCrosstalkLocalPayload,
             134 => GateType::Prep,
             200 => GateType::Idle,
             _ => panic!("Invalid gate type ID: {value}"),
@@ -141,7 +145,13 @@ impl GateType {
             | GateType::Prep => 0,
 
             // Gates with one parameter
-            GateType::RX | GateType::RY | GateType::RZ | GateType::RZZ | GateType::Idle => 1,
+            GateType::RX
+            | GateType::RY
+            | GateType::RZ
+            | GateType::RZZ
+            | GateType::Idle
+            | GateType::MeasCrosstalkGlobalPayload
+            | GateType::MeasCrosstalkLocalPayload => 1,
 
             // Gates with two parameters
             GateType::R1XY => 2,
@@ -178,7 +188,9 @@ impl GateType {
             | GateType::Measure
             | GateType::MeasureLeaked
             | GateType::Prep
-            | GateType::Idle => 1,
+            | GateType::Idle
+            | GateType::MeasCrosstalkGlobalPayload
+            | GateType::MeasCrosstalkLocalPayload => 1,
 
             // Two-qubit gates
             GateType::CX | GateType::SZZ | GateType::SZZdg | GateType::RZZ => 2,
@@ -229,6 +241,8 @@ impl fmt::Display for GateType {
             GateType::MeasureLeaked => write!(f, "MeasureLeaked"),
             GateType::Prep => write!(f, "Prep"),
             GateType::Idle => write!(f, "Idle"),
+            GateType::MeasCrosstalkGlobalPayload => write!(f, "MeasCrosstalkGlobalPayload"),
+            GateType::MeasCrosstalkLocalPayload => write!(f, "MeasCrosstalkLocalPayload"),
         }
     }
 }
@@ -250,6 +264,9 @@ mod tests {
         assert_eq!(GateType::R1XY as u8, 36);
         assert_eq!(GateType::Measure as u8, 104);
         assert_eq!(GateType::MeasureLeaked as u8, 105);
+        assert_eq!(GateType::Idle as u8, 200);
+        assert_eq!(GateType::MeasCrosstalkGlobalPayload as u8, 218);
+        assert_eq!(GateType::MeasCrosstalkLocalPayload as u8, 219);
 
         assert_eq!(GateType::from(0u8), GateType::I);
         assert_eq!(GateType::from(1u8), GateType::X);
@@ -262,6 +279,9 @@ mod tests {
         assert_eq!(GateType::from(36u8), GateType::R1XY);
         assert_eq!(GateType::from(104u8), GateType::Measure);
         assert_eq!(GateType::from(105u8), GateType::MeasureLeaked);
+        assert_eq!(GateType::from(105u8), GateType::Idle);
+        assert_eq!(GateType::from(218u8), GateType::MeasCrosstalkGlobalPayload);
+        assert_eq!(GateType::from(219u8), GateType::MeasCrosstalkLocalPayload);
     }
 
     #[test]
@@ -283,6 +303,8 @@ mod tests {
         assert_eq!(GateType::RZ.classical_arity(), 1);
         assert_eq!(GateType::RZZ.classical_arity(), 1);
         assert_eq!(GateType::Idle.classical_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkGlobalPayload.classical_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkLocalPayload.classical_arity(), 1);
 
         // Gates with two parameters
         assert_eq!(GateType::R1XY.classical_arity(), 2);
@@ -306,6 +328,8 @@ mod tests {
         assert_eq!(GateType::MeasureLeaked.quantum_arity(), 1);
         assert_eq!(GateType::Prep.quantum_arity(), 1);
         assert_eq!(GateType::Idle.quantum_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkGlobalPayload.classical_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkLocalPayload.classical_arity(), 1);
 
         // Two-qubit gates
         assert_eq!(GateType::CX.quantum_arity(), 2);
@@ -335,6 +359,8 @@ mod tests {
         assert!(GateType::R1XY.is_parameterized());
         assert!(GateType::U.is_parameterized());
         assert!(GateType::Idle.is_parameterized());
+        assert!(GateType::MeasCrosstalkGlobalPayload.is_parameterized());
+        assert!(GateType::MeasCrosstalkLocalPayload.is_parameterized());
     }
 
     #[test]
@@ -352,6 +378,8 @@ mod tests {
         assert!(GateType::MeasureLeaked.is_single_qubit());
         assert!(GateType::Prep.is_single_qubit());
         assert!(GateType::Idle.is_single_qubit());
+        assert!(GateType::MeasCrosstalkGlobalPayload.is_single_qubit());
+        assert!(GateType::MeasCrosstalkLocalPayload.is_single_qubit());
 
         // Two-qubit gates
         assert!(!GateType::CX.is_single_qubit());
@@ -375,6 +403,8 @@ mod tests {
         assert!(!GateType::MeasureLeaked.is_two_qubit());
         assert!(!GateType::Prep.is_two_qubit());
         assert!(!GateType::Idle.is_two_qubit());
+        assert!(!GateType::MeasCrosstalkGlobalPayload.is_two_qubit());
+        assert!(!GateType::MeasCrosstalkLocalPayload.is_two_qubit());
 
         // Two-qubit gates
         assert!(GateType::CX.is_two_qubit());

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -142,6 +142,8 @@ impl GateType {
             | GateType::SZZdg
             | GateType::Measure
             | GateType::MeasureLeaked
+            | GateType::MeasCrosstalkGlobalPayload
+            | GateType::MeasCrosstalkLocalPayload
             | GateType::Prep => 0,
 
             // Gates with one parameter
@@ -149,9 +151,7 @@ impl GateType {
             | GateType::RY
             | GateType::RZ
             | GateType::RZZ
-            | GateType::Idle
-            | GateType::MeasCrosstalkGlobalPayload
-            | GateType::MeasCrosstalkLocalPayload => 1,
+            | GateType::Idle => 1,
 
             // Gates with two parameters
             GateType::R1XY => 2,
@@ -297,14 +297,14 @@ mod tests {
         assert_eq!(GateType::SZZdg.classical_arity(), 0);
         assert_eq!(GateType::Measure.classical_arity(), 0);
         assert_eq!(GateType::MeasureLeaked.classical_arity(), 0);
+        assert_eq!(GateType::MeasCrosstalkGlobalPayload.classical_arity(), 0);
+        assert_eq!(GateType::MeasCrosstalkLocalPayload.classical_arity(), 0);
         assert_eq!(GateType::Prep.classical_arity(), 0);
 
         // Gates with one parameter
         assert_eq!(GateType::RZ.classical_arity(), 1);
         assert_eq!(GateType::RZZ.classical_arity(), 1);
         assert_eq!(GateType::Idle.classical_arity(), 1);
-        assert_eq!(GateType::MeasCrosstalkGlobalPayload.classical_arity(), 1);
-        assert_eq!(GateType::MeasCrosstalkLocalPayload.classical_arity(), 1);
 
         // Gates with two parameters
         assert_eq!(GateType::R1XY.classical_arity(), 2);
@@ -328,8 +328,8 @@ mod tests {
         assert_eq!(GateType::MeasureLeaked.quantum_arity(), 1);
         assert_eq!(GateType::Prep.quantum_arity(), 1);
         assert_eq!(GateType::Idle.quantum_arity(), 1);
-        assert_eq!(GateType::MeasCrosstalkGlobalPayload.classical_arity(), 1);
-        assert_eq!(GateType::MeasCrosstalkLocalPayload.classical_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkGlobalPayload.quantum_arity(), 1);
+        assert_eq!(GateType::MeasCrosstalkLocalPayload.quantum_arity(), 1);
 
         // Two-qubit gates
         assert_eq!(GateType::CX.quantum_arity(), 2);
@@ -351,6 +351,8 @@ mod tests {
         assert!(!GateType::SZZdg.is_parameterized());
         assert!(!GateType::Measure.is_parameterized());
         assert!(!GateType::MeasureLeaked.is_parameterized());
+        assert!(!GateType::MeasCrosstalkGlobalPayload.is_parameterized());
+        assert!(!GateType::MeasCrosstalkLocalPayload.is_parameterized());
         assert!(!GateType::Prep.is_parameterized());
 
         // Parameterized gates
@@ -359,8 +361,6 @@ mod tests {
         assert!(GateType::R1XY.is_parameterized());
         assert!(GateType::U.is_parameterized());
         assert!(GateType::Idle.is_parameterized());
-        assert!(GateType::MeasCrosstalkGlobalPayload.is_parameterized());
-        assert!(GateType::MeasCrosstalkLocalPayload.is_parameterized());
     }
 
     #[test]

--- a/crates/pecos-core/src/gates.rs
+++ b/crates/pecos-core/src/gates.rs
@@ -295,6 +295,43 @@ impl Gate {
         }
     }
 
+    /// Create a new MeasCrosstalkGlobalPayload with the data from runtime.
+    ///
+    /// # Arguments
+    ///
+    /// * `strength_factor` - Runtime-informed crosstalk strength. For instance, it may
+    /// reflect the length of time the crosstalk source was active for.
+    /// * `qubits` - The qubits that are guaranteed *not* to be affected by the
+    /// global crosstalk event.
+    ///
+    /// TODO: it seems unintuitive to give the complement of the list of victim qubits.
+    /// It fits better with the previous version of crosstalk, but we might want to
+    /// refactor this.
+    ///
+    /// # Returns
+    ///
+    /// A new MeasCrosstalkGlobalPayload gate with the specified parameters
+    #[must_use]
+    pub fn global_crosstalk(strength_factor: f64, qubits: Vec<QubitId>) -> Self {
+        Self::new(GateType::MeasCrosstalkGlobalPayload, vec![strength_factor], qubits)
+    }
+
+    /// Create a new MeasCrosstalkLocalPayload with the data from runtime.
+    ///
+    /// # Arguments
+    ///
+    /// * `strength_factor` - Runtime-informed crosstalk strength. For instance, it may
+    /// reflect the length of time the crosstalk source was active for.
+    /// * `qubits` - The qubits that are potential victims of the local crosstalk event.
+    ///
+    /// # Returns
+    ///
+    /// A new MeasCrosstalkLocalPayload gate with the specified parameters
+    #[must_use]
+    pub fn local_crosstalk(strength_factor: f64, qubits: Vec<QubitId>) -> Self {
+        Self::new(GateType::MeasCrosstalkLocalPayload, vec![strength_factor], qubits)
+    }
+
     /// Returns the number of angle parameters this gate requires
     ///
     /// # Returns

--- a/crates/pecos-core/src/gates.rs
+++ b/crates/pecos-core/src/gates.rs
@@ -295,12 +295,12 @@ impl Gate {
         }
     }
 
-    /// Create a new MeasCrosstalkGlobalPayload with the data from runtime.
+    /// Create a new `MeasCrosstalkGlobalPayload` with the data from runtime.
     ///
     /// # Arguments
     ///
     /// * `qubits` - The qubits that are guaranteed *not* to be affected by the
-    /// global crosstalk event.
+    ///   global crosstalk event.
     ///
     /// TODO: it seems unintuitive to give the complement of the list of victim qubits.
     /// It fits better with the previous version of crosstalk, but we might want to
@@ -308,7 +308,7 @@ impl Gate {
     ///
     /// # Returns
     ///
-    /// A new MeasCrosstalkGlobalPayload gate with the specified parameters
+    /// A new `MeasCrosstalkGlobalPayload` gate with the specified parameters
     #[must_use]
     pub fn meas_crosstalk_global_payload(qubits: &[impl Into<QubitId> + Copy]) -> Self {
         Self::new(
@@ -318,7 +318,7 @@ impl Gate {
         )
     }
 
-    /// Create a new MeasCrosstalkLocalPayload with the data from runtime.
+    /// Create a new `MeasCrosstalkLocalPayload` with the data from runtime.
     ///
     /// # Arguments
     ///
@@ -326,7 +326,7 @@ impl Gate {
     ///
     /// # Returns
     ///
-    /// A new MeasCrosstalkLocalPayload gate with the specified parameters
+    /// A new `MeasCrosstalkLocalPayload` gate with the specified parameters
     #[must_use]
     pub fn meas_crosstalk_local_payload(qubits: &[impl Into<QubitId> + Copy]) -> Self {
         Self::new(

--- a/crates/pecos-core/src/gates.rs
+++ b/crates/pecos-core/src/gates.rs
@@ -299,8 +299,6 @@ impl Gate {
     ///
     /// # Arguments
     ///
-    /// * `strength_factor` - Runtime-informed crosstalk strength. For instance, it may
-    /// reflect the length of time the crosstalk source was active for.
     /// * `qubits` - The qubits that are guaranteed *not* to be affected by the
     /// global crosstalk event.
     ///
@@ -312,10 +310,10 @@ impl Gate {
     ///
     /// A new MeasCrosstalkGlobalPayload gate with the specified parameters
     #[must_use]
-    pub fn meas_crosstalk_global_payload(strength_factor: f64, qubits: &[impl Into<QubitId> + Copy]) -> Self {
+    pub fn meas_crosstalk_global_payload(qubits: &[impl Into<QubitId> + Copy]) -> Self {
         Self::new(
             GateType::MeasCrosstalkGlobalPayload,
-            vec![strength_factor],
+            vec![],
             qubits.iter().map(|&q| q.into()).collect(),
         )
     }
@@ -324,18 +322,16 @@ impl Gate {
     ///
     /// # Arguments
     ///
-    /// * `strength_factor` - Runtime-informed crosstalk strength. For instance, it may
-    /// reflect the length of time the crosstalk source was active for.
     /// * `qubits` - The qubits that are potential victims of the local crosstalk event.
     ///
     /// # Returns
     ///
     /// A new MeasCrosstalkLocalPayload gate with the specified parameters
     #[must_use]
-    pub fn meas_crosstalk_local_payload(strength_factor: f64, qubits: &[impl Into<QubitId> + Copy]) -> Self {
+    pub fn meas_crosstalk_local_payload(qubits: &[impl Into<QubitId> + Copy]) -> Self {
         Self::new(
             GateType::MeasCrosstalkLocalPayload,
-            vec![strength_factor],
+            vec![],
             qubits.iter().map(|&q| q.into()).collect(),
         )
     }

--- a/crates/pecos-core/src/gates.rs
+++ b/crates/pecos-core/src/gates.rs
@@ -302,7 +302,7 @@ impl Gate {
     /// * `qubits` - The qubits that are guaranteed *not* to be affected by the
     ///   global crosstalk event.
     ///
-    /// TODO: it seems unintuitive to give the complement of the list of victim qubits.
+    /// NOTE: it seems unintuitive to give the complement of the list of victim qubits.
     /// It fits better with the previous version of crosstalk, but we might want to
     /// refactor this.
     ///

--- a/crates/pecos-core/src/gates.rs
+++ b/crates/pecos-core/src/gates.rs
@@ -312,8 +312,12 @@ impl Gate {
     ///
     /// A new MeasCrosstalkGlobalPayload gate with the specified parameters
     #[must_use]
-    pub fn global_crosstalk(strength_factor: f64, qubits: Vec<QubitId>) -> Self {
-        Self::new(GateType::MeasCrosstalkGlobalPayload, vec![strength_factor], qubits)
+    pub fn meas_crosstalk_global_payload(strength_factor: f64, qubits: &[impl Into<QubitId> + Copy]) -> Self {
+        Self::new(
+            GateType::MeasCrosstalkGlobalPayload,
+            vec![strength_factor],
+            qubits.iter().map(|&q| q.into()).collect(),
+        )
     }
 
     /// Create a new MeasCrosstalkLocalPayload with the data from runtime.
@@ -328,8 +332,12 @@ impl Gate {
     ///
     /// A new MeasCrosstalkLocalPayload gate with the specified parameters
     #[must_use]
-    pub fn local_crosstalk(strength_factor: f64, qubits: Vec<QubitId>) -> Self {
-        Self::new(GateType::MeasCrosstalkLocalPayload, vec![strength_factor], qubits)
+    pub fn meas_crosstalk_local_payload(strength_factor: f64, qubits: &[impl Into<QubitId> + Copy]) -> Self {
+        Self::new(
+            GateType::MeasCrosstalkLocalPayload,
+            vec![strength_factor],
+            qubits.iter().map(|&q| q.into()).collect(),
+        )
     }
 
     /// Returns the number of angle parameters this gate requires

--- a/crates/pecos-engines/src/byte_message/builder.rs
+++ b/crates/pecos-engines/src/byte_message/builder.rs
@@ -494,15 +494,15 @@ impl ByteMessageBuilder {
     }
 
     /// Add a MeasCrosstalkGlobalPayload
-    pub fn add_meas_crosstalk_global_payload(&mut self, strength_factor: f64, qubits: &[usize]) -> &mut Self {
-        let gate = Gate::meas_crosstalk_global_payload(strength_factor, qubits);
+    pub fn add_meas_crosstalk_global_payload(&mut self, qubits: &[usize]) -> &mut Self {
+        let gate = Gate::meas_crosstalk_global_payload(qubits);
         self.add_gate_command(&gate);
         self
     }
 
     /// Add a MeasCrosstalkLocalPayload
-    pub fn add_meas_crosstalk_local_payload(&mut self, strength_factor: f64, qubits: &[usize]) -> &mut Self {
-        let gate = Gate::meas_crosstalk_local_payload(strength_factor, qubits);
+    pub fn add_meas_crosstalk_local_payload(&mut self, qubits: &[usize]) -> &mut Self {
+        let gate = Gate::meas_crosstalk_local_payload(qubits);
         self.add_gate_command(&gate);
         self
     }

--- a/crates/pecos-engines/src/byte_message/builder.rs
+++ b/crates/pecos-engines/src/byte_message/builder.rs
@@ -493,6 +493,20 @@ impl ByteMessageBuilder {
         self
     }
 
+    /// Add a MeasCrosstalkGlobalPayload
+    pub fn add_meas_crosstalk_global_payload(&mut self, strength_factor: f64, qubits: &[usize]) -> &mut Self {
+        let gate = Gate::meas_crosstalk_global_payload(strength_factor, qubits);
+        self.add_gate_command(&gate);
+        self
+    }
+
+    /// Add a MeasCrosstalkLocalPayload
+    pub fn add_meas_crosstalk_local_payload(&mut self, strength_factor: f64, qubits: &[usize]) -> &mut Self {
+        let gate = Gate::meas_crosstalk_local_payload(strength_factor, qubits);
+        self.add_gate_command(&gate);
+        self
+    }
+
     /// Add a Prep gate
     pub fn add_prep(&mut self, qubits: &[usize]) -> &mut Self {
         let gate = Gate::prep(qubits);

--- a/crates/pecos-engines/src/byte_message/builder.rs
+++ b/crates/pecos-engines/src/byte_message/builder.rs
@@ -493,14 +493,14 @@ impl ByteMessageBuilder {
         self
     }
 
-    /// Add a MeasCrosstalkGlobalPayload
+    /// Add a `MeasCrosstalkGlobalPayload`
     pub fn add_meas_crosstalk_global_payload(&mut self, qubits: &[usize]) -> &mut Self {
         let gate = Gate::meas_crosstalk_global_payload(qubits);
         self.add_gate_command(&gate);
         self
     }
 
-    /// Add a MeasCrosstalkLocalPayload
+    /// Add a `MeasCrosstalkLocalPayload`
     pub fn add_meas_crosstalk_local_payload(&mut self, qubits: &[usize]) -> &mut Self {
         let gate = Gate::meas_crosstalk_local_payload(qubits);
         self.add_gate_command(&gate);

--- a/crates/pecos-engines/src/noise.rs
+++ b/crates/pecos-engines/src/noise.rs
@@ -33,7 +33,7 @@ pub use self::noise_rng::NoiseRng;
 pub use self::pass_through::{PassThroughNoiseModel, PassThroughNoiseModelBuilder};
 pub use self::utils::{NoiseUtils, ProbabilityValidator};
 pub use self::weighted_sampler::{
-    SingleQubitWeightedSampler, TwoQubitWeightedSampler, WeightedSampler,
+    SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler, WeightedSampler,
 };
 
 use crate::byte_message::ByteMessage;

--- a/crates/pecos-engines/src/noise.rs
+++ b/crates/pecos-engines/src/noise.rs
@@ -33,7 +33,7 @@ pub use self::noise_rng::NoiseRng;
 pub use self::pass_through::{PassThroughNoiseModel, PassThroughNoiseModelBuilder};
 pub use self::utils::{NoiseUtils, ProbabilityValidator};
 pub use self::weighted_sampler::{
-    SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler, WeightedSampler,
+    CrosstalkWeightedSampler, SingleQubitWeightedSampler, TwoQubitWeightedSampler, WeightedSampler,
 };
 
 use crate::byte_message::ByteMessage;

--- a/crates/pecos-engines/src/noise/biased_depolarizing.rs
+++ b/crates/pecos-engines/src/noise/biased_depolarizing.rs
@@ -189,7 +189,10 @@ impl BiasedDepolarizingNoiseModel {
                     trace!("Applying preparation with possible fault");
                     self.apply_prep_faults(&mut builder, gate);
                 }
-                GateType::Idle | GateType::I => {}
+                GateType::I
+                | GateType::Idle
+                | GateType::MeasCrosstalkLocalPayload
+                | GateType::MeasCrosstalkGlobalPayload => {}
             }
         }
 

--- a/crates/pecos-engines/src/noise/depolarizing.rs
+++ b/crates/pecos-engines/src/noise/depolarizing.rs
@@ -162,8 +162,11 @@ impl DepolarizingNoiseModel {
                     trace!("Applying preparation with possible fault");
                     self.apply_prep_faults(&mut builder, gate);
                 }
-                GateType::Idle | GateType::I => {
-                    // Idle gates just pass through with no idling noise
+                GateType::I
+                | GateType::Idle
+                | GateType::MeasCrosstalkLocalPayload
+                | GateType::MeasCrosstalkGlobalPayload => {
+                    // Just pass through with no added noise
                     // builder.add_quantum_gate(gate);
                 }
             }

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -309,7 +309,17 @@ pub struct GeneralNoiseModel {
     /// Models the probability that a measurement operation on one qubit affects nearby qubits. In
     /// ion trap systems, this could represent scattered light during fluorescence detection
     /// affecting neighboring ions.
-    p_meas_crosstalk: f64,
+    /// Further details on how crosstalk is modeled depends on information from
+    /// the device runtime, which are provided as MeasCrosstalkGlobalPayload instructions.
+    p_meas_crosstalk_global: f64,
+
+    /// Probability of crosstalk during measurement operations on local qubits
+    ///
+    /// See doc for p_meas_crosstalk_global. The intended distinction is that this
+    /// parameter applies to only qubits that are close to the measured qubit.
+    /// /// Further details on how crosstalk is modeled depends on information from
+    /// the device runtime, which are provided as MeasCrosstalkLocalPayload instructions.
+    p_meas_crosstalk_local: f64,
 
     // --- internally used variables --- //
     /// The maximum of `p_meas_0` and `p_meas_1`
@@ -520,7 +530,7 @@ impl GeneralNoiseModel {
                         self.prepared_qubits.insert(usize::from(q));
                     }
                     self.apply_prep_faults(&gate, &mut builder);
-                    self.apply_crosstalk_faults(&gate, self.p_prep_crosstalk, &mut builder);
+                    self.apply_simple_crosstalk_faults(&gate, self.p_prep_crosstalk, &mut builder);
                 }
                 GateType::Measure | GateType::MeasureLeaked => {
                     // Track which qubits are being measured for leakage handling
@@ -533,7 +543,31 @@ impl GeneralNoiseModel {
                     // Measurement noise is handled in apply_noise_on_continue_processing
                     // We still need to add the original gate here
                     builder.add_gate_command(&gate);
-                    self.apply_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
+                    // TODO: simplified crosstalk (H1/H2)
+                    // if self.simple_crosstalk:
+                    //    self.apply_simple_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
+                }
+                GateType::MeasCrosstalkGlobalPayload => {
+                    let probability = self.p_meas_crosstalk_global * gate.params[0];
+
+                    // Global crosstalk applies to all qubits that are *not* in the payload
+                    let gate_qubits: Vec<usize> = gate.qubits.iter().map(|q| usize::from(*q)).collect();
+                    let potential_victims = self.prepared_qubits
+                        .iter()
+                        .filter(|q| !gate_qubits.contains(q))
+                        .cloned()
+                        .collect();
+
+                    // Otherwise, it is the same channel for Global and Local
+                    trace!("Applying global crosstalk...");
+                    self.apply_crosstalk_faults_from_payload(probability, potential_victims, &mut builder);
+                }
+                GateType::MeasCrosstalkLocalPayload => {
+                    let probability = self.p_meas_crosstalk_local * gate.params[0];
+                    let potential_victims = gate.qubits.iter().map(|q| usize::from(*q)).collect();
+
+                    trace!("Applying local crosstalk...");
+                    self.apply_crosstalk_faults_from_payload(probability, potential_victims, &mut builder);
                 }
                 GateType::I => {
                     let err_msg = format!(
@@ -810,7 +844,7 @@ impl GeneralNoiseModel {
         }
     }
 
-    /// Apply crosstalk noise
+    /// Apply simple crosstalk noise
     ///
     /// Naive crosstalk noise model:
     /// 1. All qubits in the trap but the ones in the `gate` are subject to crosstalk
@@ -820,7 +854,7 @@ impl GeneralNoiseModel {
     ///
     /// In ion trap systems, this could represent scattered light during optical pumping
     /// affecting neighboring ions.
-    pub fn apply_crosstalk_faults(
+    pub fn apply_simple_crosstalk_faults(
         &mut self,
         gate: &Gate,
         probability: f64,
@@ -843,6 +877,50 @@ impl GeneralNoiseModel {
         self.measured_qubits.extend(
             affected_qubits.iter().map(|&q| (q, false, true)), // (qubit, is_measure_leaked, is_crosstalk)
         );
+    }
+
+    /// Apply crosstalk noise from runtime information given by Crosstalk*Payload instructions
+    ///
+    /// In ion trap systems, this could represent scattered light during optical pumping
+    /// affecting neighboring ions.
+    pub fn apply_crosstalk_faults_from_payload(
+        &mut self,
+        probability: f64,
+        qubits: Vec<usize>,
+        builder: &mut ByteMessageBuilder,
+    ) {
+        // This needs to be checked here because of the strength_factor from
+        // the payload potentially causing probability larger than 1.0
+        // TODO: do validation earlier?
+        assert!(
+            (0.0..=1.0).contains(&probability),
+            "Probability must be between 0 and 1, got {probability}"
+        );
+
+        for q in qubits {
+            // If q is already leaked, we currently skip.
+            // TODO: We should include a seepage component to crosstalk in the future.
+            if !self.is_leaked(q) && self.rng.occurs(probability) {
+                // The qubit leaks with some (hardcoded) probability
+                if self.rng.occurs(0.75) {
+                    if let Some(gate) = self.leak(usize::from(q)) {
+                        builder.add_gate_command(&gate);
+                    }
+                    trace!("Qubit {q} leaked during crosstalk");
+                // Otherwise, it results in a fully mixed distribution of 0/1 state
+                } else {
+                    // Reset the qubit
+                    builder.add_prep(&[q]);
+                    // Bit-flip with 0.5 probability to generate a full mixture
+                    if self.rng.occurs(0.5) {
+                        builder.add_x(&[q]);
+                        trace!("Qubit {q} collapsed to |1> during crosstalk");
+                    } else {
+                        trace!("Qubit {q} collapsed to |0> during crosstalk");
+                    }
+                }
+            }
+        }
     }
 
     /// Apply single-qubit gate noise faults

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -898,9 +898,11 @@ impl GeneralNoiseModel {
         );
 
         for q in qubits {
-            // If q is already leaked, we currently skip.
             // TODO: We should include a seepage component to crosstalk in the future.
-            if !self.is_leaked(q) && self.rng.occurs(probability) {
+            if self.prepared_qubits.contains(&q)
+                && !self.is_leaked(q) // If q is already leaked, we currently skip
+                && self.rng.occurs(probability)
+            {
                 // The qubit leaks with some (hardcoded) probability
                 if self.rng.occurs(0.75) {
                     if let Some(gate) = self.leak(usize::from(q)) {

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -45,14 +45,14 @@
 //! - Leakage and emission error models
 //! - Parameter scaling for error rates
 //! - Angle-dependent noise for parameterized gates
+//! - Crosstalk errors between nearby qubits
+//! - Memory/idle noise with T1/T2 processes
+//! - Coherent vs. incoherent dephasing distinction
 //!
 //! Some features from the Python implementation that are not yet fully implemented:
 //!
-//! - Crosstalk errors between nearby qubits
-//! - Memory/idle noise with T1/T2 processes
 //! - Repumping cycles for leaked qubits
 //! - Zone-specific error rates
-//! - Coherent vs. incoherent dephasing distinction
 //!
 //! ## Usage
 //!
@@ -85,7 +85,7 @@ use crate::engine_system::{ControlEngine, EngineStage};
 use crate::noise::noise_rng::NoiseRng;
 use crate::noise::utils::NoiseUtils;
 use crate::noise::utils::ProbabilityValidator;
-use crate::noise::weighted_sampler::{SingleQubitWeightedSampler, TwoQubitWeightedSampler};
+use crate::noise::weighted_sampler::{SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler};
 use crate::noise::{NoiseModel, RngManageable};
 use log::trace;
 use pecos_core::QubitId;
@@ -313,13 +313,20 @@ pub struct GeneralNoiseModel {
     /// the device runtime, which are provided as MeasCrosstalkGlobalPayload instructions.
     p_meas_crosstalk_global: f64,
 
+    /// Transition probabilities on the event of global crosstalk error
+    p_meas_crosstalk_global_model: CrosstalkWeightedSampler,
+
     /// Probability of crosstalk during measurement operations on local qubits
     ///
     /// See doc for p_meas_crosstalk_global. The intended distinction is that this
     /// parameter applies to only qubits that are close to the measured qubit.
-    /// /// Further details on how crosstalk is modeled depends on information from
+    /// Further details on how crosstalk is modeled depends on information from
     /// the device runtime, which are provided as MeasCrosstalkLocalPayload instructions.
     p_meas_crosstalk_local: f64,
+
+    /// Transition probabilities on the event of local crosstalk error
+    p_meas_crosstalk_local_model: CrosstalkWeightedSampler,
+
 
     // --- internally used variables --- //
     /// The maximum of `p_meas_0` and `p_meas_1`
@@ -543,7 +550,7 @@ impl GeneralNoiseModel {
                     // Measurement noise is handled in apply_noise_on_continue_processing
                     // We still need to add the original gate here
                     builder.add_gate_command(&gate);
-                    // TODO: simplified crosstalk (H1/H2)
+                    // TODO: simplified crosstalk (H1/H2). Helios crosstalk handled by Payload ops
                     // if self.simple_crosstalk:
                     //    self.apply_simple_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
                 }
@@ -889,13 +896,7 @@ impl GeneralNoiseModel {
         qubits: Vec<usize>,
         builder: &mut ByteMessageBuilder,
     ) {
-        // This needs to be checked here because of the strength_factor from
-        // the payload potentially causing probability larger than 1.0
-        // TODO: do validation earlier?
-        assert!(
-            (0.0..=1.0).contains(&probability),
-            "Probability must be between 0 and 1, got {probability}"
-        );
+        let mut affected_qubits = Vec::new();
 
         for q in qubits {
             // TODO: We should include a seepage component to crosstalk in the future.
@@ -903,26 +904,19 @@ impl GeneralNoiseModel {
                 && !self.is_leaked(q) // If q is already leaked, we currently skip
                 && self.rng.occurs(probability)
             {
-                // The qubit leaks with some (hardcoded) probability
-                if self.rng.occurs(0.75) {
-                    if let Some(gate) = self.leak(usize::from(q)) {
-                        builder.add_gate_command(&gate);
-                    }
-                    trace!("Qubit {q} leaked during crosstalk");
-                // Otherwise, it results in a fully mixed distribution of 0/1 state
-                } else {
-                    // Reset the qubit
-                    builder.add_prep(&[q]);
-                    // Bit-flip with 0.5 probability to generate a full mixture
-                    if self.rng.occurs(0.5) {
-                        builder.add_x(&[q]);
-                        trace!("Qubit {q} collapsed to |1> during crosstalk");
-                    } else {
-                        trace!("Qubit {q} collapsed to |0> during crosstalk");
-                    }
-                }
+                affected_qubits.push(q);
+                trace!("Qubit {q} affected by crosstalk error");
             }
         }
+
+        builder.add_measurements(&affected_qubits);
+        // We need to mark these measurements as being introduced by crosstalk rather
+        // than the user's program so that we can discard the results in
+        // apply_noise_on_continue_processing.
+        self.measured_qubits.extend(
+            affected_qubits.iter().map(|&q| (q, false, true)), // (qubit, is_measure_leaked, is_crosstalk)
+        );
+        // TODO: Crosstalk transitions need to be carried out by apply_noise_on_continue_processing
     }
 
     /// Apply single-qubit gate noise faults

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -555,7 +555,7 @@ impl GeneralNoiseModel {
                     //    self.apply_simple_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
                 }
                 GateType::MeasCrosstalkGlobalPayload => {
-                    let probability = self.p_meas_crosstalk_global * gate.params[0];
+                    let probability = self.p_meas_crosstalk_global;
 
                     // Global crosstalk applies to all qubits that are *not* in the payload
                     let gate_qubits: Vec<usize> = gate.qubits.iter().map(|q| usize::from(*q)).collect();
@@ -570,7 +570,7 @@ impl GeneralNoiseModel {
                     self.apply_crosstalk_faults_from_payload(probability, potential_victims, &mut builder);
                 }
                 GateType::MeasCrosstalkLocalPayload => {
-                    let probability = self.p_meas_crosstalk_local * gate.params[0];
+                    let probability = self.p_meas_crosstalk_local;
                     let potential_victims = gate.qubits.iter().map(|q| usize::from(*q)).collect();
 
                     trace!("Applying local crosstalk...");

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -85,7 +85,9 @@ use crate::engine_system::{ControlEngine, EngineStage};
 use crate::noise::noise_rng::NoiseRng;
 use crate::noise::utils::NoiseUtils;
 use crate::noise::utils::ProbabilityValidator;
-use crate::noise::weighted_sampler::{SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler};
+use crate::noise::weighted_sampler::{
+    CrosstalkWeightedSampler, SingleQubitWeightedSampler, TwoQubitWeightedSampler,
+};
 use crate::noise::{NoiseModel, RngManageable};
 use log::trace;
 use pecos_core::QubitId;
@@ -324,7 +326,6 @@ pub struct GeneralNoiseModel {
     /// Transition probabilities on the event of crosstalk error
     p_meas_crosstalk_model: CrosstalkWeightedSampler,
 
-
     // --- internally used variables --- //
     /// The maximum of `p_meas_0` and `p_meas_1`
     ///
@@ -401,7 +402,7 @@ impl ControlEngine for GeneralNoiseModel {
         if !next_operations.is_empty()? {
             // if there are new quantum operations to process.
             return Ok(EngineStage::NeedsProcessing(next_operations));
-        }else{
+        } else {
             // No more quantum operations to process, return results
             // collected along the way and reset the results builder.
             let results = self.results_builder.build();
@@ -562,8 +563,10 @@ impl GeneralNoiseModel {
                 }
                 GateType::MeasCrosstalkGlobalPayload => {
                     // Global crosstalk applies to all qubits that are *not* in the payload
-                    let gate_qubits: Vec<usize> = gate.qubits.iter().map(|q| usize::from(*q)).collect();
-                    let potential_victims = self.prepared_qubits
+                    let gate_qubits: Vec<usize> =
+                        gate.qubits.iter().map(|q| usize::from(*q)).collect();
+                    let potential_victims = self
+                        .prepared_qubits
                         .iter()
                         .filter(|q| !gate_qubits.contains(q))
                         .cloned()
@@ -571,13 +574,21 @@ impl GeneralNoiseModel {
 
                     // Otherwise, it is the same channel for Global and Local
                     trace!("Applying global crosstalk...");
-                    self.apply_crosstalk_faults_from_payload(gate.gate_type, potential_victims, &mut builder);
+                    self.apply_crosstalk_faults_from_payload(
+                        gate.gate_type,
+                        potential_victims,
+                        &mut builder,
+                    );
                 }
                 GateType::MeasCrosstalkLocalPayload => {
                     let potential_victims = gate.qubits.iter().map(|q| usize::from(*q)).collect();
 
                     trace!("Applying local crosstalk...");
-                    self.apply_crosstalk_faults_from_payload(gate.gate_type, potential_victims, &mut builder);
+                    self.apply_crosstalk_faults_from_payload(
+                        gate.gate_type,
+                        potential_victims,
+                        &mut builder,
+                    );
                 }
                 GateType::I => {
                     let err_msg = format!(
@@ -666,7 +677,9 @@ impl GeneralNoiseModel {
                     // It is not a measurement destined for the user, but one we
                     // injected in order to model crosstalk. Use the measurement result
                     // to determine any transitions to apply.
-                    let transition = self.p_meas_crosstalk_model.sample_gates(&mut self.rng, qubit, outcome);
+                    let transition =
+                        self.p_meas_crosstalk_model
+                            .sample_gates(&mut self.rng, qubit, outcome);
                     if transition.has_leakage() {
                         if let Some(gate) = self.leak(qubit) {
                             ops_builder.add_gate_command(&gate);
@@ -916,9 +929,8 @@ impl GeneralNoiseModel {
         // We need to mark these measurements as being introduced by crosstalk rather
         // than the user's program so that we can discard the results in
         // apply_noise_on_continue_processing.
-        self.measured_qubits.extend(
-            affected_qubits.iter().map(|&q| (q, gate.gate_type)),
-        );
+        self.measured_qubits
+            .extend(affected_qubits.iter().map(|&q| (q, gate.gate_type)));
     }
 
     /// Apply crosstalk noise from runtime information given by Crosstalk*Payload instructions
@@ -954,9 +966,8 @@ impl GeneralNoiseModel {
         // We need to mark these measurements as being introduced by crosstalk rather
         // than the user's program so that we can discard the results in
         // apply_noise_on_continue_processing.
-        self.measured_qubits.extend(
-            affected_qubits.iter().map(|&q| (q, gate_type)),
-        );
+        self.measured_qubits
+            .extend(affected_qubits.iter().map(|&q| (q, gate_type)));
         // NOTE: Crosstalk transitions are carried out by apply_noise_on_continue_processing
     }
 
@@ -1568,30 +1579,38 @@ mod tests {
         // Ensure that the biased model flips both results, while the unbiased
         // model leaves them unchanged.
 
-
         // The clean model
         let mut never_flip = GeneralNoiseModel::new(0.0, 0.0, 0.0, 0.0, 0.0);
-        let never_flip_state = request_measurements_and_give_values(&mut never_flip, &[0, 1], &[0, 1]);
+        let never_flip_state =
+            request_measurements_and_give_values(&mut never_flip, &[0, 1], &[0, 1]);
         let EngineStage::Complete(clean_results) = never_flip_state else {
             panic!("Expected results from the unbiased noise model");
         };
         let clean_outcomes = clean_results.outcomes().unwrap();
-        assert_eq!(clean_outcomes.len(), 2, "Should have two measurement results from the unbaised model");
+        assert_eq!(
+            clean_outcomes.len(),
+            2,
+            "Should have two measurement results from the unbaised model"
+        );
         assert_eq!(clean_outcomes[0], 0, "0 shouldn't be flipped to 1");
         assert_eq!(clean_outcomes[1], 1, "1 shouldn't be flipped to 0");
 
         // The noisy model
         let mut always_flip = GeneralNoiseModel::new(0.0, 1.0, 1.0, 0.0, 0.0);
-        let always_flip_state = request_measurements_and_give_values(&mut always_flip, &[0, 1], &[0, 1]);
+        let always_flip_state =
+            request_measurements_and_give_values(&mut always_flip, &[0, 1], &[0, 1]);
         let EngineStage::Complete(noisy_results) = always_flip_state else {
             panic!("Expected results from the biased noise model");
         };
         let noisy_outcomes = noisy_results.outcomes().unwrap();
-        assert_eq!(noisy_outcomes.len(), 2, "Should have two measurement results from the unbaised model");
+        assert_eq!(
+            noisy_outcomes.len(),
+            2,
+            "Should have two measurement results from the unbaised model"
+        );
         assert_eq!(noisy_outcomes[0], 1, "0 should be flipped to 1");
         assert_eq!(noisy_outcomes[1], 0, "1 should be flipped to 0");
     }
-
 
     #[test]
     fn test_prep_leak_ratio() {
@@ -1692,7 +1711,6 @@ mod tests {
         let outcomes = biased_message.outcomes().unwrap();
         assert_eq!(outcomes.len(), 1, "Should have one measurement result");
 
-
         // Verify that the leaked qubit is reported as measured as 1
         assert_eq!(outcomes[0], 1, "Leaked qubit should always measure as 1");
 
@@ -1719,7 +1737,7 @@ mod tests {
         model.mark_as_leaked(0);
 
         // Measure 0 thrice and provide measurement result 0 each time
-        let state = request_measurements_and_give_values(&mut model, &[0,0,0], &[0,0,0]);
+        let state = request_measurements_and_give_values(&mut model, &[0, 0, 0], &[0, 0, 0]);
         let EngineStage::Complete(biased_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -1781,9 +1799,7 @@ mod tests {
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0]);
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(biased_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -1849,9 +1865,7 @@ mod tests {
         builder.add_outcomes(&[1, 0, 1, 0, 1]); // Results in order
 
         // Apply measurement noise
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(noisy_results) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -1922,9 +1936,7 @@ mod tests {
         builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
         // Apply noise (should force leaked qubits to 1)
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(noisy_results) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2067,9 +2079,7 @@ mod tests {
         // Original pattern: 0,1,0,1,0,1,0,1,0,1
         builder.add_outcomes(&[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]);
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(biased_result) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2108,9 +2118,7 @@ mod tests {
         // Same original pattern: 0,1,0,1,0,1,0,1,0,1
         builder.add_outcomes(&[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]);
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(biased_result) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2161,9 +2169,7 @@ mod tests {
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 0]);
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(results_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2181,9 +2187,7 @@ mod tests {
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[1, 1]);
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(results_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2232,9 +2236,7 @@ mod tests {
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 0]);
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(results_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2289,9 +2291,7 @@ mod tests {
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 1, 0, 1]); // Simulator results before noise
 
-        let state = noise
-            .continue_processing(builder.build())
-            .unwrap();
+        let state = noise.continue_processing(builder.build()).unwrap();
         let EngineStage::Complete(results_message) = state else {
             panic!("Expected Complete stage after measurement with noise");
         };
@@ -2358,9 +2358,7 @@ mod tests {
             gate_builder.add_measurements(&[0, 1, 2, 3]);
             let _cmd = noise.start(gate_builder.build()).unwrap();
 
-            let state = noise
-                .continue_processing(builder.build())
-                .unwrap();
+            let state = noise.continue_processing(builder.build()).unwrap();
             let EngineStage::Complete(biased_result) = state else {
                 panic!("Expected Complete stage after measurement with noise");
             };
@@ -2428,7 +2426,10 @@ mod tests {
 
         let (q, gate_type) = noise.measured_qubits[0];
         assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
-        assert!(gate_type == GateType::Measure, "The first measurement should come from MCMR");
+        assert!(
+            gate_type == GateType::Measure,
+            "The first measurement should come from MCMR"
+        );
 
         for (_, gate_type) in &noise.measured_qubits[1..] {
             assert!(
@@ -2442,9 +2443,7 @@ mod tests {
         let _ = outcome_builder.for_outcomes();
         outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
-        let mcmr = noise
-            .continue_processing(outcome_builder.build())
-            .unwrap();
+        let mcmr = noise.continue_processing(outcome_builder.build()).unwrap();
 
         let EngineStage::Complete(mcmr) = mcmr else {
             panic!("Expected Complete stage after processing outcomes");

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -94,7 +94,6 @@ use rand_chacha::ChaCha8Rng;
 use std::any::Any;
 use std::collections::BTreeSet;
 
-
 /// General noise model implementation that includes parameterized error channels for various quantum operations
 ///
 /// This comprehensive noise model for quantum computers includes:
@@ -358,9 +357,7 @@ pub struct GeneralNoiseModel {
     /// Track which qubits are being measured in the current batch and their gate types
     /// This is needed to properly handle leakage during measurements as well
     /// as crosstalk.
-    /// TODO: manage this via result tags.
-    /// Each entry is (`qubit_id`, `is_measure_leaked`, `is_crosstalk`)
-    measured_qubits: Vec<(usize, bool, bool)>,
+    measured_qubits: Vec<(usize, GateType)>,
 }
 
 impl ControlEngine for GeneralNoiseModel {
@@ -401,7 +398,7 @@ impl ControlEngine for GeneralNoiseModel {
         let has_crosstalk = self
             .measured_qubits
             .iter()
-            .any(|(_, _, is_crosstalk)| *is_crosstalk);
+            .any(|(_, gate_type)| gate_type.is_crosstalk_payload());
         // Clear the measured qubits for the next batch
         self.measured_qubits.clear();
 
@@ -551,11 +548,10 @@ impl GeneralNoiseModel {
                 }
                 GateType::Measure | GateType::MeasureLeaked => {
                     // Track which qubits are being measured for leakage handling
-                    let is_measure_leaked = gate.gate_type == GateType::MeasureLeaked;
                     self.measured_qubits.extend(
                         gate.qubits
                             .iter()
-                            .map(|q| (usize::from(*q), is_measure_leaked, false)),
+                            .map(|q| (usize::from(*q), gate.gate_type)),
                     );
                     // Measurement noise is handled in apply_noise_on_continue_processing
                     // We still need to add the original gate here
@@ -565,8 +561,6 @@ impl GeneralNoiseModel {
                     //    self.apply_simple_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
                 }
                 GateType::MeasCrosstalkGlobalPayload => {
-                    let probability = self.p_meas_crosstalk_global;
-
                     // Global crosstalk applies to all qubits that are *not* in the payload
                     let gate_qubits: Vec<usize> = gate.qubits.iter().map(|q| usize::from(*q)).collect();
                     let potential_victims = self.prepared_qubits
@@ -577,14 +571,13 @@ impl GeneralNoiseModel {
 
                     // Otherwise, it is the same channel for Global and Local
                     trace!("Applying global crosstalk...");
-                    self.apply_crosstalk_faults_from_payload(probability, potential_victims, &mut builder);
+                    self.apply_crosstalk_faults_from_payload(gate.gate_type, potential_victims, &mut builder);
                 }
                 GateType::MeasCrosstalkLocalPayload => {
-                    let probability = self.p_meas_crosstalk_local;
                     let potential_victims = gate.qubits.iter().map(|q| usize::from(*q)).collect();
 
                     trace!("Applying local crosstalk...");
-                    self.apply_crosstalk_faults_from_payload(probability, potential_victims, &mut builder);
+                    self.apply_crosstalk_faults_from_payload(gate.gate_type, potential_victims, &mut builder);
                 }
                 GateType::I => {
                     let err_msg = format!(
@@ -654,7 +647,7 @@ impl GeneralNoiseModel {
         let has_crosstalk = self
             .measured_qubits
             .iter()
-            .any(|(_, _, is_crosstalk)| *is_crosstalk);
+            .any(|(_, gate_type)| gate_type.is_crosstalk_payload());
         // If the measurement outcomes originate from crosstalk, process them and
         // request to continue processing, and return the gates needed for the transitions
         if has_crosstalk {
@@ -663,19 +656,23 @@ impl GeneralNoiseModel {
             let mut builder = ByteMessage::quantum_operations_builder();
 
             for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
-                let (qubit, _, is_crosstalk) = self.measured_qubits[idx];
+                let (qubit, gate_type) = self.measured_qubits[idx];
 
                 // Sanity check: ALL measurement outcomes of this batch come from crosstalk
-                if !is_crosstalk {
+                if !gate_type.is_crosstalk_payload() {
                     return Err(PecosError::Processing(format!(
                         "A batch of crosstalk-induced measurements contains and actual measurement on qubit {qubit}"
                     )));
                 }
 
                 // Apply gates depending on crosstalk transitions
-                // TODO: here I am using local ones, but these could come from global
-                //  crosstalk, and then they should have different transitions...
-                let transition = self.p_meas_crosstalk_local_model.sample_gates(&mut self.rng, qubit, outcome);
+                let transition_model = match gate_type {
+                    GateType::MeasCrosstalkGlobalPayload => &self.p_meas_crosstalk_global_model,
+                    GateType::MeasCrosstalkLocalPayload => &self.p_meas_crosstalk_local_model,
+                    _ => panic!("Cannot match {gate_type}, this should not be possible")
+                };
+
+                let transition = transition_model.sample_gates(&mut self.rng, qubit, outcome);
                 if transition.has_leakage() {
                     if let Some(gate) = self.leak(qubit) {
                         builder.add_gate_command(&gate);
@@ -698,15 +695,15 @@ impl GeneralNoiseModel {
                 && self
                     .measured_qubits
                     .iter()
-                    .any(|(q, _, _)| self.is_leaked(*q));
+                    .any(|(q, _)| self.is_leaked(*q));
 
             for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
                 let mut val = outcome;
 
                 // Check if this measurement corresponds to a leaked qubit
-                let (qubit, is_measure_leaked, _) = self.measured_qubits[idx];
+                let (qubit, gate_type) = self.measured_qubits[idx];
                 if has_leakage && self.is_leaked(qubit) {
-                    if is_measure_leaked {
+                    if gate_type == GateType::MeasureLeaked {
                         trace!("Qubit {qubit} is leaked, MeasureLeaked returns 2");
                         // For MeasureLeaked, return 2 for leaked qubits
                         val = 2;
@@ -919,7 +916,7 @@ impl GeneralNoiseModel {
         // than the user's program so that we can discard the results in
         // apply_noise_on_continue_processing.
         self.measured_qubits.extend(
-            affected_qubits.iter().map(|&q| (q, false, true)), // (qubit, is_measure_leaked, is_crosstalk)
+            affected_qubits.iter().map(|&q| (q, gate.gate_type)),
         );
     }
 
@@ -929,10 +926,16 @@ impl GeneralNoiseModel {
     /// affecting neighboring ions.
     pub fn apply_crosstalk_faults_from_payload(
         &mut self,
-        probability: f64,
+        gate_type: GateType,
         qubits: Vec<usize>,
         builder: &mut ByteMessageBuilder,
     ) {
+        let probability = match gate_type {
+            GateType::MeasCrosstalkGlobalPayload => self.p_meas_crosstalk_global,
+            GateType::MeasCrosstalkLocalPayload => self.p_meas_crosstalk_local,
+            _ => panic!("Cannot apply crosstalk on {gate_type}"),
+        };
+
         let mut affected_qubits = Vec::new();
 
         for q in qubits {
@@ -951,9 +954,9 @@ impl GeneralNoiseModel {
         // than the user's program so that we can discard the results in
         // apply_noise_on_continue_processing.
         self.measured_qubits.extend(
-            affected_qubits.iter().map(|&q| (q, false, true)), // (qubit, is_measure_leaked, is_crosstalk)
+            affected_qubits.iter().map(|&q| (q, gate_type)),
         );
-        // TODO: Crosstalk transitions need to be carried out by apply_noise_on_continue_processing
+        // NOTE: Crosstalk transitions are carried out by apply_noise_on_continue_processing
     }
 
     /// Apply single-qubit gate noise faults
@@ -2440,13 +2443,13 @@ mod tests {
             noise.measured_qubits
         );
 
-        let (q, _, is_crosstalk) = noise.measured_qubits[0];
+        let (q, gate_type) = noise.measured_qubits[0];
         assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
-        assert!(!is_crosstalk, "The first measurement should come from MCMR");
+        assert!(gate_type == GateType::Measure, "The first measurement should come from MCMR");
 
-        for (_, _, is_crosstalk) in &noise.measured_qubits[1..] {
+        for (_, gate_type) in &noise.measured_qubits[1..] {
             assert!(
-                is_crosstalk,
+                *gate_type == GateType::Prep,
                 "The other measurements should come from crosstalk"
             );
         }

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -2442,68 +2442,71 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_meas_crosstalk() {
-        use crate::byte_message::ByteMessageBuilder;
+    // TODO: This test no longer applies, since it corresponds to the naive
+    // crosstalk model. If the naive one is maintained, this could be reintroduced
+    // but we need a flag to choose whether to use naive or new one.
+    // #[test]
+    // fn test_meas_crosstalk() {
+    //     use crate::byte_message::ByteMessageBuilder;
 
-        let mut model = GeneralNoiseModel::builder()
-            .with_p_meas_crosstalk(1.0)
-            .with_seed(42)
-            .build();
-        let noise = model
-            .as_any_mut()
-            .downcast_mut::<GeneralNoiseModel>()
-            .unwrap();
+    //     let mut model = GeneralNoiseModel::builder()
+    //         .with_p_meas_crosstalk(1.0)
+    //         .with_seed(42)
+    //         .build();
+    //     let noise = model
+    //         .as_any_mut()
+    //         .downcast_mut::<GeneralNoiseModel>()
+    //         .unwrap();
 
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_quantum_operations();
-        // Prepare a bunch of |0> states
-        builder.add_prep(&[0, 1, 2, 3, 4]);
-        // Apply mid-circuit measurement and reset
-        builder.add_measurements(&[2]);
-        builder.add_prep(&[2]);
-        let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+    //     let mut builder = ByteMessageBuilder::new();
+    //     let _ = builder.for_quantum_operations();
+    //     // Prepare a bunch of |0> states
+    //     builder.add_prep(&[0, 1, 2, 3, 4]);
+    //     // Apply mid-circuit measurement and reset
+    //     builder.add_measurements(&[2]);
+    //     builder.add_prep(&[2]);
+    //     let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
 
-        assert_eq!(
-            noise.measured_qubits.len(),
-            5,
-            "There should be 5 measured qubits: one from MCMR and the others from
-            crosstalk got: {:?}",
-            noise.measured_qubits
-        );
+    //     assert_eq!(
+    //         noise.measured_qubits.len(),
+    //         5,
+    //         "There should be 5 measured qubits: one from MCMR and the others from
+    //         crosstalk got: {:?}",
+    //         noise.measured_qubits
+    //     );
 
-        let (q, _, is_crosstalk) = noise.measured_qubits[0];
-        assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
-        assert!(!is_crosstalk, "The first measurement should come from MCMR");
+    //     let (q, _, is_crosstalk) = noise.measured_qubits[0];
+    //     assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
+    //     assert!(!is_crosstalk, "The first measurement should come from MCMR");
 
-        for (_, _, is_crosstalk) in &noise.measured_qubits[1..] {
-            assert!(
-                is_crosstalk,
-                "The other measurements should come from crosstalk"
-            );
-        }
+    //     for (_, _, is_crosstalk) in &noise.measured_qubits[1..] {
+    //         assert!(
+    //             is_crosstalk,
+    //             "The other measurements should come from crosstalk"
+    //         );
+    //     }
 
-        // All results are 0
-        let mut outcome_builder = ByteMessageBuilder::new();
-        let _ = outcome_builder.for_outcomes();
-        outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
+    //     // All results are 0
+    //     let mut outcome_builder = ByteMessageBuilder::new();
+    //     let _ = outcome_builder.for_outcomes();
+    //     outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
-        let mcmr = noise
-            .apply_noise_on_continue_processing(outcome_builder.build())
-            .unwrap();
-        let results = mcmr.outcomes().unwrap();
+    //     let mcmr = noise
+    //         .apply_noise_on_continue_processing(outcome_builder.build())
+    //         .unwrap();
+    //     let results = mcmr.outcomes().unwrap();
 
-        assert_eq!(
-            noise.measured_qubits.len(),
-            0,
-            "The list of measured_qubits should have been cleared."
-        );
-        assert_eq!(
-            results.len(),
-            1,
-            "There should only be one outcome: that of the mid-circ measurement"
-        );
-    }
+    //     assert_eq!(
+    //         noise.measured_qubits.len(),
+    //         0,
+    //         "The list of measured_qubits should have been cleared."
+    //     );
+    //     assert_eq!(
+    //         results.len(),
+    //         1,
+    //         "There should only be one outcome: that of the mid-circ measurement"
+    //     );
+    // }
 
     #[test]
     fn test_parameter_scaling() {

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -312,15 +312,15 @@ pub struct GeneralNoiseModel {
     /// ion trap systems, this could represent scattered light during fluorescence detection
     /// affecting neighboring ions.
     /// Further details on how crosstalk is modeled depends on information from
-    /// the device runtime, which are provided as MeasCrosstalkGlobalPayload instructions.
+    /// the device runtime, which are provided as `MeasCrosstalkGlobalPayload` instructions.
     p_meas_crosstalk_global: f64,
 
     /// Probability of crosstalk during measurement operations on local qubits
     ///
-    /// See doc for p_meas_crosstalk_global. The intended distinction is that this
+    /// See doc for `p_meas_crosstalk_global`. The intended distinction is that this
     /// parameter applies to only qubits that are close to the measured qubit.
     /// Further details on how crosstalk is modeled depends on information from
-    /// the device runtime, which are provided as MeasCrosstalkLocalPayload instructions.
+    /// the device runtime, which are provided as `MeasCrosstalkLocalPayload` instructions.
     p_meas_crosstalk_local: f64,
 
     /// Transition probabilities on the event of crosstalk error
@@ -399,15 +399,15 @@ impl ControlEngine for GeneralNoiseModel {
     ) -> Result<EngineStage<Self::EngineInput, Self::Output>, PecosError> {
         trace!("GeneralNoise::continue_processing");
         let next_operations = self.apply_noise_on_continue_processing(msg)?;
-        if !next_operations.is_empty()? {
-            // if there are new quantum operations to process.
-            return Ok(EngineStage::NeedsProcessing(next_operations));
-        } else {
+        if next_operations.is_empty()? {
             // No more quantum operations to process, return results
             // collected along the way and reset the results builder.
             let results = self.results_builder.build();
             self.results_builder.reset();
-            return Ok(EngineStage::Complete(results));
+            Ok(EngineStage::Complete(results))
+        } else {
+            // if there are new quantum operations to process.
+            Ok(EngineStage::NeedsProcessing(next_operations))
         }
     }
 
@@ -569,7 +569,7 @@ impl GeneralNoiseModel {
                         .prepared_qubits
                         .iter()
                         .filter(|q| !gate_qubits.contains(q))
-                        .cloned()
+                        .copied()
                         .collect();
 
                     // Otherwise, it is the same channel for Global and Local
@@ -640,8 +640,8 @@ impl GeneralNoiseModel {
     /// If a leaked qubit is measured, it remains leaked and will continue to measure as 1
     /// until a preparation operation is performed.
     ///
-    /// Returns a ByteMessage destined for quantum simulation. Any results from measurements
-    /// that are destined for the user are appended to self.results_builder.
+    /// Returns a `ByteMessage` destined for quantum simulation. Any results from measurements
+    /// that are destined for the user are appended to `self.results_builder`.
     ///
     /// # Errors
     ///
@@ -739,8 +739,7 @@ impl GeneralNoiseModel {
                 }
                 _ => {
                     return Err(PecosError::Processing(format!(
-                        "Unexpected gate type in measurement handling: {:?}",
-                        gate_type
+                        "Unexpected gate type in measurement handling: {gate_type:?}"
                     )));
                 }
             }
@@ -946,7 +945,7 @@ impl GeneralNoiseModel {
         let probability = match gate_type {
             GateType::MeasCrosstalkGlobalPayload => self.p_meas_crosstalk_global,
             GateType::MeasCrosstalkLocalPayload => self.p_meas_crosstalk_local,
-            _ => panic!("Cannot apply crosstalk on {gate_type}"),
+            _ => unreachable!(),
         };
 
         let mut affected_qubits = Vec::new();

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -706,8 +706,8 @@ impl GeneralNoiseModel {
                         val = 1;
                     }
                     if val == 1 {
-                        // TODO: we apply noise to leaked qubits that measure as 1 - is this
-                        // correct?
+                        // NOTE: we still apply bit-flip noise to the outcome 1 of leaked
+                        // qubits that measure as 1. This has been the approach since H1/H2.
                         if self.rng.occurs(self.p_meas_1) {
                             trace!("Flipped measurement outcome 1->0");
                             val = 0;
@@ -719,8 +719,10 @@ impl GeneralNoiseModel {
                     outcomes.push(val);
                 }
                 GateType::Prep => {
-                    // I don't know what to do here. Just ignore the measurement and treat it as a
-                    // passive collapse?
+                    // Just ignore the measurement.
+                    // In the future we will want to do more advanced crosstalk
+                    // on prep as well, but for now it uses apply_simple_crosstalk_faults
+                    // where the measurement outcome is just meant to be thrown away.
                 }
                 _ => {
                     return Err(PecosError::Processing(format!(

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -94,6 +94,7 @@ use rand_chacha::ChaCha8Rng;
 use std::any::Any;
 use std::collections::BTreeSet;
 
+
 /// General noise model implementation that includes parameterized error channels for various quantum operations
 ///
 /// This comprehensive noise model for quantum computers includes:
@@ -394,13 +395,22 @@ impl ControlEngine for GeneralNoiseModel {
         msg: Self::EngineOutput,
     ) -> Result<EngineStage<Self::EngineInput, Self::Output>, PecosError> {
         trace!("GeneralNoise::continue_processing");
-        let results = self
-            .apply_noise_on_continue_processing(msg)
-            .map_err(|e| PecosError::Processing(format!("Error processing noise: {e}")))?;
+        let result = self.apply_noise_on_continue_processing(msg)?;
 
-        // Calling Complete to signal that the NoiseModel is returning its msg back to the
-        // QuantumSystem.
-        Ok(EngineStage::Complete(results))
+        // Check if the outcomes come from crosstalk measurements
+        let has_crosstalk = self
+            .measured_qubits
+            .iter()
+            .any(|(_, _, is_crosstalk)| *is_crosstalk);
+        // Clear the measured qubits for the next batch
+        self.measured_qubits.clear();
+
+        // If there were crosstalk measurements, we must continue processing so that
+        // the engine applies the transitions after crosstalk
+        match has_crosstalk {
+            true => Ok(EngineStage::NeedsProcessing(result)),
+            false => Ok(EngineStage::Complete(result)),
+        }
     }
 
     fn reset(&mut self) -> Result<(), PecosError> {
@@ -637,34 +647,64 @@ impl GeneralNoiseModel {
         if !NoiseUtils::has_measurements(&message) {
             return Ok(message);
         }
-
         // Parse the measurements from the message
         let measurement_outcomes = message.outcomes()?;
 
-        // Apply biased measurement noise to each outcome
-        let mut results_builder = ByteMessage::outcomes_builder();
+        // Check if the outcomes come from crosstalk measurements
+        let has_crosstalk = self
+            .measured_qubits
+            .iter()
+            .any(|(_, _, is_crosstalk)| *is_crosstalk);
+        // If the measurement outcomes originate from crosstalk, process them and
+        // request to continue processing, and return the gates needed for the transitions
+        if has_crosstalk {
+            // Create a new message builder where the gates necessary for the
+            // transitions will be introduced
+            let mut builder = ByteMessage::quantum_operations_builder();
 
-        // Check if we have leaked qubits that were measured
-        let has_leakage = !self.leaked_qubits.is_empty()
-            && self
-                .measured_qubits
-                .iter()
-                .any(|(q, _, _)| self.is_leaked(*q));
+            for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
+                let (qubit, _, is_crosstalk) = self.measured_qubits[idx];
 
-        for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
-            let mut val = outcome;
-
-            // Check if this measurement corresponds to a leaked qubit or comes from
-            // crosstalk
-            if idx < self.measured_qubits.len() {
-                let (qubit, is_measure_leaked, is_crosstalk) = self.measured_qubits[idx];
-
-                // Check if this measurement comes from crosstalk noise. If so, ignore it.
-                if is_crosstalk {
-                    trace!("Qubit {qubit} was measured by crosstalk; outcome is ignored.");
-                    continue; // Skip this iteration
+                // Sanity check: ALL measurement outcomes of this batch come from crosstalk
+                if !is_crosstalk {
+                    return Err(PecosError::Processing(format!(
+                        "A batch of crosstalk-induced measurements contains and actual measurement on qubit {qubit}"
+                    )));
                 }
 
+                // Apply gates depending on crosstalk transitions
+                // TODO: here I am using local ones, but these could come from global
+                //  crosstalk, and then they should have different transitions...
+                let transition = self.p_meas_crosstalk_local_model.sample_gates(&mut self.rng, qubit, outcome);
+                if transition.has_leakage() {
+                    if let Some(gate) = self.leak(qubit) {
+                        builder.add_gate_command(&gate);
+                    }
+                } else if let Some(gate) = transition.gate {
+                    builder.add_gate_command(&gate);
+                }
+            }
+
+            // Pass the necessary gates to the QuantumEngine to continue
+            Ok(builder.build())
+
+        // Otherwise, these are actual measurement outcomes that need to be processed
+        } else {
+            // Apply biased measurement noise to each outcome
+            let mut results_builder = ByteMessage::outcomes_builder();
+
+            // Check if we have leaked qubits that were measured
+            let has_leakage = !self.leaked_qubits.is_empty()
+                && self
+                    .measured_qubits
+                    .iter()
+                    .any(|(q, _, _)| self.is_leaked(*q));
+
+            for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
+                let mut val = outcome;
+
+                // Check if this measurement corresponds to a leaked qubit
+                let (qubit, is_measure_leaked, _) = self.measured_qubits[idx];
                 if has_leakage && self.is_leaked(qubit) {
                     if is_measure_leaked {
                         trace!("Qubit {qubit} is leaked, MeasureLeaked returns 2");
@@ -676,30 +716,27 @@ impl GeneralNoiseModel {
                         val = 1;
                     }
                 }
-            }
 
-            // Apply asymmetric measurement noise (but not for leaked measurements returning 2)
-            if val == 2 {
-                // No noise applied to leaked measurements
-                trace!("No measurement noise applied to leaked qubit outcome");
-            } else if val == 1 {
-                if self.rng.occurs(self.p_meas_1) {
-                    trace!("Flipped measurement outcome 1->0");
-                    val = 0;
+                // Apply asymmetric measurement noise (but not for leaked measurements returning 2)
+                if val == 2 {
+                    // No noise applied to leaked measurements
+                    trace!("No measurement noise applied to leaked qubit outcome");
+                } else if val == 1 {
+                    if self.rng.occurs(self.p_meas_1) {
+                        trace!("Flipped measurement outcome 1->0");
+                        val = 0;
+                    }
+                } else if self.rng.occurs(self.p_meas_0) {
+                    trace!("Flipped measurement outcome 0->1");
+                    val = 1;
                 }
-            } else if self.rng.occurs(self.p_meas_0) {
-                trace!("Flipped measurement outcome 0->1");
-                val = 1;
+
+                results_builder.add_outcomes(&[val as usize]);
             }
 
-            results_builder.add_outcomes(&[val as usize]);
+            // Build and return the biased measurement results
+            Ok(results_builder.build())
         }
-
-        // Clear the measured qubits for the next batch
-        self.measured_qubits.clear();
-
-        // Build and return the biased measurement results
-        Ok(results_builder.build())
     }
 
     pub fn apply_idle_faults(

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -520,6 +520,15 @@ impl GeneralNoiseModel {
             .expect("Failed to parse input as quantum operations");
 
         for gate in gates {
+            // Track which qubits are being measured for leakage handling
+            if matches!(gate.gate_type, GateType::Measure | GateType::MeasureLeaked) {
+                self.measured_qubits.extend(
+                    gate.qubits
+                        .iter()
+                        .map(|q| (usize::from(*q), gate.gate_type)),
+                );
+            }
+
             // Skip noise application for noiseless gates
             if self.is_noiseless_gate(&gate.gate_type) {
                 // Just add the gate as-is, without any noise
@@ -548,12 +557,6 @@ impl GeneralNoiseModel {
                     self.apply_simple_crosstalk_faults(&gate, self.p_prep_crosstalk, &mut builder);
                 }
                 GateType::Measure | GateType::MeasureLeaked => {
-                    // Track which qubits are being measured for leakage handling
-                    self.measured_qubits.extend(
-                        gate.qubits
-                            .iter()
-                            .map(|q| (usize::from(*q), gate.gate_type)),
-                    );
                     // Measurement noise is handled in apply_noise_on_continue_processing
                     // We still need to add the original gate here
                     builder.add_gate_command(&gate);
@@ -691,7 +694,7 @@ impl GeneralNoiseModel {
                         trace!("Qubit {qubit} is leaked, MeasureLeaked returns 2");
                         // For MeasureLeaked, return 2 for leaked qubits
                         val = 2;
-                    } else {
+                    } else if !self.noiseless_gates.contains(&GateType::MeasureLeaked) {
                         // For non-leaked qubits, apply measurement noise below
                         // Apply asymmetric measurement noise to each outcome
                         if val == 1 {
@@ -715,16 +718,18 @@ impl GeneralNoiseModel {
                         // For regular Measure, force the measurement outcome to be 1
                         val = 1;
                     }
-                    if val == 1 {
-                        // NOTE: we still apply bit-flip noise to the outcome 1 of leaked
-                        // qubits that measure as 1. This has been the approach since H1/H2.
-                        if self.rng.occurs(self.p_meas_1) {
-                            trace!("Flipped measurement outcome 1->0");
-                            val = 0;
+                    // NOTE: we still apply bit-flip noise to the outcome 1 of leaked
+                    // qubits that measure as 1. This has been the approach since H1/H2.
+                    if !self.noiseless_gates.contains(&GateType::Measure) {
+                        if val == 1 {
+                            if self.rng.occurs(self.p_meas_1) {
+                                trace!("Flipped measurement outcome 1->0");
+                                val = 0;
+                            }
+                        } else if self.rng.occurs(self.p_meas_0) {
+                            trace!("Flipped measurement outcome 0->1");
+                            val = 1;
                         }
-                    } else if self.rng.occurs(self.p_meas_0) {
-                        trace!("Flipped measurement outcome 0->1");
-                        val = 1;
                     }
                     outcomes.push(val);
                 }

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -557,9 +557,6 @@ impl GeneralNoiseModel {
                     // Measurement noise is handled in apply_noise_on_continue_processing
                     // We still need to add the original gate here
                     builder.add_gate_command(&gate);
-                    // TODO: simplified crosstalk (H1/H2). Helios crosstalk handled by Payload ops
-                    // if self.simple_crosstalk:
-                    //    self.apply_simple_crosstalk_faults(&gate, self.p_meas_crosstalk, &mut builder);
                 }
                 GateType::MeasCrosstalkGlobalPayload => {
                     // Global crosstalk applies to all qubits that are *not* in the payload
@@ -2461,71 +2458,74 @@ mod tests {
         );
     }
 
-    // TODO: This test no longer applies, since it corresponds to the naive
-    // crosstalk model. If the naive one is maintained, this could be reintroduced
-    // but we need a flag to choose whether to use naive or new one.
-    // #[test]
-    // fn test_meas_crosstalk() {
-    //     use crate::byte_message::ByteMessageBuilder;
+    #[test]
+    fn test_meas_crosstalk() {
+        use crate::byte_message::ByteMessageBuilder;
 
-    //     let mut model = GeneralNoiseModel::builder()
-    //         .with_p_meas_crosstalk(1.0)
-    //         .with_seed(42)
-    //         .build();
-    //     let noise = model
-    //         .as_any_mut()
-    //         .downcast_mut::<GeneralNoiseModel>()
-    //         .unwrap();
+        let mut model = GeneralNoiseModel::builder()
+            .with_p_meas_crosstalk(1.0)
+            .with_seed(42)
+            .build();
+        let noise = model
+            .as_any_mut()
+            .downcast_mut::<GeneralNoiseModel>()
+            .unwrap();
 
-    //     let mut builder = ByteMessageBuilder::new();
-    //     let _ = builder.for_quantum_operations();
-    //     // Prepare a bunch of |0> states
-    //     builder.add_prep(&[0, 1, 2, 3, 4]);
-    //     // Apply mid-circuit measurement and reset
-    //     builder.add_measurements(&[2]);
-    //     builder.add_prep(&[2]);
-    //     let _cmd = noise.start(builder.build()).unwrap();
+        let mut builder = ByteMessageBuilder::new();
+        let _ = builder.for_quantum_operations();
+        // Prepare a bunch of |0> states
+        builder.add_prep(&[0, 1, 2, 3, 4]);
+        // Apply mid-circuit measurement and reset
+        builder.add_measurements(&[2]);
+        builder.add_meas_crosstalk_global_payload(&[2]);
+        builder.add_prep(&[2]);
+        let _cmd = noise.start(builder.build()).unwrap();
 
-    //     assert_eq!(
-    //         noise.measured_qubits.len(),
-    //         5,
-    //         "There should be 5 measured qubits: one from MCMR and the others from
-    //         crosstalk got: {:?}",
-    //         noise.measured_qubits
-    //     );
+        assert_eq!(
+            noise.measured_qubits.len(),
+            5,
+            "There should be 5 measured qubits: one from MCMR and the others from
+            crosstalk got: {:?}",
+            noise.measured_qubits
+        );
 
-    //     let (q, _, is_crosstalk) = noise.measured_qubits[0];
-    //     assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
-    //     assert!(!is_crosstalk, "The first measurement should come from MCMR");
+        let (q, gate_type) = noise.measured_qubits[0];
+        assert_eq!(q, 2, "The first measurement should be the MCMR on qubit 2");
+        assert!(
+            !gate_type.is_crosstalk_payload(),
+            "The first measurement should come from MCMR"
+        );
 
-    //     for (_, _, is_crosstalk) in &noise.measured_qubits[1..] {
-    //         assert!(
-    //             is_crosstalk,
-    //             "The other measurements should come from crosstalk"
-    //         );
-    //     }
+        for (_, gate_type) in &noise.measured_qubits[1..] {
+            assert!(
+                gate_type.is_crosstalk_payload(),
+                "The other measurements should come from crosstalk"
+            );
+        }
 
-    //     // All results are 0
-    //     let mut outcome_builder = ByteMessageBuilder::new();
-    //     let _ = outcome_builder.for_outcomes();
-    //     outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
+        // All results are 0
+        let mut outcome_builder = ByteMessageBuilder::new();
+        let _ = outcome_builder.for_outcomes();
+        outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
-    //     let mcmr = noise
-    //         .continue_processing(outcome_builder.build())
-    //         .unwrap();
-    //     let results = mcmr.outcomes().unwrap();
+        let mcmr = noise.continue_processing(outcome_builder.build()).unwrap();
 
-    //     assert_eq!(
-    //         noise.measured_qubits.len(),
-    //         0,
-    //         "The list of measured_qubits should have been cleared."
-    //     );
-    //     assert_eq!(
-    //         results.len(),
-    //         1,
-    //         "There should only be one outcome: that of the mid-circ measurement"
-    //     );
-    // }
+        let EngineStage::Complete(mcmr) = mcmr else {
+            panic!("Expected Complete stage after processing outcomes");
+        };
+        let results = mcmr.outcomes().unwrap();
+
+        assert_eq!(
+            noise.measured_qubits.len(),
+            0,
+            "The list of measured_qubits should have been cleared."
+        );
+        assert_eq!(
+            results.len(),
+            1,
+            "There should only be one outcome: that of the mid-circ measurement"
+        );
+    }
 
     #[test]
     fn test_parameter_scaling() {

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -399,6 +399,12 @@ impl ControlEngine for GeneralNoiseModel {
         // Clear the measured qubits for the next batch
         self.measured_qubits.clear();
 
+        // TODO: There may be some measurements on this batch that come from crosstalk
+        // and others that come from actual measurement operations.
+        // In the case of `has_crosstalk` we need to return a `NeedsProcessing` but
+        // we also want to save the result_outcome from the previous actual measurements
+        // so that we can return it when we issue the `Complete` stage.
+
         // If there were crosstalk measurements, we must continue processing so that
         // the engine applies the transitions after crosstalk
         match has_crosstalk {
@@ -656,6 +662,8 @@ impl GeneralNoiseModel {
                 let (qubit, gate_type) = self.measured_qubits[idx];
 
                 // Sanity check: ALL measurement outcomes of this batch come from crosstalk
+                // TODO: This is assumption is wrong! See TODO in `continue_processing`.
+                //      once that TODO is done, remove this (in)sanity check.
                 if !gate_type.is_crosstalk_payload() {
                     return Err(PecosError::Processing(format!(
                         "A batch of crosstalk-induced measurements contains and actual measurement on qubit {qubit}"

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -313,9 +313,6 @@ pub struct GeneralNoiseModel {
     /// the device runtime, which are provided as MeasCrosstalkGlobalPayload instructions.
     p_meas_crosstalk_global: f64,
 
-    /// Transition probabilities on the event of global crosstalk error
-    p_meas_crosstalk_global_model: CrosstalkWeightedSampler,
-
     /// Probability of crosstalk during measurement operations on local qubits
     ///
     /// See doc for p_meas_crosstalk_global. The intended distinction is that this
@@ -324,8 +321,8 @@ pub struct GeneralNoiseModel {
     /// the device runtime, which are provided as MeasCrosstalkLocalPayload instructions.
     p_meas_crosstalk_local: f64,
 
-    /// Transition probabilities on the event of local crosstalk error
-    p_meas_crosstalk_local_model: CrosstalkWeightedSampler,
+    /// Transition probabilities on the event of crosstalk error
+    p_meas_crosstalk_model: CrosstalkWeightedSampler,
 
 
     // --- internally used variables --- //
@@ -666,13 +663,7 @@ impl GeneralNoiseModel {
                 }
 
                 // Apply gates depending on crosstalk transitions
-                let transition_model = match gate_type {
-                    GateType::MeasCrosstalkGlobalPayload => &self.p_meas_crosstalk_global_model,
-                    GateType::MeasCrosstalkLocalPayload => &self.p_meas_crosstalk_local_model,
-                    _ => panic!("Cannot match {gate_type}, this should not be possible")
-                };
-
-                let transition = transition_model.sample_gates(&mut self.rng, qubit, outcome);
+                let transition = self.p_meas_crosstalk_model.sample_gates(&mut self.rng, qubit, outcome);
                 if transition.has_leakage() {
                     if let Some(gate) = self.leak(qubit) {
                         builder.add_gate_command(&gate);

--- a/crates/pecos-engines/src/noise/general.rs
+++ b/crates/pecos-engines/src/noise/general.rs
@@ -355,6 +355,9 @@ pub struct GeneralNoiseModel {
     /// This is needed to properly handle leakage during measurements as well
     /// as crosstalk.
     measured_qubits: Vec<(usize, GateType)>,
+
+    /// Stored outcome builder
+    results_builder: ByteMessageBuilder,
 }
 
 impl ControlEngine for GeneralNoiseModel {
@@ -368,6 +371,11 @@ impl ControlEngine for GeneralNoiseModel {
         &mut self,
         input: Self::Input,
     ) -> Result<EngineStage<Self::EngineInput, Self::Output>, PecosError> {
+        if self.results_builder.message_count() > 0 {
+            return Err(PecosError::Processing(
+                "Results builder not empty at start of processing".to_string(),
+            ));
+        }
         // Apply noise to the gates
         let noisy_gates = match self.apply_noise_on_start(&input) {
             Ok(gates) => gates,
@@ -389,27 +397,16 @@ impl ControlEngine for GeneralNoiseModel {
         msg: Self::EngineOutput,
     ) -> Result<EngineStage<Self::EngineInput, Self::Output>, PecosError> {
         trace!("GeneralNoise::continue_processing");
-        let result = self.apply_noise_on_continue_processing(msg)?;
-
-        // Check if the outcomes come from crosstalk measurements
-        let has_crosstalk = self
-            .measured_qubits
-            .iter()
-            .any(|(_, gate_type)| gate_type.is_crosstalk_payload());
-        // Clear the measured qubits for the next batch
-        self.measured_qubits.clear();
-
-        // TODO: There may be some measurements on this batch that come from crosstalk
-        // and others that come from actual measurement operations.
-        // In the case of `has_crosstalk` we need to return a `NeedsProcessing` but
-        // we also want to save the result_outcome from the previous actual measurements
-        // so that we can return it when we issue the `Complete` stage.
-
-        // If there were crosstalk measurements, we must continue processing so that
-        // the engine applies the transitions after crosstalk
-        match has_crosstalk {
-            true => Ok(EngineStage::NeedsProcessing(result)),
-            false => Ok(EngineStage::Complete(result)),
+        let next_operations = self.apply_noise_on_continue_processing(msg)?;
+        if !next_operations.is_empty()? {
+            // if there are new quantum operations to process.
+            return Ok(EngineStage::NeedsProcessing(next_operations));
+        }else{
+            // No more quantum operations to process, return results
+            // collected along the way and reset the results builder.
+            let results = self.results_builder.build();
+            self.results_builder.reset();
+            return Ok(EngineStage::Complete(results));
         }
     }
 
@@ -632,6 +629,9 @@ impl GeneralNoiseModel {
     /// If a leaked qubit is measured, it remains leaked and will continue to measure as 1
     /// until a preparation operation is performed.
     ///
+    /// Returns a ByteMessage destined for quantum simulation. Any results from measurements
+    /// that are destined for the user are appended to self.results_builder.
+    ///
     /// # Errors
     ///
     /// Returns an error if noise application fails or the message cannot be processed.
@@ -646,93 +646,93 @@ impl GeneralNoiseModel {
         // Parse the measurements from the message
         let measurement_outcomes = message.outcomes()?;
 
-        // Check if the outcomes come from crosstalk measurements
-        let has_crosstalk = self
-            .measured_qubits
-            .iter()
-            .any(|(_, gate_type)| gate_type.is_crosstalk_payload());
-        // If the measurement outcomes originate from crosstalk, process them and
-        // request to continue processing, and return the gates needed for the transitions
-        if has_crosstalk {
-            // Create a new message builder where the gates necessary for the
-            // transitions will be introduced
-            let mut builder = ByteMessage::quantum_operations_builder();
+        // Create a new message builder where the gates necessary for the
+        // transitions will be introduced
+        let mut ops_builder = ByteMessage::quantum_operations_builder();
+        let mut outcomes = vec![];
 
-            for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
-                let (qubit, gate_type) = self.measured_qubits[idx];
+        if measurement_outcomes.len() != self.measured_qubits.len() {
+            return Err(PecosError::Processing(format!(
+                "Mismatch in number of measurement outcomes ({}) and tracked measured qubits ({})",
+                measurement_outcomes.len(),
+                self.measured_qubits.len()
+            )));
+        }
 
-                // Sanity check: ALL measurement outcomes of this batch come from crosstalk
-                // TODO: This is assumption is wrong! See TODO in `continue_processing`.
-                //      once that TODO is done, remove this (in)sanity check.
-                if !gate_type.is_crosstalk_payload() {
-                    return Err(PecosError::Processing(format!(
-                        "A batch of crosstalk-induced measurements contains and actual measurement on qubit {qubit}"
-                    )));
-                }
-
-                // Apply gates depending on crosstalk transitions
-                let transition = self.p_meas_crosstalk_model.sample_gates(&mut self.rng, qubit, outcome);
-                if transition.has_leakage() {
-                    if let Some(gate) = self.leak(qubit) {
-                        builder.add_gate_command(&gate);
+        for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
+            let (qubit, gate_type) = self.measured_qubits[idx];
+            match gate_type {
+                GateType::MeasCrosstalkGlobalPayload | GateType::MeasCrosstalkLocalPayload => {
+                    // It is not a measurement destined for the user, but one we
+                    // injected in order to model crosstalk. Use the measurement result
+                    // to determine any transitions to apply.
+                    let transition = self.p_meas_crosstalk_model.sample_gates(&mut self.rng, qubit, outcome);
+                    if transition.has_leakage() {
+                        if let Some(gate) = self.leak(qubit) {
+                            ops_builder.add_gate_command(&gate);
+                        }
+                    } else if let Some(gate) = transition.gate {
+                        ops_builder.add_gate_command(&gate);
                     }
-                } else if let Some(gate) = transition.gate {
-                    builder.add_gate_command(&gate);
                 }
-            }
-
-            // Pass the necessary gates to the QuantumEngine to continue
-            Ok(builder.build())
-
-        // Otherwise, these are actual measurement outcomes that need to be processed
-        } else {
-            // Apply biased measurement noise to each outcome
-            let mut results_builder = ByteMessage::outcomes_builder();
-
-            // Check if we have leaked qubits that were measured
-            let has_leakage = !self.leaked_qubits.is_empty()
-                && self
-                    .measured_qubits
-                    .iter()
-                    .any(|(q, _)| self.is_leaked(*q));
-
-            for (idx, outcome) in measurement_outcomes.into_iter().enumerate() {
-                let mut val = outcome;
-
-                // Check if this measurement corresponds to a leaked qubit
-                let (qubit, gate_type) = self.measured_qubits[idx];
-                if has_leakage && self.is_leaked(qubit) {
-                    if gate_type == GateType::MeasureLeaked {
+                GateType::MeasureLeaked => {
+                    let mut val = outcome as usize;
+                    if self.is_leaked(qubit) {
                         trace!("Qubit {qubit} is leaked, MeasureLeaked returns 2");
                         // For MeasureLeaked, return 2 for leaked qubits
                         val = 2;
                     } else {
+                        // For non-leaked qubits, apply measurement noise below
+                        // Apply asymmetric measurement noise to each outcome
+                        if val == 1 {
+                            if self.rng.occurs(self.p_meas_1) {
+                                trace!("Flipped measurement outcome 1->0");
+                                val = 0;
+                            }
+                        } else if self.rng.occurs(self.p_meas_0) {
+                            trace!("Flipped measurement outcome 0->1");
+                            val = 1;
+                        }
+                    }
+                    outcomes.push(val);
+                }
+                GateType::Measure => {
+                    // Apply biased measurement noise to each outcome
+                    // Check if we have leaked qubits that were measured
+                    let mut val = outcome as usize;
+                    if self.is_leaked(qubit) {
                         trace!("Qubit {qubit} is leaked, Measure returns 1");
                         // For regular Measure, force the measurement outcome to be 1
                         val = 1;
                     }
-                }
-
-                // Apply asymmetric measurement noise (but not for leaked measurements returning 2)
-                if val == 2 {
-                    // No noise applied to leaked measurements
-                    trace!("No measurement noise applied to leaked qubit outcome");
-                } else if val == 1 {
-                    if self.rng.occurs(self.p_meas_1) {
-                        trace!("Flipped measurement outcome 1->0");
-                        val = 0;
+                    if val == 1 {
+                        // TODO: we apply noise to leaked qubits that measure as 1 - is this
+                        // correct?
+                        if self.rng.occurs(self.p_meas_1) {
+                            trace!("Flipped measurement outcome 1->0");
+                            val = 0;
+                        }
+                    } else if self.rng.occurs(self.p_meas_0) {
+                        trace!("Flipped measurement outcome 0->1");
+                        val = 1;
                     }
-                } else if self.rng.occurs(self.p_meas_0) {
-                    trace!("Flipped measurement outcome 0->1");
-                    val = 1;
+                    outcomes.push(val);
                 }
-
-                results_builder.add_outcomes(&[val as usize]);
+                GateType::Prep => {
+                    // I don't know what to do here. Just ignore the measurement and treat it as a
+                    // passive collapse?
+                }
+                _ => {
+                    return Err(PecosError::Processing(format!(
+                        "Unexpected gate type in measurement handling: {:?}",
+                        gate_type
+                    )));
+                }
             }
-
-            // Build and return the biased measurement results
-            Ok(results_builder.build())
         }
+        self.measured_qubits.clear();
+        self.results_builder.add_outcomes(&outcomes);
+        Ok(ops_builder.build())
     }
 
     pub fn apply_idle_faults(
@@ -1523,70 +1523,73 @@ mod tests {
         );
     }
 
+    /// Helper function to invoke a measurement request from the user to the noise
+    /// model, and respond back with measurement values from the user. The result
+    /// is the engine stage after the measurement results have been processed.
+    fn request_measurements_and_give_values(
+        noise: &mut GeneralNoiseModel,
+        qubits: &[usize],
+        values: &[usize],
+    ) -> EngineStage<ByteMessage, ByteMessage> {
+        use crate::byte_message::ByteMessageBuilder;
+        // Create a measurement operation on the given qubits
+        let mut request_builder = ByteMessageBuilder::new();
+        let _ = request_builder.for_quantum_operations();
+        for &qubit in qubits {
+            request_builder.add_gate_command(&Gate {
+                gate_type: GateType::Measure,
+                qubits: vec![QubitId(qubit)],
+                params: vec![],
+            });
+        }
+        let measurement_request = request_builder.build();
+
+        // Send the measurement requests to the noise model
+        let Ok(EngineStage::NeedsProcessing(_)) = noise.start(measurement_request) else {
+            panic!("Expected NeedsProcessing stage after measurement with noise");
+        };
+
+        // Now create the measurement results
+        let mut response_builder = ByteMessageBuilder::new();
+        let _ = response_builder.for_outcomes();
+        response_builder.add_outcomes(values);
+        let measurement_response = response_builder.build();
+
+        // Process the measurement results through the noise model
+        noise.continue_processing(measurement_response).unwrap()
+    }
     #[test]
     fn test_biased_measurement() {
-        use crate::byte_message::ByteMessageBuilder;
+        // Create a noise model with 100% flip probabilities,
+        // and a noise model with 0% flip probabilities. Have them
+        // both measure two qubits, one reporting state 0 and one in state 1.
+        // Ensure that the biased model flips both results, while the unbiased
+        // model leaves them unchanged.
 
-        // Create a noise model with 100% flip probabilities for deterministic testing
-        let mut noise = GeneralNoiseModel::new(0.0, 1.0, 1.0, 0.0, 0.0);
 
-        // Create a message with a 0 measurement result
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[0]);
-        let message_with_zero = builder.build();
+        // The clean model
+        let mut never_flip = GeneralNoiseModel::new(0.0, 0.0, 0.0, 0.0, 0.0);
+        let never_flip_state = request_measurements_and_give_values(&mut never_flip, &[0, 1], &[0, 1]);
+        let EngineStage::Complete(clean_results) = never_flip_state else {
+            panic!("Expected results from the unbiased noise model");
+        };
+        let clean_outcomes = clean_results.outcomes().unwrap();
+        assert_eq!(clean_outcomes.len(), 2, "Should have two measurement results from the unbaised model");
+        assert_eq!(clean_outcomes[0], 0, "0 shouldn't be flipped to 1");
+        assert_eq!(clean_outcomes[1], 1, "1 shouldn't be flipped to 0");
 
-        // Test measurement bias - all 0s should be flipped to 1s
-        let biased_zero = noise
-            .apply_noise_on_continue_processing(message_with_zero)
-            .unwrap();
-        let outcomes = biased_zero.outcomes().unwrap();
-        let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
-        assert_eq!(results[0].1, 1, "0 should be flipped to 1");
-
-        // Create a message with a 1 measurement result
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[1]);
-        let message_with_one = builder.build();
-
-        // Test measurement bias - all 1s should be flipped to 0s
-        let biased_one = noise
-            .apply_noise_on_continue_processing(message_with_one)
-            .unwrap();
-        let outcomes = biased_one.outcomes().unwrap();
-        let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
-        assert_eq!(results[0].1, 0, "1 should be flipped to 0");
-
-        // Create a noise model with 0% flip probabilities
-        noise = GeneralNoiseModel::new(0.0, 0.0, 0.0, 0.0, 0.0);
-
-        // Test measurement bias with 0% flip - all 0s should remain 0s
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[0]);
-        let message_with_zero = builder.build();
-
-        let unbiased_zero = noise
-            .apply_noise_on_continue_processing(message_with_zero)
-            .unwrap();
-        let outcomes = unbiased_zero.outcomes().unwrap();
-        let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
-        assert_eq!(results[0].1, 0, "0 should remain 0");
-
-        // Test measurement bias with 0% flip - all 1s should remain 1s
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[1]);
-        let message_with_one = builder.build();
-
-        let unbiased_one = noise
-            .apply_noise_on_continue_processing(message_with_one)
-            .unwrap();
-        let outcomes = unbiased_one.outcomes().unwrap();
-        let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
-        assert_eq!(results[0].1, 1, "1 should remain 1");
+        // The noisy model
+        let mut always_flip = GeneralNoiseModel::new(0.0, 1.0, 1.0, 0.0, 0.0);
+        let always_flip_state = request_measurements_and_give_values(&mut always_flip, &[0, 1], &[0, 1]);
+        let EngineStage::Complete(noisy_results) = always_flip_state else {
+            panic!("Expected results from the biased noise model");
+        };
+        let noisy_outcomes = noisy_results.outcomes().unwrap();
+        assert_eq!(noisy_outcomes.len(), 2, "Should have two measurement results from the unbaised model");
+        assert_eq!(noisy_outcomes[0], 1, "0 should be flipped to 1");
+        assert_eq!(noisy_outcomes[1], 0, "1 should be flipped to 0");
     }
+
 
     #[test]
     fn test_prep_leak_ratio() {
@@ -1665,8 +1668,6 @@ mod tests {
 
     #[test]
     fn test_leaked_qubit_measurement_behavior() {
-        use crate::byte_message::ByteMessageBuilder;
-
         // Create a noise model with no spontaneous errors
         let mut model = GeneralNoiseModel::builder()
             .with_prep_probability(0.0)
@@ -1675,52 +1676,34 @@ mod tests {
             .with_p1_probability(0.0)
             .with_p2_probability(0.0)
             .build();
-        let noise = model
-            .as_any_mut()
-            .downcast_mut::<GeneralNoiseModel>()
-            .unwrap();
 
         // Manually mark qubit 0 as leaked
-        noise.mark_as_leaked(0);
+        model.mark_as_leaked(0);
 
-        // First, we need to process a measurement gate so the noise model tracks which qubit is measured
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_quantum_operations();
-        builder.add_measurements(&[0]); // Measure qubit 0
-        let measurement_command = builder.build();
-
-        // Process the measurement gate through the noise model
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
-
-        // Now create the measurement results
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[0]); // Measurement result is 0
-
-        // Apply measurement noise - this should NOT unleak the qubit
-        let biased_message = noise
-            .apply_noise_on_continue_processing(builder.build())
-            .unwrap();
+        // First, tell the noise model that we are measuring qubit 0, and give it value 0
+        let state = request_measurements_and_give_values(&mut model, &[0], &[0]);
+        let EngineStage::Complete(biased_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         // Get the measurement results
         let outcomes = biased_message.outcomes().unwrap();
-        let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
+        assert_eq!(outcomes.len(), 1, "Should have one measurement result");
+
 
         // Verify that the leaked qubit is reported as measured as 1
-        assert_eq!(results[0].1, 1, "Leaked qubit should always measure as 1");
+        assert_eq!(outcomes[0], 1, "Leaked qubit should always measure as 1");
 
         // Verify that the qubit is still leaked after measurement
         // Measurements do not unleak qubits - only prep operations do
         assert!(
-            noise.is_leaked(0),
+            model.is_leaked(0),
             "Qubit should remain leaked after measurement"
         );
     }
 
     #[test]
     fn test_repeated_measurement_of_leaked_qubit() {
-        use crate::byte_message::ByteMessageBuilder;
-
         // Create a noise model with no spontaneous errors
         let mut model = GeneralNoiseModel::builder()
             .with_prep_probability(0.0)
@@ -1729,35 +1712,15 @@ mod tests {
             .with_p1_probability(0.0)
             .with_p2_probability(0.0)
             .build();
-        let noise = model
-            .as_any_mut()
-            .downcast_mut::<GeneralNoiseModel>()
-            .unwrap();
 
         // Manually mark qubit 0 as leaked
-        noise.mark_as_leaked(0);
+        model.mark_as_leaked(0);
 
-        // Process measurement gates - measure qubit 0 three times in a batch
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_quantum_operations();
-        builder.add_measurements(&[0]); // First measurement of qubit 0
-        builder.add_measurements(&[0]); // Second measurement of qubit 0
-        builder.add_measurements(&[0]); // Third measurement of qubit 0
-        let measurement_command = builder.build();
-
-        // Process the measurement gates through the noise model
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
-
-        // Now create the measurement results (all originally 0)
-        let mut builder = ByteMessageBuilder::new();
-        let _ = builder.for_outcomes();
-        builder.add_outcomes(&[0, 0, 0]); // Three measurement results, all 0
-
-        // Apply measurement noise
-        let biased_message = noise
-            .apply_noise_on_continue_processing(builder.build())
-            .unwrap();
-
+        // Measure 0 thrice and provide measurement result 0 each time
+        let state = request_measurements_and_give_values(&mut model, &[0,0,0], &[0,0,0]);
+        let EngineStage::Complete(biased_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
         // Get the measurement results
         let outcomes = biased_message.outcomes().unwrap();
         let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
@@ -1779,7 +1742,7 @@ mod tests {
 
         // Verify that the qubit is still leaked after all measurements
         assert!(
-            noise.is_leaked(0),
+            model.is_leaked(0),
             "Qubit should remain leaked after repeated measurements"
         );
     }
@@ -1810,19 +1773,23 @@ mod tests {
         let _ = builder.for_quantum_operations();
         builder.add_measurements(&[0]);
         let measurement_command = builder.build();
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command).unwrap();
 
         // Process measurement results
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0]);
-        let biased_message = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(biased_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         // Verify the leaked qubit measured as 1 but remains leaked
         let outcomes = biased_message.outcomes().unwrap();
         let results: Vec<(usize, u32)> = outcomes.into_iter().enumerate().collect();
+        assert_eq!(results.len(), 1, "Should have one measurement result");
         assert_eq!(results[0].1, 1, "Leaked qubit should measure as 1");
         assert!(
             noise.is_leaked(0),
@@ -1872,7 +1839,7 @@ mod tests {
         let measurement_command = builder.build();
 
         // Process the measurement gates through the noise model
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command).unwrap();
 
         // Create measurement results in the same order
         let mut builder = ByteMessageBuilder::new();
@@ -1880,9 +1847,12 @@ mod tests {
         builder.add_outcomes(&[1, 0, 1, 0, 1]); // Results in order
 
         // Apply measurement noise
-        let noisy_results = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(noisy_results) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         // Parse the noisy results
         let results = noisy_results.outcomes().unwrap();
@@ -1942,7 +1912,7 @@ mod tests {
         let measurement_command = builder.build();
 
         // Process the measurement gates
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command).unwrap();
 
         // Create measurement results (all zeros)
         let mut builder = ByteMessageBuilder::new();
@@ -1950,15 +1920,18 @@ mod tests {
         builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
         // Apply noise (should force leaked qubits to 1)
-        let noisy_results = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(noisy_results) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         // Parse results
         let results = noisy_results.outcomes().unwrap();
 
         // Verify order and leakage effects
-        assert_eq!(results.len(), 5);
+        assert_eq!(results.len(), 5, "Should have 5 measurement results");
         assert_eq!(results[0], 0, "Qubit 0 (non-leaked) should remain 0");
         assert_eq!(results[1], 1, "Qubit 1 (leaked) should be forced to 1");
         assert_eq!(results[2], 0, "Qubit 2 (non-leaked) should remain 0");
@@ -1971,8 +1944,6 @@ mod tests {
 
     #[test]
     fn test_biased_measurement_statistics() {
-        use crate::byte_message::ByteMessageBuilder;
-
         // Test with many measurements to see clear statistical pattern
         const NUM_MEASUREMENTS: usize = 1000;
 
@@ -1992,19 +1963,16 @@ mod tests {
         let mut zeros_flipped = 0;
         for i in 0..NUM_MEASUREMENTS {
             // Need to process measurement gate first
-            let mut builder = ByteMessageBuilder::new();
-            let _ = builder.for_quantum_operations();
-            builder.add_measurements(&[0]);
-            let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
-
-            let mut builder = ByteMessageBuilder::new();
-            let _ = builder.for_outcomes();
-            builder.add_outcomes(&[0]);
-
-            let biased_result = noise
-                .apply_noise_on_continue_processing(builder.build())
-                .unwrap();
+            let state = request_measurements_and_give_values(noise, &[0], &[0]);
+            let EngineStage::Complete(biased_result) = state else {
+                panic!("Expected Complete stage after measurement with noise");
+            };
             let results = biased_result.outcomes().unwrap();
+            assert_eq!(
+                results.len(),
+                1,
+                "Expected one measurement result per iteration"
+            );
 
             if results[0] == 1 {
                 zeros_flipped += 1;
@@ -2037,18 +2005,10 @@ mod tests {
 
         for i in 0..NUM_MEASUREMENTS {
             // Process measurement gate
-            let mut builder = ByteMessageBuilder::new();
-            let _ = builder.for_quantum_operations();
-            builder.add_measurements(&[0]);
-            let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
-
-            let mut builder = ByteMessageBuilder::new();
-            let _ = builder.for_outcomes();
-            builder.add_outcomes(&[1]);
-
-            let biased_result = noise
-                .apply_noise_on_continue_processing(builder.build())
-                .unwrap();
+            let state = request_measurements_and_give_values(noise, &[0], &[1]);
+            let EngineStage::Complete(biased_result) = state else {
+                panic!("Expected Complete stage after measurement with noise");
+            };
             let results = biased_result.outcomes().unwrap();
 
             if results[0] == 0 {
@@ -2098,16 +2058,19 @@ mod tests {
         for i in 0..10 {
             builder.add_measurements(&[i]);
         }
-        let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+        let _cmd = noise.start(builder.build()).unwrap();
 
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         // Original pattern: 0,1,0,1,0,1,0,1,0,1
         builder.add_outcomes(&[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]);
 
-        let biased_result = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(biased_result) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
         let results = biased_result.outcomes().unwrap();
 
         // Expected pattern after noise: 1,1,1,1,1,1,1,1,1,1 (all zeros flipped)
@@ -2136,16 +2099,19 @@ mod tests {
         for i in 0..10 {
             builder.add_measurements(&[i]);
         }
-        let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+        let _cmd = noise.start(builder.build()).unwrap();
 
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         // Same original pattern: 0,1,0,1,0,1,0,1,0,1
         builder.add_outcomes(&[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]);
 
-        let biased_result = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(biased_result) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
         let results = biased_result.outcomes().unwrap();
 
         // Expected pattern after noise: 0,0,0,0,0,0,0,0,0,0 (all ones flipped)
@@ -2186,19 +2152,21 @@ mod tests {
         builder.add_measure_leakages(&[1]); // MeasureLeaked
 
         let measurement_command = builder.build();
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command.clone()).unwrap();
 
         // Create measurement results (both qubits in |0⟩ state)
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 0]);
 
-        let results_message = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
-
+        let EngineStage::Complete(results_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
         let results = results_message.outcomes().unwrap();
-        assert_eq!(results.len(), 2);
+        assert_eq!(results.len(), 2, "Should have two measurement results");
         assert_eq!(results[0], 0, "Regular Measure of |0⟩ should return 0");
         assert_eq!(
             results[1], 0,
@@ -2206,13 +2174,17 @@ mod tests {
         );
 
         // Test with |1⟩ state
+        let _noisy_command = noise.start(measurement_command.clone()).unwrap();
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[1, 1]);
 
-        let results_message = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(results_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         let results = results_message.outcomes().unwrap();
         assert_eq!(results[0], 1, "Regular Measure of |1⟩ should return 1");
@@ -2251,19 +2223,22 @@ mod tests {
         builder.add_measure_leakages(&[1]); // MeasureLeaked on leaked qubit
 
         let measurement_command = builder.build();
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command).unwrap();
 
         // Create measurement results (simulator returns 0, but noise model will override)
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 0]);
 
-        let results_message = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(results_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         let results = results_message.outcomes().unwrap();
-        assert_eq!(results.len(), 2);
+        assert_eq!(results.len(), 2, "Should have two measurement results");
         assert_eq!(
             results[0], 1,
             "Regular Measure of leaked qubit should return 1"
@@ -2305,19 +2280,22 @@ mod tests {
         builder.add_measurements(&[3]); // Regular measure on non-leaked qubit 3
 
         let measurement_command = builder.build();
-        let _noisy_command = noise.apply_noise_on_start(&measurement_command).unwrap();
+        let _noisy_command = noise.start(measurement_command).unwrap();
 
         // Create measurement results (mix of 0s and 1s from simulator)
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_outcomes();
         builder.add_outcomes(&[0, 1, 0, 1]); // Simulator results before noise
 
-        let results_message = noise
-            .apply_noise_on_continue_processing(builder.build())
+        let state = noise
+            .continue_processing(builder.build())
             .unwrap();
+        let EngineStage::Complete(results_message) = state else {
+            panic!("Expected Complete stage after measurement with noise");
+        };
 
         let results = results_message.outcomes().unwrap();
-        assert_eq!(results.len(), 4);
+        assert_eq!(results.len(), 4, "Should have 4 measurement results");
         assert_eq!(results[0], 1, "Measure on leaked qubit 0 should return 1");
         assert_eq!(
             results[1], 1,
@@ -2356,7 +2334,7 @@ mod tests {
         let mut builder = ByteMessageBuilder::new();
         let _ = builder.for_quantum_operations();
         builder.add_measurements(&[0, 1, 2, 3]); // 0 and 2 are leaked
-        let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+        let _cmd = noise.start(builder.build()).unwrap();
 
         // All original results are 0
         let mut builder = ByteMessageBuilder::new();
@@ -2376,12 +2354,16 @@ mod tests {
             let mut gate_builder = ByteMessageBuilder::new();
             let _ = gate_builder.for_quantum_operations();
             gate_builder.add_measurements(&[0, 1, 2, 3]);
-            let _cmd = noise.apply_noise_on_start(&gate_builder.build()).unwrap();
+            let _cmd = noise.start(gate_builder.build()).unwrap();
 
-            let biased_result = noise
-                .apply_noise_on_continue_processing(builder.build())
+            let state = noise
+                .continue_processing(builder.build())
                 .unwrap();
+            let EngineStage::Complete(biased_result) = state else {
+                panic!("Expected Complete stage after measurement with noise");
+            };
             let results = biased_result.outcomes().unwrap();
+            assert_eq!(results.len(), 4, "Expected 4 measurement results");
 
             // Qubits 0 and 2 were leaked, so forced to 1, then 50% chance to flip to 0
             if results[0] == 0 {
@@ -2432,7 +2414,7 @@ mod tests {
         // Apply mid-circuit measurement and reset
         builder.add_measurements(&[2]);
         builder.add_prep(&[2]);
-        let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+        let _cmd = noise.start(builder.build()).unwrap();
 
         assert_eq!(
             noise.measured_qubits.len(),
@@ -2459,8 +2441,12 @@ mod tests {
         outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
         let mcmr = noise
-            .apply_noise_on_continue_processing(outcome_builder.build())
+            .continue_processing(outcome_builder.build())
             .unwrap();
+
+        let EngineStage::Complete(mcmr) = mcmr else {
+            panic!("Expected Complete stage after processing outcomes");
+        };
         let results = mcmr.outcomes().unwrap();
 
         assert_eq!(
@@ -2498,7 +2484,7 @@ mod tests {
     //     // Apply mid-circuit measurement and reset
     //     builder.add_measurements(&[2]);
     //     builder.add_prep(&[2]);
-    //     let _cmd = noise.apply_noise_on_start(&builder.build()).unwrap();
+    //     let _cmd = noise.start(builder.build()).unwrap();
 
     //     assert_eq!(
     //         noise.measured_qubits.len(),
@@ -2525,7 +2511,7 @@ mod tests {
     //     outcome_builder.add_outcomes(&[0, 0, 0, 0, 0]);
 
     //     let mcmr = noise
-    //         .apply_noise_on_continue_processing(outcome_builder.build())
+    //         .continue_processing(outcome_builder.build())
     //         .unwrap();
     //     let results = mcmr.outcomes().unwrap();
 
@@ -2928,7 +2914,10 @@ mod tests {
         let msg = builder.build();
 
         // Apply noise to the gates manually since we can't access apply_noise_to_gates directly
-        let message = noise.apply_noise_on_start(&msg).unwrap();
+        let state = noise.start(msg).unwrap();
+        let EngineStage::NeedsProcessing(message) = state else {
+            panic!("Expected NeedsProcessing stage after applying noise to gates");
+        };
         let gates = message.quantum_ops().unwrap();
 
         // We expect the RZ gate to be unchanged, and the X gate might have errors applied

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -1,6 +1,6 @@
 use crate::GateType;
 use crate::noise::{
-    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler,
+    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -46,10 +46,12 @@ pub struct GeneralNoiseModelBuilder {
     // measurement noise
     p_meas_0: Option<f64>,
     p_meas_1: Option<f64>,
+    meas_scale: Option<f64>,
     // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
     p_meas_crosstalk_global: Option<f64>,
+    p_meas_crosstalk_global_model: Option<CrosstalkWeightedSampler>,
     p_meas_crosstalk_local: Option<f64>,
-    meas_scale: Option<f64>,
+    p_meas_crosstalk_local_model: Option<CrosstalkWeightedSampler>,
     p_meas_crosstalk_scale: Option<f64>,
 }
 
@@ -103,9 +105,11 @@ impl GeneralNoiseModelBuilder {
             // measurement noise
             p_meas_0: None,
             p_meas_1: None,
-            p_meas_crosstalk_global: None,
-            p_meas_crosstalk_local: None,
             meas_scale: None,
+            p_meas_crosstalk_global: None,
+            p_meas_crosstalk_global_model: None,
+            p_meas_crosstalk_local: None,
+            p_meas_crosstalk_local_model: None,
             p_meas_crosstalk_scale: None,
         }
     }
@@ -249,8 +253,16 @@ impl GeneralNoiseModelBuilder {
             model.p_meas_crosstalk_global = prob;
         }
 
+        if let Some(model_map) = self.p_meas_crosstalk_global_model.clone() {
+            model.p_meas_crosstalk_global_model = model_map;
+        }
+
         if let Some(prob) = self.p_meas_crosstalk_local {
             model.p_meas_crosstalk_local = prob;
+        }
+
+        if let Some(model_map) = self.p_meas_crosstalk_local_model.clone() {
+            model.p_meas_crosstalk_local_model = model_map;
         }
 
         // scale
@@ -658,12 +670,19 @@ impl GeneralNoiseModelBuilder {
         self
     }
 
-    // TODO: See if we should put a average scaling...
     /// Set the average measurement global crosstalk
+    /// TODO: This is no longer applicable on Helios
+    // #[must_use]
+    // pub fn with_average_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
+    //     let prob: f64 = prob * 18.0 / 5.0;
+    //     self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
+    //     self
+    // }
+
+    /// Set the transition model for global measurement crosstalk
     #[must_use]
-    pub fn with_average_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
-        let prob: f64 = prob * 18.0 / 5.0;
-        self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
+    pub fn with_p_meas_crosstalk_global_model(mut self, model: &BTreeMap<String, f64>) -> Self {
+        self.p_meas_crosstalk_global_model = Some(CrosstalkWeightedSampler::new(model));
         self
     }
 
@@ -675,10 +694,18 @@ impl GeneralNoiseModelBuilder {
     }
 
     /// Set the average measurement local crosstalk
+    /// TODO: This is no longer applicable on Helios
+    // #[must_use]
+    // pub fn with_average_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
+    //     let prob: f64 = prob * 18.0 / 5.0;
+    //     self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
+    //     self
+    // }
+
+    /// Set the transition model for local measurement crosstalk
     #[must_use]
-    pub fn with_average_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
-        let prob: f64 = prob * 18.0 / 5.0;
-        self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
+    pub fn with_p_meas_crosstalk_local_model(mut self, model: &BTreeMap<String, f64>) -> Self {
+        self.p_meas_crosstalk_local_model = Some(CrosstalkWeightedSampler::new(model));
         self
     }
 

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -49,9 +49,8 @@ pub struct GeneralNoiseModelBuilder {
     meas_scale: Option<f64>,
     // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
     p_meas_crosstalk_global: Option<f64>,
-    p_meas_crosstalk_global_model: Option<CrosstalkWeightedSampler>,
     p_meas_crosstalk_local: Option<f64>,
-    p_meas_crosstalk_local_model: Option<CrosstalkWeightedSampler>,
+    p_meas_crosstalk_model: Option<CrosstalkWeightedSampler>,
     p_meas_crosstalk_scale: Option<f64>,
 }
 
@@ -107,9 +106,8 @@ impl GeneralNoiseModelBuilder {
             p_meas_1: None,
             meas_scale: None,
             p_meas_crosstalk_global: None,
-            p_meas_crosstalk_global_model: None,
             p_meas_crosstalk_local: None,
-            p_meas_crosstalk_local_model: None,
+            p_meas_crosstalk_model: None,
             p_meas_crosstalk_scale: None,
         }
     }
@@ -253,16 +251,12 @@ impl GeneralNoiseModelBuilder {
             model.p_meas_crosstalk_global = prob;
         }
 
-        if let Some(model_map) = self.p_meas_crosstalk_global_model.clone() {
-            model.p_meas_crosstalk_global_model = model_map;
-        }
-
         if let Some(prob) = self.p_meas_crosstalk_local {
             model.p_meas_crosstalk_local = prob;
         }
 
-        if let Some(model_map) = self.p_meas_crosstalk_local_model.clone() {
-            model.p_meas_crosstalk_local_model = model_map;
+        if let Some(model_map) = self.p_meas_crosstalk_model.clone() {
+            model.p_meas_crosstalk_model = model_map;
         }
 
         // scale
@@ -679,13 +673,6 @@ impl GeneralNoiseModelBuilder {
     //     self
     // }
 
-    /// Set the transition model for global measurement crosstalk
-    #[must_use]
-    pub fn with_p_meas_crosstalk_global_model(mut self, model: &BTreeMap<String, f64>) -> Self {
-        self.p_meas_crosstalk_global_model = Some(CrosstalkWeightedSampler::new(model));
-        self
-    }
-
     /// Set the probability of local crosstalk during measurement operations
     #[must_use]
     pub fn with_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
@@ -702,10 +689,10 @@ impl GeneralNoiseModelBuilder {
     //     self
     // }
 
-    /// Set the transition model for local measurement crosstalk
+    /// Set the transition model for measurement crosstalk
     #[must_use]
-    pub fn with_p_meas_crosstalk_local_model(mut self, model: &BTreeMap<String, f64>) -> Self {
-        self.p_meas_crosstalk_local_model = Some(CrosstalkWeightedSampler::new(model));
+    pub fn with_p_meas_crosstalk_model(mut self, model: &BTreeMap<String, f64>) -> Self {
+        self.p_meas_crosstalk_model = Some(CrosstalkWeightedSampler::new(model));
         self
     }
 

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -663,7 +663,7 @@ impl GeneralNoiseModelBuilder {
     #[must_use]
     pub fn with_average_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
         let prob: f64 = prob * 18.0 / 5.0;
-        self.p_meas_crosstalk_global = Some(prob);
+        self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
         self
     }
 
@@ -678,7 +678,7 @@ impl GeneralNoiseModelBuilder {
     #[must_use]
     pub fn with_average_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
         let prob: f64 = prob * 18.0 / 5.0;
-        self.p_meas_crosstalk_local = Some(prob);
+        self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
         self
     }
 

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -1,6 +1,7 @@
 use crate::GateType;
 use crate::noise::{
-    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler
+    CrosstalkWeightedSampler, GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler,
+    TwoQubitWeightedSampler,
 };
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -47,7 +47,6 @@ pub struct GeneralNoiseModelBuilder {
     p_meas_0: Option<f64>,
     p_meas_1: Option<f64>,
     meas_scale: Option<f64>,
-    // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
     p_meas_crosstalk_global: Option<f64>,
     p_meas_crosstalk_local: Option<f64>,
     p_meas_crosstalk_model: Option<CrosstalkWeightedSampler>,
@@ -664,15 +663,6 @@ impl GeneralNoiseModelBuilder {
         self
     }
 
-    /// Set the average measurement global crosstalk
-    /// TODO: This is no longer applicable on Helios
-    // #[must_use]
-    // pub fn with_average_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
-    //     let prob: f64 = prob * 18.0 / 5.0;
-    //     self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
-    //     self
-    // }
-
     /// Set the probability of local crosstalk during measurement operations
     #[must_use]
     pub fn with_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
@@ -680,14 +670,14 @@ impl GeneralNoiseModelBuilder {
         self
     }
 
-    /// Set the average measurement local crosstalk
-    /// TODO: This is no longer applicable on Helios
-    // #[must_use]
-    // pub fn with_average_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
-    //     let prob: f64 = prob * 18.0 / 5.0;
-    //     self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
-    //     self
-    // }
+    /// Set the probability of crosstalk during measurement operations
+    /// This is a shorthand that sets both global and local to the given value
+    #[must_use]
+    pub fn with_p_meas_crosstalk(mut self, prob: f64) -> Self {
+        self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
+        self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
+        self
+    }
 
     /// Set the transition model for measurement crosstalk
     #[must_use]

--- a/crates/pecos-engines/src/noise/general/builder.rs
+++ b/crates/pecos-engines/src/noise/general/builder.rs
@@ -46,7 +46,9 @@ pub struct GeneralNoiseModelBuilder {
     // measurement noise
     p_meas_0: Option<f64>,
     p_meas_1: Option<f64>,
-    p_meas_crosstalk: Option<f64>,
+    // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
+    p_meas_crosstalk_global: Option<f64>,
+    p_meas_crosstalk_local: Option<f64>,
     meas_scale: Option<f64>,
     p_meas_crosstalk_scale: Option<f64>,
 }
@@ -101,7 +103,8 @@ impl GeneralNoiseModelBuilder {
             // measurement noise
             p_meas_0: None,
             p_meas_1: None,
-            p_meas_crosstalk: None,
+            p_meas_crosstalk_global: None,
+            p_meas_crosstalk_local: None,
             meas_scale: None,
             p_meas_crosstalk_scale: None,
         }
@@ -242,8 +245,12 @@ impl GeneralNoiseModelBuilder {
 
         model.p_meas_max = model.p_meas_0.max(model.p_meas_1);
 
-        if let Some(prob) = self.p_meas_crosstalk {
-            model.p_meas_crosstalk = prob;
+        if let Some(prob) = self.p_meas_crosstalk_global {
+            model.p_meas_crosstalk_global = prob;
+        }
+
+        if let Some(prob) = self.p_meas_crosstalk_local {
+            model.p_meas_crosstalk_local = prob;
         }
 
         // scale
@@ -644,19 +651,34 @@ impl GeneralNoiseModelBuilder {
         self
     }
 
-    /// Set the probability of crosstalk during measurement operations
+    /// Set the probability of global crosstalk during measurement operations
     #[must_use]
-    pub fn with_p_meas_crosstalk(mut self, prob: f64) -> Self {
-        self.p_meas_crosstalk = Some(Self::validate_probability(prob));
+    pub fn with_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
+        self.p_meas_crosstalk_global = Some(Self::validate_probability(prob));
         self
     }
 
     // TODO: See if we should put a average scaling...
-    /// Set the average measurement crosstalk
+    /// Set the average measurement global crosstalk
     #[must_use]
-    pub fn with_average_p_meas_crosstalk(mut self, prob: f64) -> Self {
+    pub fn with_average_p_meas_crosstalk_global(mut self, prob: f64) -> Self {
         let prob: f64 = prob * 18.0 / 5.0;
-        self.p_meas_crosstalk = Some(prob);
+        self.p_meas_crosstalk_global = Some(prob);
+        self
+    }
+
+    /// Set the probability of local crosstalk during measurement operations
+    #[must_use]
+    pub fn with_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
+        self.p_meas_crosstalk_local = Some(Self::validate_probability(prob));
+        self
+    }
+
+    /// Set the average measurement local crosstalk
+    #[must_use]
+    pub fn with_average_p_meas_crosstalk_local(mut self, prob: f64) -> Self {
+        let prob: f64 = prob * 18.0 / 5.0;
+        self.p_meas_crosstalk_local = Some(prob);
         self
     }
 
@@ -751,11 +773,13 @@ impl GeneralNoiseModelBuilder {
         model.p_prep_leak_ratio = model.p_prep_leak_ratio.min(1.0);
 
         // Apply crosstalk rescaling factors
-        model.p_meas_crosstalk *= p_meas_crosstalk_scale;
+        model.p_meas_crosstalk_global *= p_meas_crosstalk_scale;
+        model.p_meas_crosstalk_local *= p_meas_crosstalk_scale;
         model.p_prep_crosstalk *= p_prep_crosstalk_scale;
 
         // Then apply the regular scaling to crosstalks
-        model.p_meas_crosstalk *= meas_scale * scale;
+        model.p_meas_crosstalk_global *= meas_scale * scale;
+        model.p_meas_crosstalk_local *= meas_scale * scale;
         model.p_prep_crosstalk *= prep_scale * scale;
 
         // Scale emission ratios

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -1,6 +1,7 @@
 use crate::noise::{
     GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler
 };
+use crate::byte_message::ByteMessage;
 use std::collections::{BTreeMap, BTreeSet};
 
 impl Default for GeneralNoiseModel {
@@ -116,6 +117,7 @@ impl Default for GeneralNoiseModel {
             noiseless_gates: BTreeSet::new(),
             p_meas_max: p_meas_0.max(p_meas_1),
             leakage_scale: 1.0,
+            results_builder: ByteMessage::outcomes_builder()
         }
     }
 }

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -1,7 +1,8 @@
-use crate::noise::{
-    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler
-};
 use crate::byte_message::ByteMessage;
+use crate::noise::{
+    CrosstalkWeightedSampler, GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler,
+    TwoQubitWeightedSampler,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 impl Default for GeneralNoiseModel {
@@ -117,7 +118,7 @@ impl Default for GeneralNoiseModel {
             noiseless_gates: BTreeSet::new(),
             p_meas_max: p_meas_0.max(p_meas_1),
             leakage_scale: 1.0,
-            results_builder: ByteMessage::outcomes_builder()
+            results_builder: ByteMessage::outcomes_builder(),
         }
     }
 }

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -74,8 +74,8 @@ impl Default for GeneralNoiseModel {
         let p_meas_1: f64 = 0.01; // 1% probability of measuring 0 when state is |1⟩
 
         let mut p_meas_crosstalk_model = BTreeMap::new();
-        p_meas_crosstalk_model.insert("0->1".to_string(), 1.0);
-        p_meas_crosstalk_model.insert("1->0".to_string(), 1.0);
+        p_meas_crosstalk_model.insert("0->0".to_string(), 1.0);
+        p_meas_crosstalk_model.insert("1->1".to_string(), 1.0);
 
         // Default error probabilities
         Self {

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -108,9 +108,8 @@ impl Default for GeneralNoiseModel {
             measured_qubits: Vec::new(),
             // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
             p_meas_crosstalk_global: 0.0,
-            p_meas_crosstalk_global_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),
             p_meas_crosstalk_local: 0.0,
-            p_meas_crosstalk_local_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),
+            p_meas_crosstalk_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),
             p_prep_crosstalk: 0.0,
 
             p_idle_coherent_to_incoherent_factor: 1.5,

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -1,5 +1,5 @@
 use crate::noise::{
-    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler,
+    GeneralNoiseModel, NoiseRng, SingleQubitWeightedSampler, TwoQubitWeightedSampler, CrosstalkWeightedSampler
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -72,6 +72,10 @@ impl Default for GeneralNoiseModel {
         let p_meas_0: f64 = 0.01; // 1% probability of measuring 1 when state is |0⟩
         let p_meas_1: f64 = 0.01; // 1% probability of measuring 0 when state is |1⟩
 
+        let mut p_meas_crosstalk_model = BTreeMap::new();
+        p_meas_crosstalk_model.insert("0->1".to_string(), 1.0);
+        p_meas_crosstalk_model.insert("1->0".to_string(), 1.0);
+
         // Default error probabilities
         Self {
             p_prep: 0.01,
@@ -104,7 +108,9 @@ impl Default for GeneralNoiseModel {
             measured_qubits: Vec::new(),
             // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
             p_meas_crosstalk_global: 0.0,
+            p_meas_crosstalk_global_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),
             p_meas_crosstalk_local: 0.0,
+            p_meas_crosstalk_local_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),
             p_prep_crosstalk: 0.0,
 
             p_idle_coherent_to_incoherent_factor: 1.5,

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -102,7 +102,9 @@ impl Default for GeneralNoiseModel {
             rng: NoiseRng::default(),
             prepared_qubits: BTreeSet::new(),
             measured_qubits: Vec::new(),
-            p_meas_crosstalk: 0.0,
+            // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
+            p_meas_crosstalk_global: 0.0,
+            p_meas_crosstalk_local: 0.0,
             p_prep_crosstalk: 0.0,
 
             p_idle_coherent_to_incoherent_factor: 1.5,

--- a/crates/pecos-engines/src/noise/general/default.rs
+++ b/crates/pecos-engines/src/noise/general/default.rs
@@ -108,7 +108,6 @@ impl Default for GeneralNoiseModel {
             rng: NoiseRng::default(),
             prepared_qubits: BTreeSet::new(),
             measured_qubits: Vec::new(),
-            // TODO: Maybe the p_meas_crosstalk parameter should remain for the simple_crosstalk?
             p_meas_crosstalk_global: 0.0,
             p_meas_crosstalk_local: 0.0,
             p_meas_crosstalk_model: CrosstalkWeightedSampler::new(&p_meas_crosstalk_model),

--- a/crates/pecos-engines/src/noise/weighted_sampler.rs
+++ b/crates/pecos-engines/src/noise/weighted_sampler.rs
@@ -362,24 +362,18 @@ impl CrosstalkWeightedSampler {
     /// - If the total weight of each sampler deviates from 1.0 by more than the tolerance
     #[must_use]
     pub fn new(weighted_map: &BTreeMap<String, f64>) -> Self {
+        const KEYS_FROM_0: [&str; 3] = ["0->0", "0->1", "0->L"];
+        const KEYS_FROM_1: [&str; 3] = ["1->1", "1->0", "1->L"];
         Self::validate_crosstalk_keys(weighted_map);
 
         // Separate the 0->* components from the 1->* components
-        const KEYS_FROM_0: [&str; 3] = ["0->0", "0->1", "0->L"];
-        const KEYS_FROM_1: [&str; 3] = ["1->1", "1->0", "1->L"];
         let weighted_map_from_0 = KEYS_FROM_0
             .into_iter()
-            .filter_map(|key| match weighted_map.get(key) {
-                Some(&val) => Some((key.to_string(), val)),
-                None => None,
-            })
+            .filter_map(|key| weighted_map.get(key).map(|&val| (key.to_string(), val)))
             .collect();
         let weighted_map_from_1 = KEYS_FROM_1
             .into_iter()
-            .filter_map(|key| match weighted_map.get(key) {
-                Some(&val) => Some((key.to_string(), val)),
-                None => None,
-            })
+            .filter_map(|key| weighted_map.get(key).map(|&val| (key.to_string(), val)))
             .collect();
 
         Self {
@@ -394,13 +388,14 @@ impl CrosstalkWeightedSampler {
         for key in weighted_map.keys() {
             assert!(
                 VALID_KEYS.contains(&key.as_str()),
-                "CrosstalkWeightedSampler: invalid key '{key}' - must be one of {:?}",
-                VALID_KEYS
+                "CrosstalkWeightedSampler: invalid key '{key}' - must be one of {VALID_KEYS:?}",
             );
         }
     }
 
     /// Get a reference to the normalized weighted map, for keys 0->* or 1->*
+    /// # Panics
+    /// - If `from_state` is not either 0 or 1.
     #[must_use]
     pub fn get_weighted_map(&self, from_state: u32) -> &BTreeMap<String, f64> {
         assert!(from_state == 0 || from_state == 1);
@@ -411,7 +406,9 @@ impl CrosstalkWeightedSampler {
         }
     }
 
-    /// Sample a raw key from the distribution, for keys 0->* or 1->*
+    /// Sample a raw key from the distribution, for keys 0->* or 1->*.
+    /// # Panics
+    /// - If `from_state` is not either 0 or 1.
     #[must_use]
     pub fn sample_keys(&self, rng: &mut NoiseRng, from_state: u32) -> String {
         assert!(from_state == 0 || from_state == 1);

--- a/crates/pecos-engines/src/noise/weighted_sampler.rs
+++ b/crates/pecos-engines/src/noise/weighted_sampler.rs
@@ -362,24 +362,25 @@ impl CrosstalkWeightedSampler {
     /// - If the total weight of each sampler deviates from 1.0 by more than the tolerance
     #[must_use]
     pub fn new(weighted_map: &BTreeMap<String, f64>) -> Self {
-
         Self::validate_crosstalk_keys(weighted_map);
 
         // Separate the 0->* components from the 1->* components
         const KEYS_FROM_0: [&str; 3] = ["0->0", "0->1", "0->L"];
         const KEYS_FROM_1: [&str; 3] = ["1->1", "1->0", "1->L"];
-        let weighted_map_from_0 = KEYS_FROM_0.into_iter().filter_map(
-            |key| match weighted_map.get(key) {
+        let weighted_map_from_0 = KEYS_FROM_0
+            .into_iter()
+            .filter_map(|key| match weighted_map.get(key) {
                 Some(&val) => Some((key.to_string(), val)),
                 None => None,
-            }
-        ).collect();
-        let weighted_map_from_1 = KEYS_FROM_1.into_iter().filter_map(
-            |key| match weighted_map.get(key) {
+            })
+            .collect();
+        let weighted_map_from_1 = KEYS_FROM_1
+            .into_iter()
+            .filter_map(|key| match weighted_map.get(key) {
                 Some(&val) => Some((key.to_string(), val)),
                 None => None,
-            }
-        ).collect();
+            })
+            .collect();
 
         Self {
             sampler_from_0: WeightedSampler::new(&weighted_map_from_0),
@@ -393,7 +394,8 @@ impl CrosstalkWeightedSampler {
         for key in weighted_map.keys() {
             assert!(
                 VALID_KEYS.contains(&key.as_str()),
-                "CrosstalkWeightedSampler: invalid key '{key}' - must be one of {:?}", VALID_KEYS
+                "CrosstalkWeightedSampler: invalid key '{key}' - must be one of {:?}",
+                VALID_KEYS
             );
         }
     }
@@ -425,7 +427,12 @@ impl CrosstalkWeightedSampler {
     /// # Panics
     /// - If the sampled key is invalid (this should never happen if the sampler was created properly)
     #[must_use]
-    pub fn sample_gates(&self, rng: &mut NoiseRng, qubit: usize, from_state: u32) -> SingleQubitNoiseResult {
+    pub fn sample_gates(
+        &self,
+        rng: &mut NoiseRng,
+        qubit: usize,
+        from_state: u32,
+    ) -> SingleQubitNoiseResult {
         let key = self.sample_keys(rng, from_state);
 
         match key.as_str() {
@@ -441,9 +448,7 @@ impl CrosstalkWeightedSampler {
                 gate: None,
                 qubit_leaked: true,
             },
-            _ => panic!(
-                "CrosstalkWeightedSampler: invalid key '{key}'"
-            ),
+            _ => panic!("CrosstalkWeightedSampler: invalid key '{key}'"),
         }
     }
 }

--- a/crates/pecos-engines/src/noise/weighted_sampler.rs
+++ b/crates/pecos-engines/src/noise/weighted_sampler.rs
@@ -411,7 +411,7 @@ impl CrosstalkWeightedSampler {
 
     /// Sample a raw key from the distribution, for keys 0->* or 1->*
     #[must_use]
-    pub fn sample_keys(&self, rng: &mut NoiseRng, from_state: u8) -> String {
+    pub fn sample_keys(&self, rng: &mut NoiseRng, from_state: u32) -> String {
         assert!(from_state == 0 || from_state == 1);
         if from_state == 0 {
             self.sampler_from_0.sample(rng)
@@ -425,7 +425,7 @@ impl CrosstalkWeightedSampler {
     /// # Panics
     /// - If the sampled key is invalid (this should never happen if the sampler was created properly)
     #[must_use]
-    pub fn sample_gates(&self, rng: &mut NoiseRng, qubit: usize, from_state: u8) -> SingleQubitNoiseResult {
+    pub fn sample_gates(&self, rng: &mut NoiseRng, qubit: usize, from_state: u32) -> SingleQubitNoiseResult {
         let key = self.sample_keys(rng, from_state);
 
         match key.as_str() {

--- a/crates/pecos-engines/src/noise/weighted_sampler.rs
+++ b/crates/pecos-engines/src/noise/weighted_sampler.rs
@@ -353,7 +353,7 @@ pub struct CrosstalkWeightedSampler {
 impl CrosstalkWeightedSampler {
     /// Create a new crosstalk sampler from a weighted map
     ///
-    /// Valid keys are: "0->1", "0->L", "1->0", "1->L"
+    /// Valid keys are: "0->0", "0->1", "0->L", "1->1", "1->0", "1->L"
     ///
     /// # Panics
     /// - If the weighted map contains invalid keys
@@ -366,8 +366,8 @@ impl CrosstalkWeightedSampler {
         Self::validate_crosstalk_keys(weighted_map);
 
         // Separate the 0->* components from the 1->* components
-        const KEYS_FROM_0: [&str; 2] = ["0->1", "0->L"];
-        const KEYS_FROM_1: [&str; 2] = ["1->0", "1->L"];
+        const KEYS_FROM_0: [&str; 3] = ["0->0", "0->1", "0->L"];
+        const KEYS_FROM_1: [&str; 3] = ["1->1", "1->0", "1->L"];
         let weighted_map_from_0 = KEYS_FROM_0.into_iter().filter_map(
             |key| match weighted_map.get(key) {
                 Some(&val) => Some((key.to_string(), val)),
@@ -388,7 +388,7 @@ impl CrosstalkWeightedSampler {
     }
 
     fn validate_crosstalk_keys(weighted_map: &BTreeMap<String, f64>) {
-        const VALID_KEYS: [&str; 4] = ["0->1", "0->L", "1->0", "1->L"];
+        const VALID_KEYS: [&str; 6] = ["0->0", "0->1", "0->L", "1->1", "1->0", "1->L"];
 
         for key in weighted_map.keys() {
             assert!(
@@ -400,7 +400,7 @@ impl CrosstalkWeightedSampler {
 
     /// Get a reference to the normalized weighted map, for keys 0->* or 1->*
     #[must_use]
-    pub fn get_weighted_map(&self, from_state: u8) -> &BTreeMap<String, f64> {
+    pub fn get_weighted_map(&self, from_state: u32) -> &BTreeMap<String, f64> {
         assert!(from_state == 0 || from_state == 1);
         if from_state == 0 {
             self.sampler_from_0.get_weighted_map()
@@ -429,13 +429,17 @@ impl CrosstalkWeightedSampler {
         let key = self.sample_keys(rng, from_state);
 
         match key.as_str() {
-            "0->L" | "1->L" => SingleQubitNoiseResult {
+            "0->0" | "1->1" => SingleQubitNoiseResult {
                 gate: None,
-                qubit_leaked: true,
+                qubit_leaked: false,
             },
             "0->1" | "1->0" => SingleQubitNoiseResult {
                 gate: Some(Gate::x(&[qubit])),
                 qubit_leaked: false,
+            },
+            "0->L" | "1->L" => SingleQubitNoiseResult {
+                gate: None,
+                qubit_leaked: true,
             },
             _ => panic!(
                 "CrosstalkWeightedSampler: invalid key '{key}'"

--- a/crates/pecos-engines/src/noise/weighted_sampler.rs
+++ b/crates/pecos-engines/src/noise/weighted_sampler.rs
@@ -343,6 +343,107 @@ impl TwoQubitWeightedSampler {
     }
 }
 
+/// Samples crosstalk noise transitions
+#[derive(Clone, Debug)]
+pub struct CrosstalkWeightedSampler {
+    sampler_from_0: WeightedSampler<String>,
+    sampler_from_1: WeightedSampler<String>,
+}
+
+impl CrosstalkWeightedSampler {
+    /// Create a new crosstalk sampler from a weighted map
+    ///
+    /// Valid keys are: "0->1", "0->L", "1->0", "1->L"
+    ///
+    /// # Panics
+    /// - If the weighted map contains invalid keys
+    /// - If the weighted map is empty
+    /// - If the total weight of each sampler is not positive
+    /// - If the total weight of each sampler deviates from 1.0 by more than the tolerance
+    #[must_use]
+    pub fn new(weighted_map: &BTreeMap<String, f64>) -> Self {
+
+        Self::validate_crosstalk_keys(weighted_map);
+
+        // Separate the 0->* components from the 1->* components
+        const KEYS_FROM_0: [&str; 2] = ["0->1", "0->L"];
+        const KEYS_FROM_1: [&str; 2] = ["1->0", "1->L"];
+        let weighted_map_from_0 = KEYS_FROM_0.into_iter().filter_map(
+            |key| match weighted_map.get(key) {
+                Some(&val) => Some((key.to_string(), val)),
+                None => None,
+            }
+        ).collect();
+        let weighted_map_from_1 = KEYS_FROM_1.into_iter().filter_map(
+            |key| match weighted_map.get(key) {
+                Some(&val) => Some((key.to_string(), val)),
+                None => None,
+            }
+        ).collect();
+
+        Self {
+            sampler_from_0: WeightedSampler::new(&weighted_map_from_0),
+            sampler_from_1: WeightedSampler::new(&weighted_map_from_1),
+        }
+    }
+
+    fn validate_crosstalk_keys(weighted_map: &BTreeMap<String, f64>) {
+        const VALID_KEYS: [&str; 4] = ["0->1", "0->L", "1->0", "1->L"];
+
+        for key in weighted_map.keys() {
+            assert!(
+                VALID_KEYS.contains(&key.as_str()),
+                "CrosstalkWeightedSampler: invalid key '{key}' - must be one of {:?}", VALID_KEYS
+            );
+        }
+    }
+
+    /// Get a reference to the normalized weighted map, for keys 0->* or 1->*
+    #[must_use]
+    pub fn get_weighted_map(&self, from_state: u8) -> &BTreeMap<String, f64> {
+        assert!(from_state == 0 || from_state == 1);
+        if from_state == 0 {
+            self.sampler_from_0.get_weighted_map()
+        } else {
+            self.sampler_from_1.get_weighted_map()
+        }
+    }
+
+    /// Sample a raw key from the distribution, for keys 0->* or 1->*
+    #[must_use]
+    pub fn sample_keys(&self, rng: &mut NoiseRng, from_state: u8) -> String {
+        assert!(from_state == 0 || from_state == 1);
+        if from_state == 0 {
+            self.sampler_from_0.sample(rng)
+        } else {
+            self.sampler_from_1.sample(rng)
+        }
+    }
+
+    /// Sample a gate operation for the given qubit
+    ///
+    /// # Panics
+    /// - If the sampled key is invalid (this should never happen if the sampler was created properly)
+    #[must_use]
+    pub fn sample_gates(&self, rng: &mut NoiseRng, qubit: usize, from_state: u8) -> SingleQubitNoiseResult {
+        let key = self.sample_keys(rng, from_state);
+
+        match key.as_str() {
+            "0->L" | "1->L" => SingleQubitNoiseResult {
+                gate: None,
+                qubit_leaked: true,
+            },
+            "0->1" | "1->0" => SingleQubitNoiseResult {
+                gate: Some(Gate::x(&[qubit])),
+                qubit_leaked: false,
+            },
+            _ => panic!(
+                "CrosstalkWeightedSampler: invalid key '{key}'"
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -600,6 +701,46 @@ mod tests {
     }
 
     #[test]
+    fn test_deterministic_sampling_crosstalk() {
+        // Test deterministic sampling with single qubit sampler
+        let mut weights = BTreeMap::new();
+        weights.insert("0->1".to_string(), 0.5);
+        weights.insert("0->L".to_string(), 0.5);
+        weights.insert("1->0".to_string(), 0.5);
+        weights.insert("1->L".to_string(), 0.5);
+
+        let sampler = CrosstalkWeightedSampler::new(&weights);
+
+        // Create two RNGs with the same seed
+        let mut rng1 = NoiseRng::<ChaCha8Rng>::with_seed(42);
+        let mut rng2 = NoiseRng::<ChaCha8Rng>::with_seed(42);
+
+        // Sample from both RNGs
+        let results1: Vec<SingleQubitNoiseResult> = (0..SAMPLE_SIZE)
+            .map(|_| sampler.sample_gates(&mut rng1, 0, 0))
+            .collect();
+        let results2: Vec<SingleQubitNoiseResult> = (0..SAMPLE_SIZE)
+            .map(|_| sampler.sample_gates(&mut rng2, 0, 0))
+            .collect();
+
+        // Verify exact sequence match
+        for (i, (r1, r2)) in results1.iter().zip(results2.iter()).enumerate() {
+            assert_eq!(
+                r1.qubit_leaked, r2.qubit_leaked,
+                "Leakage mismatch at index {i}"
+            );
+            match (&r1.gate, &r2.gate) {
+                (Some(g1), Some(g2)) => assert_eq!(
+                    g1.gate_type, g2.gate_type,
+                    "Gate type mismatch at index {i}"
+                ),
+                (None, None) => (),
+                _ => panic!("Gate presence mismatch at index {i}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_deterministic_sampling_reset() {
         // Test that resetting the RNG and using the same seed produces the same sequence
         let mut weights = BTreeMap::new();
@@ -784,6 +925,35 @@ mod tests {
                 "Both qubits should leak"
             );
             assert!(r1.gates.is_none(), "No gates should be present");
+        }
+    }
+
+    #[test]
+    fn test_deterministic_sampling_crosstalk_edge_cases() {
+        // Test edge cases for single qubit sampling
+        let mut weights = BTreeMap::new();
+        weights.insert("0->L".to_string(), 1.0); // Always leak
+        weights.insert("1->L".to_string(), 1.0); // Always leak
+
+        let sampler = CrosstalkWeightedSampler::new(&weights);
+        let mut rng1 = NoiseRng::<ChaCha8Rng>::with_seed(42);
+        let mut rng2 = NoiseRng::<ChaCha8Rng>::with_seed(42);
+
+        let results1: Vec<SingleQubitNoiseResult> = (0..SAMPLE_SIZE)
+            .map(|_| sampler.sample_gates(&mut rng1, 0, 1))
+            .collect();
+        let results2: Vec<SingleQubitNoiseResult> = (0..SAMPLE_SIZE)
+            .map(|_| sampler.sample_gates(&mut rng2, 0, 1))
+            .collect();
+
+        // Verify exact sequence match
+        for (i, (r1, r2)) in results1.iter().zip(results2.iter()).enumerate() {
+            assert_eq!(
+                r1.qubit_leaked, r2.qubit_leaked,
+                "Leakage mismatch at index {i}"
+            );
+            assert!(r1.qubit_leaked, "All results should indicate leakage");
+            assert!(r1.gate.is_none(), "No gates should be present");
         }
     }
 }

--- a/crates/pecos-engines/src/quantum.rs
+++ b/crates/pecos-engines/src/quantum.rs
@@ -313,8 +313,11 @@ impl Engine for StateVecEngine {
                         self.simulator.pz(**q);
                     }
                 }
-                GateType::Idle | GateType::I => {
-                    // For idle/identity gates, just let the system naturally evolve for the specified duration
+                GateType::I
+                | GateType::Idle
+                | GateType::MeasCrosstalkLocalPayload
+                | GateType::MeasCrosstalkGlobalPayload => {
+                    // Just let the system naturally evolve for the specified duration
                     // No active operation needed in the simulator
                 }
                 GateType::U => {

--- a/crates/pecos-engines/tests/noise_determinism.rs
+++ b/crates/pecos-engines/tests/noise_determinism.rs
@@ -98,8 +98,8 @@ fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> Vec<ByteMess
                 for gate in &gates {
                     match &gate.gate_type {
                         GateType::Measure | GateType::MeasureLeaked => {
-                            for _ in gate.qubits.iter() {
-                                let outcome = if measure_rng.random_bool(0.5) { 1 } else { 0 };
+                            for _ in &gate.qubits {
+                                let outcome = usize::from(measure_rng.random_bool(0.5));
                                 response.add_outcomes(&[outcome]);
                             }
                         }
@@ -121,20 +121,14 @@ fn compare_messages(msg1: &ByteMessage, msg2: &ByteMessage) -> bool {
     let results_left = msg1.outcomes().unwrap_or_default();
     let results_right = msg2.outcomes().unwrap_or_default();
     if quantum_ops_left != quantum_ops_right {
-        eprintln!(
-            "Quantum operations differ: {:?} vs {:?}",
-            quantum_ops_left, quantum_ops_right
-        );
+        eprintln!("Quantum operations differ: {quantum_ops_left:?} vs {quantum_ops_right:?}",);
         return false;
     }
     if results_left != results_right {
-        eprintln!(
-            "Measurement outcomes differ: {:?} vs {:?}",
-            results_left, results_right
-        );
+        eprintln!("Measurement outcomes differ: {results_left:?} vs {results_right:?}");
         return false;
     }
-    return true;
+    true
 }
 
 /// Compare two `ByteMessage` vectors by parsing their quantum operations and results
@@ -142,10 +136,7 @@ fn compare_messages(msg1: &ByteMessage, msg2: &ByteMessage) -> bool {
 /// This function extracts and compares the quantum operations and results from two
 /// vectors of messages to determine if they represent the same conversation between
 /// the noise model and the quantum engine.
-fn compare_message_lists(
-    messages_left: &Vec<ByteMessage>,
-    messages_right: &Vec<ByteMessage>,
-) -> bool {
+fn compare_message_lists(messages_left: &[ByteMessage], messages_right: &[ByteMessage]) -> bool {
     if messages_left.len() != messages_right.len() {
         eprintln!(
             "Message lengths differ: {} vs {}",
@@ -156,11 +147,11 @@ fn compare_message_lists(
     }
     for (i, (msg1, msg2)) in messages_left.iter().zip(messages_right.iter()).enumerate() {
         if !compare_messages(msg1, msg2) {
-            eprintln!("Messages differ at index {}", i);
+            eprintln!("Messages differ at index {i}");
             return false;
         }
     }
-    return true;
+    true
 }
 
 #[test]

--- a/crates/pecos-engines/tests/noise_determinism.rs
+++ b/crates/pecos-engines/tests/noise_determinism.rs
@@ -15,8 +15,11 @@ use pecos_engines::noise::general::GeneralNoiseModel;
 use pecos_engines::quantum::{QuantumEngine, StateVecEngine};
 use pecos_engines::{
     Engine, QuantumSystem, byte_message::ByteMessage, engine_system::ControlEngine,
+    GateType
 };
 use std::collections::BTreeMap;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 /// Reset a noise model and set its seed in one operation
 ///
@@ -70,42 +73,79 @@ fn create_noise_model() -> GeneralNoiseModel {
     model
 }
 
-fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> ByteMessage {
+fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> Vec<ByteMessage> {
     info!("Applying noise to message");
-    match model
-        .start(msg.clone())
-        .expect("Failed to start noise model processing")
-    {
-        pecos_engines::engine_system::EngineStage::NeedsProcessing(noisy_msg) => {
-            info!("Processing noisy message");
-            match model
-                .continue_processing(noisy_msg)
-                .expect("Failed to continue processing with noise model")
-            {
-                pecos_engines::engine_system::EngineStage::Complete(result) => result,
-                pecos_engines::engine_system::EngineStage::NeedsProcessing(_) => {
-                    panic!("Expected Complete stage")
-                }
+    // If measurement results are required from measurements, we provide pseudorandom ones,
+    // but always from the same seed. This is because we are testing that different noise models
+    // respond differently to the same inputs.
+    let mut measure_rng = ChaCha8Rng::seed_from_u64(5330);
+    let mut state = model.start(msg.clone()).expect("Failed to start noise model processing");
+    let mut messages = Vec::new();
+    loop {
+        match state {
+            pecos_engines::engine_system::EngineStage::Complete(noisy_msg) => {
+                messages.push(noisy_msg);
+                return messages;
             }
-        }
-        pecos_engines::engine_system::EngineStage::Complete(_) => {
-            panic!("Expected NeedsProcessing stage")
+            pecos_engines::engine_system::EngineStage::NeedsProcessing(intermediate_msg) => {
+                // if the intermediate message requires measurements, give it some!
+                messages.push(intermediate_msg.clone());
+                let gates = intermediate_msg.quantum_ops().expect("Failed to get quantum operations");
+                let mut response = ByteMessage::outcomes_builder();
+                for gate in &gates {
+                    match &gate.gate_type {
+                        GateType::Measure | GateType::MeasureLeaked => {
+                            for _ in gate.qubits.iter() {
+                                let outcome = if measure_rng.random_bool(0.5) { 1 } else { 0 };
+                                response.add_outcomes(&[outcome]);
+                            }
+                        },
+                        _ => {
+                        }
+                    }
+                }
+                state = model
+                    .continue_processing(response.build())
+                    .expect("Failed to continue processing with measurements");
+            }
         }
     }
 }
 
-/// Compare two `ByteMessage`s by parsing their quantum operations
-///
-/// This function extracts and compares the quantum operations from two messages
-/// to determine if they represent the same quantum circuit.
+/// Compare two `ByteMessage`s by parsing their quantum operations and results
 fn compare_messages(msg1: &ByteMessage, msg2: &ByteMessage) -> bool {
-    let ops1 = msg1.quantum_ops().unwrap_or_default();
-    let ops2 = msg2.quantum_ops().unwrap_or_default();
+    let quantum_ops_left = msg1.quantum_ops().unwrap_or_default();
+    let quantum_ops_right = msg2.quantum_ops().unwrap_or_default();
+    let results_left = msg1.outcomes().unwrap_or_default();
+    let results_right = msg2.outcomes().unwrap_or_default();
+    if quantum_ops_left != quantum_ops_right {
+        eprintln!("Quantum operations differ: {:?} vs {:?}", quantum_ops_left, quantum_ops_right);
+        return false;
+    }
+    if results_left != results_right {
+        eprintln!("Measurement outcomes differ: {:?} vs {:?}", results_left, results_right);
+        return false;
+    }
+    return true;
+}
 
-    // For determinism tests, we just need to know if they're equal
-    ops1 == ops2
-    // Note: If additional debug info is needed when messages don't match,
-    // we could expand this function to return details about the differences
+/// Compare two `ByteMessage` vectors by parsing their quantum operations and results
+///
+/// This function extracts and compares the quantum operations and results from two
+/// vectors of messages to determine if they represent the same conversation between
+/// the noise model and the quantum engine.
+fn compare_message_lists(messages_left: &Vec<ByteMessage>, messages_right: &Vec<ByteMessage>) -> bool {
+    if messages_left.len() != messages_right.len() {
+        eprintln!("Message lengths differ: {} vs {}", messages_left.len(), messages_right.len());
+        return false;
+    }
+    for (i, (msg1, msg2)) in messages_left.iter().zip(messages_right.iter()).enumerate() {
+        if !compare_messages(msg1, msg2) {
+            eprintln!("Messages differ at index {}", i);
+            return false;
+        }
+    }
+    return true;
 }
 
 #[test]
@@ -119,7 +159,7 @@ fn test_prep_determinism() {
 
     // Create a message with multiple prep gates
     let mut builder = ByteMessage::quantum_operations_builder();
-    for _ in 0..6 {
+    for _ in 0..20 {
         builder.add_prep(&[0]);
     }
     let msg = builder.build();
@@ -136,8 +176,14 @@ fn test_prep_determinism() {
     // Now these should be identical
     info!("Comparing noisy1 and noisy2 - should be identical with same seed and model");
     assert!(
-        compare_messages(&noisy1, &noisy2),
-        "Messages should be identical with same seed and model"
+        compare_message_lists(&noisy1, &noisy2),
+        "Message lists should be identical with same seed and model"
+    );
+
+    info!("Ensuring that the noise is actually being applied");
+    assert!(
+        !compare_messages(&msg, &noisy1[0]),
+        "Original message should be different from noisy message"
     );
 
     // Now create a completely different model to verify we see different noise
@@ -152,8 +198,8 @@ fn test_prep_determinism() {
     // These should be different
     info!("Comparing noisy1 and noisy3 - should be different with different seeds");
     assert!(
-        !compare_messages(&noisy1, &noisy3),
-        "Different seeds should produce different messages"
+        !compare_message_lists(&noisy1, &noisy3),
+        "Different seeds should produce different message lists"
     );
 }
 
@@ -193,14 +239,14 @@ fn test_single_qubit_gate_determinism() {
     // Verify determinism
     info!("Comparing results - should be identical with same seed");
     assert!(
-        compare_messages(&noisy1, &noisy2),
+        compare_message_lists(&noisy1, &noisy2),
         "Results should be identical with same seed"
     );
 
     // Verify that we get some errors due to noise
-    info!("Comparing original and noisy messages");
+    info!("Comparing original instruction and its noisy command output");
     assert!(
-        !compare_messages(&msg, &noisy1),
+        !compare_messages(&msg, &noisy1[0]),
         "Original message should be different from noisy message"
     );
 }
@@ -237,14 +283,14 @@ fn test_two_qubit_gate_determinism() {
     // Now these should be identical
     info!("Comparing noisy1 and noisy2 - should be identical with same seed and model");
     assert!(
-        compare_messages(&noisy1, &noisy2),
+        compare_message_lists(&noisy1, &noisy2),
         "Messages should be identical with same seed and model"
     );
 
     // Verify that the message is actually being modified by the noise model
     info!("Verifying that noise is being applied");
     assert!(
-        !compare_messages(&msg, &noisy1),
+        !compare_messages(&msg, &noisy1[0]),
         "Original message should be different from noisy message"
     );
 }
@@ -275,7 +321,7 @@ fn test_measurement_determinism() {
     let noisy2 = apply_noise(&mut model2, &msg);
 
     // Verify determinism in the quantum operations
-    assert!(compare_messages(&noisy1, &noisy2));
+    assert!(compare_message_lists(&noisy1, &noisy2));
 }
 
 #[test]
@@ -307,7 +353,7 @@ fn test_different_seeds_produce_different_results() {
     // With different seeds, we expect different noise results
     info!("Comparing outputs from different seeds - should be different");
     assert!(
-        !compare_messages(&noisy1, &noisy2),
+        !compare_message_lists(&noisy1, &noisy2),
         "Different seeds should produce different noise patterns"
     );
 }

--- a/crates/pecos-engines/tests/noise_determinism.rs
+++ b/crates/pecos-engines/tests/noise_determinism.rs
@@ -14,12 +14,11 @@ use log::info;
 use pecos_engines::noise::general::GeneralNoiseModel;
 use pecos_engines::quantum::{QuantumEngine, StateVecEngine};
 use pecos_engines::{
-    Engine, QuantumSystem, byte_message::ByteMessage, engine_system::ControlEngine,
-    GateType
+    Engine, GateType, QuantumSystem, byte_message::ByteMessage, engine_system::ControlEngine,
 };
-use std::collections::BTreeMap;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use std::collections::BTreeMap;
 
 /// Reset a noise model and set its seed in one operation
 ///
@@ -79,7 +78,9 @@ fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> Vec<ByteMess
     // but always from the same seed. This is because we are testing that different noise models
     // respond differently to the same inputs.
     let mut measure_rng = ChaCha8Rng::seed_from_u64(5330);
-    let mut state = model.start(msg.clone()).expect("Failed to start noise model processing");
+    let mut state = model
+        .start(msg.clone())
+        .expect("Failed to start noise model processing");
     let mut messages = Vec::new();
     loop {
         match state {
@@ -90,7 +91,9 @@ fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> Vec<ByteMess
             pecos_engines::engine_system::EngineStage::NeedsProcessing(intermediate_msg) => {
                 // if the intermediate message requires measurements, give it some!
                 messages.push(intermediate_msg.clone());
-                let gates = intermediate_msg.quantum_ops().expect("Failed to get quantum operations");
+                let gates = intermediate_msg
+                    .quantum_ops()
+                    .expect("Failed to get quantum operations");
                 let mut response = ByteMessage::outcomes_builder();
                 for gate in &gates {
                     match &gate.gate_type {
@@ -99,9 +102,8 @@ fn apply_noise(model: &mut GeneralNoiseModel, msg: &ByteMessage) -> Vec<ByteMess
                                 let outcome = if measure_rng.random_bool(0.5) { 1 } else { 0 };
                                 response.add_outcomes(&[outcome]);
                             }
-                        },
-                        _ => {
                         }
+                        _ => {}
                     }
                 }
                 state = model
@@ -119,11 +121,17 @@ fn compare_messages(msg1: &ByteMessage, msg2: &ByteMessage) -> bool {
     let results_left = msg1.outcomes().unwrap_or_default();
     let results_right = msg2.outcomes().unwrap_or_default();
     if quantum_ops_left != quantum_ops_right {
-        eprintln!("Quantum operations differ: {:?} vs {:?}", quantum_ops_left, quantum_ops_right);
+        eprintln!(
+            "Quantum operations differ: {:?} vs {:?}",
+            quantum_ops_left, quantum_ops_right
+        );
         return false;
     }
     if results_left != results_right {
-        eprintln!("Measurement outcomes differ: {:?} vs {:?}", results_left, results_right);
+        eprintln!(
+            "Measurement outcomes differ: {:?} vs {:?}",
+            results_left, results_right
+        );
         return false;
     }
     return true;
@@ -134,9 +142,16 @@ fn compare_messages(msg1: &ByteMessage, msg2: &ByteMessage) -> bool {
 /// This function extracts and compares the quantum operations and results from two
 /// vectors of messages to determine if they represent the same conversation between
 /// the noise model and the quantum engine.
-fn compare_message_lists(messages_left: &Vec<ByteMessage>, messages_right: &Vec<ByteMessage>) -> bool {
+fn compare_message_lists(
+    messages_left: &Vec<ByteMessage>,
+    messages_right: &Vec<ByteMessage>,
+) -> bool {
     if messages_left.len() != messages_right.len() {
-        eprintln!("Message lengths differ: {} vs {}", messages_left.len(), messages_right.len());
+        eprintln!(
+            "Message lengths differ: {} vs {}",
+            messages_left.len(),
+            messages_right.len()
+        );
         return false;
     }
     for (i, (msg1, msg2)) in messages_left.iter().zip(messages_right.iter()).enumerate() {

--- a/crates/pecos-qasm/src/engine.rs
+++ b/crates/pecos-qasm/src/engine.rs
@@ -586,7 +586,10 @@ impl QASMEngine {
         let qubits: Vec<usize> = gate.qubits.iter().map(|q| q.0).collect();
 
         match gate.gate_type {
-            GateType::I | GateType::Idle => Ok(()), // No-op gates
+            GateType::I
+            | GateType::Idle
+            | GateType::MeasCrosstalkLocalPayload
+            | GateType::MeasCrosstalkGlobalPayload => Ok(()), // No-op gates
             GateType::X
             | GateType::Y
             | GateType::Z

--- a/crates/pecos-quest/src/quantum_engine.rs
+++ b/crates/pecos-quest/src/quantum_engine.rs
@@ -159,7 +159,10 @@ impl Engine for QuestStateVecEngine {
                         self.simulator.pz(**q);
                     }
                 }
-                GateType::Idle | GateType::I => {
+                GateType::I
+                | GateType::Idle
+                | GateType::MeasCrosstalkLocalPayload
+                | GateType::MeasCrosstalkGlobalPayload => {
                     // No operation needed
                 }
                 GateType::U => {
@@ -343,7 +346,10 @@ impl Engine for QuestDensityMatrixEngine {
                         self.simulator.pz(**q);
                     }
                 }
-                GateType::Idle | GateType::I => {
+                GateType::I
+                | GateType::Idle
+                | GateType::MeasCrosstalkLocalPayload
+                | GateType::MeasCrosstalkGlobalPayload => {
                     // No operation needed
                 }
                 GateType::U => {

--- a/python/pecos-rslib/rust/src/engine_builders.rs
+++ b/python/pecos-rslib/rust/src/engine_builders.rs
@@ -832,10 +832,17 @@ impl PyGeneralNoiseModelBuilder {
         })
     }
 
-    /// Set the probability of crosstalk during measurement operations
-    fn with_p_meas_crosstalk(&self, prob: f64) -> PyResult<Self> {
+    /// Set the probability of global crosstalk during measurement operations
+    fn with_p_meas_crosstalk_global(&self, prob: f64) -> PyResult<Self> {
         Ok(Self {
-            inner: self.inner.clone().with_p_meas_crosstalk(prob),
+            inner: self.inner.clone().with_p_meas_crosstalk_global(prob),
+        })
+    }
+
+    /// Set the probability of local crosstalk during measurement operations
+    fn with_p_meas_crosstalk_local(&self, prob: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: self.inner.clone().with_p_meas_crosstalk_local(prob),
         })
     }
 

--- a/python/pecos-rslib/rust/src/engine_builders.rs
+++ b/python/pecos-rslib/rust/src/engine_builders.rs
@@ -832,17 +832,10 @@ impl PyGeneralNoiseModelBuilder {
         })
     }
 
-    /// Set the probability of global crosstalk during measurement operations
-    fn with_p_meas_crosstalk_global(&self, prob: f64) -> PyResult<Self> {
+    /// Set the probability of crosstalk during measurement operations
+    fn with_p_meas_crosstalk(&self, prob: f64) -> PyResult<Self> {
         Ok(Self {
-            inner: self.inner.clone().with_p_meas_crosstalk_global(prob),
-        })
-    }
-
-    /// Set the probability of local crosstalk during measurement operations
-    fn with_p_meas_crosstalk_local(&self, prob: f64) -> PyResult<Self> {
-        Ok(Self {
-            inner: self.inner.clone().with_p_meas_crosstalk_local(prob),
+            inner: self.inner.clone().with_p_meas_crosstalk(prob),
         })
     }
 


### PR DESCRIPTION
## Description

- Introduces new gatetypes `MeasCrosstalkLocalPayload` and `MeasCrosstalkGlobalPayload` to communicate details from runtime necessary to model crosstalk more realistically.
- Introduces noise channels for local and global crosstalk using the data from these payloads.
- The parameter `p_meas_crosstalk` has been replaced by `p_meas_crosstalk_global` and `p_meas_crosstalk_local`. The method `with_p_meas_crosstalk` from the builder now sets both of these parameters to the given value. There are also individual `with_*` methods for global and local.
- There is a new parameter `p_meas_crosstalk_model` for the transition probabilities after crosstalk-induced Z projection on the victim qubits.
- The specs for global and local crosstalk are defined here: https://github.com/quantinuum-dev/selene-pecos-plugin/issues/66 and https://github.com/quantinuum-dev/selene-pecos-plugin/issues/67.

## Discussion

- With `p_meas_crosstalk_model = {"0->0": 1.0, "1->1: 0.0"}` and using `with_p_meas_crosstalk`, the model reproduces the previous implementation of the channel... with one important caveat: PECOS does not itself introduce `MeasCrosstalk*Payload` instructions which are the ones that trigger the crosstalk channels.
  - A simple workaround for PECOS to be self-sufficient is to have an option `explicit_meas_crosstalk` (that Selene always sets to True) where, if False, causes PECOS to assume it won't receive `MeasCrosstalk*Payload` operations and instead needs to call `apply_crosstalk_faults_from_payload()` when encountering `Measure` or `MeasureLeaked`.