### PR TITLE
Resolve Python measurement refs against the circuit instead of fabricating them

### DIFF
--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1460,37 +1460,32 @@ impl TickCircuit {
     /// was not measured by it.
     #[must_use]
     pub fn meas_ref(&self, tick: usize, gate_idx: usize, qubit: QubitId) -> Option<TickMeasRef> {
-        // `record_idx` is a positional ordinal -- the cumulative count of
-        // measured qubits in circuit order -- while `MeasId` is a stable
-        // identity that `mz_with_ids` lets callers supply from an external
-        // source (e.g. Guppy result ids). They coincide only when `mz`
-        // auto-assigns them, so the ordinal must be counted, not read off the
-        // id.
-        let mut records_before = 0usize;
-        for (tick_idx, current_tick) in self.iter_ticks() {
-            for (batch_idx, batch) in current_tick.iter_gate_batches().enumerate() {
-                let gate = batch.as_gate();
-                let is_measurement = matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree);
-                if tick_idx == tick && batch_idx == gate_idx {
-                    if !is_measurement {
-                        return None;
-                    }
-                    let position = gate.qubits.iter().position(|&q| q == qubit)?;
-                    let meas_id = gate.meas_ids.get(position).copied()?;
-                    return Some(TickMeasRef {
-                        tick,
-                        gate_idx,
-                        qubit,
-                        record_idx: records_before + position,
-                        meas_id,
-                    });
-                }
-                if is_measurement {
-                    records_before += gate.qubits.len();
-                }
-            }
+        // The `MeasId` stored alongside each measured qubit is what `mz` /
+        // `mz_free` assigned at call time, so reading it back recovers the
+        // record index directly. Reconstructing the ordinal by walking stored
+        // ticks and batches instead is wrong: a later measurement can be
+        // appended to an earlier compatible batch, and `tick_at` allows filling
+        // ticks out of order, so storage order is not allocation order.
+        //
+        // Limitation: `mz_with_ids` lets callers supply external stable ids
+        // (Guppy result ids) that are not positional, and for those the record
+        // index and the id genuinely differ. `TickCircuit` does not store the
+        // positional ordinal separately, so that case cannot be resolved here;
+        // it is tracked in #387 along with the reverse-conversion conflation.
+        let batch = self.get_tick(tick)?.iter_gate_batches().nth(gate_idx)?;
+        let gate = batch.as_gate();
+        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+            return None;
         }
-        None
+        let position = gate.qubits.iter().position(|&q| q == qubit)?;
+        let meas_id = gate.meas_ids.get(position).copied()?;
+        Some(TickMeasRef {
+            tick,
+            gate_idx,
+            qubit,
+            record_idx: meas_id.index(),
+            meas_id,
+        })
     }
 
     /// Get a tick by index.
@@ -6732,38 +6727,41 @@ mod tests {
         assert!(circuit.meas_ref(0, 0, QubitId(0)).is_none());
     }
 
-    /// `record_idx` is a positional ordinal; `MeasId` is a stable identity that
-    /// callers may supply from an external source (the `mz_with_ids` binding
-    /// stamps Guppy result ids this way). Reading the ordinal off the id made a
-    /// measurement stamped `MeasId(10)` claim record 10 when it was record 0.
+    /// Storage order is not allocation order, so `meas_ref` must not
+    /// reconstruct the record index by walking ticks and batches.
+    ///
+    /// A later measurement can be appended to an earlier compatible batch, and
+    /// `tick_at` allows filling ticks out of sequence. Reading the `MeasId`
+    /// that `mz`/`mz_free` stored alongside the qubit is order-independent;
+    /// counting stored batches silently returned another measurement's index.
     #[test]
