### PR TITLE
Bump Python packages to 0.9.0.dev2

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 The final PyPI push is deliberately **manual**: artifact building and testing
 are automated, but a human runs the upload and confirms each package. This
-sequence was last exercised for `0.9.0.dev0`.
+sequence was last exercised for `0.9.0.dev1`.
 
 ## 1. Version bump (its own PR)
 

--- a/exp/zluppy/uv.lock
+++ b/exp/zluppy/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "../../python/pecos-rslib" }
 
 [package.metadata]
@@ -554,7 +554,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "../../python/pecos-rslib-llvm" }
 
 [package.metadata]
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "../../python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-workspace"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 # Meta-package; runtime deps live in the member packages. Test/example/dev
 # tooling is declared in [dependency-groups] below.
@@ -10,8 +10,8 @@ dependencies = []
 # Keep these in sync with the cuda dependency groups below. The extras support
 # `uv sync --extra cuda13`; the groups support `uv run --group cuda13 ...`.
 # Pick the extra matching your CUDA major -- do not install both.
-cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev1"]
-cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev1"]
+cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev2"]
+cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev2"]
 
 [tool.uv.workspace]
 members = [
@@ -70,10 +70,10 @@ numpy-compat = [ # NumPy/SciPy compatibility tests - verify compatibility with s
   "scipy>=1.1.0",
 ]
 cuda13 = [ # CUDA 13 Python packages for GPU-accelerated simulations (requires CUDA toolkit)
-  "quantum-pecos[cuda13]==0.9.0.dev1",
+  "quantum-pecos[cuda13]==0.9.0.dev2",
 ]
 cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
-  "quantum-pecos[cuda12]==0.9.0.dev1",
+  "quantum-pecos[cuda12]==0.9.0.dev2",
 ]
 
 [tool.uv]

--- a/python/pecos-rslib-cuda/pyproject.toml
+++ b/python/pecos-rslib-cuda/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 description = "CUDA/cuQuantum Python bindings for PECOS quantum simulators (Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-exp/pyproject.toml
+++ b/python/pecos-rslib-exp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 description = "Python bindings for experimental PECOS simulators (StabMps, Mast)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-llvm/pyproject.toml
+++ b/python/pecos-rslib-llvm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 description = "LLVM IR generation Python bindings for PECOS (llvmlite-compatible API, Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib/pyproject.toml
+++ b/python/pecos-rslib/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 description = "Rust libary extensions for Python PECOS."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quantum-pecos"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 authors = [
     {name = "The PECOS Developers"},
 ]
@@ -28,8 +28,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE"}
 keywords = ["quantum", "QEC", "simulation", "PECOS"]
 dependencies = [
-    "pecos-rslib==0.9.0.dev1",
-    "pecos-rslib-llvm==0.9.0.dev1",
+    "pecos-rslib==0.9.0.dev2",
+    "pecos-rslib-llvm==0.9.0.dev2",
     "phir>=0.3.3",
     "networkx>=2.1.0",
     # Pin to the 0.21.x line (tket.bool era). guppylang 0.22+ emits the

--- a/python/selene-plugins/pecos-selene-mast/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-mast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-mast"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 description = "PECOS Mast simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 description = "PECOS StabMps simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 description = "PECOS StabVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 description = "PECOS Stabilizer simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-statevec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-statevec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 requires-python = ">=3.10"
 description = "PECOS StateVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3080,7 +3080,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/pecos-rslib" }
 
 [package.dev-dependencies]
@@ -3111,7 +3111,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/pecos-rslib-cuda" }
 
 [package.dev-dependencies]
@@ -3127,12 +3127,12 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/pecos-rslib-exp" }
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/pecos-rslib-llvm" }
 
 [package.dev-dependencies]
@@ -3148,7 +3148,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-selene-mast"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/selene-plugins/pecos-selene-mast" }
 dependencies = [
     { name = "selene-core" },
@@ -3172,7 +3172,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/selene-plugins/pecos-selene-stab-mps" }
 dependencies = [
     { name = "selene-core" },
@@ -3196,7 +3196,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/selene-plugins/pecos-selene-stab-vec" }
 dependencies = [
     { name = "selene-core" },
@@ -3220,7 +3220,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/selene-plugins/pecos-selene-stabilizer" }
 dependencies = [
     { name = "selene-core" },
@@ -3244,7 +3244,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/selene-plugins/pecos-selene-statevec" }
 dependencies = [
     { name = "selene-core" },
@@ -3268,7 +3268,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-workspace"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -4210,7 +4210,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev1"
+version = "0.9.0.dev2"
 source = { editable = "python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },


### PR DESCRIPTION
Bumps all Python package versions from 0.9.0.dev1 to 0.9.0.dev2, following the RELEASING.md checklist:

- Version literals in the 11 pyproject.toml files (workspace root, quantum-pecos, pecos-rslib{,-llvm,-cuda,-exp}, and the five selene plugins), including the exact-version internal pins.
- Both lockfiles regenerated with the CI-pinned uv 0.11.14; diffs are version-lines-only.
- RELEASING.md historical note updated to reflect that the publish sequence was last exercised for 0.9.0.dev1 (confirmed on PyPI).

Verified: `git grep 0.9.0.dev1` returns only the RELEASING.md historical note; `uv lock --check` passes for both lockfiles; `just python-ci-sync-test` succeeds and `import pecos` reports `0.9.0.dev2`.