### PR TITLE
Clear post-merge OSV advisories (cxx, Go stdlib, cgmath)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1400,9 +1400,9 @@ checksum = "45e700c2d1c3feea9b695e79b2dfeeb93040556a58c556fae23f71b1e6b449fd"
 
 [[package]]
 name = "cxx"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+checksum = "201f2332bd98022973bbf50c87f2d2f8151200f43e640da370901b20f1bea9d3"
 dependencies = [
  "cc",
  "cxx-build",
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+checksum = "02da7762e3807681f61c4561f34e1ff791417334294b225dbe22236459c9deef"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+checksum = "21c216b8cd7c26c2798bbecdb13de2f8dc65239b9ed892756deacff10fc0fa64"
 dependencies = [
  "clap 4.6.1",
  "codespan-reporting",
@@ -1444,15 +1444,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+checksum = "61c618f09812e388d1d065fd43fdc4340fade506ab2e0903397bf238650fce45"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+checksum = "415b113deba00cc605302b9b0b4974ab3d57c41135d81737cd47b89dbaa17c38"
 dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
@@ -1860,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2345,6 +2345,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "rayon",
 ]
 
 [[package]]
@@ -2364,10 +2365,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
- "rayon",
  "serde",
  "serde_core",
 ]
@@ -2806,6 +2804,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "rayon",
  "serde",
 ]
 
@@ -2936,7 +2935,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6111,7 +6110,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6167,7 +6166,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6258,8 +6257,8 @@ checksum = "4b213df2cbfa5f580ed2c0ac3619eda06692a4ff0211f0aebbb4008eaa9724a6"
 dependencies = [
  "fixedbitset 0.5.7",
  "foldhash 0.1.5",
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
+ "hashbrown 0.15.5",
+ "indexmap 1.9.3",
  "ndarray 0.17.2",
  "num-traits",
  "petgraph 0.8.3",
@@ -6962,7 +6961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8404,7 +8403,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1860,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2345,7 +2345,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "rayon",
 ]
 
 [[package]]
@@ -2365,7 +2364,10 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -2804,7 +2806,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "rayon",
  "serde",
 ]
 
