### PR TITLE
CI/supply-chain security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,18 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+
+  # Go (gomod) - security updates only. Watches the Go module that was
+  # previously uncovered (its transitive tree had accumulated advisories).
+  - package-ecosystem: "gomod"
+    directory: "/go/pecos"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      go-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,11 @@ jobs:
             build-mode: none
 
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/cuda-build-check.yml
+++ b/.github/workflows/cuda-build-check.yml
@@ -35,6 +35,11 @@ jobs:
   cuda-build-check:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -104,6 +109,11 @@ jobs:
   cuda-testing-info:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: CUDA Testing Requirements
         run: |
           echo "=============================================="

--- a/.github/workflows/dependency-integrity-check.yml
+++ b/.github/workflows/dependency-integrity-check.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -54,6 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/github-actions-security.yml
+++ b/.github/workflows/github-actions-security.yml
@@ -39,6 +39,11 @@ jobs:
       contents: read
       actions: read
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -44,6 +44,12 @@ jobs:
         go-version: ["stable"]  # Latest stable (experimental bindings)
 
     steps:
+    - name: Harden the runner (egress audit)
+      if: runner.os == 'Linux'
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -25,6 +25,11 @@ jobs:
   check-go-versions:
     runs-on: ubuntu-latest
     steps:
+    - name: Harden the runner (egress audit)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false

--- a/.github/workflows/julia-release.yml
+++ b/.github/workflows/julia-release.yml
@@ -60,6 +60,11 @@ jobs:
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Check if should run on PR push
         id: check
         env:
@@ -104,6 +109,12 @@ jobs:
             architecture: x86_64
 
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -267,6 +278,12 @@ jobs:
             os: macos-latest
             architecture: aarch64
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -346,6 +363,11 @@ jobs:
       needs.test_binaries.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -475,6 +497,11 @@ jobs:
       needs.test_binaries.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.sha || github.sha }}

--- a/.github/workflows/julia-test.yml
+++ b/.github/workflows/julia-test.yml
@@ -44,6 +44,12 @@ jobs:
         julia-version: ["1"]  # Latest stable (experimental bindings)
 
     steps:
+    - name: Harden the runner (egress audit)
+      if: runner.os == 'Linux'
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false

--- a/.github/workflows/julia-update-hash.yml
+++ b/.github/workflows/julia-update-hash.yml
@@ -27,6 +27,11 @@ jobs:
       pull-requests: write
 
     steps:
+    - name: Harden the runner (egress audit)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false

--- a/.github/workflows/julia-version-consistency.yml
+++ b/.github/workflows/julia-version-consistency.yml
@@ -25,6 +25,11 @@ jobs:
   check-julia-versions:
     runs-on: ubuntu-latest
     steps:
+    - name: Harden the runner (egress audit)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -53,6 +53,11 @@ jobs:
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Check if should run on PR push
         id: check
         env:
@@ -122,6 +127,12 @@ jobs:
             install_cuda: true
 
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -371,6 +382,12 @@ jobs:
             os: macos-15
             architecture: aarch64
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -434,6 +451,11 @@ jobs:
       needs.build_wheelspecos_rslib.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -488,6 +510,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -543,6 +570,11 @@ jobs:
       needs.test_abi3_wheels.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Create distribution directories
         run: |
           mkdir -p dist/pecos-rslib

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -50,6 +50,12 @@ jobs:
             python-version: "3.14"
 
     steps:
+    - name: Harden the runner (egress audit)
+      if: runner.os == 'Linux'
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - name: Free Disk Space (Ubuntu)
       if: runner.os == 'Linux'
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -243,6 +249,12 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 45
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/python-version-consistency.yml
+++ b/.github/workflows/python-version-consistency.yml
@@ -21,6 +21,11 @@ jobs:
   check_python_workspace:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -45,6 +45,11 @@ jobs:
   rust-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -106,6 +111,11 @@ jobs:
   rust-lint-no-llvm:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -139,6 +149,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -168,6 +183,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-2022]
 
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/rust-version-consistency.yml
+++ b/.github/workflows/rust-version-consistency.yml
@@ -19,6 +19,11 @@ jobs:
   check_rust_versions:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/selene-plugins.yml
+++ b/.github/workflows/selene-plugins.yml
@@ -45,6 +45,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-15-intel, windows-2022]
 
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -142,6 +148,12 @@ jobs:
             package: pecos_selene_mast
 
     steps:
+      - name: Harden the runner (egress audit)
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -217,6 +229,11 @@ jobs:
     needs: build-wheels
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Download all wheel artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:

--- a/.github/workflows/test-docs-examples.yml
+++ b/.github/workflows/test-docs-examples.yml
@@ -29,6 +29,11 @@ jobs:
     name: Test and build documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/go/pecos/go.mod
+++ b/go/pecos/go.mod
@@ -1,3 +1,3 @@
 module github.com/PECOS-packages/PECOS/go/pecos
 
