### PR TITLE
feat: add configurable classical semantics

### DIFF
--- a/python/quantum-pecos/src/pecos/__init__.py
+++ b/python/quantum-pecos/src/pecos/__init__.py
@@ -269,7 +269,7 @@ from pecos.engines import circuit_runners
 from pecos.engines.cvm import (
     ClassicalSemantics,
     DefaultClassicalSemantics,
-    RTEClassicalSemantics,
+    UnsignedClassicalSemantics,
 )
 from pecos.engines.hybrid_engine_old import HybridEngine
 
@@ -339,11 +339,11 @@ __all__ = [
     "Qis",
     "QisEngineBuilder",
     "QuantumCircuit",
-    "RTEClassicalSemantics",
     "ShotMap",
     "ShotVec",
     "SignedInteger",
     "TimeUnits",
+    "UnsignedClassicalSemantics",
     "UnsignedInteger",
     "Wasm",
     "WasmError",

--- a/python/quantum-pecos/src/pecos/__init__.py
+++ b/python/quantum-pecos/src/pecos/__init__.py
@@ -266,6 +266,11 @@ from pecos._engine_builders import (
 from pecos._sim import get_guppy_backends, sim
 from pecos.circuits.quantum_circuit import QuantumCircuit
 from pecos.engines import circuit_runners
+from pecos.engines.cvm import (
+    ClassicalSemantics,
+    DefaultClassicalSemantics,
+    RTEClassicalSemantics,
+)
 from pecos.engines.hybrid_engine_old import HybridEngine
 
 # Import WasmError from pecos.exceptions (Python-defined, inherits from pecos_rslib.WasmError)
@@ -308,7 +313,9 @@ __all__ = [
     "BinArray",
     "BitInt",
     "BitUInt",
+    "ClassicalSemantics",
     "Complex",
+    "DefaultClassicalSemantics",
     "DepolarizingNoiseModelBuilder",
     "Float",
     "GateRegistry",
@@ -332,6 +339,7 @@ __all__ = [
     "Qis",
     "QisEngineBuilder",
     "QuantumCircuit",
+    "RTEClassicalSemantics",
     "ShotMap",
     "ShotVec",
     "SignedInteger",

--- a/python/quantum-pecos/src/pecos/engines/cvm/__init__.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/__init__.py
@@ -17,11 +17,11 @@ This package provides the CVM execution environment for classical computations.
 from pecos.engines.cvm.semantics import (
     ClassicalSemantics,
     DefaultClassicalSemantics,
-    RTEClassicalSemantics,
+    UnsignedClassicalSemantics,
 )
 
 __all__ = [
     "ClassicalSemantics",
     "DefaultClassicalSemantics",
-    "RTEClassicalSemantics",
+    "UnsignedClassicalSemantics",
 ]

--- a/python/quantum-pecos/src/pecos/engines/cvm/__init__.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/__init__.py
@@ -13,3 +13,15 @@ This package provides the CVM execution environment for classical computations.
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
+from pecos.engines.cvm.semantics import (
+    ClassicalSemantics,
+    DefaultClassicalSemantics,
+    RTEClassicalSemantics,
+)
+
+__all__ = [
+    "ClassicalSemantics",
+    "DefaultClassicalSemantics",
+    "RTEClassicalSemantics",
+]

--- a/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
@@ -19,6 +19,8 @@ from pecos import BitInt, BitUInt
 from pecos.engines.cvm import classical
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pecos.circuits import QuantumCircuit
     from pecos.protocols import SimulatorProtocol
 
@@ -98,36 +100,49 @@ class DefaultClassicalSemantics:
         classical.eval_cop(cop_expr, output, width=width, shot_id=shot_id)
 
 
-class RTEClassicalSemantics:
-    """Unsigned fixed-width semantics matching Quantinuum's real-time engine.
+class UnsignedClassicalSemantics:
+    """Unsigned fixed-width classical semantics.
 
     Arithmetic wraps modulo ``2**width``. Shifts are logical and mask their
     amount to ``width - 1``. Division and modulo by zero produce an all-ones
     word. Comparisons are unsigned unless an expression contains
     ``{"signed": True}``.
 
-    Circuit variables whose ``cvar_spec_type`` is ``"cbitvar"`` use
-    :class:`BitUInt` storage so narrow values are zero-extended. Other
+    By default, circuit variables whose ``cvar_spec_type`` is ``"cbitvar"``
+    use :class:`BitUInt` storage so narrow values are zero-extended. Other
     variables retain :class:`BitInt` storage for two's-complement reporting.
+    Alternate metadata type names can be supplied with
+    ``unsigned_cvar_types``.
+
+    A semantics instance has one authoritative word width. Explicit widths
+    supplied by an engine or another caller must match the configured width.
+    This prevents different components in one execution from silently
+    evaluating the same expression at different widths.
     """
 
     _COMPARISONS = frozenset({"==", "!=", "<=", ">=", "<", ">"})
-    _UNSIGNED_CVAR_TYPES = frozenset({"cbitvar"})
 
-    def __init__(self, width: int = 64) -> None:
-        """Create RTE semantics with a default word width.
+    def __init__(
+        self,
+        width: int = 32,
+        *,
+        unsigned_cvar_types: Iterable[str] = ("cbitvar",),
+    ) -> None:
+        """Create unsigned semantics for one classical word width.
 
-        The legacy hybrid engine supplies its configured ``regwidth`` to each
-        operation. The instance default makes the same evaluator directly
-        reusable by error models, circuit inspectors, and other components
-        outside the engine.
+        The default matches the legacy hybrid engine's default ``regwidth``.
+        Consumers targeting another word size should pass that size to both
+        the semantics object and the engine.
 
         Args:
             width: Default classical word width. Must be a positive power of
-                two. Quantinuum's real-time engine uses 64 bits.
+                two.
+            unsigned_cvar_types: ``cvar_spec_type`` metadata values whose
+                registers should use unsigned, zero-extending storage.
         """
         self._validate_width(width)
         self.width = width
+        self.unsigned_cvar_types = frozenset(unsigned_cvar_types)
 
     @staticmethod
     def _validate_width(width: int) -> None:
@@ -136,9 +151,13 @@ class RTEClassicalSemantics:
             raise ValueError(msg)
 
     def _resolve_width(self, width: int | None) -> int:
-        resolved = self.width if width is None else width
-        self._validate_width(resolved)
-        return resolved
+        if width is None:
+            return self.width
+        self._validate_width(width)
+        if width != self.width:
+            msg = f"Classical register width {width} does not match the semantics width {self.width}."
+            raise ValueError(msg)
+        return width
 
     @staticmethod
     def _to_signed(value: int, width: int) -> int:
@@ -285,14 +304,14 @@ class RTEClassicalSemantics:
         output: dict[str, Any] | None,
     ) -> dict[str, Any]:
         """Initialize signed and unsigned circuit-variable storage."""
-        resolved_spec = dict(circuit.metadata.get("cvar_spec", {}))
+        resolved_spec = dict(circuit.metadata.get("cvar_spec") or {})
         resolved_spec.update(output_spec or {})
         resolved_spec["__pecos_scratch"] = state.num_qubits
 
         if output is None:
             cvar_types = circuit.metadata.get("cvar_spec_type", {})
             output = {
-                symbol: (BitUInt(size) if cvar_types.get(symbol) in self._UNSIGNED_CVAR_TYPES else BitInt(size))
+                symbol: (BitUInt(size) if cvar_types.get(symbol) in self.unsigned_cvar_types else BitInt(size))
                 for symbol, size in resolved_spec.items()
             }
         return output
@@ -369,5 +388,5 @@ class RTEClassicalSemantics:
 __all__ = [
     "ClassicalSemantics",
     "DefaultClassicalSemantics",
-    "RTEClassicalSemantics",
+    "UnsignedClassicalSemantics",
 ]

--- a/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
@@ -309,7 +309,7 @@ class UnsignedClassicalSemantics:
         resolved_spec["__pecos_scratch"] = state.num_qubits
 
         if output is None:
-            cvar_types = circuit.metadata.get("cvar_spec_type", {})
+            cvar_types = circuit.metadata.get("cvar_spec_type") or {}
             output = {
                 symbol: (BitUInt(size) if cvar_types.get(symbol) in self.unsigned_cvar_types else BitInt(size))
                 for symbol, size in resolved_spec.items()

--- a/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
+++ b/python/quantum-pecos/src/pecos/engines/cvm/semantics.py
@@ -1,0 +1,373 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License.You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Configurable classical semantics for the legacy hybrid engine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pecos import BitInt, BitUInt
+from pecos.engines.cvm import classical
+
+if TYPE_CHECKING:
+    from pecos.circuits import QuantumCircuit
+    from pecos.protocols import SimulatorProtocol
+
+
+class ClassicalSemantics(Protocol):
+    """Classical operations required by the legacy :class:`HybridEngine`.
+
+    Implementations can select arithmetic, comparison, and register-storage
+    behavior without replacing or monkey-patching PECOS module functions.
+    """
+
+    def set_output(
+        self,
+        state: SimulatorProtocol,
+        circuit: QuantumCircuit,
+        output_spec: dict[str, int] | None,
+        output: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Initialize classical storage for a circuit execution."""
+        ...
+
+    def eval_condition(
+        self,
+        conditional_expr: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+        *,
+        width: int,
+    ) -> bool:
+        """Evaluate whether a conditional operation should execute."""
+        ...
+
+    def eval_cop(
+        self,
+        cop_expr: dict[str, Any],
+        output: dict[str, Any],
+        *,
+        width: int,
+        shot_id: int,
+    ) -> None:
+        """Evaluate and store a classical expression."""
+        ...
+
+
+class DefaultClassicalSemantics:
+    """PECOS's existing signed ``BitInt`` classical semantics."""
+
+    @staticmethod
+    def set_output(
+        state: SimulatorProtocol,
+        circuit: QuantumCircuit,
+        output_spec: dict[str, int] | None,
+        output: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Initialize classical storage using PECOS's default behavior."""
+        return classical.set_output(state, circuit, output_spec, output)
+
+    @staticmethod
+    def eval_condition(
+        conditional_expr: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+        *,
+        width: int,
+    ) -> bool:
+        """Evaluate a condition using PECOS's default behavior."""
+        del width
+        return classical.eval_condition(conditional_expr, output)
+
+    @staticmethod
+    def eval_cop(
+        cop_expr: dict[str, Any],
+        output: dict[str, Any],
+        *,
+        width: int,
+        shot_id: int,
+    ) -> None:
+        """Evaluate an expression using PECOS's default behavior."""
+        classical.eval_cop(cop_expr, output, width=width, shot_id=shot_id)
+
+
+class RTEClassicalSemantics:
+    """Unsigned fixed-width semantics matching Quantinuum's real-time engine.
+
+    Arithmetic wraps modulo ``2**width``. Shifts are logical and mask their
+    amount to ``width - 1``. Division and modulo by zero produce an all-ones
+    word. Comparisons are unsigned unless an expression contains
+    ``{"signed": True}``.
+
+    Circuit variables whose ``cvar_spec_type`` is ``"cbitvar"`` use
+    :class:`BitUInt` storage so narrow values are zero-extended. Other
+    variables retain :class:`BitInt` storage for two's-complement reporting.
+    """
+
+    _COMPARISONS = frozenset({"==", "!=", "<=", ">=", "<", ">"})
+    _UNSIGNED_CVAR_TYPES = frozenset({"cbitvar"})
+
+    def __init__(self, width: int = 64) -> None:
+        """Create RTE semantics with a default word width.
+
+        The legacy hybrid engine supplies its configured ``regwidth`` to each
+        operation. The instance default makes the same evaluator directly
+        reusable by error models, circuit inspectors, and other components
+        outside the engine.
+
+        Args:
+            width: Default classical word width. Must be a positive power of
+                two. Quantinuum's real-time engine uses 64 bits.
+        """
+        self._validate_width(width)
+        self.width = width
+
+    @staticmethod
+    def _validate_width(width: int) -> None:
+        if width <= 0 or width & (width - 1):
+            msg = f"Classical register width must be a positive power of two, got {width}."
+            raise ValueError(msg)
+
+    def _resolve_width(self, width: int | None) -> int:
+        resolved = self.width if width is None else width
+        self._validate_width(resolved)
+        return resolved
+
+    @staticmethod
+    def _to_signed(value: int, width: int) -> int:
+        value &= (1 << width) - 1
+        if value >> (width - 1):
+            return value - (1 << width)
+        return value
+
+    def get_val(
+        self,
+        value: BitInt | BitUInt | tuple[str, int] | list[str | int] | str | int,
+        output: dict[str, Any],
+        width: int | None,
+        shot_id: int,
+    ) -> BitUInt | BitInt:
+        """Resolve a literal or variable reference as an unsigned word."""
+        width = self._resolve_width(width)
+        if isinstance(value, (BitInt, BitUInt)):
+            return value
+        if isinstance(value, (tuple, list)):
+            symbol, index = value
+            resolved = output[symbol][index]
+        elif isinstance(value, str):
+            resolved = shot_id if value == "JOB_shotnum" else int(output[value])
+        elif isinstance(value, int):
+            resolved = value
+        else:
+            msg = f'Could not evaluate "{value!s}". Wrong type, got type: {type(value)}.'
+            raise TypeError(msg)
+        return BitUInt(width, resolved)
+
+    def eval_op(
+        self,
+        op: str,
+        a: BitUInt | BitInt | int,
+        b: BitUInt | BitInt | int | None = None,
+        *,
+        width: int | None = None,
+        signed: bool = False,
+    ) -> BitUInt:
+        """Evaluate one operation with unsigned fixed-width arithmetic."""
+        width = self._resolve_width(width)
+        left = BitUInt(width, int(a))
+        right = BitUInt(width, int(b)) if b is not None else None
+
+        if op == "=":
+            if right is not None:
+                msg = "Assignment can only have one argument (only `a`)."
+                raise ValueError(msg)
+            return left
+        if op == "~":
+            if right is not None:
+                msg = "Unary operation received a second argument."
+                raise ValueError(msg)
+            return ~left
+        if op == "|":
+            return left | right
+        if op == "^":
+            return left ^ right
+        if op == "&":
+            return left & right
+        if op == "+":
+            return left + right
+        if op == "-":
+            return left - right
+        if op == "*":
+            return left * right
+        if op == ">>":
+            return left >> (int(right) & (width - 1))
+        if op == "<<":
+            return left << (int(right) & (width - 1))
+        if op in {"/", "%"}:
+            if int(right) == 0:
+                return BitUInt(width, (1 << width) - 1)
+            return left // right if op == "/" else left % right
+        if op in self._COMPARISONS:
+            if signed:
+                left_value = self._to_signed(int(left), width)
+                right_value = self._to_signed(int(right), width)
+            else:
+                left_value = int(left)
+                right_value = int(right)
+            result = {
+                "==": left_value == right_value,
+                "!=": left_value != right_value,
+                "<=": left_value <= right_value,
+                ">=": left_value >= right_value,
+                "<": left_value < right_value,
+                ">": left_value > right_value,
+            }[op]
+            return BitUInt(width, int(result))
+        msg = f"Unsupported classical operator: {op!r}."
+        raise ValueError(msg)
+
+    def _eval_expr(
+        self,
+        expr: dict[str, Any],
+        output: dict[str, Any],
+        width: int,
+        shot_id: int,
+    ) -> BitUInt:
+        a = expr.get("a")
+        op = expr.get("op")
+        b = expr.get("b")
+        c = expr.get("c")
+        signed = bool(expr.get("signed", False))
+
+        if isinstance(a, dict):
+            a = self._eval_expr(a, output, width, shot_id)
+        elif c is not None:
+            c = (
+                self._eval_expr(c, output, width, shot_id)
+                if isinstance(c, dict)
+                else self.get_val(
+                    c,
+                    output,
+                    width,
+                    shot_id,
+                )
+            )
+            a = self.eval_op(op, c, width=width, signed=signed)
+        else:
+            a = self.get_val(a, output, width, shot_id)
+
+        if b is not None:
+            b = (
+                self._eval_expr(b, output, width, shot_id)
+                if isinstance(b, dict)
+                else self.get_val(
+                    b,
+                    output,
+                    width,
+                    shot_id,
+                )
+            )
+            a = self.eval_op(op, a, b, width=width, signed=signed)
+        return a
+
+    def set_output(
+        self,
+        state: SimulatorProtocol,
+        circuit: QuantumCircuit,
+        output_spec: dict[str, int] | None,
+        output: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Initialize signed and unsigned circuit-variable storage."""
+        resolved_spec = dict(circuit.metadata.get("cvar_spec", {}))
+        resolved_spec.update(output_spec or {})
+        resolved_spec["__pecos_scratch"] = state.num_qubits
+
+        if output is None:
+            cvar_types = circuit.metadata.get("cvar_spec_type", {})
+            output = {
+                symbol: (BitUInt(size) if cvar_types.get(symbol) in self._UNSIGNED_CVAR_TYPES else BitInt(size))
+                for symbol, size in resolved_spec.items()
+            }
+        return output
+
+    def eval_condition(
+        self,
+        conditional_expr: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+        *,
+        width: int | None = None,
+    ) -> bool:
+        """Evaluate a condition with optional signed comparison semantics."""
+        width = self._resolve_width(width)
+        if isinstance(conditional_expr, (tuple, list)):
+            if len(conditional_expr) != 2:
+                msg = "Expected a two-element conditional expression."
+                raise ValueError(msg)
+            if not isinstance(conditional_expr[1], bool):
+                msg = "Expected the second conditional element to be bool."
+                raise TypeError(msg)
+            return self.eval_condition(conditional_expr[0], output, width=width) == conditional_expr[1]
+        if conditional_expr:
+            a = classical._resolve_condition_operand(  # noqa: SLF001
+                conditional_expr["a"],
+                output,
+                "a",
+            )
+            b = classical._resolve_condition_operand(  # noqa: SLF001
+                conditional_expr["b"],
+                output,
+                "b",
+            )
+            return bool(
+                self.eval_op(
+                    conditional_expr["op"],
+                    a,
+                    b,
+                    width=width,
+                    signed=bool(conditional_expr.get("signed", False)),
+                ),
+            )
+        return True
+
+    def eval_cop(
+        self,
+        cop_expr: dict[str, Any],
+        output: dict[str, Any],
+        *,
+        width: int | None = None,
+        shot_id: int,
+    ) -> None:
+        """Evaluate and store an expression using target register semantics."""
+        width = self._resolve_width(width)
+        target = cop_expr["t"]
+        if isinstance(target, str):
+            target_symbol = target
+            target_index = None
+        elif isinstance(target, (tuple, list)) and len(target) == 2:
+            target_symbol, target_index = target
+        else:
+            msg = "`t` should be a string or a two-element variable reference."
+            raise TypeError(msg)
+
+        target_obj = output[target_symbol]
+        value = self._eval_expr(cop_expr, output, width, shot_id)
+        if target_index is not None:
+            target_obj[target_index] = value[0]
+        elif isinstance(target_obj, BitUInt):
+            target_obj.set_clip(value)
+        else:
+            target_obj.set_clip(BitInt(width, self._to_signed(int(value), width)))
+
+
+__all__ = [
+    "ClassicalSemantics",
+    "DefaultClassicalSemantics",
+    "RTEClassicalSemantics",
+]

--- a/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
+++ b/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
@@ -82,7 +82,9 @@ class HybridEngine:
         self.state = None
         self.circuit = None
         self.regwidth = regwidth
-        self.classical_semantics = classical_semantics or DefaultClassicalSemantics()
+        self.classical_semantics = (
+            classical_semantics if classical_semantics is not None else DefaultClassicalSemantics()
+        )
 
         if isinstance(seed, bool) and seed is True:
             self.seed = struct.unpack("<L", os.urandom(4))[0]

--- a/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
+++ b/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
@@ -23,8 +23,8 @@ from typing import TYPE_CHECKING
 
 import pecos as pc
 from pecos import BitInt, BitUInt
-from pecos.engines.cvm.classical import eval_condition, eval_cop, set_output
 from pecos.engines.cvm.rng_model import RNGModel
+from pecos.engines.cvm.semantics import DefaultClassicalSemantics
 from pecos.engines.cvm.wasm import eval_cfunc, get_ccop
 from pecos.exceptions import NotSupportedGateError
 from pecos.noise.fake_error_model import FakeErrorModel
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from typing import Protocol
 
     from pecos.circuits import QuantumCircuit
+    from pecos.engines.cvm.semantics import ClassicalSemantics
     from pecos.noise.parent_class_error_gen import ParentErrorModel
     from pecos.protocols import SimulatorProtocol
     from pecos.typing import GateParams
@@ -65,18 +66,23 @@ class HybridEngine:
         *,
         debug: bool = False,
         regwidth: int = 32,
+        classical_semantics: ClassicalSemantics | None = None,
     ) -> None:
-        """Initialize hybrid engine with seed, debug mode, and register width.
+        """Initialize the legacy hybrid engine.
 
         Args:
-        seed: Random seed for reproducibility. Can be bool True for random seed, int for specific seed, or None.
-        debug: Enable debug mode for additional output.
-        regwidth: Width of classical registers in bits.
+            seed: Random seed for reproducibility. Can be bool True for a random
+                seed, an integer for a specific seed, or None.
+            debug: Enable debug mode for additional output.
+            regwidth: Width of classical registers in bits.
+            classical_semantics: Classical storage and expression behavior.
+                Defaults to PECOS's signed ``BitInt`` semantics.
         """
         self.debug = debug
         self.state = None
         self.circuit = None
         self.regwidth = regwidth
+        self.classical_semantics = classical_semantics or DefaultClassicalSemantics()
 
         if isinstance(seed, bool) and seed is True:
             self.seed = struct.unpack("<L", os.urandom(4))[0]
@@ -125,7 +131,7 @@ class HybridEngine:
         Returns:
             Tuple of final simulator state and output dictionary.
         """
-        output = set_output(state, circuit, output_spec, output)
+        output = self.classical_semantics.set_output(state, circuit, output_spec, output)
         output["JOB_shotnum"] = shot_id
         output_export = {}
 
@@ -234,9 +240,24 @@ class HybridEngine:
             if params.get("skip"):
                 continue
 
-            eval_cond2 = eval_condition(params.get("cond2"), output) if params.get("cond2") else True
+            eval_cond2 = (
+                self.classical_semantics.eval_condition(
+                    params.get("cond2"),
+                    output,
+                    width=self.regwidth,
+                )
+                if params.get("cond2")
+                else True
+            )
 
-            if eval_condition(params.get("cond"), output) and eval_cond2:
+            if (
+                self.classical_semantics.eval_condition(
+                    params.get("cond"),
+                    output,
+                    width=self.regwidth,
+                )
+                and eval_cond2
+            ):
                 # Run quantum simulator
                 if symbol == "cop":
                     if (
@@ -255,7 +276,7 @@ class HybridEngine:
                             eval_cfunc(self, params, output)
 
                     elif params.get("expr"):
-                        eval_cop(
+                        self.classical_semantics.eval_cop(
                             params.get("expr"),
                             output,
                             width=self.regwidth,

--- a/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
+++ b/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
@@ -1,0 +1,166 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License.You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Tests for configurable legacy-engine classical semantics."""
+
+from __future__ import annotations
+
+import pecos as pc
+import pytest
+from pecos import BitInt, BitUInt
+from pecos.engines.cvm import DefaultClassicalSemantics, RTEClassicalSemantics
+from pecos.simulators import SparseStab
+
+
+@pytest.mark.parametrize("width", [8, 16, 32, 64])
+def test_rte_arithmetic_is_unsigned_and_fixed_width(width: int) -> None:
+    """RTE operations use logical shifts, masked shifts, and wrapping arithmetic."""
+    semantics = RTEClassicalSemantics()
+    all_ones = (1 << width) - 1
+
+    assert int(semantics.eval_op(">>", all_ones, 1, width=width)) == all_ones >> 1
+    assert int(semantics.eval_op("<<", 1, width, width=width)) == 1
+    assert int(semantics.eval_op(">>", 0b100, width + 1, width=width)) == 0b10
+    assert int(semantics.eval_op("+", all_ones, 1, width=width)) == 0
+    assert int(semantics.eval_op("-", 0, 1, width=width)) == all_ones
+    assert int(semantics.eval_op("*", 1 << (width // 2), 1 << (width // 2), width=width)) == 0
+    assert int(semantics.eval_op("/", 5, 0, width=width)) == all_ones
+    assert int(semantics.eval_op("%", 5, 0, width=width)) == all_ones
+
+
+def test_rte_unsigned_division_and_bitwise_operations() -> None:
+    """High-bit words remain unsigned throughout ALU operations."""
+    semantics = RTEClassicalSemantics()
+
+    assert int(semantics.eval_op("/", -2, 2)) == 0x7FFFFFFFFFFFFFFF
+    assert int(semantics.eval_op("~", 0)) == 0xFFFFFFFFFFFFFFFF
+    assert int(semantics.eval_op("&", 0b1100, 0b1010)) == 0b1000
+    assert int(semantics.eval_op("|", 0b1100, 0b1010)) == 0b1110
+    assert int(semantics.eval_op("^", 0b1100, 0b1010)) == 0b0110
+
+
+def test_rte_comparisons_can_select_signedness() -> None:
+    """The same word compares differently under signed and unsigned conditions."""
+    semantics = RTEClassicalSemantics()
+
+    assert int(semantics.eval_op("<", -2, 0, width=64)) == 0
+    assert int(semantics.eval_op("<", -2, 0, width=64, signed=True)) == 1
+    assert int(semantics.eval_op(">", -2, 0, width=64)) == 1
+    assert int(semantics.eval_op(">", -2, 0, width=64, signed=True)) == 0
+    assert int(semantics.eval_op("==", -2, -2, width=64)) == 1
+    assert int(semantics.eval_op("!=", -2, 3, width=64)) == 1
+
+
+def test_rte_instance_width_is_reusable_outside_hybrid_engine() -> None:
+    """Each semantics object retains an isolated default width."""
+    semantics_8 = RTEClassicalSemantics(8)
+    semantics_64 = RTEClassicalSemantics(64)
+    condition = {"a": "x", "op": "<", "b": 256}
+
+    assert int(semantics_8.eval_op("/", 5, 0)) == 0xFF
+    assert int(semantics_64.eval_op("/", 5, 0)) == 0xFFFFFFFFFFFFFFFF
+    assert semantics_8.eval_condition(condition, {"x": BitInt(8, 1)}) is False
+    assert semantics_64.eval_condition(condition, {"x": BitInt(64, 1)}) is True
+
+
+def test_rte_storage_uses_bituint_only_for_narrow_bit_variables() -> None:
+    """Variable metadata controls zero-extending versus signed storage."""
+
+    class State:
+        num_qubits = 1
+
+    circuit = pc.QuantumCircuit(
+        cvar_spec={"integer": 64, "narrow": 8, "flag": 1},
+        cvar_spec_type={"integer": "cint64", "narrow": "cbitvar", "flag": "cbool"},
+    )
+    output = RTEClassicalSemantics().set_output(State(), circuit, None, None)
+
+    assert isinstance(output["integer"], BitInt)
+    assert isinstance(output["narrow"], BitUInt)
+    assert isinstance(output["flag"], BitInt)
+
+
+def test_hybrid_engine_accepts_rte_semantics_without_global_patching() -> None:
+    """A semantics object controls one engine without changing PECOS defaults."""
+    circuit = pc.QuantumCircuit(
+        cvar_spec={"x": 64, "shifted": 64, "signed": 64, "unsigned": 64},
+        cvar_spec_type={
+            "x": "cint64",
+            "shifted": "cint64",
+            "signed": "cint64",
+            "unsigned": "cint64",
+        },
+        num_qubits=1,
+    )
+    circuit.append("cop", set(), expr={"t": "x", "op": "=", "a": -2})
+    circuit.append("cop", set(), expr={"t": "shifted", "op": ">>", "a": "x", "b": 1})
+    circuit.append(
+        "cop",
+        set(),
+        expr={"t": "signed", "op": "=", "a": 1},
+        cond={"a": "x", "op": "<", "b": 0, "signed": True},
+    )
+    circuit.append(
+        "cop",
+        set(),
+        expr={"t": "unsigned", "op": "=", "a": 1},
+        cond={"a": "x", "op": "<", "b": 0},
+    )
+
+    engine = pc.HybridEngine(
+        seed=1,
+        regwidth=64,
+        classical_semantics=RTEClassicalSemantics(),
+    )
+    output, _ = engine.run(SparseStab(1), circuit, shot_id=0)
+
+    assert int(output["x"]) == -2
+    assert int(output["shifted"]) == 0x7FFFFFFFFFFFFFFF
+    assert int(output["signed"]) == 1
+    assert int(output["unsigned"]) == 0
+
+    # A normal engine still selects the original signed behavior for the same
+    # circuit: the right shift is arithmetic and both comparisons see -2.
+    default_engine = pc.HybridEngine(seed=1, regwidth=64)
+    default_output, _ = default_engine.run(SparseStab(1), circuit, shot_id=0)
+    assert isinstance(default_engine.classical_semantics, DefaultClassicalSemantics)
+    assert int(default_output["shifted"]) == -1
+    assert int(default_output["signed"]) == 1
+    assert int(default_output["unsigned"]) == 1
+
+
+def test_hybrid_engine_masks_and_zero_extends_narrow_bit_variables() -> None:
+    """Narrow RTE variables truncate on store and zero-extend on reads."""
+    circuit = pc.QuantumCircuit(
+        cvar_spec={"narrow": 8, "extended": 64},
+        cvar_spec_type={"narrow": "cbitvar", "extended": "cint64"},
+        num_qubits=1,
+    )
+    circuit.append("cop", set(), expr={"t": "narrow", "op": "=", "a": 0xFF})
+    circuit.append("cop", set(), expr={"t": "extended", "op": "+", "a": "narrow", "b": 0})
+    circuit.append("cop", set(), expr={"t": "narrow", "op": "+", "a": "narrow", "b": 1})
+
+    engine = pc.HybridEngine(
+        seed=1,
+        regwidth=64,
+        classical_semantics=RTEClassicalSemantics(),
+    )
+    output, _ = engine.run(SparseStab(1), circuit, shot_id=0)
+
+    assert int(output["extended"]) == 0xFF
+    assert int(output["narrow"]) == 0
+
+
+@pytest.mark.parametrize("width", [0, 3, 12, 48, -8])
+def test_rte_semantics_rejects_non_power_of_two_widths(width: int) -> None:
+    """Shift masking requires a positive power-of-two word width."""
+    with pytest.raises(ValueError, match="positive power of two"):
+        RTEClassicalSemantics(width)

--- a/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
+++ b/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
@@ -16,29 +16,32 @@ from __future__ import annotations
 import pecos as pc
 import pytest
 from pecos import BitInt, BitUInt
-from pecos.engines.cvm import DefaultClassicalSemantics, RTEClassicalSemantics
+from pecos.engines.cvm import (
+    DefaultClassicalSemantics,
+    UnsignedClassicalSemantics,
+)
 from pecos.simulators import SparseStab
 
 
 @pytest.mark.parametrize("width", [8, 16, 32, 64])
-def test_rte_arithmetic_is_unsigned_and_fixed_width(width: int) -> None:
-    """RTE operations use logical shifts, masked shifts, and wrapping arithmetic."""
-    semantics = RTEClassicalSemantics()
+def test_unsigned_arithmetic_is_fixed_width(width: int) -> None:
+    """Unsigned operations use logical shifts, masked shifts, and wrapping arithmetic."""
+    semantics = UnsignedClassicalSemantics(width)
     all_ones = (1 << width) - 1
 
-    assert int(semantics.eval_op(">>", all_ones, 1, width=width)) == all_ones >> 1
-    assert int(semantics.eval_op("<<", 1, width, width=width)) == 1
-    assert int(semantics.eval_op(">>", 0b100, width + 1, width=width)) == 0b10
-    assert int(semantics.eval_op("+", all_ones, 1, width=width)) == 0
-    assert int(semantics.eval_op("-", 0, 1, width=width)) == all_ones
-    assert int(semantics.eval_op("*", 1 << (width // 2), 1 << (width // 2), width=width)) == 0
-    assert int(semantics.eval_op("/", 5, 0, width=width)) == all_ones
-    assert int(semantics.eval_op("%", 5, 0, width=width)) == all_ones
+    assert int(semantics.eval_op(">>", all_ones, 1)) == all_ones >> 1
+    assert int(semantics.eval_op("<<", 1, width)) == 1
+    assert int(semantics.eval_op(">>", 0b100, width + 1)) == 0b10
+    assert int(semantics.eval_op("+", all_ones, 1)) == 0
+    assert int(semantics.eval_op("-", 0, 1)) == all_ones
+    assert int(semantics.eval_op("*", 1 << (width // 2), 1 << (width // 2))) == 0
+    assert int(semantics.eval_op("/", 5, 0)) == all_ones
+    assert int(semantics.eval_op("%", 5, 0)) == all_ones
 
 
-def test_rte_unsigned_division_and_bitwise_operations() -> None:
+def test_unsigned_division_and_bitwise_operations() -> None:
     """High-bit words remain unsigned throughout ALU operations."""
-    semantics = RTEClassicalSemantics()
+    semantics = UnsignedClassicalSemantics(64)
 
     assert int(semantics.eval_op("/", -2, 2)) == 0x7FFFFFFFFFFFFFFF
     assert int(semantics.eval_op("~", 0)) == 0xFFFFFFFFFFFFFFFF
@@ -47,22 +50,22 @@ def test_rte_unsigned_division_and_bitwise_operations() -> None:
     assert int(semantics.eval_op("^", 0b1100, 0b1010)) == 0b0110
 
 
-def test_rte_comparisons_can_select_signedness() -> None:
+def test_unsigned_comparisons_can_select_signedness() -> None:
     """The same word compares differently under signed and unsigned conditions."""
-    semantics = RTEClassicalSemantics()
+    semantics = UnsignedClassicalSemantics(64)
 
-    assert int(semantics.eval_op("<", -2, 0, width=64)) == 0
-    assert int(semantics.eval_op("<", -2, 0, width=64, signed=True)) == 1
-    assert int(semantics.eval_op(">", -2, 0, width=64)) == 1
-    assert int(semantics.eval_op(">", -2, 0, width=64, signed=True)) == 0
-    assert int(semantics.eval_op("==", -2, -2, width=64)) == 1
-    assert int(semantics.eval_op("!=", -2, 3, width=64)) == 1
+    assert int(semantics.eval_op("<", -2, 0)) == 0
+    assert int(semantics.eval_op("<", -2, 0, signed=True)) == 1
+    assert int(semantics.eval_op(">", -2, 0)) == 1
+    assert int(semantics.eval_op(">", -2, 0, signed=True)) == 0
+    assert int(semantics.eval_op("==", -2, -2)) == 1
+    assert int(semantics.eval_op("!=", -2, 3)) == 1
 
 
-def test_rte_instance_width_is_reusable_outside_hybrid_engine() -> None:
+def test_unsigned_instance_width_is_reusable_outside_hybrid_engine() -> None:
     """Each semantics object retains an isolated default width."""
-    semantics_8 = RTEClassicalSemantics(8)
-    semantics_64 = RTEClassicalSemantics(64)
+    semantics_8 = UnsignedClassicalSemantics(8)
+    semantics_64 = UnsignedClassicalSemantics(64)
     condition = {"a": "x", "op": "<", "b": 256}
 
     assert int(semantics_8.eval_op("/", 5, 0)) == 0xFF
@@ -71,7 +74,7 @@ def test_rte_instance_width_is_reusable_outside_hybrid_engine() -> None:
     assert semantics_64.eval_condition(condition, {"x": BitInt(64, 1)}) is True
 
 
-def test_rte_storage_uses_bituint_only_for_narrow_bit_variables() -> None:
+def test_unsigned_storage_uses_bituint_for_configured_variable_types() -> None:
     """Variable metadata controls zero-extending versus signed storage."""
 
     class State:
@@ -79,16 +82,18 @@ def test_rte_storage_uses_bituint_only_for_narrow_bit_variables() -> None:
 
     circuit = pc.QuantumCircuit(
         cvar_spec={"integer": 64, "narrow": 8, "flag": 1},
-        cvar_spec_type={"integer": "cint64", "narrow": "cbitvar", "flag": "cbool"},
+        cvar_spec_type={"integer": "cint64", "narrow": "ubit", "flag": "cbool"},
     )
-    output = RTEClassicalSemantics().set_output(State(), circuit, None, None)
+    output = UnsignedClassicalSemantics(
+        unsigned_cvar_types={"ubit"},
+    ).set_output(State(), circuit, None, None)
 
     assert isinstance(output["integer"], BitInt)
     assert isinstance(output["narrow"], BitUInt)
     assert isinstance(output["flag"], BitInt)
 
 
-def test_hybrid_engine_accepts_rte_semantics_without_global_patching() -> None:
+def test_hybrid_engine_accepts_unsigned_semantics_without_global_patching() -> None:
     """A semantics object controls one engine without changing PECOS defaults."""
     circuit = pc.QuantumCircuit(
         cvar_spec={"x": 64, "shifted": 64, "signed": 64, "unsigned": 64},
@@ -118,7 +123,7 @@ def test_hybrid_engine_accepts_rte_semantics_without_global_patching() -> None:
     engine = pc.HybridEngine(
         seed=1,
         regwidth=64,
-        classical_semantics=RTEClassicalSemantics(),
+        classical_semantics=UnsignedClassicalSemantics(64),
     )
     output, _ = engine.run(SparseStab(1), circuit, shot_id=0)
 
@@ -138,7 +143,7 @@ def test_hybrid_engine_accepts_rte_semantics_without_global_patching() -> None:
 
 
 def test_hybrid_engine_masks_and_zero_extends_narrow_bit_variables() -> None:
-    """Narrow RTE variables truncate on store and zero-extend on reads."""
+    """Narrow unsigned variables truncate on store and zero-extend on reads."""
     circuit = pc.QuantumCircuit(
         cvar_spec={"narrow": 8, "extended": 64},
         cvar_spec_type={"narrow": "cbitvar", "extended": "cint64"},
@@ -151,7 +156,7 @@ def test_hybrid_engine_masks_and_zero_extends_narrow_bit_variables() -> None:
     engine = pc.HybridEngine(
         seed=1,
         regwidth=64,
-        classical_semantics=RTEClassicalSemantics(),
+        classical_semantics=UnsignedClassicalSemantics(64),
     )
     output, _ = engine.run(SparseStab(1), circuit, shot_id=0)
 
@@ -160,7 +165,54 @@ def test_hybrid_engine_masks_and_zero_extends_narrow_bit_variables() -> None:
 
 
 @pytest.mark.parametrize("width", [0, 3, 12, 48, -8])
-def test_rte_semantics_rejects_non_power_of_two_widths(width: int) -> None:
+def test_unsigned_semantics_rejects_non_power_of_two_widths(width: int) -> None:
     """Shift masking requires a positive power-of-two word width."""
     with pytest.raises(ValueError, match="positive power of two"):
-        RTEClassicalSemantics(width)
+        UnsignedClassicalSemantics(width)
+
+
+def test_unsigned_semantics_rejects_mismatched_explicit_width() -> None:
+    """One semantics object cannot silently evaluate at multiple widths."""
+    semantics = UnsignedClassicalSemantics(64)
+
+    with pytest.raises(ValueError, match="does not match"):
+        semantics.eval_op("+", 1, 2, width=32)
+
+
+def test_hybrid_engine_default_width_matches_unsigned_semantics_default() -> None:
+    """The simplest engine-policy construction uses one consistent width."""
+    semantics = UnsignedClassicalSemantics()
+    engine = pc.HybridEngine(classical_semantics=semantics)
+
+    assert engine.regwidth == semantics.width == 32
+
+
+def test_hybrid_engine_preserves_falsy_custom_semantics() -> None:
+    """Strategy selection distinguishes an explicit object from None."""
+
+    class FalsySemantics(DefaultClassicalSemantics):
+        def __bool__(self) -> bool:
+            return False
+
+    semantics = FalsySemantics()
+    engine = pc.HybridEngine(classical_semantics=semantics)
+
+    assert engine.classical_semantics is semantics
+
+
+def test_unsigned_set_output_accepts_none_cvar_spec() -> None:
+    """Nullable circuit metadata retains the scratch-register behavior."""
+
+    class State:
+        num_qubits = 2
+
+    circuit = pc.QuantumCircuit(cvar_spec=None)
+    output = UnsignedClassicalSemantics().set_output(
+        State(),
+        circuit,
+        None,
+        None,
+    )
+
+    assert set(output) == {"__pecos_scratch"}
+    assert output["__pecos_scratch"].size == 2

--- a/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
+++ b/python/quantum-pecos/tests/pecos/regression/test_engines/test_classical_semantics.py
@@ -216,3 +216,23 @@ def test_unsigned_set_output_accepts_none_cvar_spec() -> None:
 
     assert set(output) == {"__pecos_scratch"}
     assert output["__pecos_scratch"].size == 2
+
+
+def test_unsigned_set_output_accepts_none_cvar_spec_type() -> None:
+    """Nullable variable-type metadata defaults to signed storage."""
+
+    class State:
+        num_qubits = 1
+
+    circuit = pc.QuantumCircuit(
+        cvar_spec={"value": 8},
+        cvar_spec_type=None,
+    )
+    output = UnsignedClassicalSemantics().set_output(
+        State(),
+        circuit,
+        None,
+        None,
+    )
+
+    assert isinstance(output["value"], BitInt)


### PR DESCRIPTION
## Summary

- add a `ClassicalSemantics` protocol for the legacy hybrid engine
- preserve existing signed behavior through `DefaultClassicalSemantics`
- add configurable unsigned fixed-width behavior through `UnsignedClassicalSemantics`
- expose semantics per engine instead of requiring process-wide patching
- export the new API from `pecos` and `pecos.engines.cvm`

## Unsigned fixed-width behavior

- one authoritative, validated word width shared by all execution components
- logical shifts with masked shift amounts
- wrapping arithmetic at the configured word width
- unsigned division and modulo, including all-ones on division by zero
- unsigned comparisons with explicit signed-comparison support
- configurable zero-extending variable types, with `cbitvar` as the default
- signed result reporting for other register types

PECOS's existing signed `BitInt` semantics remain the default. The unsigned semantics policy defaults to the legacy engine's 32-bit register width and rejects mismatched explicit widths, preventing execution components from silently evaluating the same expression at different widths.

## Validation

- 19 focused classical-semantics regression tests
- 345 engine and integration tests passed; 39 optional tests skipped
- Black and Ruff pass

Consumers can opt in with `HybridEngine(regwidth=width, classical_semantics=UnsignedClassicalSemantics(width))` and share that same policy object with collaborating execution components.
