### PR TITLE
fix: restore custatevec import compatibility

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -801,8 +801,11 @@ sync-deps:
     # the toolkit is installed AND an NVIDIA GPU is present. Pure Rust users
     # and machines without a GPU skip this -- mirrors `pecos python build`.
     if {{pecos}} cuda check -q 2>/dev/null && nvidia-smi -L 2>/dev/null | grep -q "^GPU "; then
-        echo "CUDA toolkit + NVIDIA GPU detected -- including CUDA Python packages"
-        SYNC_ARGS+=(--group cuda)
+        # Pick the cuda group matching the CUDA major (default cuda13).
+        CUDA_GROUP=cuda13
+        if nvcc --version 2>/dev/null | grep -qE "release 12"; then CUDA_GROUP=cuda12; fi
+        echo "CUDA toolkit + NVIDIA GPU detected -- including CUDA Python packages ($CUDA_GROUP)"
+        SYNC_ARGS+=(--group "$CUDA_GROUP")
     fi
     uv sync "${SYNC_ARGS[@]}"
 

--- a/Justfile
+++ b/Justfile
@@ -803,7 +803,7 @@ sync-deps:
     if {{pecos}} cuda check -q 2>/dev/null && nvidia-smi -L 2>/dev/null | grep -q "^GPU "; then
         # Pick the cuda group matching the CUDA major (default cuda13).
         CUDA_GROUP=cuda13
-        if nvcc --version 2>/dev/null | grep -qE "release 12"; then CUDA_GROUP=cuda12; fi
+        if nvcc --version 2>/dev/null | grep -qE "release 12[.,]"; then CUDA_GROUP=cuda12; fi
         echo "CUDA toolkit + NVIDIA GPU detected -- including CUDA Python packages ($CUDA_GROUP)"
         SYNC_ARGS+=(--group "$CUDA_GROUP")
     fi

--- a/crates/pecos-cli/src/cli/cuda_cmd.rs
+++ b/crates/pecos-cli/src/cli/cuda_cmd.rs
@@ -218,7 +218,8 @@ fn run_validate(path: Option<String>) -> Result<()> {
 }
 
 /// CLI entry point for `pecos cuda setup-python`. Validates the toolkit is
