### PR TITLE
Make Selene/QIS native-library discovery cwd-independent

### DIFF
--- a/crates/pecos-qis/src/executor.rs
+++ b/crates/pecos-qis/src/executor.rs
@@ -942,7 +942,18 @@ impl QisHeliosInterface {
             .clone()
     }
 
-    /// Find the `libpecos_qis_ffi` library by searching common locations
+    /// Find the `libpecos_qis_ffi` library by searching common locations.
+    ///
+    /// Issue #365 discovery precedence is: the authoritative
+    /// `PECOS_QIS_FFI_PATH` override; executable-adjacent and compile-time
+    /// workspace artifacts from this build; `CARGO_TARGET_DIR`; then the
+    /// remaining parent/cwd fallbacks. Keeping runtime Cargo overrides below
+    /// build-associated locations reduces the risk of loading a stale,
+    /// ABI-incompatible FFI library across ownership-transferring calls.
+    ///
+    /// Unlike `PECOS_SELENE_DIR`, which is one source in a fallthrough search,
+    /// a set-but-invalid `PECOS_QIS_FFI_PATH` fails loudly because it is an
+    /// authoritative per-purpose override.
     fn find_pecos_qis_lib() -> Result<PathBuf, InterfaceError> {
         let lib_name = platform_library_name("pecos_qis_ffi");
 
@@ -975,18 +986,6 @@ impl QisHeliosInterface {
             )));
         }
 
-        let mut cargo_target_paths = Vec::new();
-        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
-            let target_dir = PathBuf::from(target_dir);
-            for profile in &profile_order {
-                cargo_target_paths.push(target_dir.join(profile).join(&lib_name));
-                cargo_target_paths.push(target_dir.join(profile).join("deps").join(&lib_name));
-            }
-            if let Some(path) = cargo_target_paths.iter().find(|path| path.is_file()) {
-                return Ok(path.clone());
-            }
-        }
-
         let exe_dir = std::env::current_exe()
             .ok()
             .and_then(|exe| exe.parent().map(std::path::Path::to_path_buf))
