### PR TITLE
Post-release papercuts: fail-closed lockfile check, llvm classifier, version-agnostic docs

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -132,8 +132,8 @@ LLVM 21.1:
 
 Python:
   [OK] uv: uv 0.11.3
-  [OK] import pecos: v0.9.0.dev0
-  [OK] pecos_rslib: v0.2.0-dev.0
+  [OK] import pecos: v<version>
+  [OK] pecos_rslib: v<version>
 
 CUDA (optional):
   [--] CUDA: not found (optional)

--- a/python/pecos-rslib-llvm/pyproject.toml
+++ b/python/pecos-rslib-llvm/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
-    "Operating System :: POSIX :: Linux",
+    "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/scripts/dependency-integrity-check.sh
+++ b/scripts/dependency-integrity-check.sh
@@ -349,6 +349,22 @@ if ((${#cargo_locks[@]} == 0)); then
     fail "no Cargo.lock files found"
 else
     for lockfile in "${cargo_locks[@]}"; do
+        # Fail-closed handling for lockfiles that are not tracked by git:
+        # - gitignored ones are documented generated artifacts (see .gitignore
+        #   for the per-entry rationale); CI checkouts never contain them and a
+        #   stale local copy fails --locked with a misleading error, so skip.
+        # - anything else is an unexpected lock that should either be committed
+        #   or gitignored with a rationale -- fail so it cannot slip through.
+        # (rg --files can list gitignored files under negation patterns, which
+        # is how these reach this loop at all.)
+        if ! git ls-files --error-unmatch "$lockfile" >/dev/null 2>&1; then
+            if git check-ignore -q "$lockfile"; then
+                echo "Skipping gitignored generated lockfile: $lockfile"
+                continue
+            fi
+            fail "$lockfile is untracked and not gitignored: commit it or gitignore it with a rationale"
+            continue
+        fi
         manifest="$(dirname "$lockfile")/Cargo.toml"
         if [[ ! -f "$manifest" ]]; then
             fail "$lockfile has no adjacent Cargo.toml"


### PR DESCRIPTION
Three post-release papercuts (plan cross-reviewed with Codex; its fail-closed adjustment adopted):

1. **Dependency-integrity check: fail-closed handling of untracked lockfiles.** The lockfile-currency loop swept in the gitignored generated doc-test lock (`rg --files` lists it despite the ignore, via negation-pattern divergence), and a stale local copy broke `just check-all` with a misleading `--locked` error. New predicate: tracked → validate; gitignored (documented generated artifacts, rationale lives in `.gitignore`) → skip with message; anything else → **fail** ("commit it or gitignore it with a rationale"), so a lock that should be committed cannot slip through. All three paths tested (including a planted unexpected lock).
2. **`pecos-rslib-llvm` classifier** said `POSIX :: Linux` but we publish macOS and Windows wheels — now `OS Independent` (matching pecos-rslib; pecos-rslib-cuda deliberately stays Linux-only, cuQuantum is Linux-only).
3. **`docs/user-guide/cli.md`** hardcoded the release version in example output, forcing doc edits on every bump — now a `v<version>` placeholder.