-    fn meas_ref_record_ordinal_is_independent_of_meas_id() {
+    fn meas_ref_is_independent_of_batch_and_tick_storage_order() {
         let mut circuit = TickCircuit::new();
-        circuit.tick().pz(&[0, 1]);
-        circuit.tick();
-        let tick_idx = circuit.num_ticks() - 1;
-        let mut gate = Gate::mz(&[0usize, 1usize]);
-        gate.meas_ids = smallvec::smallvec![MeasId(10), MeasId(20)];
-        let gate_idx = circuit
-            .get_tick_mut(tick_idx)
-            .expect("tick exists")
-            .try_add_gate(gate)
-            .expect("measurement is a valid gate");
-
-        let first = circuit
-            .meas_ref(tick_idx, gate_idx, QubitId(0))
-            .expect("ref must resolve");
-        let second = circuit
-            .meas_ref(tick_idx, gate_idx, QubitId(1))
-            .expect("ref must resolve");
-
-        assert_eq!(first.record_idx, 0, "first measurement is record 0, not 10");
+        circuit.tick().pz(&[0, 1, 2]);
+        // Interleave so the third measurement merges into the first batch.
+        let first = circuit.tick().mz(&[0]);
+        let freed = circuit.tick_at(1).mz_free(&[1]);
+        let third = circuit.tick_at(1).mz(&[2]);
         assert_eq!(
-            second.record_idx, 1,
-            "second measurement is record 1, not 20"
+            (
+                first[0].record_idx,
+                freed[0].record_idx,
+                third[0].record_idx
+            ),
+            (0, 1, 2),
+            "records are allocated in call order"
         );
-        assert_eq!(first.meas_id, MeasId(10), "the stable id is preserved");
-        assert_eq!(second.meas_id, MeasId(20));
+
+        for expected in [first[0], freed[0], third[0]] {
+            let recovered = circuit
+                .meas_ref(expected.tick, expected.gate_idx, expected.qubit)
+                .expect("every ref mz() handed out must resolve");
+            assert_eq!(
+                recovered.record_idx, expected.record_idx,
+                "qubit {:?} must recover the record it was allocated",
+                expected.qubit
+            );
+        }
     }
 
     /// `MeasureFree` consumes a measurement record exactly like `MZ`, so a

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3444,8 +3444,16 @@ impl From<&TickCircuit> for DagCircuit {
                     let node = dag.add_gate(split_gate.clone());
                     split_nodes.push(node);
 
-                    // For MZ gates, map each qubit's record to this node
-                    if split_gate.gate_type == GateType::MZ {
+                    // Every measurement consumes a record, `MeasureFree`
+                    // included -- `TickHandle::mz_free` advances
+                    // `next_meas_record` exactly like `mz`. Counting only `MZ`
+                    // here left later records unmappable, so annotations
+                    // referencing them silently resolved to nothing.
+                    //
+                    // `MeasureLeaked` is a measurement too and is still
+                    // excluded here; that inconsistency is tracked in #387
+                    // along with the remaining silent drops below.
+                    if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
                         for _q in &split_gate.qubits {
                             meas_record_to_node.insert(meas_record_idx, node);
                             meas_record_idx += 1;
@@ -6779,5 +6787,43 @@ mod tests {
             .meas_ref(kept[0].tick, kept[0].gate_idx, kept[0].qubit)
             .expect("ref must resolve");
         assert_eq!(recovered.record_idx, 2);
+    }
+
+    /// A measurement record that `mz()` handed out must still resolve after the
+    /// DAG conversion. `MeasureFree` consumes a record, so counting only `MZ`
+    /// during conversion left later records unmappable and the annotation
+    /// resolved to nothing at all.
+    #[test]
+    fn annotation_records_survive_conversion_across_measure_free() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1, 2, 3]);
+        let _freed = circuit.tick().mz_free(&[0, 1]);
+        let kept = circuit.tick().mz(&[2, 3]);
+        assert_eq!(
+            kept[0].record_idx, 2,
+            "MZ after two MeasureFree is record 2"
+        );
+        circuit.observable(&kept);
+
+        let dag = crate::DagCircuit::from(&circuit);
+        let nodes: Vec<Vec<usize>> = dag
+            .annotations()
+            .iter()
+            .filter_map(|ann| match &ann.kind {
+                AnnotationKind::Observable { measurement_nodes } => Some(measurement_nodes.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0].len(),
+            2,
+            "both records must resolve; an empty annotation silently drops the observable"
+        );
+        assert_ne!(
+            nodes[0][0], nodes[0][1],
+            "records must map to distinct nodes"
+        );
     }
 }

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1441,6 +1441,41 @@ impl TickCircuit {
         self.ticks[..tick_idx].iter().map(Tick::len).sum::<usize>() + gate_idx
     }
 
+    /// Recover the [`TickMeasRef`] for a measurement identified by its tick,
+    /// gate-batch index and qubit.
+    ///
+    /// Callers that hold only `(tick, gate_idx, qubit)` -- notably the Python
+    /// bindings, whose measurement handles are plain tuples -- need the record
+    /// index and [`MeasId`] that `mz()` assigned. Fabricating a `TickMeasRef`
+    /// with placeholder values instead silently collapses every reference onto
+    /// record 0, which corrupts detector and observable annotations built from
+    /// them (issue #382).
+    ///
+    /// `gate_idx` indexes gate *batches* within the tick, and a batch may
+    /// accumulate qubits from several `mz()` calls, so the qubit selects the
+    /// entry within the batch.
+    ///
+    /// Returns `None` when the tick or batch does not exist, when the batch is
+    /// not a measurement, when it carries no measurement ids, or when the qubit
+    /// was not measured by it.
+    #[must_use]
+    pub fn meas_ref(&self, tick: usize, gate_idx: usize, qubit: QubitId) -> Option<TickMeasRef> {
+        let batch = self.get_tick(tick)?.iter_gate_batches().nth(gate_idx)?;
+        let gate = batch.as_gate();
+        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+            return None;
+        }
+        let position = gate.qubits.iter().position(|&q| q == qubit)?;
+        let meas_id = gate.meas_ids.get(position).copied()?;
+        Some(TickMeasRef {
+            tick,
+            gate_idx,
+            qubit,
+            record_idx: meas_id.index(),
+            meas_id,
+        })
+    }
+
     /// Get a tick by index.
     #[must_use]
     pub fn get_tick(&self, idx: usize) -> Option<&Tick> {
@@ -6620,5 +6655,55 @@ mod tests {
             }
             _ => panic!("Expected detector"),
         }
