### PR TITLE
Make observable metadata win over observable annotations (fixes #377)

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -52,6 +52,12 @@ struct ParsedObservable {
     id: u32,
     records: Vec<i32>,
     meas_ids: Vec<usize>,
+    /// Human-readable name from the metadata JSON's `label` field.
+    ///
+    /// The metadata format has always carried this and callers already write
+    /// it, but it used to be parsed and dropped, leaving circuit annotations as
+    /// the only way to get a label onto an observable (issue #377).
+    label: Option<String>,
 }
 
 // ============================================================================
@@ -537,6 +543,7 @@ impl<'a> DemBuilder<'a> {
                 id: id as u32,
                 records,
                 meas_ids: Vec::new(),
+                label: None,
             })
             .collect();
         self.clear_exact_branch_cache();
@@ -810,7 +817,10 @@ impl<'a> DemBuilder<'a> {
         // Observable IDs are not shifted by tracked Paulis.
         for obs in &self.observables {
             let records = self.effective_record_offsets(&obs.records, &obs.meas_ids);
-            let def = DemOutput::new(obs.id).with_records(records.iter().copied());
+            let mut def = DemOutput::new(obs.id).with_records(records.iter().copied());
+            if let Some(label) = &obs.label {
+                def = def.with_label(label.clone());
+            }
             dem.add_observable(def);
         }
 
@@ -2654,11 +2664,16 @@ fn parse_single_observable(value: &serde_json::Value) -> Result<ParsedObservable
     )?;
 
     let (records, meas_ids) = extract_measurement_refs(object, "observable")?;
+    let label = object
+        .get("label")
+        .and_then(serde_json::Value::as_str)
+        .map(std::string::ToString::to_string);
 
     Ok(ParsedObservable {
         id,
         records,
         meas_ids,
+        label,
     })
 }
 
