### PR TITLE
Key the annotation record map on MeasId instead of storage order

### DIFF
--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3439,19 +3439,34 @@ impl From<&TickCircuit> for DagCircuit {
                     let node = dag.add_gate(split_gate.clone());
                     split_nodes.push(node);
 
-                    // Every measurement consumes a record, `MeasureFree`
-                    // included -- `TickHandle::mz_free` advances
-                    // `next_meas_record` exactly like `mz`. Counting only `MZ`
-                    // here left later records unmappable, so annotations
-                    // referencing them silently resolved to nothing.
+                    // Key the map on the `MeasId` each measurement was given at
+                    // allocation time, not on a counter over stored batches.
+                    // Storage order is not allocation order: a later
+                    // measurement can be appended to an earlier compatible
+                    // batch, and `tick_at` fills ticks out of sequence. A
+                    // positional counter therefore bound annotations to the
+                    // wrong measurement -- an observable over one qubit's `MZ`
+                    // resolving to a `MeasureFree` on another.
+                    //
+                    // This matches what `TickCircuit::meas_ref` reads and what
+                    // the reverse conversion writes. Gates carrying no ids are
+                    // externally constructed; they fall back to the positional
+                    // counter, which is the best available for them.
                     //
                     // `MeasureLeaked` is a measurement too and is still
                     // excluded here; that inconsistency is tracked in #387
                     // along with the remaining silent drops below.
                     if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
-                        for _q in &split_gate.qubits {
-                            meas_record_to_node.insert(meas_record_idx, node);
-                            meas_record_idx += 1;
+                        if split_gate.meas_ids.is_empty() {
+                            for _q in &split_gate.qubits {
+                                meas_record_to_node.insert(meas_record_idx, node);
+                                meas_record_idx += 1;
+                            }
+                        } else {
+                            for meas_id in &split_gate.meas_ids {
+                                meas_record_to_node.insert(meas_id.index(), node);
+                                meas_record_idx = meas_record_idx.max(meas_id.index() + 1);
+                            }
                         }
                     }
 
@@ -6762,6 +6777,58 @@ mod tests {
                 expected.qubit
             );
         }
+    }
+
+    /// An annotation must reach the measurement it names, even when stored
+    /// order differs from allocation order.
+    ///
+    /// A later measurement can merge into an earlier compatible batch, and
+    /// `tick_at` fills ticks out of sequence. Keying the conversion's record
+    /// map on a positional counter bound annotations to the wrong measurement:
+    /// an observable over qubit 2's `MZ` resolved to a `MeasureFree` on
+    /// qubit 1, silently and with the wrong gate type.
+    #[test]
+    fn annotation_reaches_the_named_measurement_regardless_of_storage_order() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0, 1, 2]);
+        let first = circuit.tick().mz(&[0]);
+        let freed = circuit.tick_at(1).mz_free(&[1]);
+        // Merges into the batch holding `first`, so stored order is q0, q2, q1.
+        let third = circuit.tick_at(1).mz(&[2]);
+        assert_eq!(
+            (
+                first[0].record_idx,
+                freed[0].record_idx,
+                third[0].record_idx
+            ),
+            (0, 1, 2),
+            "records are allocated in call order"
+        );
+
+        circuit.observable(&third);
+        let dag = crate::DagCircuit::from(&circuit);
+        let targets: Vec<(GateType, Vec<usize>)> = dag
+            .annotations()
+            .iter()
+            .filter_map(|ann| match &ann.kind {
+                AnnotationKind::Observable { measurement_nodes } => Some(measurement_nodes),
+                _ => None,
+            })
+            .flatten()
+            .map(|&node| {
+                let gate = dag.gate(node).expect("annotation node exists");
+                (
+                    gate.gate_type,
+                    gate.qubits.iter().map(QubitId::index).collect(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            targets,
+            vec![(GateType::MZ, vec![2])],
+            "the observable names qubit 2's MZ and must resolve to exactly that"
+        );
     }
 
     /// `MeasureFree` consumes a measurement record exactly like `MZ`, so a


### PR DESCRIPTION
Fixes a defect that landed on `dev` with #386: the Tick→DAG conversion binds annotations to the **wrong measurement** when stored order differs from allocation order.

Both reviewers of #386 identified this independently, each by running it, and it was reproduced a third time before that PR merged. #386 merged before the fix was applied.

## The defect

`TickCircuit::meas_ref` reads the `MeasId` each measurement was given at allocation time, so it is allocation-order-correct. The conversion did not: it rebuilt `meas_record_to_node` with a running counter over stored ticks and batches, ignoring the ids sitting on each split gate.

Storage order is not allocation order. A later measurement can be appended to an earlier compatible batch (`Tick::try_add_gate_piece` -> `compatible_empty_attr_batch` -> `append_batch`), and `tick_at` fills ticks out of sequence.

Reproduced on `dev` with `mz(&[0])`, `mz_free(&[1])`, `mz(&[2])` -- allocation records 0, 1, 2, stored order `[MZ(q0,q2), MeasureFree(q1)]`:

```
observable over record 2 (qubit 2's MZ)
  -> resolved to gate = MeasureFree, qubits = [1]
```

Wrong qubit and wrong gate type, silently. `DagFaultAnalyzer` treats `MeasureFree` as a real measurement column, so the DEM observable tracks the wrong measurement rather than erroring. Reachable from the plain Python API with no `tick_at` at all: `t.mz([0]); t.mz_free([1]); t.mz([2])` on one tick handle.

Note the interaction: before #386 the same scenario silently *dropped* record 2 under MZ-only counting. #386 fixed the counter, which turned a drop into a wrong answer.

## The fix

Key `meas_record_to_node` on each measurement's `MeasId` rather than a positional counter. That is what `meas_ref` reads and what the reverse conversion writes, so all three now agree. Gates carrying no ids are externally constructed and fall back to the counter, which is the best available for them.

This is the fix both reviewers proposed independently.

## What was already correct and stays correct

- Sequential circuits -- the common path, and everything the surface generators produce -- resolved correctly before this change and still do.
- d=3 surface DEMs still match Stim exactly: 76 mechanisms in all four configurations (`cx` and `szz` with physical prefixes, Z and X basis), verified by building the extension into an isolated venv.
- Both Python binding regressions still pass.

## Testing

`annotation_reaches_the_named_measurement_regardless_of_storage_order` builds the interleaved circuit and asserts the observable resolves to **exactly** `(MZ, [2])` -- not merely to some node, and not merely to a distinct one. That precision matters: #386's tests asserted only that two nodes were *distinct*, which is why they missed this.

Mutation-verified: restoring the positional counter kills it.

- `cargo test -p pecos-quantum -p pecos-qec` green: 775 `pecos-quantum` lib tests, 0 failed across both.
- `cargo clippy -p pecos-quantum -p pecos-rslib --all-targets` clean, forced cold; `cargo fmt --all --check` clean.

## Still open, tracked in #387

`MeasureLeaked` is excluded from record counting here and in `meas_ref` (consistently, in the same direction), the remaining silent `filter_map` drops, the DAG→Tick identity/ordinal conflation, and the `mz_with_ids` non-positional case. Also #387 item 6: the Python `mz` bindings advance the record counter before the gate add can fail.
