### PR TITLE
Carry observable labels from metadata JSON and reject malformed ones

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -52,6 +52,12 @@ struct ParsedObservable {
     id: u32,
     records: Vec<i32>,
     meas_ids: Vec<usize>,
+    /// Human-readable name from the metadata JSON's `label` field.
+    ///
+    /// The metadata format has always carried this and callers already write
+    /// it, but it used to be parsed and dropped, leaving circuit annotations as
+    /// the only way to get a label onto an observable.
+    label: Option<String>,
 }
 
 // ============================================================================
@@ -537,6 +543,7 @@ impl<'a> DemBuilder<'a> {
                 id: id as u32,
                 records,
                 meas_ids: Vec::new(),
+                label: None,
             })
             .collect();
         self.clear_exact_branch_cache();
@@ -810,7 +817,10 @@ impl<'a> DemBuilder<'a> {
         // Observable IDs are not shifted by tracked Paulis.
         for obs in &self.observables {
             let records = self.effective_record_offsets(&obs.records, &obs.meas_ids);
-            let def = DemOutput::new(obs.id).with_records(records.iter().copied());
+            let mut def = DemOutput::new(obs.id).with_records(records.iter().copied());
+            if let Some(label) = &obs.label {
+                def = def.with_label(label.clone());
+            }
             dem.add_observable(def);
         }
 
@@ -2654,11 +2664,23 @@ fn parse_single_observable(value: &serde_json::Value) -> Result<ParsedObservable
     )?;
 
     let (records, meas_ids) = extract_measurement_refs(object, "observable")?;
+    // A present-but-malformed label is rejected rather than silently treated as
+    // absent; the richer DEM metadata parser already holds that line.
+    let label = match object.get("label") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(label)) => Some(label.clone()),
+        Some(other) => {
+            return Err(DemBuilderError::ParseError(format!(
+                "observable label must be a string or null, got {other}"
+            )));
+        }
+    };
 
     Ok(ParsedObservable {
         id,
         records,
         meas_ids,
+        label,
     })
 }
 
@@ -5190,5 +5212,54 @@ mod tests {
             dem(&["sy"], &["szdg", "sxdg"], true),
             "X-basis variant must distinguish F from SY (the Z-blind pair)"
         );
