### PR TITLE
fix: add RNGadvance support to legacy Python CVM

### DIFF
--- a/.github/workflows/julia-release.yml
+++ b/.github/workflows/julia-release.yml
@@ -16,6 +16,9 @@ permissions:
 
 env:
   TRIGGER_ON_PR_PUSH: true  # Set to true to enable triggers on PR pushes
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_NET_RETRY: "10"
 
 on:
   push:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -5,6 +5,9 @@ permissions:
 
 env:
   TRIGGER_ON_PR_PUSH: true  # Set to true to enable triggers on PR pushes
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_NET_RETRY: "10"
   # Must match pecos_build::cmake::CMAKE_VERSION. The MWPF decoder feature
   # uses highs-sys, which needs cmake; the wheel build installs this version
   # via `pecos install cmake` and points highs-sys's cmake-rs at it via $CMAKE.

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,6 +9,7 @@ env:
   RUST_BACKTRACE: 1
   PYTHONUTF8: 1
   CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   CARGO_NET_RETRY: "10"
   LLVM_VERSION: "14.0.6"
   # Force the MWPF decoder feature on in CI so we exercise the cmake-dependent

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,8 @@ env:
   RUSTFLAGS: -C debuginfo=0
   RUST_BACKTRACE: 1
   PYTHONUTF8: 1
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "10"
   LLVM_VERSION: "14.0.6"
   # Force the MWPF decoder feature on in CI so we exercise the cmake-dependent
   # build path and catch regressions. GitHub-hosted runners ship cmake.
@@ -109,11 +111,6 @@ jobs:
         rustup default stable
         "$HOME\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:Path += ";$HOME\.cargo\bin"
-        # Cargo's default HTTP/2 multiplexing has been flaky on GitHub's
-        # Windows runners while talking to crates.io during the first
-        # dependency resolution in `just ci-env`.
-        "CARGO_HTTP_MULTIPLEXING=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        "CARGO_NET_RETRY=10" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         rustup show
 
     - name: Set up Rust (Unix)

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -109,6 +109,11 @@ jobs:
         rustup default stable
         "$HOME\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:Path += ";$HOME\.cargo\bin"
+        # Cargo's default HTTP/2 multiplexing has been flaky on GitHub's
+        # Windows runners while talking to crates.io during the first
+        # dependency resolution in `just ci-env`.
+        "CARGO_HTTP_MULTIPLEXING=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "CARGO_NET_RETRY=10" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         rustup show
 
     - name: Set up Rust (Unix)

--- a/julia/PECOS.jl/src/Decoder.jl
+++ b/julia/PECOS.jl/src/Decoder.jl
@@ -44,11 +44,17 @@ export AbstractDecoder, DecodingResult, decode, check_count, bit_count
 Result of a decoding operation.
 """
 struct DecodingResult
-    """Decoded observable/correction vector."""
+    """
+    Decoded observable/correction vector.
+    """
     observable::Vector{UInt8}
-    """Weight/cost of the solution."""
+    """
+    Weight/cost of the solution.
+    """
     weight::Float64
-    """Whether the decoder converged (nothing = unknown)."""
+    """
+    Whether the decoder converged (nothing = unknown).
+    """
     converged::Union{Bool,Nothing}
 end
 

--- a/julia/PECOS.jl/src/Simulator.jl
+++ b/julia/PECOS.jl/src/Simulator.jl
@@ -55,9 +55,13 @@ export sz!, h!, cx!, mz, reset!, rx!, rz!, rzz!
 Result of a Z-basis measurement.
 """
 struct MeasurementResult
-    """Measurement outcome: false = |0>, true = |1>."""
+    """
+    Measurement outcome: false = |0>, true = |1>.
+    """
     outcome::Bool
-    """Whether the outcome was deterministic."""
+    """
+    Whether the outcome was deterministic.
+    """
     is_deterministic::Bool
 end
 