+    }
+
+    /// `meas_ref` must recover exactly what `mz()` handed out, because the
+    /// Python bindings hold only `(tick, gate_idx, qubit)` and rebuild the ref
+    /// from it. Fabricating the record index there collapsed every annotation
+    /// reference onto record 0 (issue #382).
+    #[test]
+    fn meas_ref_recovers_what_mz_returned() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1, 2]);
+        let first = circuit.tick().mz(&[0, 1, 2]);
+        let second = circuit.tick().mz(&[1]);
+
+        for expected in first.iter().chain(&second) {
+            let recovered = circuit
+                .meas_ref(expected.tick, expected.gate_idx, expected.qubit)
+                .expect("mz() refs must resolve");
+            assert_eq!(
+                recovered.record_idx, expected.record_idx,
+                "record index for qubit {:?}",
+                expected.qubit
+            );
+            assert_eq!(recovered.meas_id, expected.meas_id);
+        }
+
+        let records: Vec<usize> = first.iter().map(|r| r.record_idx).collect();
+        assert_eq!(
+            records,
+            vec![0, 1, 2],
+            "a batched mz must hand out distinct record indices"
+        );
+        assert_eq!(second[0].record_idx, 3);
+    }
+
+    #[test]
+    fn meas_ref_rejects_refs_that_name_no_measurement() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0]);
+        let refs = circuit.tick().mz(&[0]);
+        let good = refs[0];
+
+        assert!(
+            circuit
+                .meas_ref(good.tick, good.gate_idx, QubitId(7))
+                .is_none()
+        );
+        assert!(circuit.meas_ref(good.tick, 99, good.qubit).is_none());
+        assert!(circuit.meas_ref(99, good.gate_idx, good.qubit).is_none());
+        // tick 0 holds the prep, not a measurement
+        assert!(circuit.meas_ref(0, 0, QubitId(0)).is_none());
     }
 }

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1460,20 +1460,37 @@ impl TickCircuit {
     /// was not measured by it.
     #[must_use]
     pub fn meas_ref(&self, tick: usize, gate_idx: usize, qubit: QubitId) -> Option<TickMeasRef> {
-        let batch = self.get_tick(tick)?.iter_gate_batches().nth(gate_idx)?;
-        let gate = batch.as_gate();
-        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
-            return None;
+        // `record_idx` is a positional ordinal -- the cumulative count of
+        // measured qubits in circuit order -- while `MeasId` is a stable
+        // identity that `mz_with_ids` lets callers supply from an external
+        // source (e.g. Guppy result ids). They coincide only when `mz`
+        // auto-assigns them, so the ordinal must be counted, not read off the
+        // id.
+        let mut records_before = 0usize;
+        for (tick_idx, current_tick) in self.iter_ticks() {
+            for (batch_idx, batch) in current_tick.iter_gate_batches().enumerate() {
+                let gate = batch.as_gate();
+                let is_measurement = matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree);
+                if tick_idx == tick && batch_idx == gate_idx {
+                    if !is_measurement {
+                        return None;
+                    }
+                    let position = gate.qubits.iter().position(|&q| q == qubit)?;
+                    let meas_id = gate.meas_ids.get(position).copied()?;
+                    return Some(TickMeasRef {
+                        tick,
+                        gate_idx,
+                        qubit,
+                        record_idx: records_before + position,
+                        meas_id,
+                    });
+                }
+                if is_measurement {
+                    records_before += gate.qubits.len();
+                }
+            }
         }
-        let position = gate.qubits.iter().position(|&q| q == qubit)?;
-        let meas_id = gate.meas_ids.get(position).copied()?;
-        Some(TickMeasRef {
-            tick,
-            gate_idx,
-            qubit,
-            record_idx: meas_id.index(),
-            meas_id,
-        })
+        None
     }
 
     /// Get a tick by index.
