### PR TITLE
feat: add condition-aware circuit statistics

### DIFF
--- a/python/quantum-pecos/docs/api_guide/analysis.rst
+++ b/python/quantum-pecos/docs/api_guide/analysis.rst
@@ -1,0 +1,47 @@
+Analysis
+========
+
+``CircuitStatistics`` collects operation counts and durations for the maximum,
+minimum, and actual runtime paths through a circuit. ``HybridEngine`` manages
+the run lifecycle and reports its per-operation execution decisions directly:
+
+.. code-block:: python
+
+    import pecos as pc
+    from pecos.analysis import CircuitStatistics
+    from pecos.simulators import SparseStab
+
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("H", {0}, duration=2.0)
+
+    statistics = CircuitStatistics()
+    pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        circ_inspector=statistics,
+    )
+
+    assert statistics.results["total"]["runtime"] == [2.0]
+
+Use a classifier to group circuit symbols or add parallel-layer counts without
+changing the collector:
+
+.. code-block:: python
+
+    from pecos.analysis import OperationStatistic
+
+
+    def classify(symbol, locations, metadata):
+        yield OperationStatistic(
+            key="one_qubit",
+            count=len(locations),
+            duration=metadata.get("duration"),
+        )
+
+
+    statistics = CircuitStatistics(classifier=classify)
+
+Custom inspectors that opt into exact operation events implement
+``pecos.protocols.OperationEventInspector``. Unmarked inspectors continue to
+use the legacy per-tick ``analyze`` callback.

--- a/python/quantum-pecos/docs/api_guide/index.rst
+++ b/python/quantum-pecos/docs/api_guide/index.rst
@@ -5,6 +5,7 @@ Concepts in PECOS are organized around the following namespaces:
 
 =================== =================================================
 ``circuits``        Circuits of different abstraction levels.
+``analysis``        Inspect circuits and summarize execution statistics.
 ``qeccs``           Represent QEC protocols.
 ``error_gens``      Used to specify error models and generate errors.
 ``simulators``      Simulate states and operations.
@@ -20,6 +21,7 @@ Classes and functions available in these namespaces are described in the followi
    :maxdepth: 2
 
    quantum_circuits
+   analysis
    qeccs
    logical_circuits
    simulators

--- a/python/quantum-pecos/docs/reference/index.rst
+++ b/python/quantum-pecos/docs/reference/index.rst
@@ -16,6 +16,7 @@ Modules
    :toctree: _autosummary
    :recursive:
 
+   pecos.analysis
    pecos.circuits
    pecos.classical_interpreters
    pecos.decoders

--- a/python/quantum-pecos/src/pecos/analysis/__init__.py
+++ b/python/quantum-pecos/src/pecos/analysis/__init__.py
@@ -28,6 +28,12 @@ Example:
 from pecos.analysis import fault_tolerance_checks as fault_tolerance
 from pecos.analysis import pseudo_threshold_tools as pseudo_threshold
 from pecos.analysis import threshold_tools as threshold