--- a/python/pecos-rslib/src/pecos_random_bindings.rs
+++ b/python/pecos-rslib/src/pecos_random_bindings.rs
@@ -40,6 +40,11 @@ impl RngPcg {
     pub fn srandom(&mut self, seq: u64) {
         PCGRandom::pcg32_srandom_r(&mut self.global_state, 42_u64, seq);
     }
+
+    #[must_use]
+    pub fn clone(&self) -> RngPcg {
+        *self
+    }
 }
 
 #[cfg(test)]

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -26,6 +26,7 @@ class RNGModel:
         self.shot_id = shot_id
         self.current_bound = current_bound
         self.count = 0
+        self._draw_bounds: list[int | None] = []
         self.pcg = RngPcg()
         self.set_seed(seed)
 
@@ -35,17 +36,28 @@ class RNGModel:
 
     def set_seed(self, seed: int) -> None:
         """Setting the seed for generating random numbers."""
+        self._require_non_negative("seed", seed)
         self.seed = seed
         self.pcg.srandom(seed)
         self.count = 0
+        self._draw_bounds = []
 
     def set_bound(self, bound: int) -> None:
         """Setting the current bound for generating random numbers."""
+        self._require_non_negative("bound", bound)
         self.current_bound = bound
+
+    @staticmethod
+    def _require_non_negative(name: str, value: int) -> None:
+        """Raise a clear error when an RNG parameter is negative."""
+        if value < 0:
+            error_msg = f"RNG {name} must be non-negative: got {value}"
+            raise ValueError(error_msg)
 
     def rng_random(self) -> int:
         """Generating a random number and keeping track of how many we have generated."""
         rng_num = self.pcg.random() if self.current_bound == 0 else self.pcg.boundedrand(self.current_bound)
+        self._draw_bounds.append(self.current_bound)
         self.count += 1
         return rng_num
 