@@ -998,31 +997,55 @@ impl QisHeliosInterface {
 
         debug!("Executable directory: {}", exe_dir.display());
 
-        let mut candidate_paths = cargo_target_paths;
-        candidate_paths.extend([
-            exe_dir.join(&lib_name),
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        Self::find_pecos_qis_lib_from_roots(&exe_dir, &manifest_dir, &profile_order, &lib_name)
+    }
+
+    fn find_pecos_qis_lib_from_roots(
+        exe_dir: &Path,
+        manifest_dir: &Path,
+        profile_order: &[&str; 2],
+        lib_name: &str,
+    ) -> Result<PathBuf, InterfaceError> {
+        let mut candidate_paths = vec![
+            exe_dir.join(lib_name),
             exe_dir.join(format!("deps/{lib_name}")),
-        ]);
+        ];
 
         // Editable/development installs may execute from outside the checkout.
         // Preserve the workspace target as a stable fallback in that case.
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         if let Some(workspace_root) = manifest_dir.parent().and_then(std::path::Path::parent) {
-            for profile in &profile_order {
+            for profile in profile_order {
                 candidate_paths.push(workspace_root.join(format!("target/{profile}/{lib_name}")));
                 candidate_paths
                     .push(workspace_root.join(format!("target/{profile}/deps/{lib_name}")));
             }
         }
 
+        if let Some(path) = candidate_paths.iter().find(|path| path.is_file()) {
+            return Ok(path.clone());
+        }
+
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            let target_dir = PathBuf::from(target_dir);
+            for profile in profile_order {
+                let profile_dir = target_dir.join(profile);
+                if let Some(path) = find_library_in_dir(&profile_dir, "pecos_qis_ffi") {
+                    return Ok(path);
+                }
+                candidate_paths.push(profile_dir.join(lib_name));
+                candidate_paths.push(profile_dir.join("deps").join(lib_name));
+            }
+        }
+
         if let Some(parent) = exe_dir.parent() {
-            candidate_paths.push(parent.join(&lib_name));
+            candidate_paths.push(parent.join(lib_name));
             candidate_paths.push(parent.join(format!("deps/{lib_name}")));
         }
 
         if let Ok(current_dir) = std::env::current_dir() {
             debug!("Current directory: {}", current_dir.display());
-            for profile in &profile_order {
+            for profile in profile_order {
                 candidate_paths.push(current_dir.join(format!("target/{profile}/{lib_name}")));
                 candidate_paths.push(current_dir.join(format!("target/{profile}/deps/{lib_name}")));
             }
@@ -1032,7 +1055,7 @@ impl QisHeliosInterface {
             for _ in 0..5 {
                 // Search up to 5 levels
                 if let Some(parent) = search_dir.parent() {
-                    for profile in &profile_order {
+                    for profile in profile_order {
                         candidate_paths.push(parent.join(format!("target/{profile}/{lib_name}")));
                         candidate_paths
                             .push(parent.join(format!("target/{profile}/deps/{lib_name}")));
@@ -2605,5 +2628,93 @@ mod tests {
         let error = QisHeliosInterface::find_pecos_qis_lib()
             .expect_err("empty override directory must fail");
         assert!(error.to_string().contains("PECOS_QIS_FFI_PATH"));
+    }
+
+    #[test]
+    fn qis_ffi_cargo_target_finds_hashed_deps_library() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let cargo_target = temp_dir.path().join("cargo-target");
+        let profile = if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        };
+        let deps_dir = cargo_target.join(profile).join("deps");
+        std::fs::create_dir_all(&deps_dir).expect("create Cargo deps directory");
+        let exact_name = platform_library_name("pecos_qis_ffi");
+        let (stem, extension) = exact_name
+            .rsplit_once('.')
+            .expect("platform library name has extension");
+        let library_path = deps_dir.join(format!("{stem}-abc123.{extension}"));
+        File::create(&library_path).expect("create hashed library");
+        let _env = EnvVarGuard::set("CARGO_TARGET_DIR", &cargo_target);
+
+        let fake_exe_dir = temp_dir.path().join("untrusted/bin");
+        let fake_manifest_dir = temp_dir.path().join("untrusted/workspace/crates/pecos-qis");
+        let profile_order = if cfg!(debug_assertions) {
+            ["debug", "release"]
+        } else {
+            ["release", "debug"]
+        };
+
+        assert_eq!(
+            QisHeliosInterface::find_pecos_qis_lib_from_roots(
+                &fake_exe_dir,
+                &fake_manifest_dir,
+                &profile_order,
+                &exact_name,
+            )
+            .expect("find hashed Cargo target library"),
+            library_path
+        );
+    }
+
+    #[test]
+    fn qis_ffi_build_associated_library_precedes_cargo_target() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let exe_dir = temp_dir.path().join("bin");
+        std::fs::create_dir(&exe_dir).expect("create executable directory");
+        let exact_name = platform_library_name("pecos_qis_ffi");
+        let exe_library = exe_dir.join(&exact_name);
+        File::create(&exe_library).expect("create executable-adjacent library");
+
+        let cargo_target = temp_dir.path().join("cargo-target");
+        let profile = if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        };
+        let cargo_deps = cargo_target.join(profile).join("deps");
+        std::fs::create_dir_all(&cargo_deps).expect("create Cargo deps directory");
+        let (stem, extension) = exact_name
+            .rsplit_once('.')
+            .expect("platform library name has extension");
+        File::create(cargo_deps.join(format!("{stem}-newer.{extension}")))
+            .expect("create Cargo target library");
+        let _env = EnvVarGuard::set("CARGO_TARGET_DIR", cargo_target);
+
+        let fake_manifest_dir = temp_dir.path().join("workspace/crates/pecos-qis");
+        let profile_order = if cfg!(debug_assertions) {
+            ["debug", "release"]
+        } else {
+            ["release", "debug"]
+        };
+
+        assert_eq!(
+            QisHeliosInterface::find_pecos_qis_lib_from_roots(
+                &exe_dir,
+                &fake_manifest_dir,
+                &profile_order,
+                &exact_name,
+            )
+            .expect("find build-associated library"),
+            exe_library
+        );
     }
 }

--- a/crates/pecos-qis/src/executor.rs
+++ b/crates/pecos-qis/src/executor.rs
@@ -3,6 +3,9 @@
 //! This module implements the `QisInterface` trait for Selene's Helios compiler.
 
 use crate::qis_interface::{DynamicSyncHandle, InterfaceError, ProgramFormat, QisInterface};
+use crate::selene_runtimes::{
+    find_library_in_dir, platform_hashed_library_pattern, platform_library_name,
+};
 use libloading::{Library, Symbol};
 use log::{debug, error, info, warn};
 use pecos_qis_ffi_types::OperationCollector;
@@ -941,22 +944,48 @@ impl QisHeliosInterface {
 
     /// Find the `libpecos_qis_ffi` library by searching common locations
     fn find_pecos_qis_lib() -> Result<PathBuf, InterfaceError> {
-        // On Windows, Rust cdylibs don't use the "lib" prefix
-        // On Unix (Linux/macOS), they do use the "lib" prefix
-        let (lib_prefix, lib_ext) = if cfg!(target_os = "windows") {
-            ("", "dll")
-        } else if cfg!(target_os = "macos") {
-            ("lib", "dylib")
-        } else {
-            ("lib", "so")
-        };
-
-        let lib_name = format!("{lib_prefix}pecos_qis_ffi.{lib_ext}");
+        let lib_name = platform_library_name("pecos_qis_ffi");
 
         debug!(
             "Looking for QIS FFI library: {lib_name} on {}",
             std::env::consts::OS
         );
+
+        let profile_order = if cfg!(debug_assertions) {
+            ["debug", "release"]
+        } else {
+            ["release", "debug"]
+        };
+
+        if let Some(override_path) = std::env::var_os("PECOS_QIS_FFI_PATH") {
+            let override_path = PathBuf::from(override_path);
+            let hashed_pattern = platform_hashed_library_pattern("pecos_qis_ffi");
+            if override_path.is_file() {
+                return Ok(override_path);
+            }
+            if override_path.is_dir()
+                && let Some(path) = find_library_in_dir(&override_path, "pecos_qis_ffi")
+            {
+                return Ok(path);
+            }
+
+            return Err(InterfaceError::ExecutionError(format!(
+                "PECOS_QIS_FFI_PATH is set to {}, but no library was found. Searched it as a direct file and searched for {lib_name} and {hashed_pattern} in the directory and its deps subdirectory",
+                override_path.display()
+            )));
+        }
+
+        let mut cargo_target_paths = Vec::new();
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            let target_dir = PathBuf::from(target_dir);
+            for profile in &profile_order {
+                cargo_target_paths.push(target_dir.join(profile).join(&lib_name));
+                cargo_target_paths.push(target_dir.join(profile).join("deps").join(&lib_name));
+            }
+            if let Some(path) = cargo_target_paths.iter().find(|path| path.is_file()) {
+                return Ok(path.clone());
+            }
+        }
 
         let exe_dir = std::env::current_exe()
             .ok()
@@ -969,16 +998,11 @@ impl QisHeliosInterface {
 
         debug!("Executable directory: {}", exe_dir.display());
 
-        let profile_order = if cfg!(debug_assertions) {
-            ["debug", "release"]
-        } else {
-            ["release", "debug"]
-        };
-
-        let mut candidate_paths = vec![
+        let mut candidate_paths = cargo_target_paths;
+        candidate_paths.extend([
             exe_dir.join(&lib_name),
             exe_dir.join(format!("deps/{lib_name}")),
-        ];
+        ]);
 
         // Editable/development installs may execute from outside the checkout.
         // Preserve the workspace target as a stable fallback in that case.
@@ -2509,5 +2533,77 @@ impl Drop for QisHeliosInterface {
         //
         // In both cases, leaking the context is acceptable and avoids the TLS hang.
         let _ = self.execution_context.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::{ENV_MUTEX, EnvVarGuard};
+    use std::fs::File;
+
+    #[test]
+    fn qis_ffi_env_accepts_direct_file() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let library = tempfile::NamedTempFile::new().expect("create temp library");
+        let _env = EnvVarGuard::set("PECOS_QIS_FFI_PATH", library.path());
+
+        assert_eq!(
+            QisHeliosInterface::find_pecos_qis_lib().expect("find direct library"),
+            library.path()
+        );
+    }
+
+    #[test]
+    fn qis_ffi_env_accepts_directory_with_exact_library() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let library_path = temp_dir.path().join(platform_library_name("pecos_qis_ffi"));
+        File::create(&library_path).expect("create exact library");
+        let _env = EnvVarGuard::set("PECOS_QIS_FFI_PATH", temp_dir.path());
+
+        assert_eq!(
+            QisHeliosInterface::find_pecos_qis_lib().expect("find exact library"),
+            library_path
+        );
+    }
+
+    #[test]
+    fn qis_ffi_env_accepts_directory_with_hashed_deps_library() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let deps_dir = temp_dir.path().join("deps");
+        std::fs::create_dir(&deps_dir).expect("create deps directory");
+        let exact_name = platform_library_name("pecos_qis_ffi");
+        let (stem, extension) = exact_name
+            .rsplit_once('.')
+            .expect("platform library name has extension");
+        let library_path = deps_dir.join(format!("{stem}-abc123.{extension}"));
+        File::create(&library_path).expect("create hashed library");
+        let _env = EnvVarGuard::set("PECOS_QIS_FFI_PATH", temp_dir.path());
+
+        assert_eq!(
+            QisHeliosInterface::find_pecos_qis_lib().expect("find hashed library"),
+            library_path
+        );
+    }
+
+    #[test]
+    fn qis_ffi_env_fails_fast_for_empty_directory() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let _env = EnvVarGuard::set("PECOS_QIS_FFI_PATH", temp_dir.path());
+
+        let error = QisHeliosInterface::find_pecos_qis_lib()
+            .expect_err("empty override directory must fail");
+        assert!(error.to_string().contains("PECOS_QIS_FFI_PATH"));
     }
 }

--- a/crates/pecos-qis/src/lib.rs
+++ b/crates/pecos-qis/src/lib.rs
@@ -222,3 +222,40 @@ pub fn selene_soft_rz_engine() -> Result<QisEngineBuilder, RuntimeFetchError> {
         .runtime(selene_soft_rz_runtime()?)
         .interface(helios_interface_builder()))
 }