+from pecos.analysis.circuit_statistics import (
+    CircuitStatistics,
+    OperationClassifier,
+    OperationStatistic,
+    classify_operations,
+)
 from pecos.analysis.stabilizer_verification import VerifyStabilizers
 from pecos.analysis.threshold_curve import threshold_fit
 from pecos.analysis.threshold_tools import (
@@ -40,8 +46,12 @@ from pecos.analysis.tool_anticommute import anticommute
 from pecos.analysis.tool_collection import fault_tolerance_check
 
 __all__ = [
+    "CircuitStatistics",
+    "OperationClassifier",
+    "OperationStatistic",
     "VerifyStabilizers",
     "anticommute",
+    "classify_operations",
     "codecapacity_logical_rate",
     "codecapacity_logical_rate2",
     "codecapacity_logical_rate3",

--- a/python/quantum-pecos/src/pecos/analysis/__init__.py
+++ b/python/quantum-pecos/src/pecos/analysis/__init__.py
@@ -29,9 +29,14 @@ from pecos.analysis import fault_tolerance_checks as fault_tolerance
 from pecos.analysis import pseudo_threshold_tools as pseudo_threshold
 from pecos.analysis import threshold_tools as threshold
 from pecos.analysis.circuit_statistics import (
+    CircuitRunStatistics,
     CircuitStatistics,
+    CircuitStatisticsData,
+    ExecutionViews,
     OperationClassifier,
     OperationStatistic,
+    RuntimeSummary,
+    StatisticValue,
     classify_operations,
 )
 from pecos.analysis.stabilizer_verification import VerifyStabilizers
@@ -46,9 +51,14 @@ from pecos.analysis.tool_anticommute import anticommute
 from pecos.analysis.tool_collection import fault_tolerance_check
 
 __all__ = [
+    "CircuitRunStatistics",
     "CircuitStatistics",
+    "CircuitStatisticsData",
+    "ExecutionViews",
     "OperationClassifier",
     "OperationStatistic",
+    "RuntimeSummary",
+    "StatisticValue",
     "VerifyStabilizers",
     "anticommute",
     "classify_operations",

--- a/python/quantum-pecos/src/pecos/analysis/circuit_statistics.py
+++ b/python/quantum-pecos/src/pecos/analysis/circuit_statistics.py
@@ -1,0 +1,251 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License.You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Condition-aware circuit execution statistics."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from statistics import fmean, pstdev
+from typing import TYPE_CHECKING, Any
+
+from pecos.circuits.quantum_circuit import Location
+from pecos.engines.cvm import DefaultClassicalSemantics
+
+if TYPE_CHECKING:
+    from pecos.circuits.quantum_circuit import TickView
+    from pecos.engines.cvm import ClassicalSemantics
+
+
+@dataclass(frozen=True, slots=True)
+class OperationStatistic:
+    """One count and/or duration contribution produced by a classifier.
+
+    A classifier may return multiple contributions for one circuit operation.
+    For example, a two-qubit gate can contribute to both a gate count and a
+    parallel-layer count.
+    """
+
+    key: str
+    count: int | None = None
+    duration: float | None = None
+
+
+OperationClassifier = Callable[
+    [str, set[Location], Mapping[str, Any]],
+    Iterable[OperationStatistic],
+]
+
+
+def classify_operations(
+    symbol: str,
+    locations: set[Location],
+    metadata: Mapping[str, Any],
+) -> tuple[OperationStatistic, ...]:
+    """Classify an operation under its circuit symbol.
+
+    The default policy counts each location, or one operation when there are
+    no locations, and records an optional numeric ``duration`` metadata value.
+    More specialized vocabularies can supply a custom classifier to
+    :class:`CircuitStatistics`.
+    """
+    duration = metadata.get("duration")
+    if duration is not None:
+        try:
+            duration = float(duration)
+        except (TypeError, ValueError) as exc:
+            msg = f"Operation duration must be numeric, got {duration!r}."
+            raise TypeError(msg) from exc
+
+    return (
+        OperationStatistic(
+            key=symbol,
+            count=max(1, len(locations)),
+            duration=duration,
+        ),
+    )
+
+
+class CircuitStatistics:
+    """Collect condition-aware counts and durations across circuit runs.
+
+    Each operation contributes to three views:
+
+    * ``max`` assumes every conditional operation executes.
+    * ``min`` includes only unconditional operations.
+    * ``runtime`` evaluates conditions against the current classical output.
+
+    Call :meth:`new` before each run, :meth:`analyze` for every executed tick,
+    and :meth:`finalize` after the run. The legacy hybrid engine calls
+    :meth:`analyze`; execution wrappers remain responsible for the per-run
+    lifecycle.
+    """
+
+    def __init__(
+        self,
+        classical_semantics: ClassicalSemantics | None = None,
+        *,
+        regwidth: int | None = None,
+        classifier: OperationClassifier = classify_operations,
+    ) -> None:
+        """Create a statistics collector.
+
+        Args:
+            classical_semantics: Policy used to evaluate conditional
+                operations. Defaults to PECOS's standard signed semantics.
+            regwidth: Classical word width used for conditions. Defaults to the
+                policy's configured width when available, otherwise 32.
+            classifier: Converts circuit operations into one or more count or
+                duration contributions.
+        """
+        resolved_semantics = classical_semantics if classical_semantics is not None else DefaultClassicalSemantics()
+        resolved_width = regwidth if regwidth is not None else getattr(resolved_semantics, "width", 32)
+        self.set_classical_semantics(
+            resolved_semantics,
+            regwidth=resolved_width,
+        )
+        if not callable(classifier):
+            msg = "classifier must be callable."
+            raise TypeError(msg)
+        self.classifier = classifier
+        self.data: dict[str, Any] = {"runs": []}
+        self._current_data: dict[str, Any] | None = None
+
+    def set_classical_semantics(
+        self,
+        classical_semantics: ClassicalSemantics,
+        *,
+        regwidth: int,
+    ) -> None:
+        """Set the policy and word width used for condition evaluation."""
+        self.classical_semantics = classical_semantics
+        self.regwidth = regwidth
+
+    def eval_condition(
+        self,
+        condition: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+    ) -> bool:
+        """Evaluate an operation condition with the configured policy."""
+        return self.classical_semantics.eval_condition(
+            condition,
+            output,
+            width=self.regwidth,
+        )
+
+    def new(self) -> None:
+        """Start collecting statistics for a new circuit run."""
+        current_data = {
+            "count": {
+                "max": {},
+                "min": {},
+                "runtime": {},
+            },
+            "duration": {
+                "max": {},
+                "min": {},
+                "runtime": {},
+            },
+        }
+        self.data["runs"].append(current_data)
+        self._current_data = current_data
+
+    def _current_metric(self, metric: str) -> dict[str, dict[str, float | int]]:
+        if self._current_data is None:
+            msg = "Call new() before collecting circuit statistics."
+            raise RuntimeError(msg)
+        return self._current_data[metric]
+
+    def add_count(
+        self,
+        key: str,
+        count: int,
+        condition: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+    ) -> None:
+        """Record one condition-aware count contribution."""
+        counts = self._current_metric("count")
+        counts["max"][key] = counts["max"].get(key, 0) + count
+        if condition is None:
+            counts["min"][key] = counts["min"].get(key, 0) + count
+        if self.eval_condition(condition, output):
+            counts["runtime"][key] = counts["runtime"].get(key, 0) + count
+
+    def add_duration(
+        self,
+        key: str,
+        duration: float,
+        condition: dict[str, Any] | tuple[Any, ...] | list[Any] | None,
+        output: dict[str, Any],
+    ) -> None:
+        """Record one condition-aware duration contribution."""
+        durations = self._current_metric("duration")
+        durations["max"][key] = durations["max"].get(key, 0.0) + duration
+        if condition is None:
+            durations["min"][key] = durations["min"].get(key, 0.0) + duration
+        if self.eval_condition(condition, output):
+            durations["runtime"][key] = durations["runtime"].get(key, 0.0) + duration
+
+    def analyze(
+        self,
+        tick_circuit: TickView,
+        time: int | tuple[int, ...],
+        output: dict[str, Any],
+    ) -> None:
+        """Analyze every operation in an executed circuit tick."""
+        del time
+        self._current_metric("count")
+        for symbol, locations, metadata in tick_circuit.items():
+            condition = metadata.get("cond")
+            for contribution in self.classifier(
+                symbol,
+                locations,
+                metadata,
+            ):
+                if not isinstance(contribution, OperationStatistic):
+                    msg = "classifier must return OperationStatistic objects."
+                    raise TypeError(msg)
+                if contribution.count is not None:
+                    self.add_count(
+                        contribution.key,
+                        contribution.count,
+                        condition,
+                        output,
+                    )
+                if contribution.duration is not None:
+                    self.add_duration(
+                        contribution.key,
+                        contribution.duration,
+                        condition,
+                        output,
+                    )
+
+    def finalize(self) -> None:
+        """Update aggregate runtime-duration statistics across all runs."""
+        runtimes = [sum(run["duration"]["runtime"].values()) for run in self.data["runs"]]
+        if runtimes:
+            average = fmean(runtimes)
+            deviation = pstdev(runtimes)
+        else:
+            average = deviation = float("nan")
+        self.data["total"] = {
+            "runtime": runtimes,
+            "avg_runtime": (average, deviation),
+        }
+
+
+__all__ = [
+    "CircuitStatistics",
+    "OperationClassifier",
+    "OperationStatistic",
+    "classify_operations",
+]

--- a/python/quantum-pecos/src/pecos/analysis/circuit_statistics.py
+++ b/python/quantum-pecos/src/pecos/analysis/circuit_statistics.py
@@ -14,9 +14,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from statistics import fmean, pstdev
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from pecos.circuits.quantum_circuit import Location
 from pecos.engines.cvm import DefaultClassicalSemantics
@@ -38,6 +39,39 @@ class OperationStatistic:
     key: str
     count: int | None = None
     duration: float | None = None
+
+
+# Numeric value stored for a count or duration.
+StatisticValue = int | float
+
+
+class ExecutionViews(TypedDict):
+    """Maximum, minimum, and actual runtime values for one metric."""
+
+    max: dict[str, StatisticValue]
+    min: dict[str, StatisticValue]
+    runtime: dict[str, StatisticValue]
+
+
+class CircuitRunStatistics(TypedDict):
+    """Counts and durations collected for one circuit execution."""
+
+    count: ExecutionViews
+    duration: ExecutionViews
+
+
+class RuntimeSummary(TypedDict):
+    """Runtime-duration summary across completed runs."""
+
+    runtime: list[StatisticValue]
+    avg_runtime: tuple[float, float]
+
+
+class CircuitStatisticsData(TypedDict):
+    """Complete circuit-statistics result schema."""
+
+    runs: list[CircuitRunStatistics]
+    total: RuntimeSummary
 
 
 OperationClassifier = Callable[
@@ -84,11 +118,12 @@ class CircuitStatistics:
     * ``min`` includes only unconditional operations.
     * ``runtime`` evaluates conditions against the current classical output.
 
-    Call :meth:`new` before each run, :meth:`analyze` for every executed tick,
-    and :meth:`finalize` after the run. The legacy hybrid engine calls
-    :meth:`analyze`; execution wrappers remain responsible for the per-run
-    lifecycle.
+    :class:`~pecos.HybridEngine` manages the per-run lifecycle and passes actual
+    operation execution decisions to :meth:`analyze_operation`. Manual callers
+    can use :meth:`start_run`, :meth:`analyze`, and :meth:`finish_run`.
     """
+
+    supports_operation_events = True
 
     def __init__(
         self,
@@ -117,8 +152,24 @@ class CircuitStatistics:
             msg = "classifier must be callable."
             raise TypeError(msg)
         self.classifier = classifier
-        self.data: dict[str, Any] = {"runs": []}
-        self._current_data: dict[str, Any] | None = None
+        self.data: CircuitStatisticsData = {
+            "runs": [],
+            "total": {
+                "runtime": [],
+                "avg_runtime": (float("nan"), float("nan")),
+            },
+        }
+        self._current_data: CircuitRunStatistics | None = None
+
+    @property
+    def run_active(self) -> bool:
+        """Whether a run is currently accepting operation statistics."""
+        return self._current_data is not None
+
+    @property
+    def results(self) -> CircuitStatisticsData:
+        """Return a defensive copy of the collected result."""
+        return deepcopy(self.data)
 
     def set_classical_semantics(
         self,
@@ -142,9 +193,16 @@ class CircuitStatistics:
             width=self.regwidth,
         )
 
-    def new(self) -> None:
-        """Start collecting statistics for a new circuit run."""
-        current_data = {
+    def start_run(self) -> None:
+        """Start collecting a new run.
+
+        Raises:
+            RuntimeError: If the previous run has not been finished.
+        """
+        if self.run_active:
+            msg = "Finish the active run before starting another."
+            raise RuntimeError(msg)
+        current_data: CircuitRunStatistics = {
             "count": {
                 "max": {},
                 "min": {},
@@ -159,11 +217,30 @@ class CircuitStatistics:
         self.data["runs"].append(current_data)
         self._current_data = current_data
 
-    def _current_metric(self, metric: str) -> dict[str, dict[str, float | int]]:
+    def new(self) -> None:
+        """Alias for :meth:`start_run`."""
+        self.start_run()
+
+    def _current_metric(self, metric: Literal["count", "duration"]) -> ExecutionViews:
         if self._current_data is None:
-            msg = "Call new() before collecting circuit statistics."
+            msg = "Call start_run() before collecting circuit statistics."
             raise RuntimeError(msg)
         return self._current_data[metric]
+
+    @staticmethod
+    def _record(
+        values: ExecutionViews,
+        key: str,
+        value: StatisticValue,
+        *,
+        conditional: bool,
+        executed: bool,
+    ) -> None:
+        values["max"][key] = values["max"].get(key, 0) + value
+        if not conditional:
+            values["min"][key] = values["min"].get(key, 0) + value
+        if executed:
+            values["runtime"][key] = values["runtime"].get(key, 0) + value
 
     def add_count(
         self,
@@ -173,12 +250,13 @@ class CircuitStatistics:
         output: dict[str, Any],
     ) -> None:
         """Record one condition-aware count contribution."""
-        counts = self._current_metric("count")
-        counts["max"][key] = counts["max"].get(key, 0) + count
-        if condition is None:
-            counts["min"][key] = counts["min"].get(key, 0) + count
-        if self.eval_condition(condition, output):
-            counts["runtime"][key] = counts["runtime"].get(key, 0) + count
+        self._record(
+            self._current_metric("count"),
+            key,
+            count,
+            conditional=bool(condition),
+            executed=self.eval_condition(condition, output),
+        )
 
     def add_duration(
         self,
@@ -188,12 +266,45 @@ class CircuitStatistics:
         output: dict[str, Any],
     ) -> None:
         """Record one condition-aware duration contribution."""
-        durations = self._current_metric("duration")
-        durations["max"][key] = durations["max"].get(key, 0.0) + duration
-        if condition is None:
-            durations["min"][key] = durations["min"].get(key, 0.0) + duration
-        if self.eval_condition(condition, output):
-            durations["runtime"][key] = durations["runtime"].get(key, 0.0) + duration
+        self._record(
+            self._current_metric("duration"),
+            key,
+            duration,
+            conditional=bool(condition),
+            executed=self.eval_condition(condition, output),
+        )
+
+    def analyze_operation(
+        self,
+        symbol: str,
+        locations: set[Location],
+        metadata: Mapping[str, Any],
+        *,
+        executed: bool,
+    ) -> None:
+        """Record one non-skipped operation using the engine's decision."""
+        self._current_metric("count")
+        conditional = bool(metadata.get("cond")) or bool(metadata.get("cond2"))
+        for contribution in self.classifier(symbol, locations, metadata):
+            if not isinstance(contribution, OperationStatistic):
+                msg = "classifier must return OperationStatistic objects."
+                raise TypeError(msg)
+            if contribution.count is not None:
+                self._record(
+                    self._current_metric("count"),
+                    contribution.key,
+                    contribution.count,
+                    conditional=conditional,
+                    executed=executed,
+                )
+            if contribution.duration is not None:
+                self._record(
+                    self._current_metric("duration"),
+                    contribution.key,
+                    contribution.duration,
+                    conditional=conditional,
+                    executed=executed,
+                )
 
     def analyze(
         self,
@@ -205,47 +316,61 @@ class CircuitStatistics:
         del time
         self._current_metric("count")
         for symbol, locations, metadata in tick_circuit.items():
+            if metadata.get("skip"):
+                continue
             condition = metadata.get("cond")
-            for contribution in self.classifier(
+            condition2 = metadata.get("cond2")
+            executed = self.eval_condition(condition, output)
+            if condition2:
+                executed = executed and self.eval_condition(condition2, output)
+            self.analyze_operation(
                 symbol,
                 locations,
                 metadata,
-            ):
-                if not isinstance(contribution, OperationStatistic):
-                    msg = "classifier must return OperationStatistic objects."
-                    raise TypeError(msg)
-                if contribution.count is not None:
-                    self.add_count(
-                        contribution.key,
-                        contribution.count,
-                        condition,
-                        output,
-                    )
-                if contribution.duration is not None:
-                    self.add_duration(
-                        contribution.key,
-                        contribution.duration,
-                        condition,
-                        output,
-                    )
+                executed=executed,
+            )
 
-    def finalize(self) -> None:
-        """Update aggregate runtime-duration statistics across all runs."""
+    def _update_summary(self) -> None:
         runtimes = [sum(run["duration"]["runtime"].values()) for run in self.data["runs"]]
-        if runtimes:
-            average = fmean(runtimes)
-            deviation = pstdev(runtimes)
-        else:
-            average = deviation = float("nan")
+        average = (fmean(runtimes), pstdev(runtimes)) if runtimes else (float("nan"), float("nan"))
         self.data["total"] = {
             "runtime": runtimes,
-            "avg_runtime": (average, deviation),
+            "avg_runtime": average,
         }
+
+    def finish_run(self) -> None:
+        """Finish the active run and update aggregate runtime statistics."""
+        if not self.run_active:
+            msg = "Call start_run() before finishing circuit statistics."
+            raise RuntimeError(msg)
+        self._update_summary()
+        self._current_data = None
+
+    def abort_run(self) -> None:
+        """Discard the active run after an unsuccessful engine execution."""
+        if not self.run_active:
+            msg = "Call start_run() before aborting circuit statistics."
+            raise RuntimeError(msg)
+        if not self.data["runs"] or self.data["runs"][-1] is not self._current_data:
+            msg = "The active circuit-statistics run is not the latest run."
+            raise RuntimeError(msg)
+        self.data["runs"].pop()
+        self._current_data = None
+        self._update_summary()
+
+    def finalize(self) -> None:
+        """Alias for :meth:`finish_run`."""
+        self.finish_run()
 
 
 __all__ = [
+    "CircuitRunStatistics",
     "CircuitStatistics",
+    "CircuitStatisticsData",
+    "ExecutionViews",
     "OperationClassifier",
     "OperationStatistic",
+    "RuntimeSummary",
+    "StatisticValue",
     "classify_operations",
 ]

--- a/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
+++ b/python/quantum-pecos/src/pecos/engines/hybrid_engine_old.py
@@ -30,30 +30,28 @@ from pecos.exceptions import NotSupportedGateError
 from pecos.noise.fake_error_model import FakeErrorModel
 
 if TYPE_CHECKING:
-    from typing import Protocol
+    from collections.abc import Mapping
+    from typing import Any, Protocol
 
     from pecos.circuits import QuantumCircuit
+    from pecos.circuits.quantum_circuit import Location
     from pecos.engines.cvm.semantics import ClassicalSemantics
     from pecos.noise.parent_class_error_gen import ParentErrorModel
-    from pecos.protocols import SimulatorProtocol
+    from pecos.protocols import CircuitInspector, OperationEventInspector, SimulatorProtocol
     from pecos.typing import GateParams
 
-    class CircuitInspector(Protocol):
-        """Protocol for circuit inspector objects."""
+    class OperationAnalyzer(Protocol):
+        """Callback for an operation's actual execution decision."""
 
-        def analyze(
+        def __call__(
             self,
-            tick_circuit: QuantumCircuit,
-            time: int,
-            output: dict[str, BitInt],
+            symbol: str,
+            locations: set[Location],
+            metadata: Mapping[str, Any],
+            *,
+            executed: bool,
         ) -> None:
-            """Analyze a circuit at a specific time tick.
-
-            Args:
-                tick_circuit: Quantum circuit for the current time tick.
-                time: Current time step.
-                output: Output dictionary with binary arrays.
-            """
+            """Record whether one non-skipped operation executed."""
             ...
 
 
@@ -115,7 +113,7 @@ class HybridEngine:
         error_circuits: dict[int, dict[str, QuantumCircuit | set[int]]] | None = None,
         output: dict[str, BitInt] | None = None,
         output_spec: dict[str, int] | None = None,
-        circ_inspector: CircuitInspector | None = None,
+        circ_inspector: CircuitInspector | OperationEventInspector | None = None,
     ) -> tuple[dict, dict]:
         """Run a quantum circuit with optional error modeling.
 
@@ -133,6 +131,75 @@ class HybridEngine:
         Returns:
             Tuple of final simulator state and output dictionary.
         """
+        operation_analyzer = None
+        engine_manages_inspector = False
+        finish_run = None
+        abort_run = None
+
+        if circ_inspector and getattr(circ_inspector, "supports_operation_events", False) is True:
+            start_run = getattr(circ_inspector, "start_run", None)
+            finish_run = getattr(circ_inspector, "finish_run", None)
+            abort_run = getattr(circ_inspector, "abort_run", None)
+            run_active = getattr(circ_inspector, "run_active", None)
+            candidate = getattr(circ_inspector, "analyze_operation", None)
+            invalid_members = [
+                name
+                for name, member in (
+                    ("start_run", start_run),
+                    ("finish_run", finish_run),
+                    ("abort_run", abort_run),
+                    ("analyze_operation", candidate),
+                )
+                if not callable(member)
+            ]
+            if not isinstance(run_active, bool):
+                invalid_members.append("run_active")
+            if invalid_members:
+                members = ", ".join(invalid_members)
+                msg = f"Operation-event inspector has invalid members: {members}."
+                raise TypeError(msg)
+
+            operation_analyzer = candidate
+            if not run_active:
+                start_run()
+                engine_manages_inspector = True
+
+        try:
+            result = self._run(
+                state,
+                circuit,
+                shot_id,
+                error_gen=error_gen,
+                error_params=error_params,
+                error_circuits=error_circuits,
+                output=output,
+                output_spec=output_spec,
+                circ_inspector=circ_inspector,
+                operation_analyzer=operation_analyzer,
+            )
+        except BaseException:
+            if engine_manages_inspector:
+                abort_run()
+            raise
+
+        if engine_manages_inspector:
+            finish_run()
+        return result
+
+    def _run(
+        self,
+        state: SimulatorProtocol,
+        circuit: QuantumCircuit,
+        shot_id: int,
+        error_gen: ParentErrorModel | None = None,
+        error_params: dict[str, float | dict[str, float]] | None = None,
+        error_circuits: dict[int, dict[str, QuantumCircuit | set[int]]] | None = None,
+        output: dict[str, BitInt] | None = None,
+        output_spec: dict[str, int] | None = None,
+        circ_inspector: CircuitInspector | OperationEventInspector | None = None,
+        operation_analyzer: OperationAnalyzer | None = None,
+    ) -> tuple[dict, dict]:
+        """Execute one circuit after inspector lifecycle setup."""
         output = self.classical_semantics.set_output(state, circuit, output_spec, output)
         output["JOB_shotnum"] = shot_id
         output_export = {}
@@ -188,16 +255,20 @@ class HybridEngine:
 
             # ideal tick circuit
             # ------------------
-            self.run_circuit(
-                state,
-                output,
-                output_export,
-                tick_circuit,
-                error_gen,
-                removed_locations=removed,
-            )
+            self._operation_analyzer = operation_analyzer
+            try:
+                self.run_circuit(
+                    state,
+                    output,
+                    output_export,
+                    tick_circuit,
+                    error_gen,
+                    removed_locations=removed,
+                )
+            finally:
+                self._operation_analyzer = None
 
-            if circ_inspector:
+            if circ_inspector and operation_analyzer is None:
                 circ_inspector.analyze(tick_circuit, time, output)
 
             if after_errors:
@@ -252,14 +323,25 @@ class HybridEngine:
                 else True
             )
 
-            if (
+            executed = (
                 self.classical_semantics.eval_condition(
                     params.get("cond"),
                     output,
                     width=self.regwidth,
                 )
                 and eval_cond2
-            ):
+            )
+
+            operation_analyzer = getattr(self, "_operation_analyzer", None)
+            if operation_analyzer is not None:
+                operation_analyzer(
+                    symbol,
+                    locations,
+                    params,
+                    executed=executed,
+                )
+
+            if executed:
                 # Run quantum simulator
                 if symbol == "cop":
                     if (

--- a/python/quantum-pecos/src/pecos/protocols.py
+++ b/python/quantum-pecos/src/pecos/protocols.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterator, Sequence
+    from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
     from typing import Any
 
     from pecos.circuits import LogicalCircuit, QuantumCircuit
@@ -113,6 +113,41 @@ class CircuitInspector(Protocol):
             time: Current time step.
             output: Output dictionary to store analysis results.
         """
+        ...
+
+
+class OperationEventInspector(Protocol):
+    """Inspector receiving exact per-operation execution events.
+
+    The legacy hybrid engine only enables this interface when
+    ``supports_operation_events`` is explicitly true and every lifecycle
+    member is available.
+    """
+
+    supports_operation_events: bool
+    run_active: bool
+
+    def start_run(self) -> None:
+        """Start an engine-managed inspection run."""
+        ...
+
+    def finish_run(self) -> None:
+        """Commit a successfully completed inspection run."""
+        ...
+
+    def abort_run(self) -> None:
+        """Discard an unsuccessful engine-managed inspection run."""
+        ...
+
+    def analyze_operation(
+        self,
+        symbol: str,
+        locations: LocationSet,
+        metadata: Mapping[str, Any],
+        *,
+        executed: bool,
+    ) -> None:
+        """Record one non-skipped operation and its execution decision."""
         ...
 
 

--- a/python/quantum-pecos/tests/pecos/regression/test_engines/test_circuit_statistics.py
+++ b/python/quantum-pecos/tests/pecos/regression/test_engines/test_circuit_statistics.py
@@ -120,11 +120,10 @@ def test_conditions_share_the_configured_classical_policy() -> None:
 
 
 def test_hybrid_engine_calls_concrete_inspector() -> None:
-    """The collector implements the inspector hook used by HybridEngine."""
+    """The engine manages the concrete inspector's run lifecycle."""
     circuit = pc.QuantumCircuit(num_qubits=1)
     circuit.append("X", {0}, duration=4.0)
     statistics = CircuitStatistics()
-    statistics.new()
 
     pc.HybridEngine(seed=1).run(
         SparseStab(1),
@@ -132,10 +131,221 @@ def test_hybrid_engine_calls_concrete_inspector() -> None:
         shot_id=0,
         circ_inspector=statistics,
     )
-    statistics.finalize()
 
+    assert not statistics.run_active
     assert statistics.data["runs"][0]["count"]["runtime"] == {"X": 1}
     assert statistics.data["total"]["runtime"] == [4.0]
+
+
+def test_engine_reports_pre_mutation_execution_decision() -> None:
+    """Runtime statistics use the decision made before an operation executes."""
+    circuit = pc.QuantumCircuit()
+    circuit.append(
+        "cop",
+        set(),
+        duration=2.0,
+        cond={"a": "word", "op": "==", "b": 0},
+        expr={"t": "word", "op": "=", "a": 1},
+    )
+    output = {"word": BitInt(8, 0)}
+    statistics = CircuitStatistics()
+
+    result, _errors = pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        output=output,
+        circ_inspector=statistics,
+    )
+
+    assert int(result["word"]) == 1
+    run = statistics.data["runs"][0]
+    assert run["count"]["runtime"] == {"cop": 1}
+    assert run["duration"]["runtime"] == {"cop": 2.0}
+
+
+def test_engine_decision_accounts_for_cond2_and_skip() -> None:
+    """Operations rejected by the full engine predicate are not runtime work."""
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append(
+        "X",
+        {0},
+        duration=3.0,
+        cond2={"a": "word", "op": "==", "b": 1},
+    )
+    circuit.append("Y", {0}, duration=5.0, skip=True)
+    statistics = CircuitStatistics()
+
+    pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        output={"word": BitInt(8, 0)},
+        circ_inspector=statistics,
+    )
+
+    run = statistics.data["runs"][0]
+    assert run["count"] == {
+        "max": {"X": 1},
+        "min": {},
+        "runtime": {},
+    }
+    assert run["duration"] == {
+        "max": {"X": 3.0},
+        "min": {},
+        "runtime": {},
+    }
+
+
+def test_empty_condition_is_unconditional() -> None:
+    """An empty condition contributes to the minimum execution view."""
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0}, duration=1.0, cond={})
+    statistics = CircuitStatistics()
+
+    pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        circ_inspector=statistics,
+    )
+
+    run = statistics.data["runs"][0]
+    assert run["count"]["min"] == {"X": 1}
+    assert run["count"]["runtime"] == {"X": 1}
+
+
+def test_failed_engine_run_is_aborted_and_collector_can_be_reused() -> None:
+    """A failed engine-owned run does not leave partial active statistics."""
+    attempts = 0
+
+    def flaky_classifier(symbol, locations, metadata):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "classification failed"
+            raise ValueError(msg)
+        return (
+            OperationStatistic(
+                symbol,
+                count=len(locations),
+                duration=metadata["duration"],
+            ),
+        )
+
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0}, duration=1.0)
+    statistics = CircuitStatistics(classifier=flaky_classifier)
+    engine = pc.HybridEngine(seed=1)
+
+    with pytest.raises(ValueError, match="classification failed"):
+        engine.run(
+            SparseStab(1),
+            circuit,
+            shot_id=0,
+            circ_inspector=statistics,
+        )
+
+    assert not statistics.run_active
+    assert statistics.data["runs"] == []
+
+    engine.run(
+        SparseStab(1),
+        circuit,
+        shot_id=1,
+        circ_inspector=statistics,
+    )
+    assert statistics.data["runs"][0]["count"]["runtime"] == {"X": 1}
+
+
+def test_partial_lifecycle_inspector_uses_legacy_fallback() -> None:
+    """Unmarked legacy inspectors are not opted into managed lifecycle."""
+
+    class LegacyInspector:
+        def __init__(self) -> None:
+            self.started = False
+            self.analyzed = 0
+
+        def start_run(self) -> None:
+            self.started = True
+
+        def analyze(self, *_args) -> None:
+            self.analyzed += 1
+
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0})
+    inspector = LegacyInspector()
+
+    pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        circ_inspector=inspector,
+    )
+
+    assert not inspector.started
+    assert inspector.analyzed == 1
+
+
+def test_marked_incomplete_event_inspector_fails_explicitly() -> None:
+    """An explicit event opt-in must implement the complete protocol."""
+
+    class IncompleteInspector:
+        supports_operation_events = True
+        run_active = False
+
+        def start_run(self) -> None:
+            pass
+
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0})
+
+    with pytest.raises(
+        TypeError,
+        match="finish_run, abort_run, analyze_operation",
+    ):
+        pc.HybridEngine(seed=1).run(
+            SparseStab(1),
+            circuit,
+            shot_id=0,
+            circ_inspector=IncompleteInspector(),
+        )
+
+
+def test_run_circuit_override_keeps_legacy_signature() -> None:
+    """Engine subclasses need not accept an operation-analyzer keyword."""
+
+    class LegacyEngine(pc.HybridEngine):
+        def run_circuit(
+            self,
+            state,
+            output,
+            output_export,
+            circuit,
+            error_gen,
+            removed_locations=None,
+        ):
+            return super().run_circuit(
+                state,
+                output,
+                output_export,
+                circuit,
+                error_gen,
+                removed_locations,
+            )
+
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0}, duration=1.0)
+    statistics = CircuitStatistics()
+
+    LegacyEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        circ_inspector=statistics,
+    )
+
+    assert statistics.data["runs"][0]["count"]["runtime"] == {"X": 1}
 
 
 def test_lifecycle_and_classifier_failures_are_explicit() -> None:
@@ -148,13 +358,44 @@ def test_lifecycle_and_classifier_failures_are_explicit() -> None:
         CircuitStatistics(classifier=None)
 
     statistics = CircuitStatistics()
-    with pytest.raises(RuntimeError, match=r"Call new\(\)"):
+    with pytest.raises(RuntimeError, match=r"Call start_run\(\)"):
         statistics.analyze(tick_circuit, time, {})
+    with pytest.raises(RuntimeError, match=r"Call start_run\(\)"):
+        statistics.finish_run()
 
     statistics = CircuitStatistics(classifier=lambda *_args: (object(),))
-    statistics.new()
+    statistics.start_run()
+    with pytest.raises(RuntimeError, match="Finish the active run"):
+        statistics.start_run()
     with pytest.raises(TypeError, match="OperationStatistic"):
         statistics.analyze(tick_circuit, time, {})
+
+
+def test_results_are_a_defensive_copy() -> None:
+    """Consumers cannot mutate the collector through the typed result view."""
+    circuit = pc.QuantumCircuit()
+    circuit.append("X", {0}, duration=1.0)
+    statistics = CircuitStatistics()
+    _analyze_circuit(statistics, circuit, {})
+
+    results = statistics.results
+    results["runs"][0]["count"]["runtime"]["X"] = 99
+
+    assert statistics.data["runs"][0]["count"]["runtime"]["X"] == 1
+
+
+def test_manual_contributions_treat_empty_condition_as_unconditional() -> None:
+    """Direct contribution methods match the engine's empty-condition policy."""
+    statistics = CircuitStatistics()
+    statistics.start_run()
+
+    statistics.add_count("X", 1, {}, {})
+    statistics.add_duration("X", 2.0, {}, {})
+    statistics.finish_run()
+
+    run = statistics.data["runs"][0]
+    assert run["count"]["min"] == {"X": 1}
+    assert run["duration"]["min"] == {"X": 2.0}
 
 
 def test_default_classifier_rejects_non_numeric_duration() -> None:

--- a/python/quantum-pecos/tests/pecos/regression/test_engines/test_circuit_statistics.py
+++ b/python/quantum-pecos/tests/pecos/regression/test_engines/test_circuit_statistics.py
@@ -1,0 +1,169 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License.You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Tests for condition-aware circuit execution statistics."""
+
+from __future__ import annotations
+
+import pecos as pc
+import pytest
+from pecos import BitInt
+from pecos.analysis import CircuitStatistics, OperationStatistic
+from pecos.engines.cvm import DefaultClassicalSemantics, UnsignedClassicalSemantics
+from pecos.simulators import SparseStab
+
+
+def _analyze_circuit(
+    statistics: CircuitStatistics,
+    circuit: pc.QuantumCircuit,
+    output: dict,
+) -> None:
+    statistics.new()
+    for tick_circuit, time, _metadata in circuit.iter_ticks():
+        statistics.analyze(tick_circuit, time, output)
+    statistics.finalize()
+
+
+def test_default_classifier_records_counts_durations_and_summary() -> None:
+    """Unconditional operations contribute to every execution view."""
+    circuit = pc.QuantumCircuit()
+    circuit.append("X", {0, 1}, duration=2.5)
+
+    statistics = CircuitStatistics()
+    _analyze_circuit(statistics, circuit, {})
+
+    run = statistics.data["runs"][0]
+    assert run["count"] == {
+        "max": {"X": 2},
+        "min": {"X": 2},
+        "runtime": {"X": 2},
+    }
+    assert run["duration"] == {
+        "max": {"X": 2.5},
+        "min": {"X": 2.5},
+        "runtime": {"X": 2.5},
+    }
+    assert statistics.data["total"] == {
+        "runtime": [2.5],
+        "avg_runtime": (2.5, 0.0),
+    }
+
+
+def test_classifier_can_emit_grouped_and_parallel_statistics() -> None:
+    """A caller can adapt its gate vocabulary without changing aggregation."""
+
+    def classify(symbol, locations, metadata):
+        assert symbol == "H"
+        return (
+            OperationStatistic(
+                "one_qubit",
+                count=len(locations),
+                duration=metadata["duration"],
+            ),
+            OperationStatistic("parallel_one_qubit", count=1),
+        )
+
+    circuit = pc.QuantumCircuit()
+    circuit.append("H", {0, 1}, duration=3.0)
+    statistics = CircuitStatistics(classifier=classify)
+
+    _analyze_circuit(statistics, circuit, {})
+
+    run = statistics.data["runs"][0]
+    assert run["count"]["runtime"] == {
+        "one_qubit": 2,
+        "parallel_one_qubit": 1,
+    }
+    assert run["duration"]["runtime"] == {"one_qubit": 3.0}
+
+
+def test_conditions_share_the_configured_classical_policy() -> None:
+    """Maximum, minimum, and runtime views preserve conditional semantics."""
+    condition = {"a": "word", "op": "<", "b": 0}
+    circuit = pc.QuantumCircuit()
+    circuit.append("X", {0}, duration=1.0, cond=condition)
+    output = {"word": BitInt(8, -2)}
+    statistics = CircuitStatistics(
+        UnsignedClassicalSemantics(8),
+        regwidth=8,
+    )
+
+    _analyze_circuit(statistics, circuit, output)
+
+    run = statistics.data["runs"][0]
+    assert run["count"]["max"] == {"X": 1}
+    assert run["count"]["min"] == {}
+    assert run["count"]["runtime"] == {}
+    assert run["duration"]["max"] == {"X": 1.0}
+    assert run["duration"]["min"] == {}
+    assert run["duration"]["runtime"] == {}
+
+    statistics.set_classical_semantics(
+        DefaultClassicalSemantics(),
+        regwidth=8,
+    )
+    _analyze_circuit(statistics, circuit, output)
+
+    assert statistics.data["runs"][1]["count"]["runtime"] == {"X": 1}
+    assert statistics.data["total"] == {
+        "runtime": [0, 1.0],
+        "avg_runtime": (0.5, 0.5),
+    }
+
+
+def test_hybrid_engine_calls_concrete_inspector() -> None:
+    """The collector implements the inspector hook used by HybridEngine."""
+    circuit = pc.QuantumCircuit(num_qubits=1)
+    circuit.append("X", {0}, duration=4.0)
+    statistics = CircuitStatistics()
+    statistics.new()
+
+    pc.HybridEngine(seed=1).run(
+        SparseStab(1),
+        circuit,
+        shot_id=0,
+        circ_inspector=statistics,
+    )
+    statistics.finalize()
+
+    assert statistics.data["runs"][0]["count"]["runtime"] == {"X": 1}
+    assert statistics.data["total"]["runtime"] == [4.0]
+
+
+def test_lifecycle_and_classifier_failures_are_explicit() -> None:
+    """Invalid lifecycle and classifier results fail near their source."""
+    circuit = pc.QuantumCircuit()
+    circuit.append("X", {0})
+    tick_circuit, time, _metadata = next(circuit.iter_ticks())
+
+    with pytest.raises(TypeError, match="classifier must be callable"):
+        CircuitStatistics(classifier=None)
+
+    statistics = CircuitStatistics()
+    with pytest.raises(RuntimeError, match=r"Call new\(\)"):
+        statistics.analyze(tick_circuit, time, {})
+
+    statistics = CircuitStatistics(classifier=lambda *_args: (object(),))
+    statistics.new()
+    with pytest.raises(TypeError, match="OperationStatistic"):
+        statistics.analyze(tick_circuit, time, {})
+
+
+def test_default_classifier_rejects_non_numeric_duration() -> None:
+    """Malformed duration metadata does not silently corrupt summaries."""
+    circuit = pc.QuantumCircuit()
+    circuit.append("X", {0}, duration="slow")
+    statistics = CircuitStatistics()
+    statistics.new()
+    tick_circuit, time, _metadata = next(circuit.iter_ticks())
+
+    with pytest.raises(TypeError, match="duration must be numeric"):
+        statistics.analyze(tick_circuit, time, {})


### PR DESCRIPTION
## Summary

- add a reusable circuit-statistics inspector for the legacy hybrid engine
- aggregate operation counts and durations across maximum, minimum, and runtime execution views
- report runtime work from the engine actual per-operation execution decision
- support custom operation classifiers without coupling the collector to a device gate vocabulary
- add typed result schemas, defensive result snapshots, and guarded run lifecycle
- document and export the new analysis API

## Design

`CircuitStatistics` owns run lifecycle, count and duration aggregation, and cross-run runtime summaries. An `OperationClassifier` converts each circuit operation into one or more `OperationStatistic` contributions, allowing callers to group symbols or record parallel-layer counts while keeping those policies outside the core collector.

The engine supplies the exact execution decision before an operation can mutate classical state. This keeps runtime statistics aligned with `cond`, `cond2`, and `skip` behavior. Exact operation events require the explicit `OperationEventInspector` capability; unmarked inspectors retain the legacy per-tick callback. Engine-owned failed runs are aborted rather than retained as partial successful results.

The default classifier records operations under their circuit symbol, counts locations (or one locationless operation), and consumes optional numeric `duration` metadata.

## Validation

- 15 focused circuit-statistics and compatibility regression tests
- 361 engine and integration tests passed; 39 optional hardware tests skipped
- focused pre-commit suite passed, including Ruff, Black, Blackdoc, typos, and dependency-integrity checks
- independent API, execution-semantics, and packaging/compatibility reviews completed with no remaining actionable findings