@@ -54,6 +66,7 @@ class RNGModel:
 
         The number after from the stream will be the idx of interest.
         """
+        self._require_non_negative("index", index)
         if self.count > index:
             error_msg = f"RNGindex({index}) cannot move backward: current stream index is {self.count}"
             raise ValueError(error_msg)
@@ -71,12 +84,21 @@ class RNGModel:
             raise ValueError(error_msg)
 
         if delta < 0:
+            prefix_bounds = self._draw_bounds[:target_index]
+            active_bound = self.current_bound
             self.pcg = RngPcg()
             self.pcg.srandom(self.seed)
             self.count = 0
+            self._draw_bounds = []
 
-        while self.count < target_index:
-            self.rng_random()
+            for historical_bound in prefix_bounds:
+                self.current_bound = historical_bound
+                self.rng_random()
+
+            self.current_bound = active_bound
+        else:
+            while self.count < target_index:
+                self.rng_random()
 
     def extract_val(self, param: str | int, output: dict) -> int:
         """Responsible for extracting the value of interest depending on the type of the parameter being passed in."""

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -78,28 +78,26 @@ class RNGModel:
         while self.count < target_index:
             self.rng_random()
 
-    def extract_val(self, param: str, output: dict) -> int:
+    def extract_val(self, param: str | int, output: dict) -> int:
         """Responsible for extracting the value of interest depending on the type of the parameter being passed in."""
         if isinstance(param, int):
-            val = param
-        else:
-            try:
-                val = int(param)
-            except ValueError:
-                val = None
-        if val is not None:
+            return param
+
+        try:
+            return int(param)
+        except (TypeError, ValueError):
             pass
-        elif "[" in param:
+
+        if "[" in param:
             idx_creg = param.split("[")
             creg = output[idx_creg[0]]
             idx = int(idx_creg[-1][:-1])
-            val = int(creg[idx])
+            return int(creg[idx])
         elif param == "JOB_shotnum":
-            val = self.shot_id
-        else:
-            reg = output[param]
-            val = int(reg)
-        return val
+            return self.shot_id
+
+        reg = output[param]
+        return int(reg)
 
     def eval_func(self, params: dict, output: dict) -> None:
         """Calling the appropriate functions dependent on RNG Function call passed in."""

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -27,7 +27,7 @@ class RNGModel:
         self.current_bound = current_bound
         self.count = 0
         self.pcg = RngPcg()
-        self.seed = self.set_seed(seed)
+        self.set_seed(seed)
 
     def __str__(self) -> str:
         """Returns the str representation of the model."""
@@ -37,6 +37,7 @@ class RNGModel:
         """Setting the seed for generating random numbers."""
         self.seed = seed
         self.pcg.srandom(seed)
+        self.count = 0
 
     def set_bound(self, bound: int) -> None:
         """Setting the current bound for generating random numbers."""
@@ -59,10 +60,35 @@ class RNGModel:
         while self.count < index:
             self.rng_random()
 
+    def set_relative_index(self, delta: int) -> None:
+        """Move relative to the current random-number stream index."""
+        target_index = self.count + delta
+        if target_index < 0:
+            error_msg = (
+                f"RNGadvance({delta}) cannot move before the start of the stream: "
+                f"current stream index is {self.count}"
+            )
+            raise ValueError(error_msg)
+
+        if delta < 0:
+            self.pcg = RngPcg()
+            self.pcg.srandom(self.seed)
+            self.count = 0
+
+        while self.count < target_index:
+            self.rng_random()
+
     def extract_val(self, param: str, output: dict) -> int:
         """Responsible for extracting the value of interest depending on the type of the parameter being passed in."""
-        if param.isdigit():
-            val = int(param)
+        if isinstance(param, int):
+            val = param
+        else:
+            try:
+                val = int(param)
+            except ValueError:
+                val = None
+        if val is not None:
+            pass
         elif "[" in param:
             idx_creg = param.split("[")
             creg = output[idx_creg[0]]
@@ -90,6 +116,10 @@ class RNGModel:
             index_var = params.get("args")[0]
             index = self.extract_val(index_var, output)
             self.set_index(index)
+        elif func_name == "RNGadvance":
+            delta_var = params.get("args")[0]
+            delta = self.extract_val(delta_var, output)
+            self.set_relative_index(delta)
         elif func_name == "RNGnum":
             creg_name = params.get("assign_vars")[0]
             creg = output[creg_name]

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -28,6 +28,7 @@ class RNGModel:
         self.count = 0
         self._draw_bound_runs: list[tuple[int, int]] = []
         self.pcg = RngPcg()
+        self._replay_base_pcg = self.pcg.clone()
         self.set_seed(seed)
 
     def __str__(self) -> str:
@@ -41,6 +42,14 @@ class RNGModel:
         self.pcg.srandom(seed)
         self.count = 0
         self._draw_bound_runs = []
+        self._replay_base_pcg = self.pcg.clone()
+
+    def start_shot(self, shot_id: int) -> None:
+        """Reset shot-local replay state while preserving the current stream position."""
+        self.shot_id = shot_id
+        self.count = 0
+        self._draw_bound_runs = []
+        self._replay_base_pcg = self.pcg.clone()
 
     def set_bound(self, bound: int | None) -> None:
         """Setting the current bound for generating random numbers."""
@@ -97,16 +106,19 @@ class RNGModel:
         if delta < 0:
             bound_runs = list(self._draw_bound_runs)
             active_bound = self.current_bound
-            self.set_seed(self.seed)
+            self.pcg = self._replay_base_pcg.clone()
+            self.count = 0
+            self._draw_bound_runs = []
 
             remaining = target_index
             for historical_bound, run_length in bound_runs:
-                if remaining == 0:
+                if remaining <= 0:
                     break
                 self.current_bound = historical_bound
-                for _ in range(min(run_length, remaining)):
+                replay_count = min(run_length, remaining)
+                for _ in range(replay_count):
                     self.rng_random()
-                remaining -= run_length
+                remaining -= replay_count
 
             self.current_bound = active_bound
         else:

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -24,9 +24,9 @@ class RNGModel:
     ) -> None:
         """Constructs an RNGModel object."""
         self.shot_id = shot_id
-        self.current_bound = current_bound
+        self.current_bound = self._normalize_bound(current_bound)
         self.count = 0
-        self._draw_bounds: list[int | None] = []
+        self._draw_bounds: list[int] = []
         self.pcg = RngPcg()
         self.set_seed(seed)
 
@@ -42,10 +42,9 @@ class RNGModel:
         self.count = 0
         self._draw_bounds = []
 
-    def set_bound(self, bound: int) -> None:
+    def set_bound(self, bound: int | None) -> None:
         """Setting the current bound for generating random numbers."""
-        self._require_non_negative("bound", bound)
-        self.current_bound = bound
+        self.current_bound = self._normalize_bound(bound)
 
     @staticmethod
     def _require_non_negative(name: str, value: int) -> None:
@@ -53,6 +52,14 @@ class RNGModel:
         if value < 0:
             error_msg = f"RNG {name} must be non-negative: got {value}"
             raise ValueError(error_msg)
+
+    @classmethod
+    def _normalize_bound(cls, bound: int | None) -> int:
+        """Normalize optional bounds to the unbounded sentinel used by the RNG model."""
+        if bound is None:
+            return 0
+        cls._require_non_negative("bound", bound)
+        return bound
 
     def rng_random(self) -> int:
         """Generating a random number and keeping track of how many we have generated."""

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -122,7 +122,7 @@ class RNGModel:
             creg = output[idx_creg[0]]
             idx = int(idx_creg[-1][:-1])
             return int(creg[idx])
-        elif param == "JOB_shotnum":
+        if param == "JOB_shotnum":
             return self.shot_id
 
         reg = output[param]

--- a/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/rng_model.py
@@ -26,7 +26,7 @@ class RNGModel:
         self.shot_id = shot_id
         self.current_bound = self._normalize_bound(current_bound)
         self.count = 0
-        self._draw_bounds: list[int] = []
+        self._draw_bound_runs: list[tuple[int, int]] = []
         self.pcg = RngPcg()
         self.set_seed(seed)
 
@@ -40,7 +40,7 @@ class RNGModel:
         self.seed = seed
         self.pcg.srandom(seed)
         self.count = 0
-        self._draw_bounds = []
+        self._draw_bound_runs = []
 
     def set_bound(self, bound: int | None) -> None:
         """Setting the current bound for generating random numbers."""
@@ -64,7 +64,11 @@ class RNGModel:
     def rng_random(self) -> int:
         """Generating a random number and keeping track of how many we have generated."""
         rng_num = self.pcg.random() if self.current_bound == 0 else self.pcg.boundedrand(self.current_bound)
-        self._draw_bounds.append(self.current_bound)
+        if self._draw_bound_runs and self._draw_bound_runs[-1][0] == self.current_bound:
+            bound, run_length = self._draw_bound_runs[-1]
+            self._draw_bound_runs[-1] = (bound, run_length + 1)
+        else:
+            self._draw_bound_runs.append((self.current_bound, 1))
         self.count += 1
         return rng_num
 
@@ -91,16 +95,18 @@ class RNGModel:
             raise ValueError(error_msg)
 
         if delta < 0:
-            prefix_bounds = self._draw_bounds[:target_index]
+            bound_runs = list(self._draw_bound_runs)
             active_bound = self.current_bound
-            self.pcg = RngPcg()
-            self.pcg.srandom(self.seed)
-            self.count = 0
-            self._draw_bounds = []
+            self.set_seed(self.seed)
 
-            for historical_bound in prefix_bounds:
+            remaining = target_index
+            for historical_bound, run_length in bound_runs:
+                if remaining == 0:
+                    break
                 self.current_bound = historical_bound
-                self.rng_random()
+                for _ in range(min(run_length, remaining)):
+                    self.rng_random()
+                remaining -= run_length
 
             self.current_bound = active_bound
         else:

--- a/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
+++ b/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
@@ -141,8 +141,7 @@ class HybridEngine:
         # --------------------
         self.generate_errors = True
         error_circuits = error_gen.start(circuit, error_params)
-        self.rng_model.count = 0
-        self.rng_model.shot_id = shot_id
+        self.rng_model.start_shot(shot_id)
 
         # run through the circuits...
         # ---------------------------

--- a/python/quantum-pecos/tests/pecos/unit/test_rng.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_rng.py
@@ -95,6 +95,19 @@ def test_relative_advance_backward() -> None:
     assert rng.rng_random() == draw_at_index(42, 3)
 
 
+def test_relative_advance_backward_past_start_raises() -> None:
+    """Verifies rewinds cannot move before the start of the stream."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+    rng.set_relative_index(2)
+
+    with pytest.raises(
+        ValueError,
+        match=r"RNGadvance\(-3\) cannot move before the start of the stream: current stream index is 2",
+    ):
+        rng.set_relative_index(-3)
+
+
 def test_reseed_then_advance_changes_draw_and_resets_count() -> None:
     """Verifies reseeding resets the logical position used by later relative advances."""
     rng = RNGModel(shot_id=0)

