### PR TITLE
fix(wasm): arm epoch deadline before instantiation

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -519,6 +519,9 @@ jobs:
           fi
         fi
 
+    - name: Execute WASM compatibility smoke test
+      run: python scripts/ci/smoke_wasm_foreign_object.py
+
   # Post-merge lanes excluded from the PR fast path: the slow integration
   # tests and the optional-dependency suite (guppy/selene/QIR runtime tests
   # marked `optional_dependency`).

--- a/crates/pecos-wasm/src/wasmtime_foreign_object.rs
+++ b/crates/pecos-wasm/src/wasmtime_foreign_object.rs
@@ -421,6 +421,12 @@ impl ForeignObject for WasmForeignObject {
     fn new_instance(&mut self) -> Result<(), PecosError> {
         let mut store = self.store.write();
 
+        // Instantiation can execute enough Wasm work to observe an epoch
+        // interrupt. Arm the deadline before Instance::new, just as exec does
+        // before calling an exported function.
+        let max_ticks = Self::calculate_max_ticks(self.timeout_seconds);
+        store.set_epoch_deadline(max_ticks);
+
         // Create a new instance
         let instance = Instance::new(&mut *store, &self.module, &[]).map_err(|e| {
             PecosError::Processing(format!("Failed to create WebAssembly instance: {e}"))

--- a/crates/pecos-wasm/tests/instantiation_deadline.rs
+++ b/crates/pecos-wasm/tests/instantiation_deadline.rs
@@ -1,0 +1,20 @@
+use pecos_wasm::{ForeignObject, WasmForeignObject};
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("wat")
+        .join(name)
+}
+
+#[test]
+fn finite_start_function_is_not_interrupted_during_instantiation() {
+    let wat_path = fixture_path("finite_start_loop.wat");
+    let mut wasm = WasmForeignObject::with_timeout(wat_path, 1.0)
+        .expect("a finite start function should complete within its timeout");
+
+    // init() creates a second instance, so this also covers re-instantiation.
+    wasm.init()
+        .expect("re-instantiation should re-arm the epoch deadline");
+}

--- a/crates/pecos-wasm/tests/wat/finite_start_loop.wat
+++ b/crates/pecos-wasm/tests/wat/finite_start_loop.wat
@@ -1,0 +1,18 @@
+(module
+  ;; Keep instantiation active long enough for the epoch timer thread to tick,
+  ;; while remaining comfortably inside the one-second test timeout.
+  (func $finite_start_loop
+    (local $remaining i32)
+    i32.const 50000000
+    local.set $remaining
+    (loop $spin
+      local.get $remaining
+      i32.const 1
+      i32.sub
+      local.tee $remaining
+      br_if $spin
+    )
+  )
+  (start $finite_start_loop)
+  (func (export "init"))
+)

--- a/scripts/ci/smoke_wasm_foreign_object.py
+++ b/scripts/ci/smoke_wasm_foreign_object.py
@@ -1,0 +1,16 @@
+"""Exercise WasmForeignObject from a built wheel on compatibility runners."""
+
+from pathlib import Path
+
+from pecos_rslib import WasmForeignObject
+
+repo_root = Path(__file__).resolve().parents[2]
+wat_path = repo_root / "crates" / "pecos-wasm" / "tests" / "wat" / "finite_start_loop.wat"
+
+wasm = WasmForeignObject.from_file(wat_path)
+try:
+    wasm.init()
+finally:
+    wasm.teardown()
+
+print(f"WASM compatibility smoke test passed: {wat_path.name}")


### PR DESCRIPTION
## Summary

- Arm the Wasmtime epoch deadline before Instance::new so module start functions receive the configured timeout.
- Add a Rust regression test covering initial construction and init-time re-instantiation with a tracked WAT fixture.
- Exercise the same WAT fixture through the built pecos-rslib wheel in the Python compatibility matrix, including macOS arm64.

## Context

With Wasmtime 46 on macOS arm64, the epoch thread can advance while a sufficiently complex module is being instantiated. The store previously kept Wasmtime's default epoch deadline until exec armed it for an exported call, so Instance::new could trap with interrupt before execution began.

This PR arms the existing timeout deadline for every instance creation. It intentionally tracks only the textual WAT regression fixture; no WASM binary is added.

## Validation

- cargo test -p pecos-wasm
- cargo clippy -p pecos-wasm --all-targets -- -D warnings
- cargo fmt --all --check
- uv run ruff check scripts/ci/smoke_wasm_foreign_object.py
- uv run ruff format --check scripts/ci/smoke_wasm_foreign_object.py
- qemulator targeted WASM tests: 6 passed
- qemulator full suite against an optimized patched pecos-rslib: 199 passed, 3 skipped