-go 1.18
+go 1.26.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [ # exact pins so workspace tests run against a reproducible environment
   "hypothesis==6.152.1",
   "stim==1.15.0",        # Stim-comparison and decomposition-invariant tests
   "matplotlib>=2.2.0",   # Surface-patch render tests import matplotlib directly
-  "qir-qis==0.1.8",      # QIR spec-compliance validation gate over the audit corpus (#71 Stage A)
+  "qir-qis==0.1.8",      # QIR spec-compliance validation gate over the audit corpus
 ]
 examples = [ # extras used by the examples/ tree and notebook walkthroughs
   "jupyter>=1.1.1",

--- a/python/quantum-pecos/docs/requirements.txt
+++ b/python/quantum-pecos/docs/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib==3.9.2
+pillow>=11.3.0  # security floor: Pillow is transitive via matplotlib; avoid known-vulnerable old releases
 networkx==3.3
 numpy==1.26.4
 scipy==1.14.1

--- a/scripts/dependency-integrity-check.sh
+++ b/scripts/dependency-integrity-check.sh
@@ -46,6 +46,19 @@ collect_files() {
     rg --files "$@"
 }
 
+# Static indicator lists for known supply-chain worm campaigns (the
+# Shai-Hulud npm worm and related typosquats). These catch KNOWN-bad
+# package names and payload/persistence indicators only -- novel campaigns
+# are not covered here (the live-CVE side is handled by osv-scanner +
+# Dependabot, and runtime egress by harden-runner).
+#
+# MAINTENANCE: refresh these when a new campaign is disclosed. Sources:
+#   - GitHub Security advisories / GitHub blog incident write-ups
+#   - CISA alerts (https://www.cisa.gov/news-events/alerts)
+#   - StepSecurity / Socket / OpenSSF campaign IoC reports
+# The daily scheduled run of this check (see dependency-integrity-check.yml)
+# exercises the lists against the whole tree, so an update takes effect on
+# the next scheduled scan without needing a PR to trip it.
 KNOWN_BAD_PACKAGE_RE='(mistralai|guardrails-ai|lightning|@tanstack/|@mistralai/|@uipath/|@opensearch-project/|@squawk/|@tallyui/|@beproduct/|@draftauth/|@dirigible-ai/|@ml-toolkit-ts/|@supersurkhet/|agentwork-cli|cmux-agent-mcp|cross-stitch|git-branch-selector|git-git-git|nextmove-mcp|safe-action|ts-dna|wot-api|finch-rust|sha-rust|finch_cli_rust|finch-rst|sha-rst)'
 SHAI_HULUD_IOC_RE='(shai[-_ ]?hulud|router_init\.js|router_runtime\.js|setup\.mjs|setup_bun\.js|bun_environment\.js|transformers\.pyz|git-tanstack\.com|api\.masscan\.cloud|getsession\.org|filev2\.getsession|gh-token-monitor|IfYouRevokeThisTokenItWillWipeTheComputerOfTheOwner|shai-hulud-workflow)'
 


### PR DESCRIPTION
## Summary
Supply-chain / CI hardening pass (no functional code changes — workflows, config, and dep pins only).

- **harden-runner on all CI** — adds `step-security/harden-runner` (egress **audit** mode, SHA-pinned `@9af89fc…` v2.19.4) as the first step of every CI job (35 jobs / 19 workflows), Linux-guarded on matrix/macOS/Windows legs. Gives runtime egress visibility/baseline.
- **Dependabot `gomod` coverage** — closes a gap (cargo/pip/actions were covered, Go was not), so the Go module's advisories stop drifting.
- **Bump `go/pecos` go directive 1.18 → 1.26.3** — the module is stdlib-only (zero deps); the ~77 OSV alerts there were Go **standard-library** CVEs flagged against the stale directive. Bumping clears them.
- **Pin Pillow `>=11.3.0`** in `python/quantum-pecos/docs/requirements.txt` — Pillow is transitive via matplotlib; clears 1 critical (Pillow ACE) + 4 high (libwebp/DoS/overflow) code-scanning alerts.
- **Document the IoC-list refresh process** in `scripts/dependency-integrity-check.sh`.
- Drop a stray internal planning reference from a `pyproject.toml` comment.

## Notes for reviewers
- harden-runner is intentionally **audit** (non-blocking). Follow-up: review the egress baseline, then switch to `block` with an allowlist.
- Net effect on code scanning: ~106 open alerts → roughly the 9 CodeQL FFI `access-invalid-pointer` warnings + a few transitive Rust/Python advisories (handled by Dependabot/cargo-deny).

## Deferred (tracked, not in this PR)
- CodeQL FFI `access-invalid-pointer` triage (`pecos-foreign`, `pecos-qis-ffi`).
- Release integrity (OIDC trusted-publishing when PyPI publish is automated; build-provenance attestation for Julia binaries).
- Repo settings: make security checks **required** + **disable force-push** on `dev`.

## Test plan
- [x] Local: `dependency-integrity-check` exit 0 · `just go-test debug` passes · all workflow YAML valid · ruff/black/`just lint` clean
- [ ] CI green (harden-runner audit runs, dependency-integrity-check, go/python/rust/julia tests, CodeQL)