--- a/python/quantum-pecos/tests/pecos/unit/test_rng.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_rng.py
@@ -3,6 +3,7 @@
 import sys
 
 import pecos as pc
+import pytest
 from pecos.engines.cvm.rng_model import RNGModel
 
 
@@ -97,9 +98,10 @@ def test_reseed_then_advance_changes_draw_and_resets_count() -> None:
 
     rng.set_seed(42)
     immediate_val = rng.rng_random()
+    expected_first_draw = draw_at_index(42, 0)
 
     assert advanced_val != immediate_val
-    assert immediate_val == 1085446021
+    assert immediate_val == expected_first_draw
     assert rng.count == 1
 
 
@@ -117,6 +119,35 @@ def test_relative_advance_keeps_count_consistent_after_draws() -> None:
     rng.set_relative_index(-2)
     assert rng.count == 4
     assert rng.rng_random() == draw_at_index(42, 4)
+
+
+def test_negative_values_are_rejected_for_non_advance_rng_funcs() -> None:
+    """Verifies only RNGadvance accepts negative numeric arguments."""
+    rng = RNGModel(shot_id=0)
+
+    with pytest.raises(ValueError, match=r"RNG seed must be non-negative: got -1"):
+        rng.eval_func({"func": "RNGseed", "args": ["-1"]}, {})
+
+    with pytest.raises(ValueError, match=r"RNG bound must be non-negative: got -1"):
+        rng.eval_func({"func": "RNGbound", "args": ["-1"]}, {})
+
+    with pytest.raises(ValueError, match=r"RNG index must be non-negative: got -1"):
+        rng.eval_func({"func": "RNGindex", "args": ["-1"]}, {})
+
+
+def test_relative_advance_backward_replays_historical_bounds() -> None:
+    """Verifies rewind reconstructs the stream using the original bounds history."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+    rng.set_bound(16)
+    rng.rng_random()
+    rng.set_bound(0)
+    expected_second_draw = rng.rng_random()
+
+    rng.set_relative_index(-1)
+
+    assert rng.count == 1
+    assert rng.rng_random() == expected_second_draw
 
 
 def test_multiple_bounded_rand() -> None:

--- a/python/quantum-pecos/tests/pecos/unit/test_rng.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_rng.py
@@ -24,6 +24,12 @@ def test_set_seed() -> None:
     assert rng.count == 0
 
 
+def test_init_normalizes_none_bound_to_unbounded() -> None:
+    """Verifies ``None`` uses the unbounded sentinel instead of leaking into bounded draws."""
+    rng = RNGModel(shot_id=0, current_bound=None)
+    assert rng.current_bound == 0
+
+
 def test_random_number() -> None:
     """Verifies that the random number generated is an int type."""
     rng = RNGModel(shot_id=0)

--- a/python/quantum-pecos/tests/pecos/unit/test_rng.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_rng.py
@@ -6,12 +6,21 @@ import pecos as pc
 from pecos.engines.cvm.rng_model import RNGModel
 
 
+def draw_at_index(seed: int, index: int) -> int:
+    """Return the next random value after consuming ``index`` values from a seeded stream."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(seed)
+    rng.set_index(index)
+    return rng.rng_random()
+
+
 def test_set_seed() -> None:
     """Verifies that a seed is set properly for our RNG model."""
     rng = RNGModel(shot_id=0)
     seed = 42
     rng.set_seed(seed)
     assert rng.seed == seed