@@ -5268,6 +5283,36 @@ mod tests {
             "with no observables metadata the annotation defines L0 over m0 \
              alone, so it flips at p_meas; got:\n{}",
             dem.to_string()
+        );
+    }
+
+    /// Issue #377: an observable label declared in metadata JSON must reach the
+    /// DEM without an annotation supplying it.
+    ///
+    /// The metadata format has always carried `label` and callers already write
+    /// it, but the parser dropped it, so annotations were the only route. That
+    /// coupling is what made excluding annotations lose labels.
+    #[test]
+    fn test_observable_label_comes_from_metadata_without_annotations() {
+        use pecos_num::graph::Attribute;
+        use pecos_quantum::DagCircuit;
+
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let _meas = circuit.mz(&[0]);
+        circuit.set_attr("num_measurements", Attribute::String("1".to_string()));
+        circuit.set_attr(
+            "observables",
+            Attribute::String(r#"[{"id":0,"records":[-1],"label":"from_metadata"}]"#.to_string()),
+        );
+        circuit.set_attr("detectors", Attribute::String("[]".to_string()));
+
+        let dem = DemBuilder::from_circuit(&circuit, 0.0, 0.0, 0.5, 0.0);
+        assert_eq!(dem.num_observables(), 1);
+        assert_eq!(
+            dem.observables().next().unwrap().label.as_deref(),
+            Some("from_metadata"),
+            "the label declared in observables metadata must reach the DEM"
         );
     }
 }

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -3205,14 +3205,10 @@ fn build_dem_from_circuit(
     use crate::fault_tolerance::propagator::DagFaultAnalyzer;
     use pecos_num::graph::Attribute;
 
-    let mut influence_map = DagFaultAnalyzer::new(circuit).build_influence_map();
-    let annotated_observable_records = observable_records_from_annotations(circuit, &influence_map);
-    let annotation_map = InfluenceBuilder::new(circuit)
-        .with_circuit_annotations(circuit)
-        .build();
-    influence_map.merge_dem_outputs_from(&annotation_map);
-
-    // Extract metadata before building (to avoid borrow issues)
+    // Metadata is read BEFORE annotations are collected: when the caller
+    // supplies observables JSON, that declaration wins, and an observable
+    // annotation describing the same output must not be installed into the
+    // influence map where it would silently override it (issue #377).
     let det_json = circuit.get_attr("detectors").and_then(|a| {
         if let Attribute::String(s) = a {
             Some(s.clone())
@@ -3234,6 +3230,19 @@ fn build_dem_from_circuit(
             None
         }
     });
+
+    let mut influence_map = DagFaultAnalyzer::new(circuit).build_influence_map();
+    let annotated_observable_records = observable_records_from_annotations(circuit, &influence_map);
+    let annotations = InfluenceBuilder::new(circuit);
+    // Tracked-Pauli annotations have no metadata equivalent, so they are
+    // collected either way.
+    let annotation_map = if obs_json.is_some() {
+        annotations.with_circuit_annotations_excluding_observables(circuit)
+    } else {
+        annotations.with_circuit_annotations(circuit)
+    }
+    .build();
+    influence_map.merge_dem_outputs_from(&annotation_map);
 
     let builder = DemBuilder::new(&influence_map)
         .with_noise_config(noise)
@@ -5189,6 +5198,76 @@ mod tests {
             dem(&["f"], &["szdg", "sxdg"], true),
             dem(&["sy"], &["szdg", "sxdg"], true),
             "X-basis variant must distinguish F from SY (the Z-blind pair)"
+        );
+    }
+
+    /// Issue #377: an observable annotation must not override the observable
+    /// declared in metadata JSON.
+    ///
+    /// The two sources are made to disagree on purpose -- metadata covers both
+    /// measurements, the annotation covers only the first -- and the resulting
+    /// probability says which definition was used. With `p_meas = 0.25` and two
+    /// independent measurements, an observable over both flips on an odd number
+    /// of errors (`2 * 0.25 * 0.75 = 0.375`), while an observable over only the
+    /// first flips at `0.25`. The asymmetry matters: with one measurement per
+    /// qubit and a symmetric observable the two definitions produce identical
+    /// DEMs and the test would prove nothing.
+    #[test]
+    fn test_observable_metadata_wins_over_observable_annotation() {
+        use pecos_num::graph::Attribute;
+        use pecos_quantum::DagCircuit;
+
+        fn dem_string(with_annotation: bool) -> String {
+            let mut circuit = DagCircuit::new();
+            circuit.pz(&[0]);
+            let m0 = circuit.mz(&[0]);
+            circuit.pz(&[1]);
+            let _m1 = circuit.mz(&[1]);
+            if with_annotation {
+                circuit.observable_labeled("obs_ann", &[m0[0]]);
+            }
+            circuit.set_attr("num_measurements", Attribute::String("2".to_string()));
+            circuit.set_attr(
+                "observables",
+                Attribute::String(r#"[{"id":0,"records":[-2,-1]}]"#.to_string()),
+            );
+            circuit.set_attr("detectors", Attribute::String("[]".to_string()));
+            DemBuilder::from_circuit(&circuit, 0.0, 0.0, 0.25, 0.0).to_string()
+        }
+
+        let with_annotation = dem_string(true);
+        assert_eq!(
+            with_annotation,
+            dem_string(false),
+            "an observable annotation must not change a DEM whose observables \
+             come from metadata"
+        );
+        assert!(
+            with_annotation.contains("error(0.375) L0"),
+            "metadata declares L0 over BOTH measurements, so it must flip on an \
+             odd number of the two independent p_meas errors; got:\n{with_annotation}"
+        );
+    }
+
+    /// The annotation is still the source when metadata supplies no observables.
+    #[test]
+    fn test_observable_annotation_used_when_metadata_absent() {
+        use pecos_quantum::DagCircuit;
+
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let m0 = circuit.mz(&[0]);
+        circuit.pz(&[1]);
+        let _m1 = circuit.mz(&[1]);
+        circuit.observable_labeled("obs_ann", &[m0[0]]);
+
+        let dem = DemBuilder::from_circuit(&circuit, 0.0, 0.0, 0.25, 0.0);
+        assert_eq!(dem.num_observables(), 1);
+        assert!(
+            dem.to_string().contains("error(0.25) L0"),
+            "with no observables metadata the annotation defines L0 over m0 \
+             alone, so it flips at p_meas; got:\n{}",
+            dem.to_string()
         );
     }
 }

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -185,7 +185,32 @@ impl<'a> InfluenceBuilder<'a> {
     /// by `DemSamplerBuilder::with_circuit_annotations` which maps them
     /// to auto-detected detectors.
     #[must_use]
-    pub fn with_circuit_annotations(mut self, circuit: &pecos_quantum::DagCircuit) -> Self {
+    pub fn with_circuit_annotations(self, circuit: &pecos_quantum::DagCircuit) -> Self {
+        self.with_circuit_annotations_inner(circuit, true)
+    }
+
+    /// Same as [`Self::with_circuit_annotations`] but skipping `Observable`
+    /// annotations.
+    ///
+    /// When a circuit supplies detector/observable metadata JSON, that metadata
+    /// is the caller's explicit declaration and must win. An observable
+    /// annotation describing the same `L0` would otherwise be installed into the
+    /// influence map first and silently override it (issue #377).
+    /// Tracked-Pauli annotations have no metadata equivalent, so they are still
+    /// collected.
+    #[must_use]
+    pub(crate) fn with_circuit_annotations_excluding_observables(
+        self,
+        circuit: &pecos_quantum::DagCircuit,
+    ) -> Self {
+        self.with_circuit_annotations_inner(circuit, false)
+    }
+
+    fn with_circuit_annotations_inner(
+        mut self,
+        circuit: &pecos_quantum::DagCircuit,
+        include_observables: bool,
+    ) -> Self {
         // Find TrackedPauliMeta nodes in topological order.
         // The nth meta-gate corresponds to the nth tracked-Pauli annotation.
         let meta_nodes: Vec<usize> = circuit
@@ -197,7 +222,9 @@ impl<'a> InfluenceBuilder<'a> {
         let mut operator_idx = 0;
         for ann in circuit.annotations() {
             match &ann.kind {
-                pecos_quantum::AnnotationKind::Observable { measurement_nodes } => {
+                pecos_quantum::AnnotationKind::Observable { measurement_nodes }
+                    if include_observables =>
+                {
                     let mut terms = Vec::new();
                     for &meas_node in measurement_nodes {
                         if let Some(gate) = circuit.gate(meas_node) {
@@ -223,6 +250,9 @@ impl<'a> InfluenceBuilder<'a> {
                             .with_optional_label(ann.label.clone()),
                         meta_node,
                     );
+                }
+                pecos_quantum::AnnotationKind::Observable { .. } => {
+                    // Excluded: metadata JSON declares the observables.
                 }
                 pecos_quantum::AnnotationKind::Detector { .. } => {
                     // Detectors handled separately by DemSamplerBuilder

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -251,12 +251,11 @@ impl<'a> InfluenceBuilder<'a> {
                         meta_node,
                     );
                 }
-                pecos_quantum::AnnotationKind::Observable { .. } => {
-                    // Excluded: metadata JSON declares the observables.
-                }
-                pecos_quantum::AnnotationKind::Detector { .. } => {
-                    // Detectors handled separately by DemSamplerBuilder
-                }
+                // Observables when `include_observables` is false: metadata
+                // JSON declares them. Detectors: handled separately by
+                // `DemSamplerBuilder`.
+                pecos_quantum::AnnotationKind::Observable { .. }
+                | pecos_quantum::AnnotationKind::Detector { .. } => {}
             }
         }
         self


### PR DESCRIPTION
Fixes #377.

`DetectorErrorModel::from_circuit` returned DEMs with spurious error mechanisms for any circuit carrying both circuit annotations and detector/observable metadata, which is what the surface-code generators produce. An independent Stim oracle agreed with the other DEM path and disagreed with `from_circuit` (86 mechanisms versus 76 at d=3).

## Root cause

An observable **annotation** silently overrode the observable declared in **metadata JSON**.

`build_dem_from_circuit` installed annotation-derived DEM outputs into the influence map (`merge_dem_outputs_from`) *before* it read the metadata attributes. The annotation's definition therefore won during mechanism generation even though `with_observables_json` was called with the caller's explicit declaration.

Minimal reproduction -- metadata covers both measurements, the annotation covers only the first, so the probability identifies which definition was used:

```
WITHOUT annotation:  error(0.375) L0     <- 2 * 0.25 * 0.75, observable over BOTH measurements (metadata)
WITH annotation:     error(0.25)  L0     <- flips only on the first measurement (annotation)
```

The asymmetry is essential. With one measurement per qubit and a symmetric observable the two definitions produce identical DEMs, and an earlier version of this test proved nothing for exactly that reason.

## The fix

Metadata is parsed **before** annotations are collected, and observable annotations are excluded when the circuit supplies observables JSON:

```rust
let annotation_map = if obs_json.is_some() {
    annotations.with_circuit_annotations_excluding_observables(circuit)
} else {
    annotations.with_circuit_annotations(circuit)
}
.build();
```

`with_circuit_annotations_excluding_observables` is a new `pub(crate)` sibling sharing one inner implementation, so the ~25 existing callers of the public method are untouched. Tracked-Pauli annotations are still collected either way -- metadata has no equivalent for them.

This matches the precedence the very next block already applied to observable *records*: metadata first, annotations only as fallback.

## Coupled fix: observable labels from metadata

Excluding annotations initially broke `sampler_paths_preserve_output_split_for_noiseless_and_forced_faults`, which expected a DEM-output label of `"obs0"` and got `None`.

That was not the test encoding the bug. **`parse_observables_json` discarded the `label` field.** `ParsedObservable` had no label, and DEM-output labels were populated in exactly one place (`influence_builder.rs:441`) from annotation-derived outputs -- so annotations were the only possible source of an observable label, even though the metadata format already carries one and callers already write it.

Editing that test to expect `None` would have been a real regression. Instead the metadata format is now self-sufficient: `ParsedObservable` carries `label`, `parse_single_observable` reads it, and `try_build` attaches it when emitting the observable. The previously-failing test now passes on its own merits, with the label coming from the metadata that always declared it.

## Testing

Four tests, each verified to FAIL when the corresponding change is reverted -- not merely to pass:

| test | pins |
| --- | --- |
| `test_observable_metadata_wins_over_observable_annotation` | metadata records win over a disagreeing annotation |
| `test_observable_annotation_used_when_metadata_absent` | the fallback path still works (passes either way by design -- guards against over-fixing) |
| `test_observable_label_comes_from_metadata_without_annotations` | a metadata label reaches the DEM with no annotation present |
| `sampler_paths_preserve_output_split_for_noiseless_and_forced_faults` (existing) | label survives when both sources are present |

- `cargo test -p pecos-qec` green: 598 lib tests and 58 doctests, 0 failed.
- `cargo check --workspace --all-targets`, `cargo clippy -p pecos-qec --all-targets`, `cargo fmt --all --check` all clean.

## End-to-end verification (draft criterion met)

Built the `pecos-rslib` extension from this branch into an isolated venv and re-ran the original Stim comparison. Same script, same circuits, only the binary differs:

| | `from_circuit` mechanisms | agrees with Stim? |
| --- | --- | --- |
| `dev` (pre-fix) | 86 (Z basis) / 80 (X basis) | no -- all four configs |
| this branch | **76** in all four | **yes -- all four configs** |

Covered: `interaction_basis="cx"` and `interaction_basis="szz", szz_physical_prefixes=True`, each in Z and X basis, d=3, 1 round, p2-only. `influence == stim` in both runs, confirming that path was unaffected and that nothing else shifted.

The spurious mechanisms reported in #377 are gone.

One methodology note: a `pecos_rslib.pth` initially shadowed the built wheel with the repo source tree, which would have silently tested the pre-fix binary. The run above loads the wheel's own `pecos_rslib.abi3.so` from the isolated venv.
