### PR TITLE
Smoke-test wheels against their real dependency metadata

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -231,16 +231,16 @@ jobs:
 
       - name: Install PR smoke artifacts
         run: |
-          uv pip install --system --force-reinstall ./pr-smoke-artifacts/pecos-rslib/pecos_rslib-*.whl
-          uv pip install --system --force-reinstall ./pr-smoke-artifacts/pecos-rslib-llvm/pecos_rslib_llvm-*.whl
-          uv pip install --system \
-            "phir>=0.3.3" \
-            "networkx>=2.1.0" \
-            "guppylang>=0.21.6" \
-            "tket<0.12.16" \
-            "hugr>=0.13.0" \
-            "selene-sim~=0.2.0"
-          uv pip install --system --force-reinstall --no-deps ./pr-smoke-artifacts/quantum-pecos/quantum_pecos-*.whl
+          # Install all three local wheels in ONE resolver invocation: the local
+          # wheels satisfy quantum-pecos's exact pecos-rslib/-llvm pins (which do
+          # not exist on PyPI for unreleased versions) and every other dependency
+          # resolves from the wheel's own Requires-Dist -- no hand-maintained
+          # duplicate pin list that can drift from the package metadata.
+          uv pip install --system --force-reinstall \
+            ./pr-smoke-artifacts/pecos-rslib/pecos_rslib-*.whl \
+            ./pr-smoke-artifacts/pecos-rslib-llvm/pecos_rslib_llvm-*.whl \
+            ./pr-smoke-artifacts/quantum-pecos/quantum_pecos-*.whl
+          uv pip check --system
 
       - name: Import PR smoke artifacts
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -492,14 +492,17 @@ jobs:
           uv pip install --system --force-reinstall "${llvm_wheels[0]}"
         fi
         if [ "${{ matrix.include-pecos }}" = "true" ]; then
-          uv pip install --system \
-            "phir>=0.3.3" \
-            "networkx>=2.1.0" \
-            "guppylang>=0.21.6" \
-            "tket<0.12.16" \
-            "hugr>=0.13.0" \
-            "selene-sim~=0.2.0"
-          uv pip install --system --force-reinstall --no-deps ./python-compat-smoke-artifacts/quantum-pecos/quantum_pecos-*.whl
+          # One resolver invocation: the freshly built quantum-pecos wheel plus
+          # the already-installed local native wheels (re-passed so they satisfy
+          # its exact pecos-rslib/-llvm pins, which do not exist on PyPI for
+          # unreleased versions). All other dependencies resolve from the
+          # wheel's own Requires-Dist -- no hand-maintained pin list that can
+          # drift from the package metadata.
+          uv pip install --system --force-reinstall \
+            ./python-compat-smoke-artifacts/pecos-rslib/pecos_rslib-*.whl \
+            ./python-compat-smoke-artifacts/pecos-rslib-llvm/pecos_rslib_llvm-*.whl \
+            ./python-compat-smoke-artifacts/quantum-pecos/quantum_pecos-*.whl
+          uv pip check --system
         fi
 
     - name: Run Python compatibility smoke test


### PR DESCRIPTION
Found during the Codex cross-review of the post-release maintenance plan: both wheel smoke lanes (`pr_smoke_test` in `python-release.yml`, `python-compat-smoke` in `python-test.yml`) hand-install a **stale dependency set** (`guppylang>=0.21.6`, `tket<0.12.16`, `hugr>=0.13.0`) and then install the quantum-pecos wheel with `--no-deps`. The package metadata has moved on (`tket>=0.13,<0.14`, `guppylang>=0.21.16,<0.22`, `hugr>=0.16,<0.17`), so the smoke test could pass in an environment that **violates the wheel's own `Requires-Dist`** — green smoke, unresolvable metadata.

**Fix:** install all local wheels in a single resolver invocation — the local `pecos-rslib`/`pecos-rslib-llvm` wheels satisfy quantum-pecos's exact pins (which don't exist on PyPI for unreleased versions), and every other dependency resolves from the wheel's real metadata. Then `uv pip check` validates the resulting environment. No duplicated pin list left to drift.

The lanes run on this PR, so the fix proves itself in CI here.