+    assert rng.count == 0
 
 
 def test_random_number() -> None:
@@ -54,6 +63,60 @@ def test_set_idx() -> None:
     idx = 4
     rng.set_index(idx)
     assert rng.count == idx
+
+
+def test_relative_advance_forward() -> None:
+    """Verifies that a forward relative advance lands on the expected stream position."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+
+    rng.set_relative_index(5)
+
+    assert rng.count == 5
+    assert rng.rng_random() == draw_at_index(42, 5)
+
+
+def test_relative_advance_backward() -> None:
+    """Verifies that a backward relative advance reconstructs the stream from the seed."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+    rng.set_relative_index(6)
+
+    rng.eval_func({"func": "RNGadvance", "args": ["-3"]}, {})
+
+    assert rng.count == 3
+    assert rng.rng_random() == draw_at_index(42, 3)
+
+
+def test_reseed_then_advance_changes_draw_and_resets_count() -> None:
+    """Verifies reseeding resets the logical position used by later relative advances."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+    rng.set_relative_index(5)
+    advanced_val = rng.rng_random()
+
+    rng.set_seed(42)
+    immediate_val = rng.rng_random()
+
+    assert advanced_val != immediate_val
+    assert immediate_val == 1085446021
+    assert rng.count == 1
+
+
+def test_relative_advance_keeps_count_consistent_after_draws() -> None:
+    """Verifies count tracks the current stream position after advances and draws."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+
+    rng.set_relative_index(5)
+    assert rng.count == 5
+
+    rng.rng_random()
+    assert rng.count == 6
+
+    rng.set_relative_index(-2)
+    assert rng.count == 4
+    assert rng.rng_random() == draw_at_index(42, 4)
 
 
 def test_multiple_bounded_rand() -> None:

