### PR TITLE
Changing error message for RNGIndex for more clarity

### DIFF
--- a/crates/pecos-rng/src/rng_pcg.rs
+++ b/crates/pecos-rng/src/rng_pcg.rs
@@ -320,7 +320,9 @@ impl RNGModel {
     pub fn set_index(&mut self, idx: u64) {
         assert!(
             self.count <= idx,
-            "RNGindex called after specified index already generated"
+            "Invalid start index: index {} is before the current stream index: {}",
+            idx,
+            self.count
         );
         while self.count < idx {
             self.rng_num();


### PR DESCRIPTION
Error message for RNGIndex doesn't provide enough information to the enduser on what caused the error. This patch fixes that. 