@@ -2935,7 +2936,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6110,7 +6111,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6166,7 +6167,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6257,8 +6258,8 @@ checksum = "4b213df2cbfa5f580ed2c0ac3619eda06692a4ff0211f0aebbb4008eaa9724a6"
 dependencies = [
  "fixedbitset 0.5.7",
  "foldhash 0.1.5",
- "hashbrown 0.15.5",
- "indexmap 1.9.3",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "ndarray 0.17.2",
  "num-traits",
  "petgraph 0.8.3",
@@ -6961,7 +6962,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8403,7 +8404,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/go/pecos/go.mod
+++ b/go/pecos/go.mod
@@ -1,3 +1,3 @@
 module github.com/PECOS-packages/PECOS/go/pecos
 
-go 1.26.4
+go 1.26.5

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -114,3 +114,18 @@ reason = "Transitive via rustpython-parser in the experimental zlup frontend; un
 id = "RUSTSEC-2025-0100"
 # unic-ucd-ident@0.9.0 -- unmaintained. Same chain/owner as RUSTSEC-2025-0075.
 reason = "Transitive via rustpython-parser in the experimental zlup frontend; unmaintained-crate warning, parser-internal Unicode tables, no exploit path."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0196"
+# cgmath@0.18.0 -- unmaintained; 0.18.0 is the latest release (no fix exists).
+# Chain: hugr-core -> hugr -> tket -> pecos-hugr.
+# Upstream owner: https://github.com/CQCL/hugr (awaiting a maintained geometry dep).
+reason = "Transitive via hugr/tket; unmaintained-crate warning, no exploit path in PECOS."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0197"
+# cgmath@0.18.0 -- unsound Matrix{2,3,4}::swap_columns(a, a): identical indices
+# create aliasing mutable refs passed to ptr::swap -> UB. No patched release.
+# Chain: hugr-core -> hugr -> tket -> pecos-hugr.
+# Upstream owner: https://github.com/CQCL/hugr.
+reason = "Transitive via hugr/tket; PECOS never calls cgmath swap_columns (UB needs an identical-index call, only reachable inside hugr/tket internals), no fixed version. Re-check on hugr/tket bump."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -118,14 +118,17 @@ reason = "Transitive via rustpython-parser in the experimental zlup frontend; un
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0196"
 # cgmath@0.18.0 -- unmaintained; 0.18.0 is the latest release (no fix exists).
-# Chain: hugr-core -> hugr -> tket -> pecos-hugr.
-# Upstream owner: https://github.com/CQCL/hugr (awaiting a maintained geometry dep).
-reason = "Transitive via hugr/tket; unmaintained-crate warning, no exploit path in PECOS."
+# Chains: cgmath -> hugr-core -> hugr -> tket -> pecos-hugr, and
+#         cgmath -> tket (dev-dependency) -> pecos-hugr.
+# Upstream owners: https://github.com/CQCL/hugr and https://github.com/CQCL/tket2
+# (awaiting a maintained geometry dep).
+reason = "Transitive via hugr-core and tket; unmaintained-crate warning, no exploit path in PECOS."
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0197"
 # cgmath@0.18.0 -- unsound Matrix{2,3,4}::swap_columns(a, a): identical indices
 # create aliasing mutable refs passed to ptr::swap -> UB. No patched release.
-# Chain: hugr-core -> hugr -> tket -> pecos-hugr.
-# Upstream owner: https://github.com/CQCL/hugr.
-reason = "Transitive via hugr/tket; PECOS never calls cgmath swap_columns (UB needs an identical-index call, only reachable inside hugr/tket internals), no fixed version. Re-check on hugr/tket bump."
+# Chains: cgmath -> hugr-core -> hugr -> tket -> pecos-hugr, and
+#         cgmath -> tket (dev-dependency) -> pecos-hugr.
+# Upstream owners: https://github.com/CQCL/hugr and https://github.com/CQCL/tket2.
+reason = "Transitive via hugr-core and tket; no swap_columns call exists in PECOS or in the pinned hugr-core 0.27.1/tket 0.19.0 sources, and no fixed cgmath release exists. Re-check on hugr/tket bumps."


### PR DESCRIPTION
Post-merge dependency hygiene: the OSV Scanner push-gate on `dev` went red after #347 merged, from **5 newly-disclosed advisories** in transitive deps (all Unknown severity, none introduced by #347).

| Advisory | Package | Action |
|---|---|---|
| RUSTSEC-2026-0202 | `cxx` 1.0.194 | bump lockfile → 1.0.195 (fixed) |
| GO-2026-4970, GO-2026-5856 | Go stdlib | bump `go/pecos/go.mod` → `go 1.26.5` (fixed) |
| RUSTSEC-2026-0196 | `cgmath` 0.18.0 | ignore — unmaintained; no fixed release |
| RUSTSEC-2026-0197 | `cgmath` 0.18.0 | ignore — unsound `swap_columns(a, a)` UB; no fixed release |

**cgmath triage:** both are INFO-level, transitive via `hugr-core → hugr → tket → pecos-hugr`, and 0.18.0 is the latest release (no upstream fix). RUSTSEC-2026-0197 requires calling `Matrix::swap_columns` with identical indices, which only hugr/tket internals could do — PECOS never calls it. Suppressed in `osv-scanner.toml` with the standard chain/owner/reason, to re-check on a hugr/tket bump.

**Verification:** `cargo tree` resolves (cxx 1.0.195, cgmath 0.18.0); `pecos-chromobius` (cxx consumer) builds clean; `osv-scanner.toml` parses; `go-version-consistency` structural checks unaffected and `go-test` uses `stable` (≥ 1.26.5). CI OSV Scanner is authoritative.

**Notes from review:** (1) The lockfile diff is surgically restricted to the four cxx-family hunks — `cargo update` under cargo 1.97 also wants to re-normalize unrelated dependency edges (windows-sys/unicode-width/hashbrown/indexmap duplicates); that churn is benign but was excluded to keep this diff minimal, so expect it to reappear on the next full `cargo update`. (2) Pre-existing, not changed here: govulncheck inside the OSV scanner image has been silently skipping `go/pecos` since the go.mod directive passed 1.26.4 (image ships Go 1.26.2, `GOTOOLCHAIN=local`); lockfile-level stdlib matching still catches Go advisories, but code-level reachability analysis is absent until the scanner image ships a newer Go.