--- a/python/quantum-pecos/tests/pecos/unit/test_rng.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_rng.py
@@ -169,6 +169,23 @@ def test_relative_advance_backward_replays_historical_bounds() -> None:
     assert rng.rng_random() == expected_second_draw
 
 
+def test_start_shot_resets_replay_base_to_current_stream_position() -> None:
+    """Verifies rewinds in later shots replay from the shot start, not the original seed."""
+    rng = RNGModel(shot_id=0)
+    rng.set_seed(42)
+
+    for _ in range(4):
+        rng.rng_random()
+
+    rng.start_shot(shot_id=1)
+    shot_draws = [rng.rng_random() for _ in range(3)]
+
+    rng.set_relative_index(-1)
+
+    assert rng.count == 2
+    assert rng.rng_random() == shot_draws[-1]
+
+
 def test_multiple_bounded_rand() -> None:
     """For several randomly generated number, with a random bound, verifies that its appropriate."""
     rng = RNGModel(shot_id=0)


### PR DESCRIPTION
## Summary
- add `RNGadvance(delta)` support to the legacy Python CVM RNG path, including backward replay through historical bound sequences
- preserve shot-local rewind correctness by resetting replay state at shot boundaries instead of mutating `count` directly
- keep existing `RNGseed`, `RNGindex`, and `RNGnum` behavior while tightening RNG argument validation and stream bookkeeping
- include the CI hardening and Julia formatter-only updates already present on this branch

## Reviewer Notes
- The behavior change is in `python/quantum-pecos/src/pecos/engines/cvm/rng_model.py` and the legacy caller in `python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py`.
- Backward `RNGadvance` now replays from an explicit replay base: reseeds reset that base, and each shot snapshots the current RNG state so rewinds stay correct even when the stream continues across shots.
- Bound history is stored in run-length encoded form to reduce memory growth for long runs with stable bounds.
- The Rust binding adds `RngPcg.clone()` only to snapshot the current generator state for shot-local replay.
- Workflow and Julia file changes are CI fixes, not product behavior changes.

## Validation
- `uv run maturin develop --manifest-path python/pecos-rslib/Cargo.toml`
- `uv run --frozen pytest python/quantum-pecos/tests/pecos/unit/test_rng.py`
- `uv run --frozen ruff check python/quantum-pecos/src/pecos/engines/cvm/rng_model.py python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py python/quantum-pecos/tests/pecos/unit/test_rng.py`