+    }
+
+    /// The observables metadata format carries a `label`, and callers already
+    /// write one, but the parser dropped it -- so a label could only ever reach
+    /// a DEM through a circuit annotation. That coupling meant the metadata
+    /// format was not self-sufficient.
+    #[test]
+    fn test_observable_label_comes_from_metadata_without_annotations() {
+        use pecos_num::graph::Attribute;
+        use pecos_quantum::DagCircuit;
+
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let _meas = circuit.mz(&[0]);
+        circuit.set_attr("num_measurements", Attribute::String("1".to_string()));
+        circuit.set_attr(
+            "observables",
+            Attribute::String(r#"[{"id":0,"records":[-1],"label":"from_metadata"}]"#.to_string()),
+        );
+        circuit.set_attr("detectors", Attribute::String("[]".to_string()));
+
+        let dem = DemBuilder::from_circuit(&circuit, 0.0, 0.0, 0.5, 0.0);
+        assert_eq!(dem.num_observables(), 1);
+        assert_eq!(
+            dem.observables().next().unwrap().label.as_deref(),
+            Some("from_metadata"),
+            "the label declared in observables metadata must reach the DEM"
+        );
+    }
+
+    /// A malformed label is rejected rather than silently treated as absent.
+    #[test]
+    fn test_observable_metadata_rejects_non_string_label() {
+        let err = super::parse_observables_json(r#"[{"id":0,"records":[-1],"label":42}]"#)
+            .expect_err("a non-string label must be rejected");
+        assert!(
+            err.to_string()
+                .contains("observable label must be a string"),
+            "error should name the problem, got: {err}"
+        );
+    }
+
+    /// An explicit null label is equivalent to omitting it.
+    #[test]
+    fn test_observable_metadata_accepts_null_label() {
+        let parsed = super::parse_observables_json(r#"[{"id":0,"records":[-1],"label":null}]"#)
+            .expect("null label is allowed");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].label, None);
     }
 }

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -200,6 +200,15 @@ impl<'a> DemBuilder<'a> {
     /// # Errors
     ///
     /// Returns an error if detector or observable metadata is malformed.
+    ///
+    /// # Panics
+    ///
+    /// Malformed *metadata* is reported as an error, but a circuit whose
+    /// metadata and annotations **contradict each other** is not a parse
+    /// failure and is not reported that way: two definitions of one observable
+    /// disagreeing about the label or the Pauli panic inside
+    /// [`DetectorErrorModel::add_observable`] rather than returning here. Both
+    /// sources must agree, or only one should supply the field.
     pub fn try_from_circuit(
         circuit: &pecos_quantum::DagCircuit,
         p1: f64,
@@ -219,6 +228,15 @@ impl<'a> DemBuilder<'a> {
     /// # Errors
     ///
     /// Returns an error if detector or observable metadata is malformed.
+    ///
+    /// # Panics
+    ///
+    /// Malformed *metadata* is reported as an error, but a circuit whose
+    /// metadata and annotations **contradict each other** is not a parse
+    /// failure and is not reported that way: two definitions of one observable
+    /// disagreeing about the label or the Pauli panic inside
+    /// [`DetectorErrorModel::add_observable`] rather than returning here. Both
+    /// sources must agree, or only one should supply the field.
     pub fn try_from_circuit_with_noise_config(
         circuit: &pecos_quantum::DagCircuit,
         noise: NoiseConfig,
@@ -254,6 +272,15 @@ impl<'a> DemBuilder<'a> {
     /// # Errors
     ///
     /// Returns an error if detector or observable metadata is malformed.
+    ///
+    /// # Panics
+    ///
+    /// Malformed *metadata* is reported as an error, but a circuit whose
+    /// metadata and annotations **contradict each other** is not a parse
+    /// failure and is not reported that way: two definitions of one observable
+    /// disagreeing about the label or the Pauli panic inside
+    /// [`DetectorErrorModel::add_observable`] rather than returning here. Both
+    /// sources must agree, or only one should supply the field.
     pub fn try_from_tick_circuit(
         circuit: &pecos_quantum::TickCircuit,
         p1: f64,
@@ -274,6 +301,15 @@ impl<'a> DemBuilder<'a> {
     /// # Errors
     ///
     /// Returns an error if detector or observable metadata is malformed.
+    ///
+    /// # Panics
+    ///
+    /// Malformed *metadata* is reported as an error, but a circuit whose
+    /// metadata and annotations **contradict each other** is not a parse
+    /// failure and is not reported that way: two definitions of one observable
+    /// disagreeing about the label or the Pauli panic inside
+    /// [`DetectorErrorModel::add_observable`] rather than returning here. Both
+    /// sources must agree, or only one should supply the field.
     pub fn try_from_tick_circuit_with_noise_config(
         circuit: &pecos_quantum::TickCircuit,
         noise: NoiseConfig,


### PR DESCRIPTION
The observables metadata format carries a `label`, and callers already write one, but `parse_observables_json` discarded it -- so a label could only ever reach a DEM through a circuit annotation.

Split out of #384, which is parked. This part stands on its own: it makes the metadata format self-sufficient, independently of any decision about annotation-versus-metadata precedence.

## The gap

`ParsedObservable` was `{ id, records, meas_ids }` -- no label. `parse_single_observable` read the id and measurement refs and ignored `"label"` entirely. DEM-output labels are populated in exactly one place, `influence_builder.rs:441`, from annotation-derived outputs.

So a caller writing

```json
[{"id": 0, "records": [-1], "label": "logical_Z"}]
```

got an unlabelled observable, with no indication the field had been dropped.

## The change

`ParsedObservable` carries `label`, `parse_single_observable` reads it, and `try_build` attaches it when emitting the observable.

A **malformed** label is now rejected rather than silently treated as absent:

```
observable label must be a string or null, got 42
```

`"label": 42` previously parsed as "no label", which is the same silent-discard pattern the richer DEM metadata parser already rejects. An explicit `null` remains equivalent to omitting the field.

## Testing

Both behaviours mutation-verified -- each is killed by reverting the corresponding change:

| reverted | result |
| --- | --- |
| label attached to the `DemOutput` | killed |
| malformed-label rejection (back to silent `as_str` drop) | killed |

- `test_observable_label_comes_from_metadata_without_annotations` -- a metadata label reaches the DEM with no annotation present.
- `test_observable_metadata_rejects_non_string_label` -- `"label": 42` is a `ParseError` naming the problem.
- `test_observable_metadata_accepts_null_label` -- explicit `null` parses as no label.

- `cargo test -p pecos-qec` green: 598 lib tests and 58 doctests, 0 failed.
- `cargo clippy -p pecos-qec --all-targets` clean, forced cold; `cargo fmt --all --check` clean.

## Relationship to #384

#384 proposed making metadata authoritative over annotations. That is parked: investigation in #386 established that the annotation-derived observable on the surface path was *corrupted* rather than legitimately disagreeing, so the precedence question should be decided after #387 fixes measurement-record resolution -- at which point a disagreement means something real and can be rejected loudly.

This label work was originally required by #384 (excluding annotations otherwise lost labels) but is not contingent on it.

## Interaction with #385, and a doc correction

#385 (now on `dev`) made `add_observable` panic in **every** build when two definitions of the same observable disagree about the label or the Pauli. Before this PR, metadata labels were discarded, so metadata could never contribute a label and never conflict. After it, it can.

Independent review confirmed by running: a circuit with annotation label `logical_Z` and metadata label `from_metadata` on one observable now panics, where on `dev` it silently keeps one and discards the other. That is #385's stated target case -- its doc names "metadata JSON and a circuit annotation contradicting each other" explicitly -- so the two changes are complementary rather than conflicting. This PR is what makes that case reachable.

**Real generators are unaffected.** The surface builders write observables JSON with `id`/`records` and no `label` (`circuit_builder.py:2681`, `logical_circuit.py:1008`), so the annotation label wins uncontested. Verified by reading both writers and by running a surface-shaped mimic.

Review also found the `try_*` constructors' docs stale as a result: they promise "returns parser errors instead of dropping malformed metadata", but a metadata-versus-annotation conflict -- newly reachable *because of this PR* -- panics rather than returning `DemBuilderError`. All four (`try_from_circuit`, `try_from_circuit_with_noise_config`, `try_from_tick_circuit`, `try_from_tick_circuit_with_noise_config`) now carry a `# Panics` section saying so. Malformed *metadata* is still an error; contradictory *sources* are not a parse failure and are not reported as one.
