### PR TITLE
Bump Python packages to 0.9.0.dev1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,11 +13,12 @@ The version is a literal in many coordinated places. Bump them all:
   `python/selene-plugins/*` packages)
 - Exact-version internal pins: the root's `quantum-pecos[cuda12/13]==...`
   entries and quantum-pecos's `pecos-rslib==...` / `pecos-rslib-llvm==...`
-- Regenerate both lockfiles: `uv lock` at the root and in `exp/zluppy/`
-  (verify the diffs are version-lines-only)
-- `docs/user-guide/cli.md` example output
+- Regenerate both lockfiles: `uv lock` at the root and in `exp/zluppy/`,
+  using the same uv version CI pins in `.github/workflows/` (verify the
+  diffs are version-lines-only)
 
-Verify: `git grep <old-version>` returns nothing; `uv lock --check` passes;
+Verify: `git grep <old-version>` returns nothing outside this file's
+historical note; `uv lock --check` passes;
 `just python-ci-sync-test` then `python -c "import pecos; print(pecos.__version__)"`
 reports the new version.
 

--- a/exp/zluppy/uv.lock
+++ b/exp/zluppy/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "../../python/pecos-rslib" }
 
 [package.metadata]
@@ -554,7 +554,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "../../python/pecos-rslib-llvm" }
 
 [package.metadata]
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "../../python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-workspace"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 # Meta-package; runtime deps live in the member packages. Test/example/dev
 # tooling is declared in [dependency-groups] below.
@@ -10,8 +10,8 @@ dependencies = []
 # Keep these in sync with the cuda dependency groups below. The extras support
 # `uv sync --extra cuda13`; the groups support `uv run --group cuda13 ...`.
 # Pick the extra matching your CUDA major -- do not install both.
-cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev0"]
-cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev0"]
+cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev1"]
+cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev1"]
 
 [tool.uv.workspace]
 members = [
@@ -70,10 +70,10 @@ numpy-compat = [ # NumPy/SciPy compatibility tests - verify compatibility with s
   "scipy>=1.1.0",
 ]
 cuda13 = [ # CUDA 13 Python packages for GPU-accelerated simulations (requires CUDA toolkit)
-  "quantum-pecos[cuda13]==0.9.0.dev0",
+  "quantum-pecos[cuda13]==0.9.0.dev1",
 ]
 cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
-  "quantum-pecos[cuda12]==0.9.0.dev0",
+  "quantum-pecos[cuda12]==0.9.0.dev1",
 ]
 
 [tool.uv]

--- a/python/pecos-rslib-cuda/pyproject.toml
+++ b/python/pecos-rslib-cuda/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 description = "CUDA/cuQuantum Python bindings for PECOS quantum simulators (Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-exp/pyproject.toml
+++ b/python/pecos-rslib-exp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 description = "Python bindings for experimental PECOS simulators (StabMps, Mast)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-llvm/pyproject.toml
+++ b/python/pecos-rslib-llvm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 description = "LLVM IR generation Python bindings for PECOS (llvmlite-compatible API, Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib/pyproject.toml
+++ b/python/pecos-rslib/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 description = "Rust libary extensions for Python PECOS."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quantum-pecos"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 authors = [
     {name = "The PECOS Developers"},
 ]
@@ -28,8 +28,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE"}
 keywords = ["quantum", "QEC", "simulation", "PECOS"]
 dependencies = [
-    "pecos-rslib==0.9.0.dev0",
-    "pecos-rslib-llvm==0.9.0.dev0",
+    "pecos-rslib==0.9.0.dev1",
+    "pecos-rslib-llvm==0.9.0.dev1",
     "phir>=0.3.3",
     "networkx>=2.1.0",
     # Pin to the 0.21.x line (tket.bool era). guppylang 0.22+ emits the

--- a/python/selene-plugins/pecos-selene-mast/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-mast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-mast"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 description = "PECOS Mast simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 description = "PECOS StabMps simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 description = "PECOS StabVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 description = "PECOS Stabilizer simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-statevec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-statevec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 requires-python = ">=3.10"
 description = "PECOS StateVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1186,7 +1186,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (python_full_version < '3.13' and extra != 'extra-13-quantum-pecos-cuda12' and extra != 'extra-13-quantum-pecos-cuda13') or (python_full_version >= '3.13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (python_full_version >= '3.13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-13-quantum-pecos-cuda13' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda13' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-13-quantum-pecos-cuda12' and extra == 'extra-13-quantum-pecos-cuda13') or (extra == 'extra-15-pecos-workspace-cuda12' and extra == 'extra-15-pecos-workspace-cuda13') or (extra == 'group-15-pecos-workspace-cuda12' and extra == 'group-15-pecos-workspace-cuda13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3080,7 +3080,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/pecos-rslib" }
 
 [package.dev-dependencies]
@@ -3111,7 +3111,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/pecos-rslib-cuda" }
 
 [package.dev-dependencies]
@@ -3127,12 +3127,12 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/pecos-rslib-exp" }
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/pecos-rslib-llvm" }
 
 [package.dev-dependencies]
@@ -3148,7 +3148,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-selene-mast"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/selene-plugins/pecos-selene-mast" }
 dependencies = [
     { name = "selene-core" },
@@ -3172,7 +3172,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/selene-plugins/pecos-selene-stab-mps" }
 dependencies = [
     { name = "selene-core" },
@@ -3196,7 +3196,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/selene-plugins/pecos-selene-stab-vec" }
 dependencies = [
     { name = "selene-core" },
@@ -3220,7 +3220,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/selene-plugins/pecos-selene-stabilizer" }
 dependencies = [
     { name = "selene-core" },
@@ -3244,7 +3244,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/selene-plugins/pecos-selene-statevec" }
 dependencies = [
     { name = "selene-core" },
@@ -3268,7 +3268,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-workspace"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -4210,7 +4210,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },


### PR DESCRIPTION
## Summary

- Bump all Python package versions from 0.9.0.dev0 to 0.9.0.dev1 in preparation for the next pre-release: root meta-package, pecos-rslib{,-llvm,-cuda,-exp}, quantum-pecos, and the five selene plugins.
- Update the exact-version internal pins (root's `quantum-pecos[cuda12/13]==...` and quantum-pecos's `pecos-rslib==...` / `pecos-rslib-llvm==...`).
- Regenerate both lockfiles with uv 0.11.14 (the version CI pins).
- RELEASING.md: drop the stale `docs/user-guide/cli.md` bullet (the doctor example was made version-agnostic in #353), note that lockfiles should be regenerated with the CI-pinned uv version, and scope the `git grep` verification to exclude this file's historical note.

## Notes

- The lockfile diffs are version-lines-only with one exception: uv re-simplified the marker on exceptiongroup's typing-extensions dependency edge. Verified benign: every edge into exceptiongroup is gated `python_full_version < '3.11'`, so the simplified marker is equivalent for all reachable environments. A newer local uv (0.11.16) produced additional marker churn, which is why the locks were regenerated with the pinned 0.11.14.

## Validation

- `git grep 0.9.0.dev0` matches only RELEASING.md's historical notes
- `uvx uv@0.11.14 lock --check` passes at the root and in exp/zluppy/
- `just python-ci-sync-test` succeeds; `importlib.metadata` reports 0.9.0.dev1 for quantum-pecos, pecos-rslib, and pecos-rslib-llvm, and `pecos.__version__` is 0.9.0.dev1