+
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::ffi::{OsStr, OsString};
+    use std::sync::Mutex;
+
+    pub(crate) static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        pub(crate) fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: Environment-mutating tests hold ENV_MUTEX for the guard's lifetime.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: Environment-mutating tests hold ENV_MUTEX for the guard's lifetime.
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+}

--- a/crates/pecos-qis/src/lib.rs
+++ b/crates/pecos-qis/src/lib.rs
@@ -228,6 +228,8 @@ pub(crate) mod test_env {
     use std::ffi::{OsStr, OsString};
     use std::sync::Mutex;
 
+    // Environment variables are process-wide. Every test in this crate that
+    // reads or mutates environment state must hold this lock.
     pub(crate) static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     pub(crate) struct EnvVarGuard {

--- a/crates/pecos-qis/src/selene_runtimes.rs
+++ b/crates/pecos-qis/src/selene_runtimes.rs
@@ -33,7 +33,8 @@ pub(crate) fn find_library_in_dir(dir: &Path, lib_name: &str) -> Option<PathBuf>
     let exact_name = platform_library_name(lib_name);
     let hashed_stem_prefix = format!("{lib_prefix}{lib_name}-");
 
-    for search_dir in [dir.to_path_buf(), dir.join("deps")] {
+    // Cargo dependency artifacts are fresher than copied top-level artifacts.
+    for search_dir in [dir.join("deps"), dir.to_path_buf()] {
         let exact_path = search_dir.join(&exact_name);
         if exact_path.is_file() {
             return Some(exact_path);
@@ -56,6 +57,30 @@ pub(crate) fn find_library_in_dir(dir: &Path, lib_name: &str) -> Option<PathBuf>
                         .is_some_and(|hash| !hash.is_empty())
             })
             .collect::<Vec<_>>();
+
+        let modified_times = hashed_paths
+            .iter()
+            .map(|path| path.metadata().and_then(|metadata| metadata.modified()))
+            .collect::<Result<Vec<_>, _>>();
+        if let Ok(modified_times) = modified_times {
+            let mut paths_with_times = hashed_paths
+                .into_iter()
+                .zip(modified_times)
+                .collect::<Vec<_>>();
+            paths_with_times.sort_unstable_by(
+                |(left_path, left_time), (right_path, right_time)| {
+                    right_time
+                        .cmp(left_time)
+                        .then_with(|| left_path.cmp(right_path))
+                },
+            );
+            if let Some((path, _)) = paths_with_times.into_iter().next() {
+                return Some(path);
+            }
+            continue;
+        }
+
+        // Some filesystems do not expose modification times.
         hashed_paths.sort_unstable();
         if let Some(path) = hashed_paths.into_iter().next() {
             return Some(path);
@@ -248,6 +273,14 @@ fn find_cargo_target_dir() -> Option<PathBuf> {
 /// 2. Current target/release or target/debug
 /// 3. Workspace target directory
 /// 4. System library paths
+///
+/// Hash-suffixed matching is anchored on the complete requested library name
+/// followed by `-`. A partial name such as `"simple"` therefore does not match
+/// `selene_simple_runtime-*` artifacts.
+///
+/// `PECOS_SELENE_DIR` is one source in this fallthrough search, so a bad value
+/// warns and continues. In contrast, `PECOS_QIS_FFI_PATH` is an authoritative
+/// per-purpose override and fails loudly when set incorrectly.
 #[must_use]
 pub fn find_selene_runtime(name: &str) -> Option<PathBuf> {
     let lib_name = if name.starts_with("selene_") {
@@ -338,6 +371,7 @@ mod tests {
     use super::*;
     use crate::test_env::{ENV_MUTEX, EnvVarGuard};
     use std::fs::File;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn test_find_selene_runtime() {
@@ -370,6 +404,34 @@ mod tests {
         assert_eq!(
             find_selene_runtime("selene_simple_runtime"),
             Some(runtime_path)
+        );
+    }
+
+    #[test]
+    fn library_scan_prefers_newest_hashed_dep_over_top_level_exact() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let exact_path = temp_dir
+            .path()
+            .join(platform_library_name("selene_simple_runtime"));
+        File::create(exact_path).expect("create top-level exact library");
+
+        let deps_dir = temp_dir.path().join("deps");
+        std::fs::create_dir(&deps_dir).expect("create deps directory");
+        let (prefix, ext) = platform_library_parts();
+        let older_path = deps_dir.join(format!("{prefix}selene_simple_runtime-aaa-old.{ext}"));
+        let older_file = File::create(older_path).expect("create older hashed library");
+        older_file
+            .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
+            .expect("set older modification time");
+        let newer_path = deps_dir.join(format!("{prefix}selene_simple_runtime-zzz-new.{ext}"));
+        let newer_file = File::create(&newer_path).expect("create newer hashed library");
+        newer_file
+            .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(2))
+            .expect("set newer modification time");
+
+        assert_eq!(
+            find_library_in_dir(temp_dir.path(), "selene_simple_runtime"),
+            Some(newer_path)
         );
     }
 }

--- a/crates/pecos-qis/src/selene_runtimes.rs
+++ b/crates/pecos-qis/src/selene_runtimes.rs
@@ -5,7 +5,65 @@
 //! Selene repository is found at ../selene (relative to PECOS).
 
 use crate::SeleneRuntime;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+fn platform_library_parts() -> (&'static str, &'static str) {
+    if cfg!(target_os = "windows") {
+        ("", "dll")
+    } else if cfg!(target_os = "macos") {
+        ("lib", "dylib")
+    } else {
+        ("lib", "so")
+    }
+}
+
+pub(crate) fn platform_library_name(lib_name: &str) -> String {
+    let (lib_prefix, lib_ext) = platform_library_parts();
+    format!("{lib_prefix}{lib_name}.{lib_ext}")
+}
+
+pub(crate) fn platform_hashed_library_pattern(lib_name: &str) -> String {
+    let (lib_prefix, lib_ext) = platform_library_parts();
+    format!("{lib_prefix}{lib_name}-*.{lib_ext}")
+}
+
+/// Find an exact or Cargo hash-suffixed dynamic library in a directory or its `deps/`.
+pub(crate) fn find_library_in_dir(dir: &Path, lib_name: &str) -> Option<PathBuf> {
+    let (lib_prefix, lib_ext) = platform_library_parts();
+    let exact_name = platform_library_name(lib_name);
+    let hashed_stem_prefix = format!("{lib_prefix}{lib_name}-");
+
+    for search_dir in [dir.to_path_buf(), dir.join("deps")] {
+        let exact_path = search_dir.join(&exact_name);
+        if exact_path.is_file() {
+            return Some(exact_path);
+        }
+
+        let mut hashed_paths = std::fs::read_dir(&search_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case(lib_ext))
+                    && path
+                        .file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .and_then(|stem| stem.strip_prefix(&hashed_stem_prefix))
+                        .is_some_and(|hash| !hash.is_empty())
+            })
+            .collect::<Vec<_>>();
+        hashed_paths.sort_unstable();
+        if let Some(path) = hashed_paths.into_iter().next() {
+            return Some(path);
+        }
+    }
+
+    None
+}
 
 /// Error type for runtime fetching
 #[derive(Debug)]
@@ -115,15 +173,6 @@ pub fn selene_soft_rz_runtime() -> Result<SeleneRuntime, RuntimeFetchError> {
 /// the Selene runtimes are built as dependencies that may not exist when the build
 /// script runs.
 fn find_built_selene_runtime(lib_name: &str) -> Result<PathBuf, RuntimeFetchError> {
-    // Platform-specific library extension
-    let lib_ext = if cfg!(target_os = "macos") {
-        "dylib"
-    } else if cfg!(target_os = "windows") {
-        "dll"
-    } else {
-        "so"
-    };
-
     // Note: We don't check build-time environment variables here because they may be stale
     // The build script runs before Selene runtime dependencies are built, so those env vars
     // would point to non-existent paths. We rely solely on runtime detection instead.
@@ -139,43 +188,13 @@ fn find_built_selene_runtime(lib_name: &str) -> Result<PathBuf, RuntimeFetchErro
             "release"
         };
         let profiles = if current_profile == "release" {
-            vec!["release", "debug"]
+            ["release", "debug"]
         } else {
-            vec!["debug", "release"]
+            ["debug", "release"]
         };
 
         for profile in &profiles {
-            // Check deps directory where cargo puts cdylib dependencies
-            let deps_dir = target.join(profile).join("deps");
-            if deps_dir.exists()
-                && let Ok(entries) = std::fs::read_dir(&deps_dir)
-            {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if let Some(filename) = path.file_name().and_then(|f| f.to_str())
-                        // On Windows, libraries don't have "lib" prefix; on Unix they do
-                        && (filename.starts_with(&format!("lib{lib_name}"))
-                            || filename.starts_with(lib_name))
-                        && path
-                            .extension()
-                            .is_some_and(|ext| ext.eq_ignore_ascii_case(lib_ext))
-                    {
-                        log::info!("Found Selene runtime in cargo deps: {}", path.display());
-                        return Ok(path);
-                    }
-                }
-            }
-
-            // Also check standard location - try both with and without "lib" prefix
-            let lib_prefix = if cfg!(target_os = "windows") {
-                ""
-            } else {
-                "lib"
-            };
-            let runtime_path = target
-                .join(profile)
-                .join(format!("{lib_prefix}{lib_name}.{lib_ext}"));
-            if runtime_path.exists() {
+            if let Some(runtime_path) = find_library_in_dir(&target.join(profile), lib_name) {
                 log::info!(
                     "Found Selene runtime in cargo target: {}",
                     runtime_path.display()
@@ -231,59 +250,42 @@ fn find_cargo_target_dir() -> Option<PathBuf> {
 /// 4. System library paths
 #[must_use]
 pub fn find_selene_runtime(name: &str) -> Option<PathBuf> {
-    // Platform-specific library extension
-    let lib_ext = if cfg!(target_os = "macos") {
-        "dylib"
-    } else if cfg!(target_os = "windows") {
-        "dll"
+    let lib_name = if name.starts_with("selene_") {
+        name.to_string()
     } else {
-        "so"
+        format!("selene_{name}")
     };
-    let filename = format!("libselene_{name}.{lib_ext}");
+    let filename = platform_library_name(&lib_name);
+    let hashed_pattern = platform_hashed_library_pattern(&lib_name);
 
     // Check environment variable
-    if let Ok(selene_dir) = std::env::var("PECOS_SELENE_DIR") {
-        let path = PathBuf::from(selene_dir).join(&filename);
-        if path.exists() {
+    if let Some(selene_dir) = std::env::var_os("PECOS_SELENE_DIR") {
+        let selene_dir = PathBuf::from(selene_dir);
+        if let Some(path) = find_library_in_dir(&selene_dir, &lib_name) {
             return Some(path);
         }
+        log::warn!(
+            "PECOS_SELENE_DIR is set to {}, but neither {filename} nor {hashed_pattern} was found there or in its deps directory",
+            selene_dir.display()
+        );
     }
 
     // Check target directories in current project
     for profile in &["release", "debug"] {
-        let path = PathBuf::from("target").join(profile).join(&filename);
-        if path.exists() {
+        let profile_dir = PathBuf::from("target").join(profile);
+        if let Some(path) = find_library_in_dir(&profile_dir, &lib_name) {
             return Some(path);
-        }
-
-        // Check deps directory
-        let deps_path = PathBuf::from("target").join(profile).join("deps");
-        if deps_path.exists()
-            && let Ok(entries) = std::fs::read_dir(&deps_path)
-        {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(file_name) = path.file_name().and_then(|f| f.to_str())
-                    && file_name.starts_with(&format!("libselene_{name}"))
-                    && path
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case(lib_ext))
-                {
-                    return Some(path);
-                }
-            }
         }
 
         // Check parent directories (in case we're in a workspace member)
         if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-            let workspace_target = PathBuf::from(manifest_dir)
+            let workspace_profile = PathBuf::from(manifest_dir)
                 .parent()?
                 .parent()? // Go up to workspace root
                 .join("target")
-                .join(profile)
-                .join(&filename);
-            if workspace_target.exists() {
-                return Some(workspace_target);
+                .join(profile);
+            if let Some(path) = find_library_in_dir(&workspace_profile, &lib_name) {
+                return Some(path);
             }
         }
     }
@@ -334,14 +336,40 @@ pub fn selene_runtime_auto(lib_name: &str) -> Result<SeleneRuntime, RuntimeFetch
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{ENV_MUTEX, EnvVarGuard};
+    use std::fs::File;
 
     #[test]
     fn test_find_selene_runtime() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // This might not find anything in test environment
         let result = find_selene_runtime("simple");
         // Just verify it doesn't panic
         if let Some(path) = result {
             assert!(path.to_string_lossy().contains("selene_simple"));
         }
+    }
+
+    #[test]
+    fn test_find_selene_runtime_in_hashed_env_deps_dir() {
+        let _env_lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let deps_dir = temp_dir.path().join("deps");
+        std::fs::create_dir(&deps_dir).expect("create deps directory");
+        let runtime_path = deps_dir.join({
+            let (prefix, ext) = platform_library_parts();
+            format!("{prefix}selene_simple_runtime-abc123.{ext}")
+        });
+        File::create(&runtime_path).expect("create hashed runtime library");
+        let _env = EnvVarGuard::set("PECOS_SELENE_DIR", temp_dir.path());
+
+        assert_eq!(
+            find_selene_runtime("selene_simple_runtime"),
+            Some(runtime_path)
+        );
     }
 }

--- a/python/quantum-pecos/src/pecos/_engine_builders.py
+++ b/python/quantum-pecos/src/pecos/_engine_builders.py
@@ -237,12 +237,29 @@ def _looks_like_library_path(value: str) -> bool:
     return path.exists() or "/" in value or "\\" in value or path.suffix in {".so", ".dylib", ".dll"}
 
 
+def _materialize_plugin_candidate(candidate: object) -> tuple[object | None, Exception | None]:
+    try:
+        plugin = candidate() if isinstance(candidate, type) else candidate
+        library_file = getattr(plugin, "library_file", None)
+    except (AssertionError, AttributeError, OSError, RuntimeError, TypeError, ValueError) as error:
+        return None, error
+    return (plugin, None) if library_file is not None else (None, None)
+
+
 def _plugin_object_from_module(module: object) -> object:
-    for exported_name in getattr(module, "__all__", ()):
-        exported = getattr(module, exported_name, None)
-        if isinstance(exported, type):
-            return exported()
-    return module
+    selection_failures = []
+    exported_candidates = [getattr(module, exported_name, None) for exported_name in getattr(module, "__all__", ())]
+    for candidate in [*exported_candidates, module]:
+        plugin, failure = _materialize_plugin_candidate(candidate)
+        if plugin is not None:
+            return plugin
+        if failure is not None:
+            selection_failures.append(failure)
+
+    error = TypeError("Selene plugin module exposes no usable no-argument runtime plugin with 'library_file'.")
+    if selection_failures:
+        raise error from selection_failures[-1]
+    raise error
 
 
 def _configure_selene_runtime(builder: object, runtime: object | None) -> object:
@@ -254,11 +271,10 @@ def _configure_selene_runtime(builder: object, runtime: object | None) -> object
         except RuntimeError as original_error:
             try:
                 plugin_module = import_module("selene_simple_runtime_plugin")
-            except ImportError:
-                # The discovery error is the actionable one; a missing plugin
-                # package must not mask it.
-                raise original_error from None
-            return _configure_selene_runtime(builder, _plugin_object_from_module(plugin_module))
+                plugin = _plugin_object_from_module(plugin_module)
+                return _configure_selene_runtime(builder, plugin)
+            except Exception as fallback_error:
+                raise original_error from fallback_error
 
     if isinstance(runtime, str):
         if _looks_like_library_path(runtime):
@@ -268,9 +284,10 @@ def _configure_selene_runtime(builder: object, runtime: object | None) -> object
         except RuntimeError as original_error:
             try:
                 plugin_module = import_module(f"{runtime}_plugin")
-            except ImportError:
-                raise original_error from None
-            return _configure_selene_runtime(builder, _plugin_object_from_module(plugin_module))
+                plugin = _plugin_object_from_module(plugin_module)
+                return _configure_selene_runtime(builder, plugin)
+            except Exception as fallback_error:
+                raise original_error from fallback_error
 
     if isinstance(runtime, PathLike):
         return builder.selene_runtime_plugin(fspath(runtime))

--- a/python/quantum-pecos/src/pecos/_engine_builders.py
+++ b/python/quantum-pecos/src/pecos/_engine_builders.py
@@ -17,6 +17,7 @@ Python program wrappers from pecos.programs.
 
 from __future__ import annotations
 
+from importlib import import_module
 from os import PathLike, fspath
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -236,14 +237,40 @@ def _looks_like_library_path(value: str) -> bool:
     return path.exists() or "/" in value or "\\" in value or path.suffix in {".so", ".dylib", ".dll"}
 
 
+def _plugin_object_from_module(module: object) -> object:
+    for exported_name in getattr(module, "__all__", ()):
+        exported = getattr(module, exported_name, None)
+        if isinstance(exported, type):
+            return exported()
+    return module
+
+
 def _configure_selene_runtime(builder: object, runtime: object | None) -> object:
     if runtime is None:
-        return builder.selene_runtime()
+        # Issue #365: freshly built Cargo artifacts win for dev iteration; the
+        # installed plugin package is the stable cwd-independent fallback.
+        try:
+            return builder.selene_runtime()
+        except RuntimeError as original_error:
+            try:
+                plugin_module = import_module("selene_simple_runtime_plugin")
+            except ImportError:
+                # The discovery error is the actionable one; a missing plugin
+                # package must not mask it.
+                raise original_error from None
+            return _configure_selene_runtime(builder, _plugin_object_from_module(plugin_module))
 
     if isinstance(runtime, str):
         if _looks_like_library_path(runtime):
             return builder.selene_runtime_plugin(runtime)
-        return builder.selene_runtime(runtime)
+        try:
+            return builder.selene_runtime(runtime)
+        except RuntimeError as original_error:
+            try:
+                plugin_module = import_module(f"{runtime}_plugin")
+            except ImportError:
+                raise original_error from None
+            return _configure_selene_runtime(builder, _plugin_object_from_module(plugin_module))
 
     if isinstance(runtime, PathLike):
         return builder.selene_runtime_plugin(fspath(runtime))

--- a/python/quantum-pecos/tests/pecos/test_selene_interface_integration.py
+++ b/python/quantum-pecos/tests/pecos/test_selene_interface_integration.py
@@ -1,6 +1,10 @@
 """Test the Selene Interface integration from Python side."""
 
+import os
 import platform
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -174,6 +178,46 @@ def test_sim_guppy_can_use_selene_engine_via_qis_path() -> None:
 
     results = pecos.sim(pecos.Guppy(coin)).classical(selene).qubits(1).seed(42).run(10).to_dict()
     assert len(results["measurement_0"]) == 10
+
+
+def test_selene_engine_is_cwd_independent(tmp_path) -> None:
+    """The installed runtime plugin resolves when the process starts outside the checkout."""
+    probe = tmp_path / "selene_cwd_probe.py"
+    probe.write_text(
+        textwrap.dedent(
+            """
+            import pecos
+            from guppylang import guppy
+            from guppylang.std.quantum import measure, qubit
+
+            @guppy
+            def measure_one() -> bool:
+                q = qubit()
+                return measure(q)
+
+            results = (
+                pecos.sim(pecos.Guppy(measure_one))
+                .classical(pecos.selene_engine())
+                .quantum(pecos.stabilizer())
+                .qubits(1)
+                .run(1)
+                .to_dict()
+            )
+            assert len(results["measurement_0"]) == 1
+            """,
+        ),
+        encoding="utf-8",
+    )
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("PECOS", "CARGO"))}
+
+    subprocess.run(
+        [sys.executable, str(probe)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_sim_guppy_reuses_physical_slot_after_measurement() -> None:

--- a/python/quantum-pecos/tests/pecos/test_selene_interface_integration.py
+++ b/python/quantum-pecos/tests/pecos/test_selene_interface_integration.py
@@ -5,6 +5,7 @@ import platform
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -162,6 +163,41 @@ def test_selene_engine_accepts_generic_runtime_plugin_shape() -> None:
     assert isinstance(engine_builder, pecos.QisEngineBuilder)
 
 
+def test_default_runtime_falls_back_to_installed_plugin_package() -> None:
+    """A failed Cargo lookup configures the real builder from the installed plugin."""
+    import pecos_rslib
+    from pecos._engine_builders import _configure_selene_runtime
+    from selene_simple_runtime_plugin import SimpleRuntimePlugin
+
+    class FailingCargoRuntimeBuilder:
+        def __init__(self) -> None:
+            self.builder = pecos_rslib.qis_engine()
+            self.plugin_call: tuple[str, list[str], list[str]] | None = None
+
+        def selene_runtime(self) -> object:
+            msg = "forced Cargo runtime discovery failure"
+            raise RuntimeError(msg)
+
+        def selene_runtime_plugin(
+            self,
+            library_file: str,
+            init_args: list[str],
+            library_search_dirs: list[str],
+        ) -> object:
+            self.plugin_call = (library_file, init_args, library_search_dirs)
+            return self.builder.selene_runtime_plugin(
+                library_file,
+                init_args,
+                library_search_dirs,
+            )
+
+    builder = FailingCargoRuntimeBuilder()
+    _configure_selene_runtime(builder, None)
+
+    assert builder.plugin_call is not None
+    assert Path(builder.plugin_call[0]) == SimpleRuntimePlugin().library_file
+
+
 def test_sim_guppy_can_use_selene_engine_via_qis_path() -> None:
     """Test that sim(Guppy(...)).classical(selene_engine()) routes HUGR through the QIS path."""
     import pecos
@@ -180,8 +216,7 @@ def test_sim_guppy_can_use_selene_engine_via_qis_path() -> None:
     assert len(results["measurement_0"]) == 10
 
 
-def test_selene_engine_is_cwd_independent(tmp_path) -> None:
-    """The installed runtime plugin resolves when the process starts outside the checkout."""
+def _run_selene_cwd_probe(tmp_path: Path, cargo_target_dir: Path | None = None) -> None:
     probe = tmp_path / "selene_cwd_probe.py"
     probe.write_text(
         textwrap.dedent(
@@ -209,6 +244,8 @@ def test_selene_engine_is_cwd_independent(tmp_path) -> None:
         encoding="utf-8",
     )
     env = {key: value for key, value in os.environ.items() if not key.startswith(("PECOS", "CARGO"))}
+    if cargo_target_dir is not None:
+        env["CARGO_TARGET_DIR"] = str(cargo_target_dir)
 
     subprocess.run(
         [sys.executable, str(probe)],
@@ -218,6 +255,19 @@ def test_selene_engine_is_cwd_independent(tmp_path) -> None:
         capture_output=True,
         text=True,
     )
+
+
+def test_selene_engine_is_cwd_independent(tmp_path: Path) -> None:
+    """The runtime resolves when the process starts outside the checkout."""
+    _run_selene_cwd_probe(tmp_path)
+
+
+def test_selene_engine_uses_plugin_when_cargo_target_is_empty(tmp_path: Path) -> None:
+    """An empty explicit Cargo target forces the module-relative runtime fallback."""
+    empty_cargo_target = tmp_path / "empty-cargo-target"
+    empty_cargo_target.mkdir()
+
+    _run_selene_cwd_probe(tmp_path, empty_cargo_target)
 
 
 def test_sim_guppy_reuses_physical_slot_after_measurement() -> None:


### PR DESCRIPTION
Closes #365.

Implements the issue's three suggested directions:

- **`PECOS_QIS_FFI_PATH`** (new): highest-priority override for `find_pecos_qis_lib` — accepts a direct file or a directory (searched with its `deps/`, exact and hash-suffixed names). Set-but-wrong fails loudly naming the variable rather than silently falling through. `CARGO_TARGET_DIR` is now honored by this lookup too.
- **`PECOS_SELENE_DIR`** now finds hash-suffixed artifacts under `deps/`-style layouts, via a shared exact/hashed directory scanner also used by `find_built_selene_runtime` (deterministic pick: sorted).
- **Module-relative default-runtime resolution**: when Cargo-artifact discovery fails (e.g. the extension was built in a since-deleted uv/maturin sandbox, so the baked workspace path is dead), `pecos.selene_engine()` resolves the default runtime through the installed `selene_simple_runtime_plugin` package — the cwd-independent home the wheels already ship. Same fallback for named runtimes via `{name}_plugin`. Freshly built Cargo artifacts still win for dev iteration; discovery errors are never masked by a missing plugin package.

## Testing
- New Rust regressions for both env vars (direct file, exact-in-dir, hashed-in-deps, set-but-missing errors) behind a shared env-test mutex with state restoration; `cargo test -p pecos-qis` 39+8 green, clippy clean.
- New subprocess acceptance test running a Selene trace from a temp cwd with PECOS/CARGO env stripped.
- Forced-failure probe verified the plugin fallback carries resolution end-to-end on its own (not via the baked path).
- The issue's original reproduction — same script, cwd outside the repo — now succeeds; full `just lint` clean.

Implementation by Codex from a reviewed task packet; hunk-by-hunk review, an error-masking fix on the `runtime=None` path, and all verification re-run independently.