-/// present, then runs `uv sync --locked --group cuda` and prints next-step hints.
+/// present, then runs `uv sync --locked --group <cuda12|cuda13>` (matching the
+/// detected CUDA major) and prints next-step hints.
 fn run_setup_python() -> Result<()> {
     if find_cuda().is_none() {
         eprintln!("Error: CUDA toolkit not found.");
@@ -239,17 +240,27 @@ fn run_setup_python() -> Result<()> {
     Ok(())
 }
 
-/// Run `uv sync --locked --group cuda` to install Python CUDA packages.
+/// Pick the CUDA-major dependency group (`cuda12` / `cuda13`) for the detected
+/// toolkit, defaulting to `cuda13` (the recommended, latest path).
+pub(super) fn cuda_python_group() -> &'static str {
+    let is_cuda12 = find_cuda()
+        .and_then(|path| get_cuda_version(&path).ok())
+        .is_some_and(|version| version.split('.').next() == Some("12"));
+    if is_cuda12 { "cuda12" } else { "cuda13" }
+}
+
+/// Run `uv sync --locked --group <cuda12|cuda13>` to install Python CUDA packages.
 ///
 /// Reusable from other CLI commands (e.g. `pecos setup`) once they've already
 /// confirmed the user wants this. Does NOT validate toolkit presence -- caller
 /// is responsible for that check.
 pub(super) fn install_cuda_python_packages() -> Result<()> {
-    println!("Installing CUDA Python packages (cupy, cuquantum, pytket-cutensornet)...");
+    let group = cuda_python_group();
+    println!("Installing CUDA Python packages (cupy, cuquantum, pytket-cutensornet) [{group}]...");
     println!();
 
     let status = Command::new("uv")
-        .args(["sync", "--locked", "--group", "cuda"])
+        .args(["sync", "--locked", "--group", group])
         .status();
 
     match status {
@@ -263,7 +274,7 @@ pub(super) fn install_cuda_python_packages() -> Result<()> {
             eprintln!("Failed to install CUDA Python packages.");
             eprintln!();
             eprintln!("You may need to install manually:");
-            eprintln!("  uv sync --locked --group cuda");
+            eprintln!("  uv sync --locked --group {group}");
             Err(Error::Cuda(
                 "Failed to install CUDA Python packages".to_string(),
             ))

--- a/crates/pecos-cli/src/cli/setup_cmd.rs
+++ b/crates/pecos-cli/src/cli/setup_cmd.rs
@@ -131,7 +131,7 @@ fn print_status_summary(skip_llvm: bool, skip_cuda: bool, skip_cmake: bool) {
         if super::cuda_cmd::cuda_python_packages_installed() {
             println!("  cupy:       installed (CUDA Python packages synced)");
         } else {
-            println!("  cupy:       not installed (~500 MB via `uv sync --locked --group cuda`)");
+            println!("  cupy:       not installed (~500 MB via `pecos cuda setup-python`)");
         }
     }
 
@@ -353,7 +353,7 @@ fn setup_cuda_python(mode: PromptMode) -> Result<()> {
     }
 
     if confirm(
-        "Install CUDA Python packages? (cupy, cuquantum, pytket-cutensornet via `uv sync --locked --group cuda`)",
+        "Install CUDA Python packages? (cupy, cuquantum, pytket-cutensornet via `pecos cuda setup-python`)",
         true, // default yes when CUDA toolkit + NVIDIA GPU are present
         mode,
     ) {

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -62,10 +62,12 @@ For developers who want to contribute or modify PECOS:
    |---------------|-------------------------------------------------------------|-------------------------------|
    | `examples`    | Running notebooks under `examples/` or DataFrame benchmarks | `uv sync --group examples`    |
    | `numpy-compat`| Verifying older NumPy/SciPy minimums                        | `uv sync --group numpy-compat`|
-   | `cuda`        | Building/running GPU simulators (requires CUDA toolkit)     | `uv sync --group cuda`        |
+   | `cuda13`      | GPU simulators on CUDA 13 (Turing/CC 7.5+; requires CUDA toolkit) | `uv sync --group cuda13`  |
+   | `cuda12`      | GPU simulators on CUDA 12 (incl. V100/Volta)               | `uv sync --group cuda12`      |
 
    Combine groups with multiple `--group` flags
-   (e.g. `uv sync --group examples --group cuda`).
+   (e.g. `uv sync --group examples --group cuda13`). Pick one CUDA major --
+   `cuda12` and `cuda13` are mutually exclusive.
 
 6. **LLVM 14 Setup (Required for LLVM IR/QIS Support)**
 

--- a/docs/user-guide/cuda-setup.md
+++ b/docs/user-guide/cuda-setup.md
@@ -31,7 +31,10 @@ Both approaches require:
 
 ### Hardware Requirements
 
-- **NVIDIA GPU** with Compute Capability 7.0 or higher
+- **NVIDIA GPU** with Compute Capability **7.5 or higher** (Turing and newer) for the
+  default CUDA 13 path. Current cuStateVec (cuQuantum >= 25.09) and CUDA 13 dropped
+  Volta, so **V100 / CC 7.0** is supported only via the CUDA 12 path with an older,
+  Volta-capable cuQuantum pinned `cuquantum-python-cu12>=25.3,<25.9` (see below).
   - To check your GPU: `nvidia-smi`
   - To check compute capability: Visit [NVIDIA's GPU Compute Capability List](https://developer.nvidia.com/cuda-gpus)
 
@@ -119,22 +122,27 @@ If `nvcc` is not found, ensure CUDA's bin directory is in your PATH.
 PECOS uses `uv` as the package manager. Install the CUDA-related Python packages:
 
 ```bash
-# Install CUDA 13 packages
-uv pip install cupy-cuda13x>=13.0.0
-uv pip install cuquantum-python-cu13>=25.3.0
-uv pip install pytket-cutensornet>=0.12.0
+# CUDA 13 (Turing / CC 7.5+ GPUs):
+uv pip install "cupy-cuda13x>=13.0.0" "cuquantum-python-cu13>=25.9.0" "pytket-cutensornet>=0.12.0"
+
+# CUDA 12:
+uv pip install "cupy-cuda12x>=13.0.0" "cuquantum-python-cu12>=25.3.0" "pytket-cutensornet>=0.12.0"
 ```
 
-**Important**: Use packages matching your CUDA version:
-- For CUDA 13: `cupy-cuda13x`, `cuquantum-python-cu13`
-- For CUDA 12: `cupy-cuda12x`, `cuquantum-python-cu12`
+**Important**:
+- Install packages matching your CUDA major (CUDA 13 -> `*-cu13` / `*-cuda13x`; CUDA 12 -> `*-cu12` / `*-cuda12x`). Do **not** install both.
+- PECOS requires the **`cuquantum.bindings` API (cuQuantum >= 25.03)**; older cuQuantum is rejected with a clear error when you use `CuStateVec`. The lowest CUDA 13 wheel is `25.9.0`.
+- **V100 / Volta (CC 7.0)**: pin `cuquantum-python-cu12>=25.3,<25.9` (cuStateVec dropped Volta at 25.09).
 
 ### Step 5: Install PECOS with CUDA Support
 
 #### Option A: Install from PyPI with CUDA extras
 
 ```bash
-uv pip install quantum-pecos[cuda]
+# CUDA 13 (recommended); use [cuda12] for CUDA 12. These pull the Python cuStateVec
+# / MPS stack (CuPy + cuquantum-python). The Rust GPU backend is a separate install
+# (see "Rust cuQuantum Bindings Setup" below): pip install pecos-rslib-cuda
+uv pip install "quantum-pecos[cuda13]"
 ```
 
 #### Option B: Install from source (for development)
@@ -148,8 +156,8 @@ just build-cuda  # Build with CUDA support
 just devc        # Full dev cycle: clean + build-cuda + test
 just devcl       # Dev cycle + linting
 
-# Option 2: Manual installation
-uv pip install -e "./python/quantum-pecos[all,cuda]"
+# Option 2: Manual installation (use [all,cuda12] for CUDA 12)
+uv pip install -e "./python/quantum-pecos[all,cuda13]"
 ```
 
 ## Verification
@@ -203,14 +211,15 @@ uv run pytest python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_
 
 ## Package Versions
 
-Current recommended versions (as of 2025):
+Minimum versions (CUDA 13 path shown; for CUDA 12 use the `-cu12` / `-cuda12x` equivalents):
 
-| Package | Version | Release Date | Purpose |
-|---------|---------|--------------|---------|
-| cupy-cuda13x | 13.6.0+ | Aug 2025 | NumPy/SciPy for GPU |
-| cuquantum-python-cu13 | 25.9.0+ | Sept 2025 | cuQuantum Python API |
-| custatevec-cu13 | 1.10.0+ | Sept 2025 | State vector operations (included in cuquantum) |
-| pytket-cutensornet | 0.12.0+ | 2025 | MPS simulator |
+| Package | Minimum | Purpose |
+|---------|---------|---------|
+| cupy-cuda13x | 13.0.0 | NumPy/SciPy for GPU |
+| cuquantum-python-cu13 | 25.9.0 | cuQuantum Python API (the `cuquantum.bindings >= 25.03` surface; lowest cu13 wheel is 25.9.0) |
+| pytket-cutensornet | 0.12.0 | MPS simulator |
+
+For CUDA 12 the floor is `cuquantum-python-cu12>=25.3.0`; **V100/Volta** needs `>=25.3,<25.9`.
 
 ## Troubleshooting
 
@@ -226,19 +235,26 @@ export LD_LIBRARY_PATH=/usr/local/cuda-13/lib64:$LD_LIBRARY_PATH
 source ~/.bashrc
 ```
 
-#### 2. `CuStateVec is None` or tests are skipped
+#### 2. `CuStateVec` unavailable / constructing it raises
 
-**Solution**: Python packages not properly installed or CUDA Toolkit version mismatch.
+`import pecos` always works, but constructing `CuStateVec` (or
+`QuantumSimulator("CuStateVec")`) without CuPy and a bindings-era cuQuantum raises
+an actionable error naming what to install/upgrade. PECOS requires the
+`cuquantum.bindings` API (cuQuantum >= 25.03); the legacy top-level
+`cuquantum.custatevec` is not used.
 
 ```bash
-# Verify installations
+# Ask PECOS directly (no GPU needed):
+python -c "from pecos.simulators.custatevec._cuquantum_compat import custatevec_available, custatevec_unavailable_reason; print(custatevec_available(), '|', custatevec_unavailable_reason())"
+
+# Or check the underlying packages:
 python -c "import cupy; print(cupy.__version__)"
 python -c "from cuquantum.bindings import custatevec; print('OK')"
-
-# Reinstall if needed
-uv pip uninstall cupy-cuda13x cuquantum-python-cu13
-uv pip install cupy-cuda13x cuquantum-python-cu13
 ```
+
+If the reason says cuQuantum "predates the cuquantum.bindings API", upgrade to
+`cuquantum-python-cu13>=25.9.0` (CUDA 13) or `cuquantum-python-cu12>=25.3.0`
+(CUDA 12; V100/Volta `>=25.3,<25.9`).
 
 #### 3. CUDA version mismatch errors
 
@@ -281,7 +297,7 @@ If you encounter issues:
 1. Check [NVIDIA cuQuantum Documentation](https://docs.nvidia.com/cuda/cuquantum/latest/)
 2. Check [pytket-cutensornet GitHub Issues](https://github.com/Quantinuum/pytket-cutensornet/issues)
 3. Check [PECOS GitHub Issues](https://github.com/PECOS-packages/PECOS/issues)
-4. Verify your GPU compute capability is 7.0 or higher
+4. Verify your GPU compute capability is 7.5+ (CUDA 13) or 7.0 (V100 via the capped CUDA 12 path)
 
 ## Alternative: Using Conda
 
@@ -451,12 +467,12 @@ To use GPU simulators in PECOS:
 
 ### Option A: Python cuQuantum Bindings (Easier Setup)
 
-1. **Verify NVIDIA GPU** (Compute Capability 7.0+)
-2. **Install CUDA Toolkit 13** (system-level)
-3. **Install Python packages**: `cupy-cuda13x`, `cuquantum-python-cu13`, `pytket-cutensornet`
-4. **Install PECOS with `[cuda]` extras**:
+1. **Verify NVIDIA GPU** (Compute Capability 7.5+ for CUDA 13; V100/CC 7.0 only via the capped CUDA 12 path)
+2. **Install CUDA Toolkit 13** (system-level; or CUDA 12)
+3. **Install Python packages**: `cupy-cuda13x`, `cuquantum-python-cu13`, `pytket-cutensornet` (or the `-cu12`/`-cuda12x` equivalents)
+4. **Install PECOS with the matching CUDA extra**:
    ```bash
-   uv pip install quantum-pecos[cuda]
+   uv pip install "quantum-pecos[cuda13]"   # or [cuda12] for CUDA 12
    # or for development:
    just build-cuda
    ```

--- a/docs/user-guide/cuda-setup.md
+++ b/docs/user-guide/cuda-setup.md
@@ -233,7 +233,7 @@ source ~/.bashrc
 ```bash
 # Verify installations
 python -c "import cupy; print(cupy.__version__)"
-python -c "from cuquantum import custatevec; print('OK')"
+python -c "from cuquantum.bindings import custatevec; print('OK')"
 
 # Reinstall if needed
 uv pip uninstall cupy-cuda13x cuquantum-python-cu13

--- a/docs/user-guide/qec-guppy.md
+++ b/docs/user-guide/qec-guppy.md
@@ -389,7 +389,7 @@ results = (
     .quantum(state_vector())
     .noise(depolarizing_noise().with_uniform_probability(0.001))
     .seed(42)
-    .run(1000)
+    .run(100)
 )
 ```
 

--- a/docs/user-guide/simulators.md
+++ b/docs/user-guide/simulators.md
@@ -254,7 +254,8 @@ results = sim(Qasm(circuit)).quantum(CuStateVec).run(100)
 - cuQuantum and cupy packages
 
 ```bash
-pip install quantum-pecos[cuda]
+# CUDA 13 (recommended); use [cuda12] for CUDA 12 / V100. Do not install both.
+pip install "quantum-pecos[cuda13]"
 ```
 
 See [CUDA Setup Guide](cuda-setup.md) for detailed installation instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,13 @@ cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
 
 [tool.uv]
 default-groups = ["dev", "test"]
+# CUDA 12 and CUDA 13 stacks are mutually exclusive (separate cupy/cuquantum
+# wheels per CUDA major). Declare them conflicting so the lock never co-resolves
+# both -- co-resolution downgrades cu12 to satisfy cu13.
+conflicts = [
+  [{ extra = "cuda12" }, { extra = "cuda13" }],
+  [{ group = "cuda12" }, { group = "cuda13" }],
+]
 # Prevent uv from caching native workspace wheels - always use freshly built versions.
 # This fixes stale code issues when uv sync/run reinstalls cached old wheels.
 # See: https://github.com/astral-sh/uv/issues/11390

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,11 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
-# Keep this in sync with the cuda dependency group below. The extra supports
-# `uv sync --extra cuda`; the group supports `uv run --group cuda ...`.
-cuda = ["quantum-pecos[cuda]==0.8.0.dev8"]
+# Keep these in sync with the cuda dependency groups below. The extras support
+# `uv sync --extra cuda13`; the groups support `uv run --group cuda13 ...`.
+# Pick the extra matching your CUDA major -- do not install both.
+cuda13 = ["quantum-pecos[cuda13]==0.8.0.dev8"]
+cuda12 = ["quantum-pecos[cuda12]==0.8.0.dev8"]
 
 [tool.uv.workspace]
 members = [
@@ -67,8 +69,11 @@ numpy-compat = [ # NumPy/SciPy compatibility tests - verify compatibility with s
   "numpy>=1.15.0",
   "scipy>=1.1.0",
 ]
-cuda = [ # CUDA Python packages for GPU-accelerated simulations (requires CUDA toolkit)
-  "quantum-pecos[cuda]==0.8.0.dev8",
+cuda13 = [ # CUDA 13 Python packages for GPU-accelerated simulations (requires CUDA toolkit)
+  "quantum-pecos[cuda13]==0.8.0.dev8",
+]
+cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
+  "quantum-pecos[cuda12]==0.8.0.dev8",
 ]
 
 [tool.uv]

--- a/python/quantum-pecos/README.md
+++ b/python/quantum-pecos/README.md
@@ -178,7 +178,8 @@ Certain simulators from `pecos.simulators` require external packages that are no
 
 **Quick install** (after installing CUDA Toolkit):
 ```bash
-uv pip install quantum-pecos[cuda]
+# CUDA 13 (recommended); use [cuda12] for CUDA 12 / V100. Do not install both.
+uv pip install "quantum-pecos[cuda13]"
 
 # For development with CUDA support:
 make build-cuda  # Build with CUDA

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -94,6 +94,10 @@ cuda12 = [
 # Dependency groups are defined at workspace root (pyproject.toml)
 # Package-specific groups can be added here if needed
 
+[tool.uv]
+# CUDA 12 and CUDA 13 use different, mutually exclusive cupy/cuquantum wheels.
+conflicts = [[{ extra = "cuda12" }, { extra = "cuda13" }]]
+
 [tool.uv.sources]
 pecos-rslib = { workspace = true }
 pecos-rslib-llvm = { workspace = true }

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -101,7 +101,6 @@ conflicts = [[{ extra = "cuda12" }, { extra = "cuda13" }]]
 [tool.uv.sources]
 pecos-rslib = { workspace = true }
 pecos-rslib-llvm = { workspace = true }
-pecos-rslib-cuda = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pecos"]

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -70,18 +70,26 @@ all = [
     "quantum-pecos[stim]",
 ]
 
-# CUDA dependencies. See docs/user-guide/cuda-setup.md for detailed installation instructions
-# Requires CUDA Toolkit 13 or 12 installed at system level first.
-# For Ubuntu/Pop!_OS: sudo apt install cuda-toolkit-13
-# These packages work with uv/pip once CUDA toolkit is installed.
-# Note: CUDA packages require Python 3.11+ due to cuquantum-python-cu13 requirements
-cuda = [
-    "pecos-rslib-cuda==0.8.0.dev8",
-    "cupy-cuda13x>=13.0.0; python_version >= '3.11'",  # Use cupy-cuda12x for CUDA 12
-    "cuquantum-python-cu13>=25.3.0; python_version >= '3.11'",  # Use cuquantum-python-cu12 for CUDA 12
+# CUDA dependencies for the Python cuStateVec / MPS backends. See
+# docs/user-guide/cuda-setup.md. Requires a system CUDA toolkit and a matching NVIDIA
+# driver. Pick the extra matching your CUDA major -- do NOT install both (mixing
+# cupy-cudaXXx wheels is unsupported). Python 3.11+ required.
+#   uv pip install -e .[cuda13]   # CUDA 13, Turing/CC 7.5+ GPUs (recommended)
+#   uv pip install -e .[cuda12]   # CUDA 12
+# V100/Volta (CC 7.0): cuStateVec dropped Volta at 25.09, so pin
+#   cuquantum-python-cu12>=25.3,<25.9 manually (see cuda-setup.md).
+# The Rust GPU backend (CudaStateVec/CudaStabilizer) is a separate install:
+#   pip install pecos-rslib-cuda
+cuda13 = [
+    "cupy-cuda13x>=13.0.0; python_version >= '3.11'",
+    "cuquantum-python-cu13>=25.9.0; python_version >= '3.11'",
     "pytket-cutensornet>=0.12.0; python_version >= '3.11'",
 ]
-# Install with: uv pip install -e .[cuda]
+cuda12 = [
+    "cupy-cuda12x>=13.0.0; python_version >= '3.11'",
+    "cuquantum-python-cu12>=25.3.0; python_version >= '3.11'",
+    "pytket-cutensornet>=0.12.0; python_version >= '3.11'",
+]
 
 # Dependency groups are defined at workspace root (pyproject.toml)
 # Package-specific groups can be added here if needed

--- a/python/quantum-pecos/src/pecos/simulators/__init__.py
+++ b/python/quantum-pecos/src/pecos/simulators/__init__.py
@@ -40,14 +40,11 @@ from pecos.simulators.sparsestab import (
 )
 from pecos.simulators.statevec import StateVec
 
-# Attempt to import optional cuquantum and cupy packages (Python cuQuantum bindings)
+# Python cuQuantum CuStateVec backend. Import always succeeds if the package is
+# present; CuPy / cuQuantum availability is checked at construction time (like the
+# Rust CudaStateVec below), so users get a clear error only when they use it.
 try:
-    import cupy
-    import cuquantum
-
-    from pecos.simulators.custatevec.state import (
-        CuStateVec,
-    )
+    from pecos.simulators.custatevec.state import CuStateVec
 except ImportError:
     CuStateVec = None
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -1,5 +1,7 @@
 """Compatibility helpers for cuQuantum import surface changes."""
 
+__all__ = ["cusv"]
+
 _BINDINGS_MISSING_NAMES = {"cuquantum.bindings", "cuquantum.bindings.custatevec"}
 _BINDINGS_MISSING_MEMBER = "cannot import name 'custatevec' from 'cuquantum.bindings'"
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -23,29 +23,32 @@ __all__ = [
 
 # Recommended install targets (kept in the messages so users get an actionable fix).
 _CU13 = "cuquantum-python-cu13>=25.9.0"  # CUDA 13 (Turing/CC 7.5+)
-_CU12 = "cuquantum-python-cu12>=25.3.0"  # CUDA 12 (V100/Volta: pin >=25.3,<25.9)
+_CU12 = "cuquantum-python-cu12>=25.3.0 (V100/Volta: >=25.3,<25.9)"  # CUDA 12
 
+# These optional imports must NEVER break ``import pecos`` -- a broken/partial CUDA
+# install can raise OSError/RuntimeError (not just ImportError) at import time, so we
+# catch broadly and defer to a loud, actionable error at construction.
 try:
     import cupy as cp
-except ImportError:
+except Exception:  # noqa: BLE001 -- optional dependency; failures defer to construction
     cp = None
 
 cusv = None
 ComputeType = None
 cudaDataType = None  # noqa: N816 -- mirrors cuQuantum's API name
-_cuquantum_error: ImportError | None = None
+_cuquantum_error: Exception | None = None
 _cuquantum_version: str | None = None
 try:
     from cuquantum import ComputeType, cudaDataType
     from cuquantum.bindings import custatevec as cusv
-except ImportError as exc:
+except Exception as exc:  # noqa: BLE001 -- optional dependency; failures defer to construction
     _cuquantum_error = exc
     try:
         import cuquantum
 
         _cuquantum_version = getattr(cuquantum, "__version__", "unknown")
-    except ImportError:
-        _cuquantum_version = None  # cuQuantum is not installed at all
+    except Exception:  # noqa: BLE001 -- optional dependency; failures defer to construction
+        _cuquantum_version = None  # cuQuantum is not installed (or its import is broken)
 
 
 def _cuquantum_reason() -> str | None:

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -1,20 +1,102 @@
-"""Compatibility helpers for cuQuantum import surface changes."""
+"""Optional CUDA-dependency availability for the Python cuStateVec backend.
 
-__all__ = ["cusv"]
+This is the single place the cuStateVec simulator imports CuPy and the cuQuantum
+bindings. It never raises at import time: when CuPy or a bindings-era cuQuantum
+(``cuquantum.bindings``, introduced in cuQuantum 25.03) is missing, the names are
+set to ``None`` and a classified, actionable reason is recorded. ``CuStateVec``
+stays importable so ``import pecos`` works without CUDA; the failure surfaces
+(loudly) only when the user constructs/uses ``CuStateVec``, via
+``require_custatevec()``.
+"""
 
-_BINDINGS_MISSING_NAMES = {"cuquantum.bindings", "cuquantum.bindings.custatevec"}
-_BINDINGS_MISSING_MEMBER = "cannot import name 'custatevec' from 'cuquantum.bindings'"
+from __future__ import annotations
 
+__all__ = [
+    "ComputeType",
+    "cp",
+    "cudaDataType",
+    "custatevec_available",
+    "custatevec_unavailable_reason",
+    "cusv",
+    "require_custatevec",
+]
 
-def _should_fallback_to_legacy(exc: ImportError) -> bool:
-    if isinstance(exc, ModuleNotFoundError):
-        return exc.name in _BINDINGS_MISSING_NAMES
-    return _BINDINGS_MISSING_MEMBER in str(exc)
-
+# Recommended install targets (kept in the messages so users get an actionable fix).
+_CU13 = "cuquantum-python-cu13>=25.9.0"  # CUDA 13 (Turing/CC 7.5+)
+_CU12 = "cuquantum-python-cu12>=25.3.0"  # CUDA 12 (V100/Volta: pin >=25.3,<25.9)
 
 try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+cusv = None
+ComputeType = None
+cudaDataType = None  # noqa: N816 -- mirrors cuQuantum's API name
+_cuquantum_error: ImportError | None = None
+_cuquantum_version: str | None = None
+try:
+    from cuquantum import ComputeType, cudaDataType
     from cuquantum.bindings import custatevec as cusv
 except ImportError as exc:
-    if not _should_fallback_to_legacy(exc):
-        raise
-    from cuquantum import custatevec as cusv
+    _cuquantum_error = exc
+    try:
+        import cuquantum
+
+        _cuquantum_version = getattr(cuquantum, "__version__", "unknown")
+    except ImportError:
+        _cuquantum_version = None  # cuQuantum is not installed at all
+
+
+def _cuquantum_reason() -> str | None:
+    """Classify why the bindings-era cuQuantum import failed (``None`` if it is fine)."""
+    if cusv is not None and ComputeType is not None and cudaDataType is not None:
+        return None
+    if _cuquantum_version is None:
+        return f"cuQuantum is not installed (install {_CU13} for CUDA 13 or {_CU12} for CUDA 12)"
+    err = _cuquantum_error
+    # Old (pre-25.03) cuQuantum: the bindings module/member is absent. Depending on the
+    # layout this is either ModuleNotFoundError (no cuquantum.bindings package) or a plain
+    # ImportError ("cannot import name 'custatevec' from 'cuquantum.bindings'", e.g. 24.11).
+    pre_bindings = (
+        isinstance(err, ModuleNotFoundError) and err.name in {"cuquantum.bindings", "cuquantum.bindings.custatevec"}
+    ) or (isinstance(err, ImportError) and "cannot import name 'custatevec'" in str(err))
+    if pre_bindings:
+        return (
+            f"cuQuantum {_cuquantum_version} predates the cuquantum.bindings API (requires >= 25.03); "
+            f"upgrade to {_CU13} (CUDA 13) or {_CU12} (CUDA 12)"
+        )
+    # Bindings-era cuQuantum is present but importing custatevec failed for another reason
+    # (e.g. a broken/partial install). Surface the original error rather than blaming version.
+    return f"cuQuantum {_cuquantum_version} is installed but importing custatevec failed: {err}"
+
+
+def _build_unavailable_reason() -> str | None:
+    parts = []
+    if cp is None:
+        parts.append("CuPy is not installed (install cupy-cuda13x for CUDA 13 or cupy-cuda12x for CUDA 12)")
+    cuquantum_reason = _cuquantum_reason()
+    if cuquantum_reason is not None:
+        parts.append(cuquantum_reason)
+    if not parts:
+        return None
+    return "CuStateVec requires CuPy and a bindings-era cuQuantum. " + "; ".join(parts) + "."
+
+
+_UNAVAILABLE_REASON = _build_unavailable_reason()
+
+
+def custatevec_available() -> bool:
+    """Whether the Python cuStateVec backend can be constructed in this environment."""
+    return _UNAVAILABLE_REASON is None
+
+
+def custatevec_unavailable_reason() -> str | None:
+    """Human-readable reason CuStateVec is unavailable, or ``None`` if it is available."""
+    return _UNAVAILABLE_REASON
+
+
+def require_custatevec() -> None:
+    """Raise an actionable error if the Python cuStateVec backend is unavailable."""
+    if _UNAVAILABLE_REASON is not None:
+        raise RuntimeError(_UNAVAILABLE_REASON)

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -1,8 +1,18 @@
 """Compatibility helpers for cuQuantum import surface changes."""
 
+_BINDINGS_MISSING_NAMES = {"cuquantum.bindings", "cuquantum.bindings.custatevec"}
+_BINDINGS_MISSING_MEMBER = "cannot import name 'custatevec' from 'cuquantum.bindings'"
+
+
+def _should_fallback_to_legacy(exc: ImportError) -> bool:
+    if isinstance(exc, ModuleNotFoundError):
+        return exc.name in _BINDINGS_MISSING_NAMES
+    return _BINDINGS_MISSING_MEMBER in str(exc)
+
+
 try:
     from cuquantum.bindings import custatevec as cusv
-except ModuleNotFoundError as exc:
-    if exc.name not in {"cuquantum.bindings", "cuquantum.bindings.custatevec"}:
+except ImportError as exc:
+    if not _should_fallback_to_legacy(exc):
         raise
     from cuquantum import custatevec as cusv

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -1,0 +1,6 @@
+"""Compatibility helpers for cuQuantum import surface changes."""
+
+try:
+    from cuquantum.bindings import custatevec as cusv
+except ImportError:
+    from cuquantum import custatevec as cusv

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -47,8 +47,12 @@ except Exception as exc:  # noqa: BLE001 -- optional dependency; failures defer 
         import cuquantum
 
         _cuquantum_version = getattr(cuquantum, "__version__", "unknown")
-    except Exception:  # noqa: BLE001 -- optional dependency; failures defer to construction
-        _cuquantum_version = None  # cuQuantum is not installed (or its import is broken)
+    except ModuleNotFoundError:
+        _cuquantum_version = None  # cuQuantum genuinely not installed
+    except Exception:  # noqa: BLE001 -- installed but its import is broken
+        # Present but broken: keep a non-None version so the reason surfaces the
+        # original error (from _cuquantum_error) instead of claiming "not installed".
+        _cuquantum_version = "unknown"
 
 
 def _cuquantum_reason() -> str | None:

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -28,10 +28,14 @@ _CU12 = "cuquantum-python-cu12>=25.3.0 (V100/Volta: >=25.3,<25.9)"  # CUDA 12
 # These optional imports must NEVER break ``import pecos`` -- a broken/partial CUDA
 # install can raise OSError/RuntimeError (not just ImportError) at import time, so we
 # catch broadly and defer to a loud, actionable error at construction.
+cp = None
+_cupy_error: Exception | None = None
 try:
     import cupy as cp
-except Exception:  # noqa: BLE001 -- optional dependency; failures defer to construction
-    cp = None
+except ModuleNotFoundError:
+    pass  # CuPy genuinely not installed
+except Exception as exc:  # noqa: BLE001 -- present but broken; defer to construction
+    _cupy_error = exc
 
 cusv = None
 ComputeType = None
@@ -78,10 +82,20 @@ def _cuquantum_reason() -> str | None:
     return f"cuQuantum {_cuquantum_version} is installed but importing custatevec failed: {err}"
 
 
+def _cupy_reason() -> str | None:
+    """Why CuPy is unavailable (``None`` if it imported fine)."""
+    if cp is not None:
+        return None
+    if _cupy_error is None:
+        return "CuPy is not installed (install cupy-cuda13x for CUDA 13 or cupy-cuda12x for CUDA 12)"
+    return f"CuPy is installed but failed to import: {_cupy_error}"
+
+
 def _build_unavailable_reason() -> str | None:
     parts = []
-    if cp is None:
-        parts.append("CuPy is not installed (install cupy-cuda13x for CUDA 13 or cupy-cuda12x for CUDA 12)")
+    cupy_reason = _cupy_reason()
+    if cupy_reason is not None:
+        parts.append(cupy_reason)
     cuquantum_reason = _cuquantum_reason()
     if cuquantum_reason is not None:
         parts.append(cuquantum_reason)

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/_cuquantum_compat.py
@@ -2,5 +2,7 @@
 
 try:
     from cuquantum.bindings import custatevec as cusv
-except ImportError:
+except ModuleNotFoundError as exc:
+    if exc.name not in {"cuquantum.bindings", "cuquantum.bindings.custatevec"}:
+        raise
     from cuquantum import custatevec as cusv

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_meas.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_meas.py
@@ -24,8 +24,8 @@ import pecos as pc
 if TYPE_CHECKING:
     from pecos.simulators.custatevec.state import CuStateVec
     from pecos.typing import SimulatorGateParams
-from cuquantum.bindings import custatevec as cusv
 
+from pecos.simulators.custatevec._cuquantum_compat import cusv
 
 def meas_z(state: CuStateVec, qubit: int, **_params: SimulatorGateParams) -> int:
     """Measure in the Z-basis, collapse and normalise.

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_meas.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_meas.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 from pecos.simulators.custatevec._cuquantum_compat import cusv
 
+
 def meas_z(state: CuStateVec, qubit: int, **_params: SimulatorGateParams) -> int:
     """Measure in the Z-basis, collapse and normalise.
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_one_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_one_qubit.py
@@ -20,14 +20,12 @@ from __future__ import annotations
 import cmath
 from typing import TYPE_CHECKING
 
-import cupy as cp
-
 if TYPE_CHECKING:
     from pecos.simulators.custatevec.state import CuStateVec
     from pecos.typing import SimulatorGateParams
 
 import pecos as pc
-from pecos.simulators.custatevec._cuquantum_compat import cusv
+from pecos.simulators.custatevec._cuquantum_compat import cp, cusv
 
 
 def _apply_one_qubit_matrix(state: CuStateVec, qubit: int, matrix: cp.ndarray) -> None:

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_one_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_one_qubit.py
@@ -25,9 +25,9 @@ import cupy as cp
 if TYPE_CHECKING:
     from pecos.simulators.custatevec.state import CuStateVec
     from pecos.typing import SimulatorGateParams
-from cuquantum.bindings import custatevec as cusv
 
 import pecos as pc
+from pecos.simulators.custatevec._cuquantum_compat import cusv
 
 
 def _apply_one_qubit_matrix(state: CuStateVec, qubit: int, matrix: cp.ndarray) -> None:

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_two_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_two_qubit.py
@@ -20,14 +20,12 @@ from __future__ import annotations
 import cmath
 from typing import TYPE_CHECKING
 
-import cupy as cp
-
 if TYPE_CHECKING:
     from pecos.simulators.custatevec.state import CuStateVec
     from pecos.typing import SimulatorGateParams
 
 import pecos as pc
-from pecos.simulators.custatevec._cuquantum_compat import cusv
+from pecos.simulators.custatevec._cuquantum_compat import cp, cusv
 from pecos.simulators.custatevec.gates_one_qubit import H
 
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/gates_two_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/gates_two_qubit.py
@@ -25,9 +25,9 @@ import cupy as cp
 if TYPE_CHECKING:
     from pecos.simulators.custatevec.state import CuStateVec
     from pecos.typing import SimulatorGateParams
-from cuquantum.bindings import custatevec as cusv
 
 import pecos as pc
+from pecos.simulators.custatevec._cuquantum_compat import cusv
 from pecos.simulators.custatevec.gates_one_qubit import H
 
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
@@ -21,8 +21,8 @@ from typing import TYPE_CHECKING
 
 import cupy as cp
 from cuquantum import ComputeType, cudaDataType
-from cuquantum.bindings import custatevec as cusv
 
+from pecos.simulators.custatevec._cuquantum_compat import cusv
 from pecos.simulators.custatevec import bindings
 from pecos.simulators.sim_class_types import StateVector
 

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING
 import cupy as cp
 from cuquantum import ComputeType, cudaDataType
 
-from pecos.simulators.custatevec._cuquantum_compat import cusv
 from pecos.simulators.custatevec import bindings
+from pecos.simulators.custatevec._cuquantum_compat import cusv
 from pecos.simulators.sim_class_types import StateVector
 
 if TYPE_CHECKING:

--- a/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
+++ b/python/quantum-pecos/src/pecos/simulators/custatevec/state.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import cupy as cp
-from cuquantum import ComputeType, cudaDataType
-
 from pecos.simulators.custatevec import bindings
-from pecos.simulators.custatevec._cuquantum_compat import cusv
+from pecos.simulators.custatevec._cuquantum_compat import (
+    ComputeType,
+    cp,
+    cudaDataType,
+    cusv,
+    require_custatevec,
+)
 from pecos.simulators.sim_class_types import StateVector
 
 if TYPE_CHECKING:
@@ -50,6 +53,9 @@ class CuStateVec(StateVector):
             num_qubits (int): Number of qubits being represented.
             _seed (int): Seed for randomness (kept for API compatibility, not used in GPU-based simulator).
         """
+        # Fail loudly (and only here, at construction) if CuPy / bindings-era cuQuantum
+        # is unavailable -- importing pecos must stay non-fatal without CUDA installed.
+        require_custatevec()
         self.libhandle = None
         if not isinstance(num_qubits, int):
             msg = "``num_qubits`` should be of type ``int``."

--- a/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
+++ b/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
@@ -33,6 +33,7 @@ from pecos.simulators import (
     CuStateVec,
     StateVec,
 )
+from pecos.simulators.custatevec._cuquantum_compat import custatevec_available
 from pecos.testing import assert_allclose
 
 str_to_sim = {
@@ -56,6 +57,10 @@ def check_dependencies(
         A function that creates a simulator instance with the given parameters.
     """
     if simulator not in str_to_sim or str_to_sim[simulator] is None:
+        pytest.skip(f"Requirements to test {simulator} are not met.")
+    # CuStateVec is always importable now; CUDA/CuPy availability is checked here
+    # (it raises a loud error at construction otherwise).
+    if simulator == "CuStateVec" and not custatevec_available():
         pytest.skip(f"Requirements to test {simulator} are not met.")
     sim_class = str_to_sim[simulator]
 

--- a/python/quantum-pecos/tests/pecos/integration/test_backend_seed_determinism.py
+++ b/python/quantum-pecos/tests/pecos/integration/test_backend_seed_determinism.py
@@ -249,13 +249,10 @@ def test_error_pattern_reproducibility(backend: str) -> None:
 # Optional backends (require special dependencies)
 def test_custatevec_determinism() -> None:
     """Test seed determinism for CuStateVec (GPU simulator)."""
-    try:
-        from pecos.simulators import CuStateVec
+    from pecos.simulators.custatevec._cuquantum_compat import custatevec_available
 
-        if CuStateVec is None:
-            pytest.skip("CuStateVec not available")
-    except ImportError:
-        pytest.skip("CuStateVec requires cuQuantum")
+    if not custatevec_available():
+        pytest.skip("CuStateVec unavailable (requires CuPy + cuQuantum >= 25.03)")
 
     seed = 7
     shots = 100

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -153,6 +153,9 @@ def test_import_nonfatal_on_broken_dependency(monkeypatch) -> None:
     compat = _load_module()  # must not raise despite the RuntimeError
 
     assert not compat.custatevec_available()
+    reason = compat.custatevec_unavailable_reason()
+    assert "CuPy is not installed" not in reason
+    assert "synthetic broken cupy install" in reason
     with pytest.raises(RuntimeError):
         compat.require_custatevec()
 

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -131,3 +131,27 @@ def test_loud_when_cupy_missing(monkeypatch) -> None:
     assert "CuPy" in compat.custatevec_unavailable_reason()
     with pytest.raises(RuntimeError, match="CuPy"):
         compat.require_custatevec()
+
+
+def test_import_nonfatal_on_broken_dependency(monkeypatch) -> None:
+    """A broken optional package (raising at import, not just absent) must not break
+    `import pecos`; it defers to a loud error at construction."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.split(".")[0] == "cupy":
+            msg = "synthetic broken cupy install"
+            raise RuntimeError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for mod in list(sys.modules):
+        if mod.split(".")[0] == "cupy":
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    _fake_cuquantum(monkeypatch, "26.3.2", with_custatevec=True)
+
+    compat = _load_module()  # must not raise despite the RuntimeError
+
+    assert not compat.custatevec_available()
+    with pytest.raises(RuntimeError):
+        compat.require_custatevec()

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -10,112 +10,124 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-"""Tests for cuQuantum import compatibility shims."""
+"""Tests for cuStateVec optional-dependency availability (``_cuquantum_compat``).
+
+The module must never raise at import time, and must report a classified,
+actionable reason (and raise it from ``require_custatevec``) when CuPy or a
+bindings-era cuQuantum (>= 25.03) is missing -- never a silent ``None`` or a
+legacy fallback. These tests mock the optional deps so they hold regardless of
+whether real CuPy/cuQuantum is installed in the test environment.
+"""
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import sys
 import types
 from pathlib import Path
 
+import pytest
+
 _MODULE_PATH = Path(__file__).resolve().parents[3] / "src/pecos/simulators/custatevec/_cuquantum_compat.py"
 
 
-def _load_module(module_name: str):
-    spec = importlib.util.spec_from_file_location(module_name, _MODULE_PATH)
+def _load_module():
+    """Execute a fresh copy of the compat module under the current mocks."""
+    spec = importlib.util.spec_from_file_location("_test_cuquantum_compat", _MODULE_PATH)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
     try:
         spec.loader.exec_module(module)
         return module
     finally:
-        sys.modules.pop(module_name, None)
+        sys.modules.pop("_test_cuquantum_compat", None)
 
 
-def test_prefers_bindings_custatevec(monkeypatch) -> None:
-    legacy = object()
-    bindings = object()
-
+def _fake_cuquantum(monkeypatch, version: str, *, with_custatevec: bool) -> None:
+    """Install a fake ``cuquantum`` package. Omitting ``custatevec`` reproduces the
+    pre-25.03 shape where ``cuquantum.bindings`` exists but lacks the member."""
     cuquantum = types.ModuleType("cuquantum")
     cuquantum.__path__ = []
-    cuquantum.custatevec = legacy
-    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
-    cuquantum_bindings.__path__ = []
-    cuquantum_bindings.custatevec = bindings
-
+    cuquantum.__version__ = version
+    cuquantum.ComputeType = object()
+    cuquantum.cudaDataType = object()
+    bindings = types.ModuleType("cuquantum.bindings")
+    bindings.__path__ = []
     monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
-    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
-
-    module = _load_module("_test_cuquantum_compat_bindings")
-
-    assert module.cusv is bindings
-
-
-def test_falls_back_to_legacy_custatevec(monkeypatch) -> None:
-    legacy = object()
-
-    cuquantum = types.ModuleType("cuquantum")
-    cuquantum.__path__ = []
-    cuquantum.custatevec = legacy
-
-    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
-    monkeypatch.delitem(sys.modules, "cuquantum.bindings", raising=False)
-
-    module = _load_module("_test_cuquantum_compat_legacy")
-
-    assert module.cusv is legacy
-
-
-def test_falls_back_to_legacy_custatevec_when_bindings_lacks_member(monkeypatch) -> None:
-    legacy = object()
-
-    cuquantum = types.ModuleType("cuquantum")
-    cuquantum.__path__ = []
-    cuquantum.custatevec = legacy
-    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
-    cuquantum_bindings.__path__ = []
-
-    original_import = __import__
-
-    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
-        if name == "cuquantum.bindings" and "custatevec" in fromlist:
-            msg = "cannot import name 'custatevec' from 'cuquantum.bindings'"
-            raise ImportError(msg)
-        return original_import(name, globals_, locals_, fromlist, level)
-
-    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
-    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
-    monkeypatch.setattr("builtins.__import__", fake_import)
-
-    module = _load_module("_test_cuquantum_compat_missing_member")
-
-    assert module.cusv is legacy
-
-
-def test_propagates_non_missing_module_errors(monkeypatch) -> None:
-    cuquantum = types.ModuleType("cuquantum")
-    cuquantum.__path__ = []  # mark as package for import machinery
-    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
-
-    original_import = __import__
-
-    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
-        if name == "cuquantum.bindings" and "custatevec" in fromlist:
-            msg = "libcustatevec.so: cannot open shared object file"
-            raise ModuleNotFoundError(msg, name="libcustatevec.so")
-        return original_import(name, globals_, locals_, fromlist, level)
-
-    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
-    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
-    monkeypatch.setattr("builtins.__import__", fake_import)
-
-    try:
-        _load_module("_test_cuquantum_compat_import_error")
-    except ModuleNotFoundError as exc:
-        assert exc.name == "libcustatevec.so"
+    monkeypatch.setitem(sys.modules, "cuquantum.bindings", bindings)
+    if with_custatevec:
+        custatevec = types.ModuleType("cuquantum.bindings.custatevec")
+        bindings.custatevec = custatevec
+        monkeypatch.setitem(sys.modules, "cuquantum.bindings.custatevec", custatevec)
     else:
-        msg = "expected ModuleNotFoundError to propagate"
-        raise AssertionError(msg)
+        # Evict any real submodule so `from cuquantum.bindings import custatevec` actually
+        # fails (the test env may have a modern cuQuantum installed).
+        monkeypatch.delitem(sys.modules, "cuquantum.bindings.custatevec", raising=False)
+
+
+def _block_imports(monkeypatch, *top_levels: str) -> None:
+    """Make the named top-level packages un-importable (overrides a real install)."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.split(".")[0] in top_levels:
+            msg = f"No module named {name!r}"
+            raise ModuleNotFoundError(msg, name=name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for mod in list(sys.modules):
+        if mod.split(".")[0] in top_levels:
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+
+def test_available_when_cupy_and_bindings_present(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cupy", types.ModuleType("cupy"))
+    _fake_cuquantum(monkeypatch, "26.3.2", with_custatevec=True)
+
+    compat = _load_module()
+
+    assert compat.custatevec_available()
+    assert compat.custatevec_unavailable_reason() is None
+    assert compat.cusv is sys.modules["cuquantum.bindings.custatevec"]
+    compat.require_custatevec()  # must not raise
+
+
+def test_loud_when_cuquantum_too_old(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cupy", types.ModuleType("cupy"))
+    _fake_cuquantum(monkeypatch, "24.11.0", with_custatevec=False)
+
+    compat = _load_module()
+
+    assert not compat.custatevec_available()
+    reason = compat.custatevec_unavailable_reason()
+    assert "25.03" in reason
+    assert "24.11.0" in reason
+    with pytest.raises(RuntimeError, match=r"25\.03"):
+        compat.require_custatevec()
+
+
+def test_loud_when_cuquantum_missing(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cupy", types.ModuleType("cupy"))
+    _block_imports(monkeypatch, "cuquantum")
+
+    compat = _load_module()
+
+    assert not compat.custatevec_available()
+    assert "not installed" in compat.custatevec_unavailable_reason()
+    with pytest.raises(RuntimeError):
+        compat.require_custatevec()
+
+
+def test_loud_when_cupy_missing(monkeypatch) -> None:
+    _block_imports(monkeypatch, "cupy")
+    _fake_cuquantum(monkeypatch, "26.3.2", with_custatevec=True)
+
+    compat = _load_module()
+
+    assert not compat.custatevec_available()
+    assert "CuPy" in compat.custatevec_unavailable_reason()
+    with pytest.raises(RuntimeError, match="CuPy"):
+        compat.require_custatevec()

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Tests for cuQuantum import compatibility shims."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+_MODULE_PATH = Path(__file__).resolve().parents[3] / "src/pecos/simulators/custatevec/_cuquantum_compat.py"
+
+
+def _load_module(module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prefers_bindings_custatevec(monkeypatch) -> None:
+    legacy = object()
+    bindings = object()
+
+    cuquantum = types.ModuleType("cuquantum")
+    cuquantum.custatevec = legacy
+    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
+    cuquantum_bindings.custatevec = bindings
+
+    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
+    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
+
+    module = _load_module("_test_cuquantum_compat_bindings")
+
+    assert module.cusv is bindings
+
+
+def test_falls_back_to_legacy_custatevec(monkeypatch) -> None:
+    legacy = object()
+
+    cuquantum = types.ModuleType("cuquantum")
+    cuquantum.custatevec = legacy
+
+    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
+    monkeypatch.delitem(sys.modules, "cuquantum.bindings", raising=False)
+
+    module = _load_module("_test_cuquantum_compat_legacy")
+
+    assert module.cusv is legacy

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -28,8 +28,11 @@ def _load_module(module_name: str):
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def test_prefers_bindings_custatevec(monkeypatch) -> None:
@@ -61,3 +64,27 @@ def test_falls_back_to_legacy_custatevec(monkeypatch) -> None:
     module = _load_module("_test_cuquantum_compat_legacy")
 
     assert module.cusv is legacy
+
+
+def test_propagates_non_missing_module_errors(monkeypatch) -> None:
+    cuquantum = types.ModuleType("cuquantum")
+    cuquantum.__path__ = []  # mark as package for import machinery
+    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
+
+    original_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "cuquantum.bindings" and "custatevec" in fromlist:
+            raise ModuleNotFoundError("libcustatevec.so: cannot open shared object file", name="libcustatevec.so")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
+    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    try:
+        _load_module("_test_cuquantum_compat_import_error")
+    except ModuleNotFoundError as exc:
+        assert exc.name == "libcustatevec.so"
+    else:
+        raise AssertionError("expected ModuleNotFoundError to propagate")

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -40,8 +40,10 @@ def test_prefers_bindings_custatevec(monkeypatch) -> None:
     bindings = object()
 
     cuquantum = types.ModuleType("cuquantum")
+    cuquantum.__path__ = []
     cuquantum.custatevec = legacy
     cuquantum_bindings = types.ModuleType("cuquantum.bindings")
+    cuquantum_bindings.__path__ = []
     cuquantum_bindings.custatevec = bindings
 
     monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
@@ -56,6 +58,7 @@ def test_falls_back_to_legacy_custatevec(monkeypatch) -> None:
     legacy = object()
 
     cuquantum = types.ModuleType("cuquantum")
+    cuquantum.__path__ = []
     cuquantum.custatevec = legacy
 
     monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -155,3 +155,27 @@ def test_import_nonfatal_on_broken_dependency(monkeypatch) -> None:
     assert not compat.custatevec_available()
     with pytest.raises(RuntimeError):
         compat.require_custatevec()
+
+
+def test_present_but_broken_cuquantum_surfaces_real_error(monkeypatch) -> None:
+    """A present-but-broken cuQuantum (import raises non-ImportError) reports the
+    original error, not a misleading 'not installed'."""
+    monkeypatch.setitem(sys.modules, "cupy", types.ModuleType("cupy"))
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.split(".")[0] == "cuquantum":
+            msg = "synthetic broken cuquantum: libcustatevec.so"
+            raise RuntimeError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for mod in list(sys.modules):
+        if mod.split(".")[0] == "cuquantum":
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    compat = _load_module()
+
+    reason = compat.custatevec_unavailable_reason()
+    assert "not installed" not in reason
+    assert "synthetic broken cuquantum" in reason

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -66,6 +66,31 @@ def test_falls_back_to_legacy_custatevec(monkeypatch) -> None:
     assert module.cusv is legacy
 
 
+def test_falls_back_to_legacy_custatevec_when_bindings_lacks_member(monkeypatch) -> None:
+    legacy = object()
+
+    cuquantum = types.ModuleType("cuquantum")
+    cuquantum.__path__ = []
+    cuquantum.custatevec = legacy
+    cuquantum_bindings = types.ModuleType("cuquantum.bindings")
+    cuquantum_bindings.__path__ = []
+
+    original_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "cuquantum.bindings" and "custatevec" in fromlist:
+            raise ImportError("cannot import name 'custatevec' from 'cuquantum.bindings'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
+    monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    module = _load_module("_test_cuquantum_compat_missing_member")
+
+    assert module.cusv is legacy
+
+
 def test_propagates_non_missing_module_errors(monkeypatch) -> None:
     cuquantum = types.ModuleType("cuquantum")
     cuquantum.__path__ = []  # mark as package for import machinery

--- a/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
+++ b/python/quantum-pecos/tests/pecos/unit/test_cuquantum_compat.py
@@ -19,13 +19,13 @@ import sys
 import types
 from pathlib import Path
 
-
 _MODULE_PATH = Path(__file__).resolve().parents[3] / "src/pecos/simulators/custatevec/_cuquantum_compat.py"
 
 
 def _load_module(module_name: str):
     spec = importlib.util.spec_from_file_location(module_name, _MODULE_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     try:
@@ -80,10 +80,11 @@ def test_falls_back_to_legacy_custatevec_when_bindings_lacks_member(monkeypatch)
 
     original_import = __import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
         if name == "cuquantum.bindings" and "custatevec" in fromlist:
-            raise ImportError("cannot import name 'custatevec' from 'cuquantum.bindings'")
-        return original_import(name, globals, locals, fromlist, level)
+            msg = "cannot import name 'custatevec' from 'cuquantum.bindings'"
+            raise ImportError(msg)
+        return original_import(name, globals_, locals_, fromlist, level)
 
     monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
     monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
@@ -101,10 +102,11 @@ def test_propagates_non_missing_module_errors(monkeypatch) -> None:
 
     original_import = __import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, globals_=None, locals_=None, fromlist=(), level=0):
         if name == "cuquantum.bindings" and "custatevec" in fromlist:
-            raise ModuleNotFoundError("libcustatevec.so: cannot open shared object file", name="libcustatevec.so")
-        return original_import(name, globals, locals, fromlist, level)
+            msg = "libcustatevec.so: cannot open shared object file"
+            raise ModuleNotFoundError(msg, name="libcustatevec.so")
+        return original_import(name, globals_, locals_, fromlist, level)
 
     monkeypatch.setitem(sys.modules, "cuquantum", cuquantum)
     monkeypatch.setitem(sys.modules, "cuquantum.bindings", cuquantum_bindings)
@@ -115,4 +117,5 @@ def test_propagates_non_missing_module_errors(monkeypatch) -> None:
     except ModuleNotFoundError as exc:
         assert exc.name == "libcustatevec.so"
     else:
-        raise AssertionError("expected ModuleNotFoundError to propagate")
+        msg = "expected ModuleNotFoundError to propagate"
+        raise AssertionError(msg)

--- a/scripts/setup_cuda.sh
+++ b/scripts/setup_cuda.sh
@@ -300,9 +300,11 @@ echo ""
 if [ "$CUDA_VERSION" = "13" ]; then
     CUPY_PACKAGE="cupy-cuda13x"
     CUQUANTUM_PACKAGE="cuquantum-python-cu13"
+    CUQUANTUM_FLOOR="25.9.0" # lowest cu13 wheel (bindings era)
 elif [ "$CUDA_VERSION" = "12" ]; then
     CUPY_PACKAGE="cupy-cuda12x"
     CUQUANTUM_PACKAGE="cuquantum-python-cu12"
+    CUQUANTUM_FLOOR="25.3.0" # bindings era (V100/Volta: pin >=25.3,<25.9)
 fi
 
 PYTKET_PACKAGE="pytket-cutensornet"
@@ -331,8 +333,8 @@ if check_python_package "$CUQUANTUM_PACKAGE"; then
     CUQUANTUM_VERSION=$(uv pip list 2>/dev/null | grep "^$CUQUANTUM_PACKAGE " | awk '{print $2}')
     print_status "$CUQUANTUM_PACKAGE $CUQUANTUM_VERSION is already installed"
 else
-    print_info "Installing $CUQUANTUM_PACKAGE>=25.3.0..."
-    run_cmd uv pip install "$CUQUANTUM_PACKAGE>=25.3.0"
+    print_info "Installing $CUQUANTUM_PACKAGE>=$CUQUANTUM_FLOOR..."
+    run_cmd uv pip install "$CUQUANTUM_PACKAGE>=$CUQUANTUM_FLOOR"
     print_status "$CUQUANTUM_PACKAGE installed successfully"
 fi
 

--- a/scripts/setup_cuda.sh
+++ b/scripts/setup_cuda.sh
@@ -363,7 +363,7 @@ QUANTUM_PECOS_DIR="$PECOS_ROOT/python/quantum-pecos"
 if [ -d "$QUANTUM_PECOS_DIR" ]; then
     print_info "Installing PECOS with CUDA extras..."
     cd "$QUANTUM_PECOS_DIR"
-    run_cmd uv pip install -e ".[cuda]"
+    run_cmd uv pip install -e ".[cuda${CUDA_VERSION}]"
     print_status "PECOS installed with CUDA support"
 else
     print_warning "quantum-pecos directory not found at $QUANTUM_PECOS_DIR"
@@ -440,7 +440,7 @@ print_info "Test 3: Testing cuQuantum..."
 CUQUANTUM_TEST=$(python3 -c "
 import sys
 try:
-    from cuquantum import custatevec
+    from cuquantum.bindings import custatevec
     print('cuStateVec imported successfully')
     sys.exit(0)
 except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,16 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
+conflicts = [[
+    { package = "pecos-workspace", extra = "cuda12" },
+    { package = "pecos-workspace", extra = "cuda13" },
+], [
+    { package = "pecos-workspace", group = "cuda12" },
+    { package = "pecos-workspace", group = "cuda13" },
+], [
+    { package = "quantum-pecos", extra = "cuda12" },
+    { package = "quantum-pecos", extra = "cuda13" },
+]]
 
 [manifest]
 members = [
@@ -39,9 +49,9 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -132,7 +142,7 @@ name = "async-lru"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
 wheels = [
@@ -194,8 +204,8 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
@@ -258,7 +268,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -454,7 +464,7 @@ name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
@@ -488,7 +498,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -561,7 +571,7 @@ resolution-markers = [
     "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -753,15 +763,58 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "12.9.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')",
+]
+dependencies = [
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/2e/b1b14be5884519917f9df4d9106d3e16575c19fa847d13a3f6e9d272b5cd/cuda_bindings-12.9.7-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a318075ef3277ca2fdd7df5d4bf671388696b4f2b65e2c4483f1853517692e3b", size = 7127291, upload-time = "2026-05-27T18:44:02.409Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1f/0809c53f694693d703c9efee0379875089db17ab50196845e08f6c686fd4/cuda_bindings-12.9.7-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f95debd2c54c5f087462668511bcb2b1295baa389cd6de9e768212f3cab2bbe2", size = 7657751, upload-time = "2026-05-27T18:44:04.365Z" },
+    { url = "https://files.pythonhosted.org/packages/19/26/fdd044c00e8f20f783bcb8b9cce0144fbefacf6ed23a64318dc1c4d8db99/cuda_bindings-12.9.7-cp310-cp310-win_amd64.whl", hash = "sha256:62e245bfa4830d473b038d0d7e5ab9cc1b377a09d2bc9afceaf5c5bab96ab1c6", size = 7190277, upload-time = "2026-05-27T18:44:06.044Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/f9d1095f90d2a4df24cfcafe7487fd9444c6dacb94e3722be6fedd8ac26c/cuda_bindings-12.9.7-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16043ef5b15ab88fe9954c5c2061b1d8007591b27f2c916331056de0ebc6187e", size = 7114834, upload-time = "2026-05-27T18:44:07.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8a/1251e1794b69865aacd5629936006b18ea0816a495de4ecea9a825556eb3/cuda_bindings-12.9.7-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6496a88d84b1209d6651b0370c19c26319e157c22f6d018bf9a358cd8049041", size = 7647147, upload-time = "2026-05-27T18:44:09.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/39/158392f6572e6e0def70ca39029c46b75e02ea4a43c63ff7320b3d180a29/cuda_bindings-12.9.7-cp311-cp311-win_amd64.whl", hash = "sha256:c392ffa5010ef4073bfd9dfff4d1ae56032094ed52d3d732014f8e41a73e6b59", size = 7218081, upload-time = "2026-05-27T18:44:11.104Z" },
+    { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/e3c6e58ece26a053419ba0a18444b5443cfc64451bbf37f84e8143b8bdca/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c7ef48c5e13ae90f3b2ecfb72f8e99ac43c8f4c43e67e1325b8aae331453687", size = 7611059, upload-time = "2026-05-27T18:44:15.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/afaa3de4d491a55af8961081e0b69c08d51bfbe471c359a7bddb4a28ca41/cuda_bindings-12.9.7-cp312-cp312-win_amd64.whl", hash = "sha256:3c089aaf4f5f570ec50244c68f5a2b00a2c9a8e01e04219fd2e36e340be0d88b", size = 7400841, upload-time = "2026-05-27T18:44:17.164Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7b/f1575e41e1a17dc2f2a408b2e8e864c9324e41e3e23f6401e5efc54c152a/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:266379e4942051f544a8e7ea1a30ead8d7e8199b6b30fcdc8917cae2bf614e61", size = 6978549, upload-time = "2026-05-27T18:44:18.839Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dc/62d62eb4f91eb721bcf46da51b13e9872ccd8fa7e60eb8ba7b7baeac72c6/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59cf4a37b0d662ba15037c9ceebe1a306ebf2c01a8235a09be13cd07094fdb74", size = 7457675, upload-time = "2026-05-27T18:44:20.637Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/753fe88151001d0dc23f56a8e119fe06b991b0d1a885fa02f9852b12f523/cuda_bindings-12.9.7-cp313-cp313-win_amd64.whl", hash = "sha256:5bd89dcb78475a6d8a4620ea94b74edf0cbbeacee6d1622d8f94452c1e8d3f15", size = 7360097, upload-time = "2026-05-27T18:44:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/77/94d9b85f26add6fe9c9cb7c4ec3b96bc598f7ea5cfbd7490cc0a36adf5be/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbcd4801954eb3508f4dc2fa0d0c8eb93eb3f45326fd61be2731418c371e7a0", size = 6870886, upload-time = "2026-05-27T18:44:24.164Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/3ec34b569e1b990b11276feba306bf8f446656cc38e8ed0f49b5facfeffa/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3747ea132642416786a8e31bf229032df3a7856911ae5426a7be53d032df183d", size = 7345663, upload-time = "2026-05-27T18:44:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c8/d79a20ba396e7ab2dfdd4b72b62356972b25b88aee2ded49a70c797ddea1/cuda_bindings-12.9.7-cp313-cp313t-win_amd64.whl", hash = "sha256:64f7ade7a7a3b69001489753acc21706d9dbda32db8deb68a767a0a0aab30b68", size = 7780136, upload-time = "2026-05-27T18:44:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e4/075052d42872cf8162da53f14447a4b8abc004c3750e4b724ee502428da0/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:775960ac9e530717f3b48e165cc6f68684fa9a4141764fd923e4c1a9820acc73", size = 7060090, upload-time = "2026-05-27T18:44:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/cd/3289c810a4d45e5364a3387a74b4c9b6f6f57ee96ae0e5b537cc61dec242/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c47ec1a7a441d91aab32339951df7a1be53451121a12c094bba51467717a35a", size = 7504419, upload-time = "2026-05-27T18:44:31.992Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a0/c429fdcfa5aae181415504c5085ea5944f782b417dd16a7f2a14be0da80d/cuda_bindings-12.9.7-cp314-cp314-win_amd64.whl", hash = "sha256:1e2a4f2ec5b67408c04bb4fbed45d214b66de1f00ee2e972865cacb8708d4e1e", size = 7493876, upload-time = "2026-05-27T18:44:33.618Z" },
+    { url = "https://files.pythonhosted.org/packages/11/43/472a6281c3d94e71687e27c657a8f60718d3579b4d94c41deea503165f8a/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a833d399b31071fab4cf3de2929840ae462dc4848116eeff033d09219e7116", size = 6899146, upload-time = "2026-05-27T18:44:35.556Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/13/10c1d0b32a9da65142d213e0733d748457fb3fd066aee4317335266f15c6/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11aeafa2b33995f890086b3fb0f062075176d956e9b6a6fe1a699dddc413f6ad", size = 7369087, upload-time = "2026-05-27T18:44:37.359Z" },
+    { url = "https://files.pythonhosted.org/packages/33/10/c71a07cd2a1d4db119bada1848b4752a874ccfe4927d419bfdd05f250920/cuda_bindings-12.9.7-cp314-cp314t-win_amd64.whl", hash = "sha256:ece8dfbc22e6de96a26940ab9887eb3cfe1fc1bc3966169391cdb866bb82bb64", size = 8208198, upload-time = "2026-05-27T18:44:39.053Z" },
 ]
 
 [[package]]
 name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')",
+]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -789,8 +842,8 @@ name = "cuda-core"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/b2/c9bb66a400baae14d5cd25cca9e7cf69f9328543edb37efa6e7ba1088cc7/cuda_core-0.7.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8feaf99613cd1d025b26374b1c92ff72d9e8078a3236fc78aa550ff3b0028e3", size = 28962792, upload-time = "2026-04-08T17:03:00.541Z" },
@@ -826,8 +879,8 @@ name = "cudensitymat-cu12"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cutensor-cu12", marker = "python_full_version >= '3.11'" },
-    { name = "cutensornet-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "cutensor-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cutensornet-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/17/2af6a937b4cec0d4d0f52b0118841a81d9b3a43c945a34cb711fafecaca9/cudensitymat_cu12-0.5.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:378a90436c3ee13bd55b45d9ced390dd68008e4e722e4c6713432a9b7ef8be88", size = 18701564, upload-time = "2026-04-30T23:56:01.181Z" },
@@ -839,12 +892,21 @@ name = "cudensitymat-cu13"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cutensor-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "cutensornet-cu13", marker = "python_full_version >= '3.11'" },
+    { name = "cutensor-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cutensornet-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/35/d315cddc6b5acf7f275b2d306b4f9cd197dc35deaed4719d9fc86850ec9f/cudensitymat_cu13-0.5.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:ec3c22e98e472622eac7d3701572c38a859e992f5719ef38d818e0c9da788477", size = 15808498, upload-time = "2026-04-30T23:57:57.021Z" },
     { url = "https://files.pythonhosted.org/packages/fd/67/8ccb65ea1233301bbfdff67f2120df370bc16b716b8b3d0ec4a61a1ec50e/cudensitymat_cu13-0.5.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:74b28ad826316707bf53ff8f533de9bb9802d6a786e24221d80cda688dce03a8", size = 15836100, upload-time = "2026-04-30T23:52:43.267Z" },
+]
+
+[[package]]
+name = "cupauliprop-cu12"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b4/5cb65541e23c3c97a93a807bb4577b36c4639638aa3c37549295d85a8fad/cupauliprop_cu12-0.3.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8414a4fb87d5c8066e8e7d82c37dfb3295bfec0552715abc1ceffe743c134d48", size = 62583255, upload-time = "2026-04-30T23:55:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0f/937f0761d679c0383ee353d88974fc5dc4e874dcd51624d3da838a8dc1ee/cupauliprop_cu12-0.3.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:878abf853681fe2fb02fcc1a8fbeef19d1999642dbc6294228316b33a5bdb662", size = 62698714, upload-time = "2026-04-30T23:51:02.483Z" },
 ]
 
 [[package]]
@@ -861,8 +923,8 @@ name = "cupy-cuda12x"
 version = "14.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/18/8ec57a901a11d6955f90e1fbf3e04c8f26721066c99dfa25276e3e3b1f1d/cupy_cuda12x-14.1.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:909c4b8ac05eee43edfbe791522ee5d593e3504be7bd5c20e2de12b050db2a26", size = 143787561, upload-time = "2026-06-01T04:51:46.125Z" },
@@ -889,8 +951,8 @@ name = "cupy-cuda13x"
 version = "14.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/9d/5f271070c17aac8e30b140b5ec9c129983f57b49899a8fc34c3f114d09f7/cupy_cuda13x-14.0.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4d6d5ae87eb1a6eb55f5a3d54c606f5263c54319c3d85afe4627cb7fff403050", size = 72993295, upload-time = "2026-02-20T10:23:48.346Z" },
@@ -912,22 +974,26 @@ wheels = [
 
 [[package]]
 name = "cuquantum-python-cu12"
-version = "25.6.0"
+version = "26.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cudensitymat-cu12", marker = "python_full_version >= '3.11'" },
-    { name = "cupy-cuda12x", marker = "python_full_version >= '3.11'" },
-    { name = "custatevec-cu12", marker = "python_full_version >= '3.11'" },
-    { name = "cutensornet-cu12", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cuda-bindings", version = "12.9.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cudensitymat-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cupauliprop-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cupy-cuda12x", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "custabilizer-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "custatevec-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cutensornet-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "nvmath-python", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/6e/2b69770e4c695b16427cc94611245524a534c1f000240cdc668801c2ef3c/cuquantum_python_cu12-25.6.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:88db8cddee05fbe7911b2b028acd3ce7697ddb0781c5501313321a5964401552", size = 6020575, upload-time = "2025-07-03T22:16:42.346Z" },
-    { url = "https://files.pythonhosted.org/packages/24/4f/60a55efef5c874717f3bd50d13df08ff80b0ee6bddbb97559cb446129824/cuquantum_python_cu12-25.6.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:506aeeba5f9a4959558bd2b220d7af00da2775ddddc86d943a5dc862ee55a62e", size = 5959171, upload-time = "2025-07-03T22:16:43.86Z" },
-    { url = "https://files.pythonhosted.org/packages/44/2c/6fbae50358b3d0cae60ca9914f63a4dc6d7ff357ab4a1c192d9bb2624070/cuquantum_python_cu12-25.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:4c8cbfdea0f537a911778aa2cf640f967df2af9a7ae5a36beb55536325a61164", size = 6008861, upload-time = "2025-07-03T22:16:45.47Z" },
-    { url = "https://files.pythonhosted.org/packages/45/40/574cc9392ffb6c49049d3842ec758fd6a4872e3c5abf90768de99cad6971/cuquantum_python_cu12-25.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:c1d30b23af06e5adafc89b71d2857a945b14244dd102e0d15173406fcd95d2d6", size = 5977444, upload-time = "2025-07-03T22:16:46.85Z" },
-    { url = "https://files.pythonhosted.org/packages/12/8e/c77bbdac04f3b1e3c267b44e4f4efd4e1d96ffd9fb9215e12de849ead389/cuquantum_python_cu12-25.6.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:6747b389218953189cb57df6787fcd30d249e001be9848b0e54c56a2820e9e21", size = 6017332, upload-time = "2025-07-03T22:16:48.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/a1da24554956c86409c0ea86acf3ad917bd2e94e81da00e0d72888f31534/cuquantum_python_cu12-25.6.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:5947b58a6a998ff98e810b688653a0326e6e569de67c9d83669dabe20632a33c", size = 5969217, upload-time = "2025-07-03T22:16:50.112Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6e/054c440bc9661b77df3f04e55d96a44233d7707b3b0bbc39cf168b8540bc/cuquantum_python_cu12-26.3.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:21b0bcd74e9859f9269b0533a9ddedbcf887a0d4c5de1f1196027ddee1728bca", size = 8779375, upload-time = "2026-05-01T00:01:10.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d9/3337145159e2284d3b710ff9da115688ba1092fdad77201c5672653118fd/cuquantum_python_cu12-26.3.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:b31c89da39e1d1752ff9d2bf656ad3bd2c2c9537202fd931fdc779f9432cec42", size = 8707048, upload-time = "2026-04-30T23:58:10.894Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/27/d5caa3749ce528c198a1677fca4f46db34c24b38b56efe944d16ed59c20f/cuquantum_python_cu12-26.3.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:5ebbb7a8010056ace3cac940a2779d7a0d26f12b4314cead546e8ba09b984c6c", size = 8810948, upload-time = "2026-05-01T00:00:29.452Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0d/3eaee3d3fbacc64234405de38623ceb5bea0ab46f66f541d5d1c75592434/cuquantum_python_cu12-26.3.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:5a153785c8be5ae0385cab950152b280135b1c92c095c07bd3d15e9e58176888", size = 8766148, upload-time = "2026-04-30T23:57:48.303Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/65/0276f84eaf4a46155b2ef2e7fa4449563f0a6d8d568af14bb49b826e4c69/cuquantum_python_cu12-26.3.2-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:f621190d0a8711889e5a5caf57a01e7692403f78df980706ed1f4d1e46c82b84", size = 8798413, upload-time = "2026-04-30T23:59:41.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a3/238b69899c86217c9007b0f245f6e7e104138e63155b19e5a49f8dd24148/cuquantum_python_cu12-26.3.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:94a77d9cae6b8c4693d9a7e978fc61fea5f3971d7e0687e87fa40b84d23fa1dd", size = 8724990, upload-time = "2026-04-30T23:57:29.297Z" },
 ]
 
 [[package]]
@@ -935,15 +1001,15 @@ name = "cuquantum-python-cu13"
 version = "26.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version >= '3.11'" },
-    { name = "cudensitymat-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "cupauliprop-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "cupy-cuda13x", marker = "python_full_version >= '3.11'" },
-    { name = "custabilizer-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "custatevec-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "cutensornet-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvmath-python", marker = "python_full_version >= '3.11'" },
+    { name = "cuda-bindings", version = "13.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cudensitymat-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cupauliprop-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cupy-cuda13x", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "custabilizer-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "custatevec-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cutensornet-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "nvmath-python", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/bd/db7e127084c5d8b60970114a138e65bf29c822189103e3bf655598ef2838/cuquantum_python_cu13-26.3.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d6eda6360c0e06b4211866c5dacbe2fc70d822b46276dff2b1c428b908161db2", size = 8779331, upload-time = "2026-05-01T00:03:21.764Z" },
@@ -952,6 +1018,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/0c/e24ead4771d061e2f0366be96e9e300f9cb992dce7c3e23f6d3755c02606/cuquantum_python_cu13-26.3.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:c7017f7a53034559295007a8e7cf8f1fbf74a74ebb3a1318e074154de2c310d9", size = 8766068, upload-time = "2026-04-30T23:58:48.49Z" },
     { url = "https://files.pythonhosted.org/packages/e3/0a/47fd861a7673ca6d95029008d280da5bfdbdab31fcedac1f646a8aea24ef/cuquantum_python_cu13-26.3.2-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:c17c8b33387ca36542fa0eca74c794975d43eb6cae90ffe52484dc8ba2d2e927", size = 8798288, upload-time = "2026-05-01T00:01:53.533Z" },
     { url = "https://files.pythonhosted.org/packages/ad/1a/7469ab32a47bcd097ed21d6aca1137bb0fe7bca7020cbf50d99b4daf082d/cuquantum_python_cu13-26.3.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:b2840f6edf73eae4600c380d9f617cf4c8ff32ec12ce398f4e991c4a811a0d92", size = 8724906, upload-time = "2026-04-30T23:58:29.653Z" },
+]
+
+[[package]]
+name = "custabilizer-cu12"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/c0/89314e470f8364ce04c8c00ab5e4d66098c6f65d3f219656b8f26833e226/custabilizer_cu12-0.3.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a3e4522d0901b8104774c2f96a1117fe9ab1b8ccec3a3a59576f9fa23a408666", size = 7087321, upload-time = "2026-03-30T17:36:22.158Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/c5ca3baef11ced94a6f65aad13a51dafc9e9e5eab7a361a885e66c07e032/custabilizer_cu12-0.3.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:00733d0403541e3696ffe0ca82126e982cb48a21766e343c0f1c4647de793789", size = 7073337, upload-time = "2026-03-30T19:58:58.886Z" },
 ]
 
 [[package]]
@@ -1006,7 +1081,7 @@ name = "cutensornet-cu12"
 version = "2.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cutensor-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "cutensor-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/21/97630117bc5fd72196915f133bd5de3322cccd893d1ee0a468fe8ae105fd/cutensornet_cu12-2.12.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:e17cb372d7aa21e8998d6623cfa7d2f94dfd5f127eb520e50ebe91768e0e6005", size = 3099322, upload-time = "2026-04-30T23:31:29.515Z" },
@@ -1018,7 +1093,7 @@ name = "cutensornet-cu13"
 version = "2.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cutensor-cu13", marker = "python_full_version >= '3.11'" },
+    { name = "cutensor-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/a9/59db9aa28e7b54ff7b7f134dd5708c8b5a4ed3b7f5ecb54247092b30019b/cutensornet_cu13-2.12.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:f0e956fcbbb96eba95df426a6747c2078ee5538cdc18501e77efc2e031b5e0be", size = 2911602, upload-time = "2026-04-30T23:32:22.669Z" },
@@ -1095,7 +1170,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1231,8 +1306,8 @@ version = "0.21.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "guppylang-internals" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "selene-hugr-qis-compiler" },
     { name = "selene-sim" },
     { name = "tqdm" },
@@ -1345,7 +1420,7 @@ name = "hypothesis"
 version = "6.152.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "sortedcontainers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
@@ -1385,11 +1460,11 @@ name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -1414,17 +1489,17 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version >= '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version >= '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version >= '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version >= '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform == 'win32' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1442,18 +1517,18 @@ resolution-markers = [
     "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform == 'win32' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'emscripten' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform == 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "psutil", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -1465,7 +1540,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1478,8 +1553,8 @@ version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comm" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "jupyterlab-widgets" },
     { name = "traitlets" },
     { name = "widgetsnbextension" },
@@ -1622,8 +1697,8 @@ version = "6.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipykernel" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "prompt-toolkit" },
@@ -1694,10 +1769,10 @@ dependencies = [
     { name = "jupyter-server-terminals" },
     { name = "nbconvert" },
     { name = "nbformat" },
-    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "overrides", marker = "python_full_version < '3.12' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -1715,7 +1790,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -1739,7 +1814,7 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "packaging" },
     { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
@@ -1991,9 +2066,25 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/8d/5baf1cef7f9c084fb35a8afbde88074f0d6a727bc63ef764fe0e7543ba40/llvmlite-0.45.1.tar.gz", hash = "sha256:09430bb9d0bb58fc45a45a57c7eae912850bedc095cd0810a57de109c69e1c32", size = 185600, upload-time = "2025-10-01T17:59:52.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/6d/585c84ddd9d2a539a3c3487792b3cf3f988e28ec4fa281bf8b0e055e1166/llvmlite-0.45.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:1b1af0c910af0978aa55fa4f60bbb3e9f39b41e97c2a6d94d199897be62ba07a", size = 43043523, upload-time = "2025-10-01T18:02:58.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/34/992bd12d3ff245e0801bcf6013961daa8c19c9b9c2e61cb4b8bce94566f9/llvmlite-0.45.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02a164db2d79088bbd6e0d9633b4fe4021d6379d7e4ac7cc85ed5f44b06a30c5", size = 37253122, upload-time = "2025-10-01T18:03:55.159Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7b/6d7585998a5991fa74dc925aae57913ba8c7c2efff909de9d34cc1cd3c27/llvmlite-0.45.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2d47f34e4029e6df3395de34cc1c66440a8d72712993a6e6168db228686711b", size = 56288210, upload-time = "2025-10-01T18:00:41.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e2/a4abea058633bfc82eb08fd69ce242c118fdb9b0abad1fdcbe0bc6aedab5/llvmlite-0.45.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7319e5f9f90720578a7f56fbc805bdfb4bc071b507c7611f170d631c3c0f1e0", size = 55140958, upload-time = "2025-10-01T18:01:55.694Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c0/233468e96ed287b953239c3b24b1d69df47c6ba9262bfdca98eda7e83a04/llvmlite-0.45.1-cp310-cp310-win_amd64.whl", hash = "sha256:4edb62e685867799e336723cb9787ec6598d51d0b1ed9af0f38e692aa757e898", size = 38132232, upload-time = "2025-10-01T18:04:41.538Z" },
     { url = "https://files.pythonhosted.org/packages/04/ad/9bdc87b2eb34642c1cfe6bcb4f5db64c21f91f26b010f263e7467e7536a3/llvmlite-0.45.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:60f92868d5d3af30b4239b50e1717cb4e4e54f6ac1c361a27903b318d0f07f42", size = 43043526, upload-time = "2025-10-01T18:03:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ea/c25c6382f452a943b4082da5e8c1665ce29a62884e2ec80608533e8e82d5/llvmlite-0.45.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98baab513e19beb210f1ef39066288784839a44cd504e24fff5d17f1b3cf0860", size = 37253118, upload-time = "2025-10-01T18:04:06.783Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/af/85fc237de98b181dbbe8647324331238d6c52a3554327ccdc83ced28efba/llvmlite-0.45.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3adc2355694d6a6fbcc024d59bb756677e7de506037c878022d7b877e7613a36", size = 56288209, upload-time = "2025-10-01T18:01:00.168Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/df/3daf95302ff49beff4230065e3178cd40e71294968e8d55baf4a9e560814/llvmlite-0.45.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f3377a6db40f563058c9515dedcc8a3e562d8693a106a28f2ddccf2c8fcf6ca", size = 55140958, upload-time = "2025-10-01T18:02:11.199Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/56/4c0d503fe03bac820ecdeb14590cf9a248e120f483bcd5c009f2534f23f0/llvmlite-0.45.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9c272682d91e0d57f2a76c6d9ebdfccc603a01828cdbe3d15273bdca0c3363a", size = 38132232, upload-time = "2025-10-01T18:04:52.181Z" },
     { url = "https://files.pythonhosted.org/packages/e2/7c/82cbd5c656e8991bcc110c69d05913be2229302a92acb96109e166ae31fb/llvmlite-0.45.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:28e763aba92fe9c72296911e040231d486447c01d4f90027c8e893d89d49b20e", size = 43043524, upload-time = "2025-10-01T18:03:30.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/bc/5314005bb2c7ee9f33102c6456c18cc81745d7055155d1218f1624463774/llvmlite-0.45.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1a53f4b74ee9fd30cb3d27d904dadece67a7575198bd80e687ee76474620735f", size = 37253123, upload-time = "2025-10-01T18:04:18.177Z" },
+    { url = "https://files.pythonhosted.org/packages/96/76/0f7154952f037cb320b83e1c952ec4a19d5d689cf7d27cb8a26887d7bbc1/llvmlite-0.45.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b3796b1b1e1c14dcae34285d2f4ea488402fbd2c400ccf7137603ca3800864f", size = 56288211, upload-time = "2025-10-01T18:01:24.079Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b1/0b581942be2683ceb6862d558979e87387e14ad65a1e4db0e7dd671fa315/llvmlite-0.45.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:779e2f2ceefef0f4368548685f0b4adde34e5f4b457e90391f570a10b348d433", size = 55140958, upload-time = "2025-10-01T18:02:30.482Z" },
+    { url = "https://files.pythonhosted.org/packages/33/94/9ba4ebcf4d541a325fd8098ddc073b663af75cc8b065b6059848f7d4dce7/llvmlite-0.45.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e6c9949baf25d9aa9cd7cf0f6d011b9ca660dd17f5ba2b23bdbdb77cc86b116", size = 38132231, upload-time = "2025-10-01T18:05:03.664Z" },
     { url = "https://files.pythonhosted.org/packages/1d/e2/c185bb7e88514d5025f93c6c4092f6120c6cea8fe938974ec9860fb03bbb/llvmlite-0.45.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:d9ea9e6f17569a4253515cc01dade70aba536476e3d750b2e18d81d7e670eb15", size = 43043524, upload-time = "2025-10-01T18:03:43.249Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/b5437b9ecb2064e89ccf67dccae0d02cd38911705112dd0dcbfa9cd9a9de/llvmlite-0.45.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c9f3cadee1630ce4ac18ea38adebf2a4f57a89bd2740ce83746876797f6e0bfb", size = 37253121, upload-time = "2025-10-01T18:04:30.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/ad1a907c0173a90dd4df7228f24a3ec61058bc1a9ff8a0caec20a0cc622e/llvmlite-0.45.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:57c48bf2e1083eedbc9406fb83c4e6483017879714916fe8be8a72a9672c995a", size = 56288210, upload-time = "2025-10-01T18:01:40.26Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d8/c99c8ac7a326e9735401ead3116f7685a7ec652691aeb2615aa732b1fc4a/llvmlite-0.45.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3aa3dfceda4219ae39cf18806c60eeb518c1680ff834b8b311bd784160b9ce40", size = 55140957, upload-time = "2025-10-01T18:02:46.244Z" },
+    { url = "https://files.pythonhosted.org/packages/09/56/ed35668130e32dbfad2eb37356793b0a95f23494ab5be7d9bf5cb75850ee/llvmlite-0.45.1-cp313-cp313-win_amd64.whl", hash = "sha256:080e6f8d0778a8239cd47686d402cb66eb165e421efa9391366a9b7e5810a38b", size = 38132232, upload-time = "2025-10-01T18:05:14.477Z" },
 ]
 
 [[package]]
@@ -2161,13 +2252,13 @@ name = "matplotlib"
 version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -2248,7 +2339,7 @@ name = "maturin"
 version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/1c/612d23d33ec21b9ae7ece7b3f0dd5f9dfd57b4009e9d2938165869ebd6ae/maturin-1.13.3.tar.gz", hash = "sha256:771e1e9e71a278e56db01552e0d1acfd1464259f9575b6e72842f893cd299079", size = 357934, upload-time = "2026-05-11T07:43:39.027Z" }
 wheels = [
@@ -2290,7 +2381,7 @@ name = "mistune"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
@@ -2303,7 +2394,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2410,7 +2501,7 @@ dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
 wheels = [
@@ -2720,11 +2811,12 @@ name = "nvmath-python"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version >= '3.11'" },
-    { name = "cuda-core", marker = "python_full_version >= '3.11'" },
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pywin32", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "cuda-bindings", version = "12.9.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cuda-bindings", version = "13.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cuda-core", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pywin32", marker = "(python_full_version >= '3.11' and sys_platform == 'win32' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and sys_platform == 'win32' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'win32' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/a1/3571648e040c5c3bdc96d8758bf879247bbf1bbd69e55546990feed3fbed/nvmath_python-0.9.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b9bd878f6da62f1f43394f234dc364d3007cab55543f7546821832e55d7a7b8e", size = 4313451, upload-time = "2026-04-22T02:28:45.816Z" },
@@ -2821,13 +2913,13 @@ source = { editable = "python/pecos-rslib" }
 
 [package.dev-dependencies]
 dev = [
-    { name = "patchelf", marker = "sys_platform != 'win32'" },
+    { name = "patchelf", marker = "sys_platform != 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 numpy-compat = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 test = [
     { name = "pytest" },
@@ -3007,18 +3099,20 @@ source = { virtual = "." }
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "quantum-pecos", extra = ["cuda12"] },
+    { name = "quantum-pecos", extra = ["cuda12"], marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 cuda13 = [
-    { name = "quantum-pecos", extra = ["cuda13"] },
+    { name = "quantum-pecos", extra = ["cuda13"], marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 
 [package.dev-dependencies]
 cuda12 = [
-    { name = "quantum-pecos", extra = ["cuda12"] },
+    { name = "quantum-pecos", marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12')" },
+    { name = "quantum-pecos", extra = ["cuda12"], marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12') or (extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12') or (extra == 'extra-15-pecos-workspace-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 cuda13 = [
-    { name = "quantum-pecos", extra = ["cuda13"] },
+    { name = "quantum-pecos", marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "quantum-pecos", extra = ["cuda13"], marker = "(extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 dev = [
     { name = "black" },
@@ -3027,21 +3121,21 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "patchelf", marker = "sys_platform != 'win32'" },
+    { name = "patchelf", marker = "sys_platform != 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "pre-commit" },
     { name = "ruff" },
     { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 examples = [
     { name = "jupyter" },
     { name = "polars" },
 ]
 numpy-compat = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 test = [
     { name = "hypothesis" },
@@ -3571,13 +3665,13 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -3652,13 +3746,13 @@ dependencies = [
     { name = "graphviz" },
     { name = "jinja2" },
     { name = "lark" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "qwasm" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "sympy" },
     { name = "typing-extensions" },
 ]
@@ -3685,8 +3779,8 @@ name = "pytket-cutensornet"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pytket", marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pytket", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/fd/2159cd0f1aa74854926b381a512928bd2af79d430f989f4e781e24edd367/pytket_cutensornet-0.12.1-py3-none-any.whl", hash = "sha256:3376c0b737f8713f9e34d4b9e461aeff4c8e46a47b6214c63f9d0e62a277cbbb", size = 90007, upload-time = "2026-01-07T15:16:46.961Z" },
@@ -3856,7 +3950,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -3929,7 +4023,7 @@ name = "pyzstd"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/82/7bcafbf06ee83a66990ce5badbb8f4dc32184346bab20de7e468b1a2f6ec/pyzstd-0.18.0.tar.gz", hash = "sha256:81b6851ab1ca2e5f2c709e896a1362e3065a64f271f43db77fb7d5e4a78e9861", size = 806048, upload-time = "2025-10-05T08:19:47.994Z" }
 wheels = [
@@ -4029,8 +4123,8 @@ source = { editable = "python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },
     { name = "hugr" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "pecos-rslib" },
     { name = "pecos-rslib-llvm" },
     { name = "phir" },
@@ -4045,14 +4139,14 @@ all = [
     { name = "stim" },
 ]
 cuda12 = [
-    { name = "cupy-cuda12x", marker = "python_full_version >= '3.11'" },
-    { name = "cuquantum-python-cu12", marker = "python_full_version >= '3.11'" },
-    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11'" },
+    { name = "cupy-cuda12x", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cuquantum-python-cu12", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pytket-cutensornet", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda12') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 cuda13 = [
-    { name = "cupy-cuda13x", marker = "python_full_version >= '3.11'" },
-    { name = "cuquantum-python-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11'" },
+    { name = "cupy-cuda13x", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "cuquantum-python-cu13", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pytket-cutensornet", marker = "(python_full_version >= '3.11' and extra == 'extra-13-quantum-pecos-cuda13') or (python_full_version < '3.11' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version < '3.11' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 stim = [
     { name = "stim" },
@@ -4105,7 +4199,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -4329,7 +4423,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4391,7 +4485,7 @@ resolution-markers = [
     "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4464,10 +4558,10 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hugr" },
     { name = "lief" },
-    { name = "llvmlite", version = "0.45.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
-    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "llvmlite", version = "0.45.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (platform_machine != 'x86_64' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (platform_machine != 'x86_64' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'darwin' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (sys_platform != 'darwin' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'darwin' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'darwin' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (sys_platform != 'darwin' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (sys_platform != 'darwin' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "pydantic" },
     { name = "pydot" },
     { name = "pyyaml" },
@@ -4495,8 +4589,8 @@ name = "selene-sim"
 version = "0.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "pyyaml" },
     { name = "selene-core" },
     { name = "selene-hugr-qis-compiler" },
@@ -4583,8 +4677,8 @@ name = "stim"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/15/0218eacd61cda992daf398bc36daf9830c8b430157a3ac0c06379598d24a/stim-1.15.0.tar.gz", hash = "sha256:95236006859d6754be99629d4fb44788e742e962ac8c59caad421ca088f7350e", size = 853226, upload-time = "2025-05-07T06:19:30.452Z" }
 wheels = [
@@ -4631,8 +4725,8 @@ name = "terminado"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
+    { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (os_name != 'nt' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
@@ -4768,7 +4862,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -4865,7 +4959,7 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
     { name = "python-discovery" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -822,6 +822,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cudensitymat-cu12"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cutensor-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "cutensornet-cu12", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/17/2af6a937b4cec0d4d0f52b0118841a81d9b3a43c945a34cb711fafecaca9/cudensitymat_cu12-0.5.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:378a90436c3ee13bd55b45d9ced390dd68008e4e722e4c6713432a9b7ef8be88", size = 18701564, upload-time = "2026-04-30T23:56:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b8/44231de69d6b740acaa1efb4107fc39d41ab081592d50e393c0ea69575d1/cudensitymat_cu12-0.5.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c3f7c685da3b77a0df3e94161c1e59904f42eca85d2af77e56d99ac8931236b6", size = 18720020, upload-time = "2026-04-30T23:51:51.541Z" },
+]
+
+[[package]]
 name = "cudensitymat-cu13"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -841,6 +854,34 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/7c/c44e93a2e7e66dfff3b46714ae0390c3d646a06a02a2772ffedbb14832f6/cupauliprop_cu13-0.3.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:df2b26ca9137cc4a2ad3b3b5ce18a759cbf019fcf9d27341bb7398f63e364146", size = 52781066, upload-time = "2026-04-30T23:57:04.428Z" },
     { url = "https://files.pythonhosted.org/packages/90/b8/d05707092c441c413655cece349e9de387d664c0955c77550fa98467934f/cupauliprop_cu13-0.3.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:05722c6c72e27b7aedaaea6bda1d21f7c9d84b1eaad172ef3a7e738702cfad5a", size = 53097635, upload-time = "2026-04-30T23:52:17.447Z" },
+]
+
+[[package]]
+name = "cupy-cuda12x"
+version = "14.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/18/8ec57a901a11d6955f90e1fbf3e04c8f26721066c99dfa25276e3e3b1f1d/cupy_cuda12x-14.1.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:909c4b8ac05eee43edfbe791522ee5d593e3504be7bd5c20e2de12b050db2a26", size = 143787561, upload-time = "2026-06-01T04:51:46.125Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/79/6a4e1562b3b6b18e93365955adfd4f66a84b60bdacf559becc0e3e0f1012/cupy_cuda12x-14.1.1-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:71b8de628a4a9ab24b6cc2af2162db2898e65a44a50a6d79cbc131c4f36405de", size = 132662808, upload-time = "2026-06-01T04:51:54.719Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/df/39530cffd84a00dfe98484a9ece77eed4acdc14717e1f77fa2a3e82a40dc/cupy_cuda12x-14.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:519e50b7dec2400e3fddbe9e6c4066937fd622a16774f375ab5be9d1cb1ea05e", size = 95338688, upload-time = "2026-06-01T04:51:59.685Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/65/13c173fec4923b9c4e1573344fc4a5585bf0e4efe5d9a5632e9bb18b2a31/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5d4c1c74f9f7fc9de0aa5781cf3ec54f9f05143f5761e21a8798772c8eedd0be", size = 145089362, upload-time = "2026-06-01T04:52:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/ccd2fea320ece269dd7237649da384cad71fbb1ba30937a1eb3311c31b77/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:8889cb83dbb7dbea593e60c85fcc91e21b0ccd10cd5380dfdfaac70b6bd9390a", size = 134012855, upload-time = "2026-06-01T04:52:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/93970d536e8401cf31d8f5602141f1c2edfc304e6d6b8702041688509509/cupy_cuda12x-14.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:e39a081fc4fe2166f95ef8be38fe2a95b2c4decb3ec991b4f26bfc9673d16b17", size = 95336905, upload-time = "2026-06-01T04:52:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6e/290ee2d7cc4ad63d66e67acfd7ff3026f2b648dd04449a1bf88ffaa36b1e/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7aae7d3bed37985e2aa39f0914b88ad90dbd3a6141d3e8198d73fce65859013c", size = 144383812, upload-time = "2026-06-01T04:52:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/dc03c1ddc940f33b3d32803898e2fdae5c9538a2127a25f499494c84b183/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a1138f20080489a46209291498cd12f792226d0a57d50c64a586c162a875a069", size = 133516927, upload-time = "2026-06-01T04:52:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/d4a8045b533af634bc791572e8c87981065e4a27b5d3e09d0d4d285742fd/cupy_cuda12x-14.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:85bebce86ffc25ecf31727b25da7b3793daf07b6fd9952704546af574d250988", size = 95238722, upload-time = "2026-06-01T04:52:46.296Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/00fe874c47207b26c9b6ac950d0cecc533b4a145491641932df17e573f3c/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:afbb3d1fa9484b0ae20d76372c5939a8c5da327e3fc8711b77b2354566cac355", size = 143920086, upload-time = "2026-06-01T04:52:51.726Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a4/c46ff91dba0dbe2a0a557974faf4c090a3159d6e7296431ca6846038d047/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:76ea35469e2aa0a8332b88f72505ea2f7871a0bc8f9b0c87184f57e47c9aa3bf", size = 133071615, upload-time = "2026-06-01T04:52:57.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a0/46778424035ad3fc920d49471f079687a054f74d179142e9520014c2514e/cupy_cuda12x-14.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:64072f4139b44df38215f0519a6badc14138fa0e4bb5b2db44fe94d05f8b9c8b", size = 95219598, upload-time = "2026-06-01T04:53:02.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/d72336481264c3483b162ea128d58f80abb50009f1df82ca82905e0b8fd7/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:22d0ff2755a7f29cb225d1d5fb979a73428c5534ea0bca91b0c02698e9948f84", size = 143788629, upload-time = "2026-06-01T04:53:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/77/c43a67e6809e03780d88caf690fa44a8b3152db2d8f848714bec327c9881/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:1059581507343e7cf6231facce30932a195c7aad4fa7771d00e4a252683915a1", size = 132406367, upload-time = "2026-06-01T04:53:16.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/dc/96cd37de6da41239e02fc7f17e3364d60f99bd6816673d622916a06113ec/cupy_cuda12x-14.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:e707e0eceee174d323be21652e87bb97be982e6966b5dc241756307df42842aa", size = 95793971, upload-time = "2026-06-01T04:53:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c6/0ddec1be851de546e883ae3da5f03c1ea69738628b38234dce4362b5e38b/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:e09897636b7468a90efa1152109f0b19ba49ebc9a423d5dbd4682ed589e57843", size = 144093057, upload-time = "2026-06-01T04:53:28.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/80/5e05de89ba61df072aab6f8a6ee3ffeec57db68a0a456825b3b4ce608426/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:238080487174268d0f09770fe518de7c5b206527bef5c6792aef7ba0626a1c48", size = 132635338, upload-time = "2026-06-01T04:53:35.229Z" },
 ]
 
 [[package]]
@@ -867,6 +908,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/e5480aefcc86cfa45abe12c323e8e65b8a04727c227f67dff1cae99ead1b/cupy_cuda13x-14.0.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:70a5b3d4b20367abf978e2c75bd0235f0768b5901a6102398877aef044628151", size = 73012147, upload-time = "2026-02-20T10:24:45.12Z" },
     { url = "https://files.pythonhosted.org/packages/61/9e/cd8ddc220283272a7891a8277fb911a584a9224bd1c8f56d75ca6f62d976/cupy_cuda13x-14.0.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:2e6fbfb24bc336ba91507e9e6488589665a4c7366453bb80c717d874fce3c373", size = 68714185, upload-time = "2026-02-20T10:24:49.984Z" },
     { url = "https://files.pythonhosted.org/packages/c1/f5/273193563cdc37cdb22de3b73e7db12819b39fafb73de6bcf7d48f20945e/cupy_cuda13x-14.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:22b50139e05c4612fac905dd6c3390f8687e0e390f0e200d5be14be1726e3d04", size = 35474838, upload-time = "2026-02-20T10:24:54.198Z" },
+]
+
+[[package]]
+name = "cuquantum-python-cu12"
+version = "25.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cudensitymat-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "cupy-cuda12x", marker = "python_full_version >= '3.11'" },
+    { name = "custatevec-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "cutensornet-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/6e/2b69770e4c695b16427cc94611245524a534c1f000240cdc668801c2ef3c/cuquantum_python_cu12-25.6.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:88db8cddee05fbe7911b2b028acd3ce7697ddb0781c5501313321a5964401552", size = 6020575, upload-time = "2025-07-03T22:16:42.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4f/60a55efef5c874717f3bd50d13df08ff80b0ee6bddbb97559cb446129824/cuquantum_python_cu12-25.6.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:506aeeba5f9a4959558bd2b220d7af00da2775ddddc86d943a5dc862ee55a62e", size = 5959171, upload-time = "2025-07-03T22:16:43.86Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2c/6fbae50358b3d0cae60ca9914f63a4dc6d7ff357ab4a1c192d9bb2624070/cuquantum_python_cu12-25.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:4c8cbfdea0f537a911778aa2cf640f967df2af9a7ae5a36beb55536325a61164", size = 6008861, upload-time = "2025-07-03T22:16:45.47Z" },
+    { url = "https://files.pythonhosted.org/packages/45/40/574cc9392ffb6c49049d3842ec758fd6a4872e3c5abf90768de99cad6971/cuquantum_python_cu12-25.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:c1d30b23af06e5adafc89b71d2857a945b14244dd102e0d15173406fcd95d2d6", size = 5977444, upload-time = "2025-07-03T22:16:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8e/c77bbdac04f3b1e3c267b44e4f4efd4e1d96ffd9fb9215e12de849ead389/cuquantum_python_cu12-25.6.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:6747b389218953189cb57df6787fcd30d249e001be9848b0e54c56a2820e9e21", size = 6017332, upload-time = "2025-07-03T22:16:48.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/a1da24554956c86409c0ea86acf3ad917bd2e94e81da00e0d72888f31534/cuquantum_python_cu12-25.6.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:5947b58a6a998ff98e810b688653a0326e6e569de67c9d83669dabe20632a33c", size = 5969217, upload-time = "2025-07-03T22:16:50.112Z" },
 ]
 
 [[package]]
@@ -903,12 +964,31 @@ wheels = [
 ]
 
 [[package]]
+name = "custatevec-cu12"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/1c/3ca3983b416e9f0f9a4da902d4eb69879969a08bc2db05b4e7854fdd6a61/custatevec_cu12-1.13.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:ee55f85e81cac11c09fbde3b63e64c309279537efbe9fb91b57d5e35cd3b8073", size = 73147948, upload-time = "2026-04-13T18:21:05.772Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c0/4b092e048b44c6658521bbaaca4a08daf964e3a1de1d8fe024c008fa9343/custatevec_cu12-1.13.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:359626fd842e53fa0d84912bd7c6e2a891ac8b6ea3e490479fba73805425a410", size = 73152910, upload-time = "2026-04-13T18:10:34.608Z" },
+]
+
+[[package]]
 name = "custatevec-cu13"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/df/a726ce52085d7d0ff96c89e6c2a4347b59a523994390d8d396c20968525f/custatevec_cu13-1.13.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:00965de9edfe2c862768e58f9b3ae3593e378c51691993be4800575866bbe34f", size = 58624353, upload-time = "2026-04-13T18:22:58.568Z" },
     { url = "https://files.pythonhosted.org/packages/93/d0/cfe2e3403ebaecf01201d50f7efe2d22dbdc6687120dd88c0e16f79e0332/custatevec_cu13-1.13.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c3ab6cbd6f028f96570c753acf0766a74728c9ba2341bd9a2067b8b82bb84845", size = 58750550, upload-time = "2026-04-13T18:11:28.145Z" },
+]
+
+[[package]]
+name = "cutensor-cu12"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/7744b62f5d0c3ec0e4f1442ecd119343462d6f3a0d025508ace4f319d32a/cutensor_cu12-2.7.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4518081e13a22c6fe1d7941ee7b0358f4ad71a1484e2a92563f0d1336476f939", size = 332968151, upload-time = "2026-06-15T21:45:41.944Z" },
+    { url = "https://files.pythonhosted.org/packages/30/0b/c9a0d71cc847c7b90d21ae1062737dbc16104fc2c2219b51ec64752017c4/cutensor_cu12-2.7.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ddedf0d94555c457c6c282dd7369c10fd10db22029f3731f1ed9420600188e6d", size = 332959918, upload-time = "2026-06-15T21:47:51.934Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bc/18bd0789acfb9d746b4542c9a794efe5debb21bf7114fb39f16662805c46/cutensor_cu12-2.7.0-py3-none-win_amd64.whl", hash = "sha256:6b5df750a43218a395b0ddc2607623c07f610a10ff2e5a071273d93e568010f0", size = 316268223, upload-time = "2026-06-15T21:49:59.18Z" },
 ]
 
 [[package]]
@@ -919,6 +999,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/d3/f94addb70feacd027dab0b2a2a116b3385083cebd63c4165ec0eb045ec41/cutensor_cu13-2.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:ab3ae0e4b0373d39f3dfef26f968dfe353d3b7ca813d4abc2c98a426bc7ae8f3", size = 204718027, upload-time = "2026-03-17T09:20:15.558Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/514b83bad4e5e18ff8c7ff17e5f05f01bb44908e85643d5cce3d3a5efbaf/cutensor_cu13-2.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2c0c47bf0fa31652dc8e1dd8989b6273e34fb12d68430a50e1cf1dc368a67a24", size = 205168796, upload-time = "2026-03-17T09:22:25.187Z" },
     { url = "https://files.pythonhosted.org/packages/c6/b0/e29b8d87c1eed35e10b97f3d9da92e0f6689468b93cd84aca0fbc990209d/cutensor_cu13-2.6.0-py3-none-win_amd64.whl", hash = "sha256:2bb9d35480c205d6df80dd6813a4a13988905021b49d82ec08050bd5541ced05", size = 187835568, upload-time = "2026-03-17T09:24:27.08Z" },
+]
+
+[[package]]
+name = "cutensornet-cu12"
+version = "2.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cutensor-cu12", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/21/97630117bc5fd72196915f133bd5de3322cccd893d1ee0a468fe8ae105fd/cutensornet_cu12-2.12.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:e17cb372d7aa21e8998d6623cfa7d2f94dfd5f127eb520e50ebe91768e0e6005", size = 3099322, upload-time = "2026-04-30T23:31:29.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4b/b47dfe6eda899aa252e197bfe9eb2eb25e6a8fa563588591c715faee88e9/cutensornet_cu12-2.12.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1f3fe15974c26da60e5310e786badce3cf2cd3331dbaaf032ab5bc4a5ba61323", size = 3174943, upload-time = "2026-04-30T23:30:31.524Z" },
 ]
 
 [[package]]
@@ -2914,13 +3006,19 @@ version = "0.8.0.dev8"
 source = { virtual = "." }
 
 [package.optional-dependencies]
-cuda = [
-    { name = "quantum-pecos", extra = ["cuda"] },
+cuda12 = [
+    { name = "quantum-pecos", extra = ["cuda12"] },
+]
+cuda13 = [
+    { name = "quantum-pecos", extra = ["cuda13"] },
 ]
 
 [package.dev-dependencies]
-cuda = [
-    { name = "quantum-pecos", extra = ["cuda"] },
+cuda12 = [
+    { name = "quantum-pecos", extra = ["cuda12"] },
+]
+cuda13 = [
+    { name = "quantum-pecos", extra = ["cuda13"] },
 ]
 dev = [
     { name = "black" },
@@ -2956,11 +3054,15 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "quantum-pecos", extras = ["cuda"], marker = "extra == 'cuda'", editable = "python/quantum-pecos" }]
-provides-extras = ["cuda"]
+requires-dist = [
+    { name = "quantum-pecos", extras = ["cuda12"], marker = "extra == 'cuda12'", editable = "python/quantum-pecos" },
+    { name = "quantum-pecos", extras = ["cuda13"], marker = "extra == 'cuda13'", editable = "python/quantum-pecos" },
+]
+provides-extras = ["cuda13", "cuda12"]
 
 [package.metadata.requires-dev]
-cuda = [{ name = "quantum-pecos", extras = ["cuda"], editable = "python/quantum-pecos" }]
+cuda12 = [{ name = "quantum-pecos", extras = ["cuda12"], editable = "python/quantum-pecos" }]
+cuda13 = [{ name = "quantum-pecos", extras = ["cuda13"], editable = "python/quantum-pecos" }]
 dev = [
     { name = "black" },
     { name = "markdown-exec", extras = ["ansi"] },
@@ -3942,10 +4044,14 @@ all = [
     { name = "plotly" },
     { name = "stim" },
 ]
-cuda = [
+cuda12 = [
+    { name = "cupy-cuda12x", marker = "python_full_version >= '3.11'" },
+    { name = "cuquantum-python-cu12", marker = "python_full_version >= '3.11'" },
+    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11'" },
+]
+cuda13 = [
     { name = "cupy-cuda13x", marker = "python_full_version >= '3.11'" },
     { name = "cuquantum-python-cu13", marker = "python_full_version >= '3.11'" },
-    { name = "pecos-rslib-cuda" },
     { name = "pytket-cutensornet", marker = "python_full_version >= '3.11'" },
 ]
 stim = [
@@ -3958,25 +4064,27 @@ visualization = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cupy-cuda13x", marker = "python_full_version >= '3.11' and extra == 'cuda'", specifier = ">=13.0.0" },
-    { name = "cuquantum-python-cu13", marker = "python_full_version >= '3.11' and extra == 'cuda'", specifier = ">=25.3.0" },
+    { name = "cupy-cuda12x", marker = "python_full_version >= '3.11' and extra == 'cuda12'", specifier = ">=13.0.0" },
+    { name = "cupy-cuda13x", marker = "python_full_version >= '3.11' and extra == 'cuda13'", specifier = ">=13.0.0" },
+    { name = "cuquantum-python-cu12", marker = "python_full_version >= '3.11' and extra == 'cuda12'", specifier = ">=25.3.0" },
+    { name = "cuquantum-python-cu13", marker = "python_full_version >= '3.11' and extra == 'cuda13'", specifier = ">=25.9.0" },
     { name = "guppylang", specifier = ">=0.21.6" },
     { name = "hugr", specifier = ">=0.13.0" },
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=2.2.0" },
     { name = "networkx", specifier = ">=2.1.0" },
     { name = "pecos-rslib", editable = "python/pecos-rslib" },
-    { name = "pecos-rslib-cuda", marker = "extra == 'cuda'", editable = "python/pecos-rslib-cuda" },
     { name = "pecos-rslib-llvm", editable = "python/pecos-rslib-llvm" },
     { name = "phir", specifier = ">=0.3.3" },
     { name = "plotly", marker = "extra == 'visualization'", specifier = "~=5.9.0" },
-    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11' and extra == 'cuda'", specifier = ">=0.12.0" },
+    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11' and extra == 'cuda12'", specifier = ">=0.12.0" },
+    { name = "pytket-cutensornet", marker = "python_full_version >= '3.11' and extra == 'cuda13'", specifier = ">=0.12.0" },
     { name = "quantum-pecos", extras = ["stim"], marker = "extra == 'all'", editable = "python/quantum-pecos" },
     { name = "quantum-pecos", extras = ["visualization"], marker = "extra == 'all'", editable = "python/quantum-pecos" },
     { name = "selene-sim", specifier = "~=0.2.0" },
     { name = "stim", marker = "extra == 'stim'", specifier = ">=1.15.0" },
     { name = "tket", specifier = "<0.12.16" },
 ]
-provides-extras = ["stim", "visualization", "all", "cuda"]
+provides-extras = ["stim", "visualization", "all", "cuda13", "cuda12"]
 
 [[package]]
 name = "qwasm"


### PR DESCRIPTION
## Summary

Make the Python `CuStateVec` backend **fail loud** on unsupported cuQuantum, and support **both CUDA 12 and CUDA 13**.

- `CuStateVec` now requires the bindings-era cuQuantum API (`cuquantum.bindings`, cuQuantum **>= 25.03**) and never uses the legacy top-level `cuquantum.custatevec`.
- Missing/too-old/broken CuPy or cuQuantum no longer silently sets `CuStateVec = None`. `import pecos` stays non-fatal without CUDA; the failure surfaces as a **clear, actionable error at construction** (which package to install/upgrade) — mirroring the existing Rust `CudaStateVec` pattern.
- Packaging: the cu13-only `[cuda]` extra is replaced by explicit **`[cuda12]` / `[cuda13]`** extras (Python cuStateVec/MPS path), declared mutually exclusive via `[tool.uv] conflicts` so each resolves to its latest independently.

## Background

`cuquantum.bindings.custatevec` was introduced in cuQuantum **25.03** (top-level `cuquantum.custatevec` deprecated then, removed at **25.9.0**). The previous code imported the new path unconditionally, so deployed environments with an older pre-pin cuQuantum saw `gpu-state-vector` reported as unavailable. Rather than fall back to the legacy API, this PR requires the bindings era and fails loud below it — a one-line `pip` upgrade for users, independent of CUDA/hardware.

## Changes

- **`_cuquantum_compat.py`** (new): the single place CuPy + `cuquantum.bindings` are imported. Never raises at import; records a classified reason (not-installed / pre-25.03 / present-but-broken / cupy-missing). Exposes `cusv`, `ComputeType`, `cudaDataType`, `custatevec_available()`, `custatevec_unavailable_reason()`, `require_custatevec()`.
- **`state.py` / gate modules**: import CuPy + cuQuantum via the compat; `CuStateVec.__init__` calls `require_custatevec()` first. `simulators/__init__.py` drops the import-time CuPy/cuQuantum preflight (the class is always importable now).
- **Packaging**: `[cuda12]` (`cuquantum-python-cu12>=25.3.0`) / `[cuda13]` (`cuquantum-python-cu13>=25.9.0`), uv conflicts, root extras+groups mirrored, `uv.lock` regenerated. The Rust GPU backend (`pecos-rslib-cuda`) is no longer bundled in these extras — install it separately.
- **Consumers**: `pecos cuda setup-python` / `pecos setup` and the Justfile auto-detect the CUDA major; `setup_cuda.sh`, README, `DEVELOPMENT.md`, `simulators.md`, and `cuda-setup.md` updated (CC 7.5+ default; V100/Volta via the capped `cuquantum-python-cu12>=25.3,<25.9`).
- **Tests**: `test_cuquantum_compat.py` rewritten (available / too-old / missing / cupy-missing / broken-import cases). `test_statevec.py` and `test_backend_seed_determinism.py` gate on `custatevec_available()` instead of `CuStateVec is None`.

## Notes for reviewers

- **`state.py` is not rewritten.** Its large diff is a one-time **CRLF → LF normalization** (the file was committed with CRLF, violating `.gitattributes eol=lf`) plus the small import/`require_custatevec()` edits. Review with whitespace hidden to see the real change.
- **V100 / Volta (CC 7.0)** is supported only on CUDA 12 with cuQuantum **25.3–25.6** (cuStateVec dropped Volta at 25.09); the default `[cuda12]` resolves to current cuQuantum, so V100 users pin `cuquantum-python-cu12>=25.3,<25.9` (documented).
- Recommend **squash-merge** (the branch has iterative review/fix commits).

## Validation

- Full CI green (78/78).
- `test_cuquantum_compat.py` unit tests; `test_statevec.py` / seed-determinism on an RTX 4090 (CUDA 13) — correct Bell state.
- Simulated no-CUDA env: `import pecos` non-fatal; `CuStateVec(2)` and `QuantumSimulator("CuStateVec")` raise the actionable error.
- `uv lock --check`, `cargo clippy -p pecos-cli -D warnings`, and full `pre-commit` all clean.

---
Developed and reviewed with Claude Code (Claude Opus 4.8) and cross-reviewed with Codex (GPT-5.5).
