### PR TITLE
Bump Python packages to 0.9.0.dev0

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -132,7 +132,7 @@ LLVM 21.1:
 
 Python:
   [OK] uv: uv 0.11.3
-  [OK] import pecos: v0.8.0.dev8
+  [OK] import pecos: v0.9.0.dev0
   [OK] pecos_rslib: v0.2.0-dev.0
 
 CUDA (optional):

--- a/exp/zluppy/uv.lock
+++ b/exp/zluppy/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "../../python/pecos-rslib" }
 
 [package.metadata]
@@ -554,7 +554,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "../../python/pecos-rslib-llvm" }
 
 [package.metadata]
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "../../python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-workspace"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 # Meta-package; runtime deps live in the member packages. Test/example/dev
 # tooling is declared in [dependency-groups] below.
@@ -10,8 +10,8 @@ dependencies = []
 # Keep these in sync with the cuda dependency groups below. The extras support
 # `uv sync --extra cuda13`; the groups support `uv run --group cuda13 ...`.
 # Pick the extra matching your CUDA major -- do not install both.
-cuda13 = ["quantum-pecos[cuda13]==0.8.0.dev8"]
-cuda12 = ["quantum-pecos[cuda12]==0.8.0.dev8"]
+cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev0"]
+cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev0"]
 
 [tool.uv.workspace]
 members = [
@@ -70,10 +70,10 @@ numpy-compat = [ # NumPy/SciPy compatibility tests - verify compatibility with s
   "scipy>=1.1.0",
 ]
 cuda13 = [ # CUDA 13 Python packages for GPU-accelerated simulations (requires CUDA toolkit)
-  "quantum-pecos[cuda13]==0.8.0.dev8",
+  "quantum-pecos[cuda13]==0.9.0.dev0",
 ]
 cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
-  "quantum-pecos[cuda12]==0.8.0.dev8",
+  "quantum-pecos[cuda12]==0.9.0.dev0",
 ]
 
 [tool.uv]