@@ -3427,8 +3444,12 @@ impl From<&TickCircuit> for DagCircuit {
                     let node = dag.add_gate(split_gate.clone());
                     split_nodes.push(node);
 
-                    // For MZ gates, map each qubit's record to this node
-                    if split_gate.gate_type == GateType::MZ {
+                    // Every measurement consumes a record, `MeasureFree`
+                    // included -- `TickHandle::mz_free` advances
+                    // `next_meas_record` exactly like `mz`. Counting only `MZ`
+                    // here shifted every later record and silently remapped
+                    // annotations onto the wrong measurements (issue #382).
+                    if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
                         for _q in &split_gate.qubits {
                             meas_record_to_node.insert(meas_record_idx, node);
                             meas_record_idx += 1;
@@ -3471,9 +3492,22 @@ impl From<&TickCircuit> for DagCircuit {
                     measurement_nodes,
                     coords,
                 } => {
+                    // Dropping unresolved records silently produced an
+                    // annotation over fewer measurements than the caller asked
+                    // for -- in the worst case an empty one that still
+                    // suppressed the record-based fallback (issue #382).
                     let dag_nodes: Vec<usize> = measurement_nodes
                         .iter()
-                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
+                        .map(|&rec| {
+                            *meas_record_to_node.get(&rec).unwrap_or_else(|| {
+                                panic!(
+                                    "annotation references measurement record {rec}, which this \
+                                     circuit does not have ({} records); the annotation and the \
+                                     circuit disagree",
+                                    meas_record_to_node.len()
+                                )
+                            })
+                        })
                         .collect();
                     AnnotationKind::Detector {
                         measurement_nodes: dag_nodes,
@@ -3481,9 +3515,22 @@ impl From<&TickCircuit> for DagCircuit {
                     }
                 }
                 AnnotationKind::Observable { measurement_nodes } => {
+                    // Dropping unresolved records silently produced an
+                    // annotation over fewer measurements than the caller asked
+                    // for -- in the worst case an empty one that still
+                    // suppressed the record-based fallback (issue #382).
                     let dag_nodes: Vec<usize> = measurement_nodes
                         .iter()
-                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
+                        .map(|&rec| {
+                            *meas_record_to_node.get(&rec).unwrap_or_else(|| {
+                                panic!(
+                                    "annotation references measurement record {rec}, which this \
+                                     circuit does not have ({} records); the annotation and the \
+                                     circuit disagree",
+                                    meas_record_to_node.len()
+                                )
+                            })
+                        })
                         .collect();
                     AnnotationKind::Observable {
                         measurement_nodes: dag_nodes,
@@ -6705,5 +6752,92 @@ mod tests {
         assert!(circuit.meas_ref(99, good.gate_idx, good.qubit).is_none());
         // tick 0 holds the prep, not a measurement
         assert!(circuit.meas_ref(0, 0, QubitId(0)).is_none());
+    }
+
+    /// `record_idx` is a positional ordinal; `MeasId` is a stable identity that
+    /// callers may supply from an external source (the `mz_with_ids` binding
+    /// stamps Guppy result ids this way). Reading the ordinal off the id made a
+    /// measurement stamped `MeasId(10)` claim record 10 when it was record 0.
+    #[test]
+    fn meas_ref_record_ordinal_is_independent_of_meas_id() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1]);
+        circuit.tick();
+        let tick_idx = circuit.num_ticks() - 1;
+        let mut gate = Gate::mz(&[0usize, 1usize]);
+        gate.meas_ids = smallvec::smallvec![MeasId(10), MeasId(20)];
+        let gate_idx = circuit
+            .get_tick_mut(tick_idx)
+            .expect("tick exists")
+            .try_add_gate(gate)
+            .expect("measurement is a valid gate");
+
+        let first = circuit
+            .meas_ref(tick_idx, gate_idx, QubitId(0))
+            .expect("ref must resolve");
+        let second = circuit
+            .meas_ref(tick_idx, gate_idx, QubitId(1))
+            .expect("ref must resolve");
+
+        assert_eq!(first.record_idx, 0, "first measurement is record 0, not 10");
+        assert_eq!(
+            second.record_idx, 1,
+            "second measurement is record 1, not 20"
+        );
+        assert_eq!(first.meas_id, MeasId(10), "the stable id is preserved");
+        assert_eq!(second.meas_id, MeasId(20));
+    }
+
+    /// `MeasureFree` consumes a measurement record exactly like `MZ`, so a
+    /// later `MZ` must not be renumbered as though the free measurements never
+    /// happened.
+    #[test]
+    fn measure_free_consumes_a_record_ordinal() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1, 2]);
+        let freed = circuit.tick().mz_free(&[0, 1]);
+        let kept = circuit.tick().mz(&[2]);
+
+        assert_eq!(freed[0].record_idx, 0);
+        assert_eq!(freed[1].record_idx, 1);
+        assert_eq!(
+            kept[0].record_idx, 2,
+            "MZ after two MeasureFree is record 2"
+        );
+
+        let recovered = circuit
+            .meas_ref(kept[0].tick, kept[0].gate_idx, kept[0].qubit)
+            .expect("ref must resolve");
+        assert_eq!(recovered.record_idx, 2);
+    }
+
+    /// The DAG conversion must map every annotation record onto a distinct
+    /// measurement node, including across `MeasureFree`. Counting only `MZ`
+    /// shifted later records and silently remapped the annotation.
+    #[test]
+    fn dag_conversion_maps_annotation_records_across_measure_free() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1, 2, 3]);
+        let _freed = circuit.tick().mz_free(&[0, 1]);
+        let kept = circuit.tick().mz(&[2, 3]);
+        circuit.observable(&kept);
+
+        let dag = crate::DagCircuit::from(&circuit);
+        let observable_nodes: Vec<Vec<usize>> = dag
+            .annotations()
+            .iter()
+            .filter_map(|ann| match &ann.kind {
+                AnnotationKind::Observable { measurement_nodes } => Some(measurement_nodes.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(observable_nodes.len(), 1);
+        let nodes = &observable_nodes[0];
+        assert_eq!(nodes.len(), 2, "both measurements must survive the remap");
+        assert_ne!(
+            nodes[0], nodes[1],
+            "records must map to distinct measurement nodes, not collapse"
+        );
     }
 }

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3444,12 +3444,8 @@ impl From<&TickCircuit> for DagCircuit {
                     let node = dag.add_gate(split_gate.clone());
                     split_nodes.push(node);
 
-                    // Every measurement consumes a record, `MeasureFree`
-                    // included -- `TickHandle::mz_free` advances
-                    // `next_meas_record` exactly like `mz`. Counting only `MZ`
-                    // here shifted every later record and silently remapped
-                    // annotations onto the wrong measurements (issue #382).
-                    if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+                    // For MZ gates, map each qubit's record to this node
+                    if split_gate.gate_type == GateType::MZ {
                         for _q in &split_gate.qubits {
                             meas_record_to_node.insert(meas_record_idx, node);
                             meas_record_idx += 1;
@@ -3492,22 +3488,9 @@ impl From<&TickCircuit> for DagCircuit {
                     measurement_nodes,
                     coords,
                 } => {
-                    // Dropping unresolved records silently produced an
-                    // annotation over fewer measurements than the caller asked
-                    // for -- in the worst case an empty one that still
-                    // suppressed the record-based fallback (issue #382).
                     let dag_nodes: Vec<usize> = measurement_nodes
                         .iter()
-                        .map(|&rec| {
-                            *meas_record_to_node.get(&rec).unwrap_or_else(|| {
-                                panic!(
-                                    "annotation references measurement record {rec}, which this \
-                                     circuit does not have ({} records); the annotation and the \
-                                     circuit disagree",
-                                    meas_record_to_node.len()
-                                )
-                            })
-                        })
+                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
                         .collect();
                     AnnotationKind::Detector {
                         measurement_nodes: dag_nodes,
@@ -3515,22 +3498,9 @@ impl From<&TickCircuit> for DagCircuit {
                     }
                 }
                 AnnotationKind::Observable { measurement_nodes } => {
-                    // Dropping unresolved records silently produced an
-                    // annotation over fewer measurements than the caller asked
-                    // for -- in the worst case an empty one that still
-                    // suppressed the record-based fallback (issue #382).
                     let dag_nodes: Vec<usize> = measurement_nodes
                         .iter()
-                        .map(|&rec| {
-                            *meas_record_to_node.get(&rec).unwrap_or_else(|| {
-                                panic!(
-                                    "annotation references measurement record {rec}, which this \
-                                     circuit does not have ({} records); the annotation and the \
-                                     circuit disagree",
-                                    meas_record_to_node.len()
-                                )
-                            })
-                        })
+                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
                         .collect();
                     AnnotationKind::Observable {
                         measurement_nodes: dag_nodes,
@@ -6809,35 +6779,5 @@ mod tests {
             .meas_ref(kept[0].tick, kept[0].gate_idx, kept[0].qubit)
             .expect("ref must resolve");
         assert_eq!(recovered.record_idx, 2);
-    }
-
-    /// The DAG conversion must map every annotation record onto a distinct
-    /// measurement node, including across `MeasureFree`. Counting only `MZ`
-    /// shifted later records and silently remapped the annotation.
-    #[test]
-    fn dag_conversion_maps_annotation_records_across_measure_free() {
-        let mut circuit = TickCircuit::new();
-        circuit.tick().pz(&[0, 1, 2, 3]);
-        let _freed = circuit.tick().mz_free(&[0, 1]);
-        let kept = circuit.tick().mz(&[2, 3]);
-        circuit.observable(&kept);
-
-        let dag = crate::DagCircuit::from(&circuit);
-        let observable_nodes: Vec<Vec<usize>> = dag
-            .annotations()
-            .iter()
-            .filter_map(|ann| match &ann.kind {
-                AnnotationKind::Observable { measurement_nodes } => Some(measurement_nodes.clone()),
-                _ => None,
-            })
-            .collect();
-
-        assert_eq!(observable_nodes.len(), 1);
-        let nodes = &observable_nodes[0];
-        assert_eq!(nodes.len(), 2, "both measurements must survive the remap");
-        assert_ne!(
-            nodes[0], nodes[1],
-            "records must map to distinct measurement nodes, not collapse"
-        );
     }
 }

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -2968,7 +2968,7 @@ impl PyTickCircuit {
         measurements: &Bound<'_, pyo3::types::PyList>,
         label: Option<String>,
     ) -> PyResult<usize> {
-        let refs = extract_tick_meas_refs(measurements)?;
+        let refs = extract_tick_meas_refs(&self.inner, measurements)?;
         let idx = if let Some(l) = label {
             self.inner.detector_labeled(&l, &refs)
         } else {
@@ -2984,7 +2984,7 @@ impl PyTickCircuit {
         measurements: &Bound<'_, pyo3::types::PyList>,
         label: Option<String>,
     ) -> PyResult<usize> {
-        let refs = extract_tick_meas_refs(measurements)?;
+        let refs = extract_tick_meas_refs(&self.inner, measurements)?;
         let idx = if let Some(l) = label {
             self.inner.observable_labeled(&l, &refs)
         } else {
@@ -3031,6 +3031,7 @@ impl PyTickCircuit {
 
 /// Extract `TickMeasRef` from Python list of `(tick, gate_idx, qubit)` tuples.
 fn extract_tick_meas_refs(
+    circuit: &pecos_quantum::TickCircuit,
     list: &Bound<'_, pyo3::types::PyList>,
 ) -> PyResult<Vec<pecos_quantum::TickMeasRef>> {
     list.iter()
@@ -3040,12 +3041,17 @@ fn extract_tick_meas_refs(
                     "measurements must be (tick, gate_idx, qubit) tuples from mz()",
                 )
             })?;
-            Ok(pecos_quantum::TickMeasRef {
-                tick,
-                gate_idx,
-                qubit: pecos_core::QubitId::from(qubit),
-                record_idx: 0, // Populated by TickCircuit; placeholder for external construction
-                meas_id: pecos_core::MeasId(0), // Placeholder
+            let qubit = pecos_core::QubitId::from(qubit);
+            // Resolve against the circuit rather than fabricating the record
+            // index. `TickCircuit::detector`/`observable` read `record_idx`
+            // immediately, so a placeholder collapsed every reference onto
+            // record 0 and silently corrupted the annotation (issue #382).
+            circuit.meas_ref(tick, gate_idx, qubit).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "measurement ref (tick={tick}, gate_idx={gate_idx}, qubit={}) does not \
+                     identify a measurement in this circuit; pass refs returned by mz()",
+                    qubit.index()
+                ))
             })
         })
         .collect()

--- a/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
+++ b/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Measurement references from Python must identify distinct measurements.
+
+The binding rebuilds a ``TickMeasRef`` from the ``(tick, gate_idx, qubit)``
+tuples ``mz()`` returns. It used to fabricate the record index as ``0``, so an
+annotation spanning several measurements collapsed onto one. These tests
+exercise that path through the public Python API, which the Rust unit tests
+around ``TickCircuit::meas_ref`` do not reach.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_observable_over_two_measurements_uses_both() -> None:
+    """An observable over two measurements must flip on either one.
+
+    With independent ``p_meas`` errors on both, the observable flips on an odd
+    number of them: ``2 * 0.25 * 0.75 = 0.375``. If the two references collapse
+    onto a single record, the XOR-parity of the annotation cancels them and the
+    observable ends up over nothing or over one measurement, giving a different
+    probability -- or no ``L0`` mechanism at all.
+    """
+    from pecos.qec import DetectorErrorModel
+    from pecos.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0, 1])
+    refs = tc.tick().mz([0, 1])
+    assert len(refs) == 2
+    tc.observable(refs)
+    tc.set_meta("num_measurements", "2")
+    tc.set_meta("detectors", "[]")
+
+    dem = DetectorErrorModel.from_circuit(tc, p1=0.0, p2=0.0, p_meas=0.25, p_prep=0.0)
+    text = dem.to_string()
+
+    assert dem.num_observables == 1
+    assert "error(0.375) L0" in text, (
+        "an observable over two measurements must flip on an odd number of the "
+        f"two independent p_meas errors; got:\n{text}"
+    )
+
+
+# Detector annotations are deliberately not covered here: `build_dem_from_circuit`
+# takes detectors from the `detectors` metadata JSON, and
+# `InfluenceBuilder::with_circuit_annotations` routes detector annotations to the
+# sampler path instead. The binding fix corrects that path too, but exercising it
+# needs a sampler-level test; tracked with the rest of the annotation work in #387.
+
+
+def test_measurement_ref_from_another_circuit_is_rejected() -> None:
+    """A reference that does not identify a measurement is an error, not a guess.
+
+    The binding used to fabricate a placeholder for anything it was handed.
+    """
+    from pecos.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0])
+    tc.tick().mz([0])
+
+    with pytest.raises(ValueError, match="does not identify a measurement"):
+        tc.observable([(99, 0, 0)])


### PR DESCRIPTION
Part of #382, and fixes #377 for the generated-surface reproduction. Two coupled defects in how measurement records are identified between Python, `TickCircuit` and `DagCircuit`.

## 1. The Python binding fabricated measurement references

`extract_tick_meas_refs` (`dag_circuit_bindings.rs`) rebuilt a `TickMeasRef` from a `(tick, gate_idx, qubit)` tuple and invented the rest:

```rust
record_idx: 0, // Populated by TickCircuit; placeholder for external construction
meas_id: pecos_core::MeasId(0), // Placeholder
```

`PyTickCircuit::detector` and `PyTickCircuit::observable` pass the result straight to `TickCircuit::detector` / `observable`, which read `record_idx` immediately. So **every** annotation built from Python collapsed all of its references onto record 0. The comment's premise -- that `TickCircuit` fills the field in later -- does not hold for the only callers there are.

`TickCircuit::meas_ref(tick, gate_idx, qubit)` now recovers the real reference by reading the `MeasId` that `mz`/`mz_free` stored alongside the qubit; the binding returns a `ValueError` naming the offending tuple rather than fabricating one.

An intermediate revision instead reconstructed the record index by walking stored ticks and batches. Review caught that this is wrong, and it reproduces: **storage order is not allocation order.** A later measurement can be appended to an earlier compatible batch, and `tick_at` permits filling ticks out of sequence. Interleaving `mz(q0)`, `mz_free(q1)`, `mz(q2)` allocates records `0, 1, 2` but stores `[MZ(q0,q2), MeasureFree(q1)]`, and the reconstruction returned `q1 -> 2`, `q2 -> 1`. That is worse in kind than the bug it replaced: the placeholder was obviously wrong, a swapped index is plausibly wrong. Reading the stored id is order-independent and needs no reconstruction.

**Known limitation:** `mz_with_ids` lets callers supply external stable ids (Guppy result ids) that are not positional, and for those the record index and the id genuinely differ. `TickCircuit` does not store the positional ordinal separately, so that case cannot be resolved here. It is tracked in #387 together with the reverse-conversion conflation, which would defeat any fix confined to this side anyway.

## 2. `MeasureFree` did not advance the Tick -> DAG record counter

`TickHandle::mz_free` advances `next_meas_record` exactly like `mz`, but the conversion counted `MZ` only, so later records became unmappable and the annotation remap silently dropped them.

**These two must land together.** Fixing only the binding produces *correct* record ordinals that the conversion then cannot resolve -- trading "collapsed onto record 0" for "dropped entirely", which is not an improvement. An earlier revision of this PR narrowed to the binding alone; review caught that the narrowed form was not a safe intermediate state, and this restores the pairing.

## Verified end to end

Built the extension into an isolated venv and compared d=3 surface DEMs against Stim:

| | `from_circuit` mechanisms | matches Stim? |
| --- | --- | --- |
| `dev` | 86 (Z) / 80 (X) | no |
| binding fix alone | 76 | no -- 13 differ, all `L0` membership |
| **this branch** | **76 in all four configs** | **yes, exact match** |

`cx` and `szz` with physical prefixes, Z and X basis.

## Testing

**Python-level regressions, which is what the previous revisions lacked.** Both were verified to **fail against a placeholder-reverted build** and pass against this one:

```
=== placeholder build:  2 failed
=== fixed build:        2 passed
```

- `test_observable_over_two_measurements_uses_both` -- an observable over two measurements must yield `error(0.375) L0` (`2 * 0.25 * 0.75`, odd parity of two independent `p_meas` errors). Collapsed references cancel by XOR parity and give a different probability or no `L0` at all.
- `test_measurement_ref_from_another_circuit_is_rejected` -- a tuple that identifies no measurement raises `ValueError` instead of being fabricated.

Rust tests, each mutation-verified to be killed by reverting its change: `meas_ref_recovers_what_mz_returned`, `meas_ref_rejects_refs_that_name_no_measurement`, `meas_ref_record_ordinal_is_independent_of_meas_id`, `measure_free_consumes_a_record_ordinal`, `annotation_records_survive_conversion_across_measure_free`.

`meas_ref_is_independent_of_batch_and_tick_storage_order` covers the interleaving case above and kills the reconstruction approach. It was added only after review found that defect -- the earlier tests all built circuits sequentially and could not see it.

- `cargo test -p pecos-quantum -p pecos-qec` green: 774 `pecos-quantum` lib tests, 0 failed across both.
- `cargo check --workspace --all-targets`, `cargo clippy -p pecos-quantum -p pecos-rslib --all-targets`, `cargo fmt --all --check` clean.

## Deliberately not fixed here -- tracked in #387

- `MeasureLeaked` is a measurement in `Gate::validate` and in DAG→Tick, but not in Tick→DAG or `meas_ref`.
- Unresolvable annotation records are still silently dropped in three places. Making the `tick_circuit.rs` site panic was tried and reverted: panicking inside `impl From<&TickCircuit> for DagCircuit` is not a safe resolution for an infallible std conversion trait.
- The identity/ordinal conflation persists in the DAG→Tick direction.
- Detector annotations reach the DEM only through the sampler path, which this binding fix also corrects but which has no Python regression here.

