### PR TITLE
Make conflicting observable label and Pauli definitions fail in every build

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -5085,16 +5085,35 @@ impl DetectorErrorModel {
         self.observables.push(observable);
     }
 
+    /// Merge a second definition of an already-declared observable.
+    ///
+    /// Records combine by parity, but the label and Pauli identify the
+    /// observable rather than accumulate, so two definitions disagreeing about
+    /// either describe different observables sharing an id. That is malformed
+    /// input -- typically metadata JSON and a circuit annotation contradicting
+    /// each other -- and there is no defensible way to pick a winner.
+    ///
+    /// These checks deliberately fire in every build. They were
+    /// `debug_assert_eq!`, which meant release builds silently kept whichever
+    /// definition arrived first and discarded the other, so a contradiction
+    /// produced a quietly wrong DEM rather than a diagnostic.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `incoming` disagrees with `existing` about the label or the
+    /// Pauli.
     fn merge_observable_definition(existing: &mut DemOutput, incoming: DemOutput) {
         existing.kind = Some(DemOutputKind::Observable);
         merge_record_parity(&mut existing.records, incoming.records);
 
         if let Some(incoming_pauli) = incoming.pauli {
             if let Some(existing_pauli) = &existing.pauli {
-                debug_assert_eq!(
+                assert_eq!(
                     existing_pauli, &incoming_pauli,
-                    "conflicting Pauli metadata for observable L{}",
-                    existing.id
+                    "conflicting Pauli metadata for observable L{}: already declared as {:?}, \
+                     redeclared as {incoming_pauli:?}. Two definitions sharing an observable id \
+                     must agree; supply the Pauli from one source only, or give them distinct ids",
+                    existing.id, existing_pauli
                 );
             } else {
                 existing.pauli = Some(incoming_pauli);
@@ -5103,9 +5122,11 @@ impl DetectorErrorModel {
 
         if let Some(incoming_label) = incoming.label {
             if let Some(existing_label) = &existing.label {
-                debug_assert_eq!(
+                assert_eq!(
                     existing_label, &incoming_label,
-                    "conflicting labels for observable L{}",
+                    "conflicting labels for observable L{}: already labelled {existing_label:?}, \
+                     relabelled {incoming_label:?}. Two definitions sharing an observable id must \
+                     agree; supply the label from one source only, or give them distinct ids",
                     existing.id
                 );
             } else {
@@ -6525,7 +6546,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
     #[should_panic(expected = "conflicting labels for observable L0")]
     fn test_duplicate_observable_definitions_reject_conflicting_labels() {
         let mut dem = DetectorErrorModel::new();
@@ -6534,7 +6554,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
     #[should_panic(expected = "conflicting Pauli metadata for observable L0")]
     fn test_duplicate_observable_definitions_reject_conflicting_paulis() {
         use pecos_core::pauli::{X, Z};

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -2055,6 +2055,21 @@ impl DemOutput {
     }
 }
 
+/// Compare two Pauli strings ignoring global phase.
+///
+/// A DEM output flip is an anticommutation property, so global phase carries no
+/// meaning -- [`DemOutput::with_pauli`] strips it for exactly that reason. The
+/// `pauli` field is public and can be set without going through that
+/// constructor, so an equality check must not treat `-X` and `+X` as different
+/// observables.
+fn pauli_eq_ignoring_phase(left: &PauliString, right: &PauliString) -> bool {
+    let mut left = left.clone();
+    let mut right = right.clone();
+    left.set_phase(pecos_core::QuarterPhase::PlusOne);
+    right.set_phase(pecos_core::QuarterPhase::PlusOne);
+    left == right
+}
+
 fn merge_record_parity(existing: &mut SmallVec<[i32; 4]>, incoming: SmallVec<[i32; 4]>) {
     for record in incoming {
         toggle_dem_output_record(existing, record);
@@ -5098,40 +5113,43 @@ impl DetectorErrorModel {
     /// definition arrived first and discarded the other, so a contradiction
     /// produced a quietly wrong DEM rather than a diagnostic.
     ///
+    /// Both are checked before anything is mutated, and the Pauli comparison
+    /// ignores global phase, which carries no DEM meaning.
+    ///
     /// # Panics
     ///
-    /// Panics when `incoming` disagrees with `existing` about the label or the
-    /// Pauli.
+    /// Panics when `incoming` disagrees with `existing` about the label, or
+    /// about the Pauli up to global phase.
     fn merge_observable_definition(existing: &mut DemOutput, incoming: DemOutput) {
-        existing.kind = Some(DemOutputKind::Observable);
-        merge_record_parity(&mut existing.records, incoming.records);
-
-        if let Some(incoming_pauli) = incoming.pauli {
-            if let Some(existing_pauli) = &existing.pauli {
-                assert_eq!(
-                    existing_pauli, &incoming_pauli,
-                    "conflicting Pauli metadata for observable L{}: already declared as {:?}, \
-                     redeclared as {incoming_pauli:?}. Two definitions sharing an observable id \
-                     must agree; supply the Pauli from one source only, or give them distinct ids",
-                    existing.id, existing_pauli
-                );
-            } else {
-                existing.pauli = Some(incoming_pauli);
-            }
+        // Validate before mutating anything: a caught panic must not leave a
+        // half-merged output behind.
+        if let (Some(existing_pauli), Some(incoming_pauli)) = (&existing.pauli, &incoming.pauli) {
+            assert!(
+                pauli_eq_ignoring_phase(existing_pauli, incoming_pauli),
+                "conflicting Pauli metadata for observable L{}: already declared as \
+                 {existing_pauli:?}, redeclared as {incoming_pauli:?}. Two definitions sharing \
+                 an observable id must agree; supply the Pauli from one source only, or give \
+                 them distinct ids",
+                existing.id
+            );
+        }
+        if let (Some(existing_label), Some(incoming_label)) = (&existing.label, &incoming.label) {
+            assert_eq!(
+                existing_label, incoming_label,
+                "conflicting labels for observable L{}: already labelled {existing_label:?}, \
+                 relabelled {incoming_label:?}. Two definitions sharing an observable id must \
+                 agree; supply the label from one source only, or give them distinct ids",
+                existing.id
+            );
         }
 
-        if let Some(incoming_label) = incoming.label {
-            if let Some(existing_label) = &existing.label {
-                assert_eq!(
-                    existing_label, &incoming_label,
-                    "conflicting labels for observable L{}: already labelled {existing_label:?}, \
-                     relabelled {incoming_label:?}. Two definitions sharing an observable id must \
-                     agree; supply the label from one source only, or give them distinct ids",
-                    existing.id
-                );
-            } else {
-                existing.label = Some(incoming_label);
-            }
+        existing.kind = Some(DemOutputKind::Observable);
+        merge_record_parity(&mut existing.records, incoming.records);
+        if existing.pauli.is_none() {
+            existing.pauli = incoming.pauli;
+        }
+        if existing.label.is_none() {
+            existing.label = incoming.label;
         }
     }
 
@@ -6546,15 +6564,60 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "conflicting labels for observable L0")]
+    #[should_panic(expected = "already labelled \"first\", relabelled \"second\"")]
     fn test_duplicate_observable_definitions_reject_conflicting_labels() {
         let mut dem = DetectorErrorModel::new();
         dem.add_observable(DemOutput::new(0).with_label("first"));
         dem.add_observable(DemOutput::new(0).with_label("second"));
     }
 
+    /// Global phase carries no DEM meaning, so `-X` and `+X` describe the same
+    /// observable. `with_pauli` strips phase, but `pauli` is a public field and
+    /// can be set directly, so the conflict check must compare phase-free
+    /// rather than rejecting a legitimate redeclaration.
     #[test]
-    #[should_panic(expected = "conflicting Pauli metadata for observable L0")]
+    fn duplicate_observable_definitions_ignore_global_phase() {
+        use pecos_core::pauli::X;
+
+        let mut plus = X(0);
+        plus.set_phase(pecos_core::QuarterPhase::PlusOne);
+        let mut minus = X(0);
+        minus.set_phase(pecos_core::QuarterPhase::MinusOne);
+
+        let mut dem = DetectorErrorModel::new();
+        let mut first = DemOutput::new(0);
+        first.pauli = Some(plus);
+        let mut second = DemOutput::new(0);
+        second.pauli = Some(minus);
+
+        dem.add_observable(first);
+        dem.add_observable(second); // must not panic
+        assert_eq!(dem.num_observables(), 1);
+    }
+
+    /// The merge must not mutate before it validates -- a caught panic should
+    /// leave the existing definition intact.
+    #[test]
+    fn conflicting_definitions_do_not_mutate_before_panicking() {
+        let mut dem = DetectorErrorModel::new();
+        dem.add_observable(DemOutput::new(0).with_records([-1]).with_label("first"));
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dem.add_observable(DemOutput::new(0).with_records([-2]).with_label("second"));
+        }));
+        assert!(outcome.is_err(), "conflicting labels must panic");
+
+        let observable = dem.observables().next().expect("observable survives");
+        assert_eq!(observable.label.as_deref(), Some("first"));
+        assert_eq!(
+            observable.records.as_slice(),
+            &[-1],
+            "records must not have been merged before the conflict was detected"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "conflicting Pauli metadata for observable L0: already declared as")]
     fn test_duplicate_observable_definitions_reject_conflicting_paulis() {
         use pecos_core::pauli::{X, Z};
 


### PR DESCRIPTION
Two definitions of the same observable that disagree about the label or the Pauli were resolved silently in release builds. Now they fail in every build, with a message naming both values.

Found during the review of #384.

## The defect

`DetectorErrorModel::add_observable` merges a second definition of an already-declared observable. Records combine by parity, which is correct -- they accumulate. But the label and the Pauli *identify* the observable rather than accumulate, so two definitions disagreeing about either describe different observables sharing an id.

That was handled with `debug_assert_eq!`. Debug builds panicked; **release builds silently kept whichever definition arrived first and discarded the other**, producing a quietly mislabelled DEM with no diagnostic. Reachable from user input -- metadata JSON and a circuit annotation contradicting each other is exactly the situation #377 was about.

## The change

Both checks are now `assert_eq!`/`assert!`, so they fire in every build:

```
conflicting labels for observable L0: already labelled "first", relabelled "second".
Two definitions sharing an observable id must agree; supply the label from one
source only, or give them distinct ids
```

Two refinements from review:

- **Validate before mutating.** The first revision merged `kind` and records before checking the label and Pauli, so a caught panic left a half-merged output. Validation now happens first. (Notably the borrow checker enforces this shape: moving the mutation earlier fails to compile, because validation borrows fields the mutation moves.)
- **Compare Paulis ignoring global phase.** `DemOutput::with_pauli` strips phase because it carries no DEM meaning, but `pauli` is a public field that can be set directly. Comparing raw would have rejected `-X` against `+X` -- a spurious panic on input the library explicitly treats as equivalent. A new `pauli_eq_ignoring_phase` compares phase-free.

## Deliberately not converted

The remaining `debug_assert!`s in this module are **not** all internal invariants -- an earlier version of this description claimed they were, and that was wrong. `FaultMechanism::from_sorted`, `from_sorted_with_tracked_paulis` and `MeasurementMechanism::from_sorted` are `pub` and validate their sortedness precondition debug-only, while `xor` depends on it.

They are left as-is deliberately: the precondition is stated in the function name, these are per-mechanism constructors on the DEM construction path, and always-validating would add an O(n) scan to each call. That is the "trust the caller, state the contract" case rather than boundary validation. Converting them, or adding fallible variants, is a reasonable separate change if the API is revisited.

`add_observable` and its ~21 callers are infallible, so returning `Result` would be a public-API redesign rather than a fix to the silent path. Panicking loudly is the smaller change that removes the actual defect.

## Also out of scope

Review flagged two wider instances of the same disease, filed for follow-up rather than bundled: `apply_pecos_metadata_json` and `ParsedDem` still do last-writer-wins via `*existing = target` on paths that already return `Result` and could report properly; and duplicate tracked-Pauli / detector ids remain silently merged.

## Testing

The control is what makes this worth reading. On `dev`, in release:

```
test result: ok. 1 passed; ... 592 filtered out
```

Only one of the three tests exists -- both conflict tests were gated `#[cfg(debug_assertions)]`, so the release-mode silent path was untested by construction. That gate is removed.

Each production change was **verified to be killed** by reverting it:

| reverted | result |
| --- | --- |
| phase-free Pauli comparison | killed |
| `assert_eq!` back to `debug_assert_eq!` (release) | killed |
| validate-before-mutate | killed |

The `should_panic` strings now match the *added detail* (`already labelled "first", relabelled "second"`), not just the unchanged prefix, so they would fail if the improved messages regressed.

New tests: `duplicate_observable_definitions_ignore_global_phase`, `conflicting_definitions_do_not_mutate_before_panicking`.

- `cargo test -p pecos-qec` green in debug **and** release: 597 lib tests, 0 failed.
- `cargo clippy -p pecos-qec --all-targets` clean, forced cold; `cargo fmt --all --check` clean.
