### PR TITLE
Raise the python-core post-merge timeout to 75 minutes

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -137,7 +137,10 @@ jobs:
 
   python-core:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # The full post-merge core suite passed at ~40m in late June and has since
+    # grown past 45m (timing out at ~83% of the suite on every dev push since
+    # 2026-07-07). 75m restores the original ~35% headroom.
+    timeout-minutes: 75
     steps:
     - name: Harden the runner (egress audit)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
The post-merge `python-core` job (the full core Python suite; PRs run only the fast-path lockfile check per #331's critical-path design) has been **timing out at its 45-minute limit on every dev push since 2026-07-07** ("Dep bump (#322)" was the first). GitHub reports job timeouts as "cancelled," so it never showed as a red failure — the last ~17% of the suite simply hasn't executed on dev since then.

Data points:
- Last pass: 2026-06-28, at **40m34s** of the 45m budget (already ~90%).
- Every dev push since #322 dies at 45m with pytest progressing normally, reaching ~**83%** (mid `qec/test_from_guppy_dem.py`) — implying the grown suite needs ~55m.
- Suite growth since the budget was set: docs-CI generated examples, #339, #347's expanded parity coverage (~3,200 differential cases), plus any slowdown from #322's dependency bumps.
- All other jobs in the workflow have ample headroom (lint 13m/30m, slow-postmerge 33m/90m, smokes 2–16m) — only `python-core` is miscalibrated.

**Change:** `timeout-minutes: 45 → 75`, restoring roughly the original ~35% headroom.

**Follow-up (not this PR):** profile per-test durations to attribute how much #322 specifically added, and consider sharding the qec tree into a parallel job if the suite keeps growing toward the new budget.
