### PR TITLE
Give the Windows compat-smoke build a 30-minute timeout to absorb runner-setup variance

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -229,7 +229,7 @@ jobs:
 
   python-compat-smoke-build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.job-timeout }}
     strategy:
       fail-fast: false
       matrix:
@@ -239,16 +239,22 @@ jobs:
             artifact-name: python-compat-smoke-ubuntu
             build-llvm: true
             build-quantum-pecos: true
+            job-timeout: 20
+          # 30 minutes: Windows runner preparation (disk cleanup) varies by
+          # several minutes and the pecos-rslib wheel compile alone takes
+          # 10-12, so 20 minutes cancelled a healthy build (issue #360).
           - os: windows-2022
             python-version: "3.10"
             artifact-name: python-compat-smoke-windows
             build-llvm: false
             build-quantum-pecos: false
+            job-timeout: 30
           - os: macOS-latest
             python-version: "3.10"
             artifact-name: python-compat-smoke-macos
             build-llvm: true
             build-quantum-pecos: false
+            job-timeout: 20
 
     steps:
     - name: Harden the runner (egress audit)

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -229,7 +229,9 @@ jobs:
 
   python-compat-smoke-build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.job-timeout }}
+    # The || guard keeps a future entry that forgets job-timeout at the
+    # historical 20 minutes instead of GitHub's 360-minute default.
+    timeout-minutes: ${{ matrix.job-timeout || 20 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes #360.

The python-compat-smoke-build job shared one 20-minute timeout across its OS matrix. On Windows, runner preparation (Free Disk Space) varies by several minutes and the pecos-rslib wheel compile alone takes 10-12, so a slow-setup run cancelled a healthy build with no compiler or test failure (PR #359 attempt 1; identical rerun passed in 15m58s).

Per the issue's proposed hardening, the timeout is now a per-matrix-entry value: Windows gets 30 minutes, Ubuntu and macOS keep 20. All build and compatibility coverage is unchanged; genuine failures still fail the job.

## Testing
- YAML validated; matrix expression confirmed to resolve per entry (ubuntu 20, windows-2022 30, macOS 20).
- The Windows lane of this PR's own CI run exercises the changed job.