--- a/python/pecos-rslib-cuda/pyproject.toml
+++ b/python/pecos-rslib-cuda/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-cuda"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 description = "CUDA/cuQuantum Python bindings for PECOS quantum simulators (Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-exp/pyproject.toml
+++ b/python/pecos-rslib-exp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-exp"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 description = "Python bindings for experimental PECOS simulators (StabMps, Mast)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-llvm/pyproject.toml
+++ b/python/pecos-rslib-llvm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-llvm"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 description = "LLVM IR generation Python bindings for PECOS (llvmlite-compatible API, Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib/pyproject.toml
+++ b/python/pecos-rslib/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 description = "Rust libary extensions for Python PECOS."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quantum-pecos"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 authors = [
     {name = "The PECOS Developers"},
 ]
@@ -28,8 +28,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE"}
 keywords = ["quantum", "QEC", "simulation", "PECOS"]
 dependencies = [
-    "pecos-rslib==0.8.0.dev8",
-    "pecos-rslib-llvm==0.8.0.dev8",
+    "pecos-rslib==0.9.0.dev0",
+    "pecos-rslib-llvm==0.9.0.dev0",
     "phir>=0.3.3",
     "networkx>=2.1.0",
     # Pin to the 0.21.x line (tket.bool era). guppylang 0.22+ emits the

--- a/python/selene-plugins/pecos-selene-mast/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-mast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-mast"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS Mast simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-mps"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StabMps simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-vec"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StabVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stabilizer"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS Stabilizer simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-statevec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-statevec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-statevec"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StateVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/scripts/publish-wheels.sh
+++ b/scripts/publish-wheels.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  -f, --file FILE      Path to the GitHub Actions artifact zip (default: pecos-distribution.zip)"
-            echo "  -p, --package PKG    Publish only specific package (pecos-rslib or quantum-pecos)"
+            echo "  -p, --package PKG    Publish only specific package (pecos-rslib, pecos-rslib-llvm, or quantum-pecos)"
             echo "  --dry-run            Show what would be uploaded without actually uploading"
             echo "  -h, --help           Show this help message"
             echo ""
@@ -137,16 +137,18 @@ publish_package() {
 # Main execution
 if [ -n "$PACKAGE" ]; then
     # Publish specific package
-    if [[ "$PACKAGE" != "pecos-rslib" && "$PACKAGE" != "quantum-pecos" ]]; then
+    if [[ "$PACKAGE" != "pecos-rslib" && "$PACKAGE" != "pecos-rslib-llvm" && "$PACKAGE" != "quantum-pecos" ]]; then
         echo -e "${RED}Error: Invalid package name '$PACKAGE'${NC}"
-        echo "Valid options are: pecos-rslib, quantum-pecos"
+        echo "Valid options are: pecos-rslib, pecos-rslib-llvm, quantum-pecos"
         exit 1
     fi
     publish_package "$PACKAGE"
 else
-    # Publish all packages
+    # Publish all packages. quantum-pecos pins pecos-rslib and pecos-rslib-llvm
+    # at exact versions, so publish the dependencies first.
     echo -e "${GREEN}Publishing all PECOS packages${NC}"
     publish_package "pecos-rslib"
+    publish_package "pecos-rslib-llvm"
     publish_package "quantum-pecos"
 fi
 

--- a/uv.lock
+++ b/uv.lock
@@ -2927,7 +2927,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/pecos-rslib" }
 
 [package.dev-dependencies]
@@ -2956,7 +2956,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-cuda"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/pecos-rslib-cuda" }
 
 [package.dev-dependencies]
@@ -2972,12 +2972,12 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-exp"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/pecos-rslib-exp" }
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/pecos-rslib-llvm" }
 
 [package.dev-dependencies]
@@ -2993,7 +2993,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-selene-mast"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-mast" }
 dependencies = [
     { name = "selene-core" },
@@ -3017,7 +3017,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-mps"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stab-mps" }
 dependencies = [
     { name = "selene-core" },
@@ -3041,7 +3041,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-vec"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stab-vec" }
 dependencies = [
     { name = "selene-core" },
@@ -3065,7 +3065,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stabilizer"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stabilizer" }
 dependencies = [
     { name = "selene-core" },
@@ -3089,7 +3089,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-statevec"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-statevec" }
 dependencies = [
     { name = "selene-core" },
@@ -3113,7 +3113,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-workspace"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -4051,7 +4051,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.8.0.dev8"
+version = "0.9.0.dev0"
 source = { editable = "python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },


### PR DESCRIPTION
Coordinated Python version bump `0.8.0.dev8` → `0.9.0.dev0`, prepping the release that flips `HybridEngine`'s default classical interpreter to Rust (#347).

**Why a minor bump:** the default-interpreter switch is a user-visible default-behavior change; in the 0.x convention the minor number is the signal for that (additive-only would be a patch/dev increment). It gives the release note — and the `cinterp="python"` escape hatch — a clear version boundary.

**What's bumped (every occurrence, verified zero stragglers):**
- `version =` in all 11 workspace `pyproject.toml`s (root meta-package, pecos-rslib, -llvm, -cuda, -exp, quantum-pecos, 5 selene plugins)
- Exact-version internal pins: root `quantum-pecos[cuda12/13]==...` (4) and quantum-pecos's `pecos-rslib==...` / `pecos-rslib-llvm==...`
- `uv.lock` + `exp/zluppy/uv.lock` regenerated — diffs are version-lines-only (11 and 3 respectively, no dependency churn)
- `docs/user-guide/cli.md` example output

**Verification:** `git grep 0.8.0.dev8` → no matches; `uv lock --check` passes; CI-standard sync rebuilds cleanly and `pecos.__version__` reports `0.9.0.dev0` with the Rust default interpreter intact.

After merge: tag `py-0.9.0.dev0` (or at cut time) to build the tagged artifact bundle; publishing remains manual from the collected artifacts.
