### PR TITLE
Give DagCircuit measurements a MeasId of their own

### DIFF
--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -204,6 +204,22 @@ impl GateType {
         matches!(self, GateType::TrackedPauliMeta)
     }
 
+    /// Returns true if this gate consumes a measurement record.
+    ///
+    /// A measurement record is a slot in the classical result stream, named by a
+    /// [`MeasId`](crate::MeasId). Every site that allocates, counts, or resolves
+    /// records must agree on which gates get one, or two different measurements
+    /// end up sharing a record. Use this predicate rather than spelling the gate
+    /// types out, so there is one place to change.
+    ///
+    /// `MeasureLeaked` is a measurement to `Gate::validate` and collapses the
+    /// qubit, but it produces no classical result and so consumes no record.
+    /// Deciding otherwise means changing this function and nothing else.
+    #[must_use]
+    pub const fn consumes_measurement_record(self) -> bool {
+        matches!(self, GateType::MZ | GateType::MeasureFree)
+    }
+
     /// Returns the number of angle parameters this gate type requires
     ///
     /// # Returns

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -1690,10 +1690,11 @@ fn remap_history_onto_records(
             if let Some(&dependency_column) = column_of.get(&dependency) {
                 outcome.insert(dependency_column);
             } else {
-                let (tick, qubits) = leaked_sites
-                    .get(&dependency)
-                    .cloned()
-                    .unwrap_or((usize::MAX, Vec::new()));
+                let (tick, qubits) = leaked_sites.get(&dependency).cloned().expect(
+                    "every simulator measurement index is either a record column or a \
+                     leaked site, so a dependency outside both means the two maps were \
+                     not built from the same walk",
+                );
                 return Err(MeasurementHistoryError::LeakedMeasurementNotRepresentable {
                     tick,
                     qubits,

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -271,7 +271,7 @@ pub(crate) fn flatten_tick_circuit(tc: &TickCircuit) -> (Vec<GateLoc>, HashMap<u
                 .iter()
                 .map(pecos_core::QubitId::index)
                 .collect();
-            if is_supported_measurement_gate(gate.gate_type()) {
+            if gate.gate_type().consumes_measurement_record() {
                 meas_positions.insert(gates.len(), meas_count);
                 meas_count += 1;
             }

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -39,7 +39,7 @@ use pecos_random::{PecosRng, RngExt};
 use pecos_simulators::measurement_sampler::{MeasurementKind, SampleResult};
 use pecos_simulators::symbolic_sparse_stab::MeasurementHistory;
 use pecos_simulators::{BitmaskPauliProp, CliffordGateable};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
 /// Error returned when `build_fault_table` encounters an unsupported gate.
@@ -1511,13 +1511,17 @@ impl From<UnsupportedGateError> for MeasurementHistoryError {
 /// Iterates tick-by-tick to match the `TickCircuit`'s measurement numbering
 /// (which detector/DEM-output record indices reference).
 ///
-/// Errors on unsupported gates with tick/gate/qubit context (same gate set
-/// as [`build_fault_table`]).
+/// One column per measurement *record*. `MeasureLeaked` collapses its qubit but
+/// consumes no record, so it gets no column and the remaining columns are
+/// renumbered around it.
 ///
 /// # Errors
 ///
-/// Returns [`UnsupportedGateError`] when the circuit contains a gate outside
-/// the supported Clifford/prep/measurement/metadata set.
+/// Returns [`MeasurementHistoryError::UnsupportedGate`] for a gate outside the
+/// supported Clifford/prep/measurement/metadata set, and
+/// [`MeasurementHistoryError::LeakedMeasurementNotRepresentable`] when a
+/// recorded outcome depends on a `MeasureLeaked` result -- that dependency
+/// names a column this history has no way to express.
 pub fn symbolic_measurement_history(
     tc: &TickCircuit,
 ) -> Result<MeasurementHistory, MeasurementHistoryError> {
@@ -1531,6 +1535,10 @@ pub fn symbolic_measurement_history(
         .unwrap_or(0);
 
     let mut sim = SymbolicSparseStab::new(num_qubits);
+    // Simulator measurement index -> record column, for the measurements that
+    // consume a record; and the leaked ones, which consume none.
+    let mut column_of: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut leaked_sites: BTreeMap<usize, (usize, Vec<usize>)> = BTreeMap::new();
 
     for (tick_idx, tick) in tc.iter_ticks() {
         for gate in tick.iter_gate_batches() {
@@ -1620,14 +1628,18 @@ pub fn symbolic_measurement_history(
                 // every reference to it. Representing that needs a notion of a
                 // hidden random source this history does not have, so say so
                 // rather than return a history whose dependencies dangle.
-                GateType::MeasureLeaked => {
-                    return Err(MeasurementHistoryError::LeakedMeasurementNotRepresentable {
-                        tick: tick_idx,
-                        qubits: qs,
-                    });
-                }
-                GateType::MZ | GateType::MeasureFree => {
-                    sim.mz(&qs);
+                GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked => {
+                    // Every measurement collapses its qubit, so all three run.
+                    // Only the record-bearing ones earn a column.
+                    let records_a_result = gate.gate_type.consumes_measurement_record();
+                    for result in sim.mz(&qs) {
+                        if records_a_result {
+                            let column = column_of.len();
+                            column_of.insert(result.index, column);
+                        } else {
+                            leaked_sites.insert(result.index, (tick_idx, qs.clone()));
+                        }
+                    }
                 }
                 GateType::I
                 | GateType::Idle
@@ -1649,7 +1661,55 @@ pub fn symbolic_measurement_history(
         }
     }
 
-    Ok(sim.measurement_history().clone())
+    if leaked_sites.is_empty() {
+        return Ok(sim.measurement_history().clone());
+    }
+    remap_history_onto_records(sim.measurement_history(), &column_of, &leaked_sites)
+}
+
+/// Renumber a measurement history onto record columns, dropping the leaked
+/// measurements that hold no record.
+///
+/// A symbolic result names its dependencies by the simulator's own measurement
+/// index, so dropping a column means every surviving reference has to be
+/// rewritten. A dependency on a *leaked* measurement cannot be rewritten at all
+/// -- it names a random source with no column -- so that is where this gives up
+/// rather than emit a history whose dependencies dangle.
+fn remap_history_onto_records(
+    history: &MeasurementHistory,
+    column_of: &BTreeMap<usize, usize>,
+    leaked_sites: &BTreeMap<usize, (usize, Vec<usize>)>,
+) -> Result<MeasurementHistory, MeasurementHistoryError> {
+    let mut remapped = MeasurementHistory::new();
+    for result in history.iter() {
+        let Some(&column) = column_of.get(&result.index) else {
+            continue;
+        };
+        let mut outcome = pecos_core::BitSet::new();
+        for dependency in &result.outcome {
+            if let Some(&dependency_column) = column_of.get(&dependency) {
+                outcome.insert(dependency_column);
+            } else {
+                let (tick, qubits) = leaked_sites
+                    .get(&dependency)
+                    .cloned()
+                    .unwrap_or((usize::MAX, Vec::new()));
+                return Err(MeasurementHistoryError::LeakedMeasurementNotRepresentable {
+                    tick,
+                    qubits,
+                });
+            }
+        }
+        remapped.push(
+            pecos_simulators::symbolic_sparse_stab::SymbolicMeasurementResult {
+                outcome,
+                flip: result.flip,
+                is_deterministic: result.is_deterministic,
+                index: column,
+            },
+        );
+    }
+    Ok(remapped)
 }
 
 fn symbolic_pairs(qs: &[usize]) -> Vec<(usize, usize)> {
@@ -2479,13 +2539,32 @@ mod tests {
         );
     }
 
-    /// A record-aligned history cannot represent a `MeasureLeaked`: it consumes
-    /// no record, so it has no column, but later outcomes can depend on its
-    /// result and those dependencies are carried as indices into the
-    /// simulator's own numbering. Dropping the column strands them, so the
-    /// circuit is refused instead.
+    /// A leaked measurement nothing depends on is simply renumbered around: it
+    /// holds no record, so the measurements that do keep contiguous columns.
     #[test]
-    fn measure_leaked_is_refused_rather_than_dropped_from_the_history() {
+    fn a_leaked_measurement_nothing_depends_on_is_renumbered_around() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick()
+            .try_add_gate(pecos_core::Gate::measure_leaked(&[0usize]))
+            .expect("gate is valid");
+        tc.tick().mz(&[1]);
+
+        let history = symbolic_measurement_history(&tc)
+            .expect("nothing records a dependency on the leaked result");
+        assert_eq!(history.len(), 1, "only the MZ holds a record");
+        assert_eq!(
+            history.get(0).expect("one column").index,
+            0,
+            "the surviving measurement takes column 0, not the simulator's index 1"
+        );
+    }
+
+    /// When a recorded outcome *does* depend on the leaked result, there is no
+    /// column to point at, so the circuit is refused rather than handed back
+    /// with a dependency naming a column that does not exist.
+    #[test]
+    fn a_recorded_outcome_depending_on_a_leaked_result_is_refused() {
         let mut tc = TickCircuit::new();
         tc.tick().pz(&[0, 1]);
         tc.tick().h(&[0]);
@@ -2495,29 +2574,36 @@ mod tests {
             .expect("gate is valid");
         tc.tick().mz(&[1]);
 
-        let err = symbolic_measurement_history(&tc)
-            .expect_err("a leaked measurement has no place in a record-aligned history");
-        assert!(
-            matches!(
-                err,
-                MeasurementHistoryError::LeakedMeasurementNotRepresentable { .. }
-            ),
-            "expected the leaked-measurement refusal, got: {err}"
-        );
+        match symbolic_measurement_history(&tc)
+            .expect_err("the MZ outcome depends on the leaked measurement")
+        {
+            MeasurementHistoryError::LeakedMeasurementNotRepresentable { tick, qubits } => {
+                assert_eq!(tick, 3, "the error must name the leaked measurement's tick");
+                assert_eq!(qubits, vec![0], "and its qubit");
+            }
+            other @ MeasurementHistoryError::UnsupportedGate(_) => {
+                panic!("expected the leaked-dependency refusal, got: {other}")
+            }
+        }
     }
 
-    /// The same circuit without the leaked measurement is fine, so the refusal
-    /// is about the leaked measurement and not the surrounding gates.
+    /// `MeasureFree` consumes a record, so it keeps a column of its own. Nothing
+    /// else pinned that arm, so dropping it went unnoticed.
     #[test]
-    fn the_same_circuit_without_a_leaked_measurement_is_accepted() {
+    fn measure_free_keeps_its_record_column() {
         let mut tc = TickCircuit::new();
         tc.tick().pz(&[0, 1]);
         tc.tick().h(&[0]);
         tc.tick().cx(&[(0, 1)]);
+        tc.tick().mz_free(&[0]);
         tc.tick().mz(&[1]);
 
         let history = symbolic_measurement_history(&tc).expect("supported gates");
-        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history.len(),
+            2,
+            "both the MeasureFree and the MZ consume a record"
+        );
     }
 
     // ---- symbolic_measurement_history tests ----

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -1464,6 +1464,42 @@ fn toggle_sorted(values: &mut Vec<usize>, value: usize) {
     }
 }
 
+/// Why a circuit cannot be turned into a record-aligned measurement history.
+#[derive(Debug, Clone)]
+pub enum MeasurementHistoryError {
+    /// A gate outside the supported Clifford/prep/measurement/metadata set.
+    UnsupportedGate(UnsupportedGateError),
+    /// The circuit contains a `MeasureLeaked`.
+    ///
+    /// It collapses its qubit and later outcomes can depend on the result, but
+    /// it consumes no measurement record, so it has no column in a
+    /// record-aligned history and its dependencies cannot be expressed without
+    /// one.
+    LeakedMeasurementNotRepresentable { tick: usize, qubits: Vec<usize> },
+}
+
+impl fmt::Display for MeasurementHistoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedGate(err) => write!(f, "{err}"),
+            Self::LeakedMeasurementNotRepresentable { tick, qubits } => write!(
+                f,
+                "MeasureLeaked at tick {tick} on qubits {qubits:?} consumes no measurement \
+                 record, so it cannot appear in a record-aligned measurement history; \
+                 remove it or use a path that does not require record alignment"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MeasurementHistoryError {}
+
+impl From<UnsupportedGateError> for MeasurementHistoryError {
+    fn from(err: UnsupportedGateError) -> Self {
+        Self::UnsupportedGate(err)
+    }
+}
+
 // ============================================================================
 // Shared symbolic simulation helper
 // ============================================================================
@@ -1484,7 +1520,7 @@ fn toggle_sorted(values: &mut Vec<usize>, value: usize) {
 /// the supported Clifford/prep/measurement/metadata set.
 pub fn symbolic_measurement_history(
     tc: &TickCircuit,
-) -> Result<MeasurementHistory, UnsupportedGateError> {
+) -> Result<MeasurementHistory, MeasurementHistoryError> {
     use pecos_simulators::SymbolicSparseStab;
 
     let num_qubits = tc
@@ -1495,7 +1531,6 @@ pub fn symbolic_measurement_history(
         .unwrap_or(0);
 
     let mut sim = SymbolicSparseStab::new(num_qubits);
-    let mut recorded = pecos_simulators::MeasurementHistory::new();
 
     for (tick_idx, tick) in tc.iter_ticks() {
         for gate in tick.iter_gate_batches() {
@@ -1577,17 +1612,22 @@ pub fn symbolic_measurement_history(
                 GateType::SWAP => {
                     sim.swap(&symbolic_pairs(&qs));
                 }
-                GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked => {
-                    // Every measurement collapses its qubit, so all three run on
-                    // the simulator. Only the record-bearing ones get a history
-                    // column, so the columns line up with the record indices
-                    // detectors reference.
-                    let results = sim.mz(&qs);
-                    if gate.gate_type.consumes_measurement_record() {
-                        for result in results {
-                            recorded.push(result);
-                        }
-                    }
+                // `MeasureLeaked` consumes no measurement record, so it has no
+                // place in a record-aligned history -- but it does collapse its
+                // qubit, and later outcomes can depend on the result. A symbolic
+                // result carries its dependencies as indices into the
+                // simulator's own numbering, so dropping the column would strand
+                // every reference to it. Representing that needs a notion of a
+                // hidden random source this history does not have, so say so
+                // rather than return a history whose dependencies dangle.
+                GateType::MeasureLeaked => {
+                    return Err(MeasurementHistoryError::LeakedMeasurementNotRepresentable {
+                        tick: tick_idx,
+                        qubits: qs,
+                    });
+                }
+                GateType::MZ | GateType::MeasureFree => {
+                    sim.mz(&qs);
                 }
                 GateType::I
                 | GateType::Idle
@@ -1596,18 +1636,20 @@ pub fn symbolic_measurement_history(
                 | GateType::MeasCrosstalkLocalPayload
                 | GateType::TrackedPauliMeta => {}
                 other => {
-                    return Err(UnsupportedGateError {
-                        gate_type: other,
-                        tick: tick_idx,
-                        gate_in_tick: gate_idx,
-                        qubits: qs,
-                    });
+                    return Err(MeasurementHistoryError::UnsupportedGate(
+                        UnsupportedGateError {
+                            gate_type: other,
+                            tick: tick_idx,
+                            gate_in_tick: gate_idx,
+                            qubits: qs,
+                        },
+                    ));
                 }
             }
         }
     }
 
-    Ok(recorded)
+    Ok(sim.measurement_history().clone())
 }
 
 fn symbolic_pairs(qs: &[usize]) -> Vec<(usize, usize)> {
@@ -2437,27 +2479,45 @@ mod tests {
         );
     }
 
-    /// The symbolic history must have one column per measurement *record*, so it
-    /// lines up with the record indices detectors reference. `MeasureLeaked`
-    /// still runs on the simulator -- it collapses its qubit -- but consumes no
-    /// record, so it must not occupy a column. It used to, leaving the history
-    /// one column longer than the fault mechanisms' record space and writing
-    /// faults into the wrong detector.
+    /// A record-aligned history cannot represent a `MeasureLeaked`: it consumes
+    /// no record, so it has no column, but later outcomes can depend on its
+    /// result and those dependencies are carried as indices into the
+    /// simulator's own numbering. Dropping the column strands them, so the
+    /// circuit is refused instead.
     #[test]
-    fn measure_leaked_collapses_its_qubit_without_taking_a_history_column() {
+    fn measure_leaked_is_refused_rather_than_dropped_from_the_history() {
         let mut tc = TickCircuit::new();
         tc.tick().pz(&[0, 1]);
+        tc.tick().h(&[0]);
+        tc.tick().cx(&[(0, 1)]);
         tc.tick()
             .try_add_gate(pecos_core::Gate::measure_leaked(&[0usize]))
             .expect("gate is valid");
         tc.tick().mz(&[1]);
 
-        let history = symbolic_measurement_history(&tc).expect("supported gates");
-        assert_eq!(
-            history.len(),
-            1,
-            "only the MZ consumes a record, so only it gets a column"
+        let err = symbolic_measurement_history(&tc)
+            .expect_err("a leaked measurement has no place in a record-aligned history");
+        assert!(
+            matches!(
+                err,
+                MeasurementHistoryError::LeakedMeasurementNotRepresentable { .. }
+            ),
+            "expected the leaked-measurement refusal, got: {err}"
         );
+    }
+
+    /// The same circuit without the leaked measurement is fine, so the refusal
+    /// is about the leaked measurement and not the surrounding gates.
+    #[test]
+    fn the_same_circuit_without_a_leaked_measurement_is_accepted() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick().h(&[0]);
+        tc.tick().cx(&[(0, 1)]);
+        tc.tick().mz(&[1]);
+
+        let history = symbolic_measurement_history(&tc).expect("supported gates");
+        assert_eq!(history.len(), 1);
     }
 
     // ---- symbolic_measurement_history tests ----
@@ -2471,10 +2531,16 @@ mod tests {
 
         let result = symbolic_measurement_history(&tc);
         assert!(result.is_err(), "T should be rejected");
-        let err = result.unwrap_err();
-        assert_eq!(err.gate_type, GateType::T);
-        assert_eq!(err.tick, 1);
-        assert_eq!(err.qubits, vec![0]);
+        match result.unwrap_err() {
+            MeasurementHistoryError::UnsupportedGate(err) => {
+                assert_eq!(err.gate_type, GateType::T);
+                assert_eq!(err.tick, 1);
+                assert_eq!(err.qubits, vec![0]);
+            }
+            other @ MeasurementHistoryError::LeakedMeasurementNotRepresentable { .. } => {
+                panic!("expected an unsupported-gate error, got: {other}")
+            }
+        }
     }
 
     #[test]

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -1495,6 +1495,7 @@ pub fn symbolic_measurement_history(
         .unwrap_or(0);
 
     let mut sim = SymbolicSparseStab::new(num_qubits);
+    let mut recorded = pecos_simulators::MeasurementHistory::new();
 
     for (tick_idx, tick) in tc.iter_ticks() {
         for gate in tick.iter_gate_batches() {
@@ -1577,7 +1578,16 @@ pub fn symbolic_measurement_history(
                     sim.swap(&symbolic_pairs(&qs));
                 }
                 GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked => {
-                    sim.mz(&qs);
+                    // Every measurement collapses its qubit, so all three run on
+                    // the simulator. Only the record-bearing ones get a history
+                    // column, so the columns line up with the record indices
+                    // detectors reference.
+                    let results = sim.mz(&qs);
+                    if gate.gate_type.consumes_measurement_record() {
+                        for result in results {
+                            recorded.push(result);
+                        }
+                    }
                 }
                 GateType::I
                 | GateType::Idle
@@ -1597,7 +1607,7 @@ pub fn symbolic_measurement_history(
         }
     }
 
-    Ok(sim.measurement_history().clone())
+    Ok(recorded)
 }
 
 fn symbolic_pairs(qs: &[usize]) -> Vec<(usize, usize)> {
@@ -2397,6 +2407,57 @@ mod tests {
         assert_eq!(err.tick, 1, "T is in tick 1");
         assert_eq!(err.gate_in_tick, 0, "T is gate 0 within that tick");
         assert_eq!(err.qubits, vec![0], "full original qubit list");
+    }
+
+    /// The fault catalogue numbers measurements by record, so a `MeasureLeaked`
+    /// must not take a position. It used to, which put every later measurement's
+    /// faults one column off from the detector metadata.
+    #[test]
+    fn flatten_gives_no_record_position_to_measure_leaked() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick()
+            .try_add_gate(pecos_core::Gate::measure_leaked(&[0usize]))
+            .expect("gate is valid");
+        tc.tick().mz(&[1]);
+
+        let (gates, meas_positions) = flatten_tick_circuit(&tc);
+
+        assert_eq!(
+            meas_positions.len(),
+            1,
+            "only the MZ consumes a record position"
+        );
+        let (&loc_idx, &record) = meas_positions.iter().next().expect("one entry");
+        assert_eq!(record, 0, "the MZ holds record 0, not record 1");
+        assert_eq!(
+            gates[loc_idx].gate_type,
+            pecos_core::gate_type::GateType::MZ,
+            "the recorded position must belong to the MZ, not the leaked measurement"
+        );
+    }
+
+    /// The symbolic history must have one column per measurement *record*, so it
+    /// lines up with the record indices detectors reference. `MeasureLeaked`
+    /// still runs on the simulator -- it collapses its qubit -- but consumes no
+    /// record, so it must not occupy a column. It used to, leaving the history
+    /// one column longer than the fault mechanisms' record space and writing
+    /// faults into the wrong detector.
+    #[test]
+    fn measure_leaked_collapses_its_qubit_without_taking_a_history_column() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick()
+            .try_add_gate(pecos_core::Gate::measure_leaked(&[0usize]))
+            .expect("gate is valid");
+        tc.tick().mz(&[1]);
+
+        let history = symbolic_measurement_history(&tc).expect("supported gates");
+        assert_eq!(
+            history.len(),
+            1,
+            "only the MZ consumes a record, so only it gets a column"
+        );
     }
 
     // ---- symbolic_measurement_history tests ----

--- a/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
@@ -416,7 +416,7 @@ fn measurement_records_by_node(
         // numbered it positionally while real measurements were numbered by
         // their `MeasId`, so a leaked measurement and a real one could claim the
         // same record.
-        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+        if !gate.gate_type.consumes_measurement_record() {
             continue;
         }
         if !gate.meas_ids.is_empty() && gate.meas_ids.len() != gate.qubits.len() {
@@ -498,8 +498,13 @@ fn propagate_tracked_pauli_forward(
                         if prop.contains_x(qubit) {
                             affected_measurements.insert(record);
                         }
-                        clear_qubit(&mut prop, qubit);
                     }
+                }
+                // Every measurement collapses the qubit, including one that
+                // consumes no record. Clearing used to sit inside the record
+                // lookup above, so a `MeasureLeaked` let the Pauli propagate on.
+                for qubit in &gate.qubits {
+                    clear_qubit(&mut prop, qubit.index());
                 }
             }
             GateType::PZ | GateType::QAlloc => {
@@ -561,6 +566,28 @@ fn clear_qubit(prop: &mut PauliProp, qubit: usize) {
 mod tests {
     use super::*;
     use pecos_quantum::Gate;
+
+    /// `MeasureFree` does consume a record, so it must be numbered here.
+    #[test]
+    fn measure_free_claims_a_measurement_record() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        let freed = dag.add_gate_auto_wire(Gate::mz_free(&[0usize]));
+        let measured = dag.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        let (by_node, num_measurements) =
+            measurement_records_by_node(&dag).expect("mapping succeeds");
+
+        assert_eq!(
+            by_node.get(&freed).map(Vec::as_slice),
+            Some([(0usize, 0usize)].as_slice())
+        );
+        assert_eq!(
+            by_node.get(&measured).map(Vec::as_slice),
+            Some([(1usize, 1usize)].as_slice())
+        );
+        assert_eq!(num_measurements, 2);
+    }
 
     /// `MeasureLeaked` must not consume a measurement record here.
     ///

--- a/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
@@ -567,6 +567,62 @@ mod tests {
     use super::*;
     use pecos_quantum::Gate;
 
+    /// A `MeasureLeaked` must affect a propagating Pauli exactly as an `MZ`
+    /// does. Clearing used to sit inside the record lookup, so once
+    /// `MeasureLeaked` stopped consuming a record it also stopped touching the
+    /// Pauli, and an X propagated straight through it to flip a later
+    /// measurement that an `MZ` in the same position would have shielded.
+    ///
+    /// This pins the two against each other rather than against an absolute,
+    /// because whether a non-destructive measurement should clear at all is a
+    /// separate question -- see the collapse-semantics issue.
+    #[test]
+    fn measure_leaked_affects_a_propagating_pauli_like_an_mz() {
+        fn later_measurement_flipped(leading: GateType) -> bool {
+            let mut dag = DagCircuit::new();
+            dag.pz(&[0]);
+            let start = dag.add_gate_auto_wire(Gate::simple(
+                GateType::TrackedPauliMeta,
+                vec![pecos_quantum::QubitId::from(0usize)],
+            ));
+            let leading_gate = match leading {
+                GateType::MeasureLeaked => Gate::measure_leaked(&[0usize]),
+                _ => Gate::mz(&[0usize]),
+            };
+            dag.add_gate_auto_wire(leading_gate);
+            let later = dag.add_gate_auto_wire(Gate::mz(&[0usize]));
+
+            let topo_order = dag.topological_order();
+            let start_pos = topo_order
+                .iter()
+                .position(|&n| n == start)
+                .expect("meta node is in the order");
+            let (records, _) = measurement_records_by_node(&dag).expect("mapping succeeds");
+            let affected = propagate_tracked_pauli_forward(
+                &dag,
+                &topo_order,
+                &records,
+                start_pos,
+                &PauliString::xs(&[0usize]),
+            );
+            // Only the *later* measurement matters: with a leading MZ the first
+            // one is legitimately flipped, so a bare "anything affected" check
+            // would compare different things.
+            let later_record = records
+                .get(&later)
+                .and_then(|entries| entries.first())
+                .map(|&(_, record)| record)
+                .expect("the later MZ holds a record");
+            affected.contains(&later_record)
+        }
+
+        assert_eq!(
+            later_measurement_flipped(GateType::MeasureLeaked),
+            later_measurement_flipped(GateType::MZ),
+            "a leaked measurement must not let a Pauli through that an MZ stops"
+        );
+    }
+
     /// `MeasureFree` does consume a record, so it must be numbered here.
     #[test]
     fn measure_free_claims_a_measurement_record() {

--- a/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
@@ -412,10 +412,11 @@ fn measurement_records_by_node(
         let Some(gate) = dag.gate(node) else {
             continue;
         };
-        if !matches!(
-            gate.gate_type,
-            GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
-        ) {
+        // `MeasureLeaked` consumes no measurement record. Including it here
+        // numbered it positionally while real measurements were numbered by
+        // their `MeasId`, so a leaked measurement and a real one could claim the
+        // same record.
+        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
             continue;
         }
         if !gate.meas_ids.is_empty() && gate.meas_ids.len() != gate.qubits.len() {
@@ -553,5 +554,39 @@ fn clear_qubit(prop: &mut PauliProp, qubit: usize) {
     }
     if prop.contains_z(qubit) {
         prop.track_z(&[qubit]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pecos_quantum::Gate;
+
+    /// `MeasureLeaked` must not consume a measurement record here.
+    ///
+    /// It used to, and because `DagCircuit` mints no id for it, it took the
+    /// positional branch and claimed record 0 -- the same record the first real
+    /// measurement holds by its `MeasId`. Two different measurements then mapped
+    /// to one record.
+    #[test]
+    fn measure_leaked_does_not_claim_a_measurement_record() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        let leaked = dag.add_gate_auto_wire(Gate::measure_leaked(&[0usize]));
+        let measured = dag.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        let (by_node, num_measurements) =
+            measurement_records_by_node(&dag).expect("mapping succeeds");
+
+        assert!(
+            !by_node.contains_key(&leaked),
+            "a leaked measurement holds no record"
+        );
+        assert_eq!(
+            by_node.get(&measured).map(Vec::as_slice),
+            Some([(1usize, 0usize)].as_slice()),
+            "the real measurement keeps record 0"
+        );
+        assert_eq!(num_measurements, 1);
     }
 }

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -2555,15 +2555,20 @@ mod tests {
     // Helper Functions
     // =========================================================================
 
-    /// Measurement extraction orders by `MeasId`, which is insertion order --
-    /// the order the program writes the measurements in.
+    /// Measurement extraction orders by `MeasId`, never by topological position.
     ///
-    /// Before every `DagCircuit` measurement carried an id, id-less circuits
-    /// fell back to topological position, so the two orderings could disagree
-    /// for circuits whose wiring does not follow insertion order. Program order
-    /// is what a measurement record means, so it is the one that survives.
+    /// Id-less circuits used to fall back to topological position, so the two
+    /// orderings disagreed for circuits whose wiring does not follow the order
+    /// the measurements were written. The id is what names a measurement, so it
+    /// is what orders them.
+    ///
+    /// For minted ids that comes out as the order the program writes its
+    /// measurements, which is what this case covers. It is a *consequence* of
+    /// minting being sequential, not the rule -- see
+    /// `extraction_follows_supplied_ids_not_the_order_they_were_added` for the
+    /// case where the two differ.
     #[test]
-    fn measurements_extract_in_insertion_order_not_topological_order() {
+    fn minted_ids_extract_in_the_order_the_measurements_were_written() {
         let mut dag = DagCircuit::new();
         dag.pz(&[0, 1]);
         // q0 is measured first in program order but sits behind a longer chain,
@@ -2587,6 +2592,40 @@ mod tests {
             meas_ids.iter().map(|id| id.index()).collect::<Vec<_>>(),
             vec![0, 1],
             "and the ids must agree with it"
+        );
+    }
+
+    /// Supplied ids own the numbering, so extraction follows them even when they
+    /// run counter to the order the measurements were added.
+    ///
+    /// `mz_with_ids` accepts external ids -- Guppy result ids, where the number
+    /// is the result index -- and those need not arrive in ascending order. So
+    /// "id order" is the rule; matching the order of addition is not.
+    #[test]
+    fn extraction_follows_supplied_ids_not_the_order_they_were_added() {
+        use pecos_core::MeasId;
+        use pecos_quantum::Gate;
+
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        let mut later_id = Gate::mz(&[0usize]);
+        later_id.meas_ids = smallvec::smallvec![MeasId(9)];
+        dag.add_gate_auto_wire(later_id);
+        let mut earlier_id = Gate::mz(&[1usize]);
+        earlier_id.meas_ids = smallvec::smallvec![MeasId(4)];
+        dag.add_gate_auto_wire(earlier_id);
+
+        let analyzer = DagFaultAnalyzer::new(&dag);
+        let (measurements, meas_ids) = analyzer.extract_measurements();
+
+        assert_eq!(
+            measurements.iter().map(|&(_, q, _)| q).collect::<Vec<_>>(),
+            vec![1, 0],
+            "qubit 1 holds the lower id, so it comes first despite being added second"
+        );
+        assert_eq!(
+            meas_ids.iter().map(|id| id.index()).collect::<Vec<_>>(),
+            vec![4, 9]
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -2555,6 +2555,41 @@ mod tests {
     // Helper Functions
     // =========================================================================
 
+    /// Measurement extraction orders by `MeasId`, which is insertion order --
+    /// the order the program writes the measurements in.
+    ///
+    /// Before every `DagCircuit` measurement carried an id, id-less circuits
+    /// fell back to topological position, so the two orderings could disagree
+    /// for circuits whose wiring does not follow insertion order. Program order
+    /// is what a measurement record means, so it is the one that survives.
+    #[test]
+    fn measurements_extract_in_insertion_order_not_topological_order() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        // q0 is measured first in program order but sits behind a longer chain,
+        // so a topological sweep reaches q1's measurement first.
+        dag.h(&[0]);
+        dag.h(&[0]);
+        dag.h(&[0]);
+        dag.mz(&[0]);
+        dag.mz(&[1]);
+
+        let analyzer = DagFaultAnalyzer::new(&dag);
+        let (measurements, meas_ids) = analyzer.extract_measurements();
+
+        let qubits: Vec<usize> = measurements.iter().map(|&(_, q, _)| q).collect();
+        assert_eq!(
+            qubits,
+            vec![0, 1],
+            "extraction must follow the order the measurements were written"
+        );
+        assert_eq!(
+            meas_ids.iter().map(|id| id.index()).collect::<Vec<_>>(),
+            vec![0, 1],
+            "and the ids must agree with it"
+        );
+    }
+
     /// Simple Z-stabilizer measurement circuit: measures Z0 Z1 parity
     fn simple_syndrome_circuit() -> DagCircuit {
         let mut dag = DagCircuit::new();

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -1918,21 +1918,19 @@ impl<'a> DagFaultAnalyzer<'a> {
         map
     }
 
-    /// Extracts all measurements from the circuit in a deterministic order.
+    /// Extracts all measurements from the circuit, ordered by [`MeasId`].
     ///
-    /// Measurements are sorted by:
-    /// 1. Topological position (to respect causal dependencies)
-    /// 2. Qubit index (to break ties for concurrent/independent measurements)
+    /// The id is what names a measurement, so it is what orders them; qubit index
+    /// breaks ties. Measurements carrying no id fall back to topological
+    /// position, which only happens for circuits built outside `DagCircuit`'s
+    /// builders.
     ///
-    /// This gives deterministic measurement ordering where measurements on
-    /// lower-indexed qubits appear first when they are in the same "layer" of
-    /// the circuit.
+    /// Returns `(measurements, meas_ids)` where `measurements` is
+    /// `Vec<(node, qubit, basis)>` and `meas_ids` is empty for circuits whose
+    /// measurements carry no ids.
+    ///
+    /// [`MeasId`]: pecos_core::MeasId
     #[must_use]
-    /// Extract measurements with optional `MeasId` IDs.
-    ///
-    /// Returns `(measurements, meas_ids)` where:
-    /// - `measurements` is `Vec<(node, qubit, basis)>` in `MeasId` order
-    /// - `meas_ids` is `Vec<MeasId>` (empty for legacy circuits)
     pub fn extract_measurements(&self) -> (Vec<(usize, usize, u8)>, Vec<pecos_core::MeasId>) {
         let mut entries = Vec::new(); // (sort_key, qubit, node, basis, Option<MeasId>)
 
@@ -2606,26 +2604,40 @@ mod tests {
         use pecos_core::MeasId;
         use pecos_quantum::Gate;
 
+        // Three measurements whose insertion order, topological depth and id
+        // order are pairwise different, so passing this test means following the
+        // ids and nothing else:
+        //   insertion   q0, q1, q2
+        //   topological q1, q2, q0  (by chain depth)
+        //   id order    q2, q0, q1  (ids 1, 5, 9)
         let mut dag = DagCircuit::new();
-        dag.pz(&[0, 1]);
-        let mut later_id = Gate::mz(&[0usize]);
-        later_id.meas_ids = smallvec::smallvec![MeasId(9)];
-        dag.add_gate_auto_wire(later_id);
-        let mut earlier_id = Gate::mz(&[1usize]);
-        earlier_id.meas_ids = smallvec::smallvec![MeasId(4)];
-        dag.add_gate_auto_wire(earlier_id);
+        dag.pz(&[0, 1, 2]);
+        dag.h(&[0]);
+        dag.h(&[0]);
+        let mut deep = Gate::mz(&[0usize]);
+        deep.meas_ids = smallvec::smallvec![MeasId(5)];
+        dag.add_gate_auto_wire(deep);
+
+        let mut shallow = Gate::mz(&[1usize]);
+        shallow.meas_ids = smallvec::smallvec![MeasId(9)];
+        dag.add_gate_auto_wire(shallow);
+
+        dag.h(&[2]);
+        let mut middle = Gate::mz(&[2usize]);
+        middle.meas_ids = smallvec::smallvec![MeasId(1)];
+        dag.add_gate_auto_wire(middle);
 
         let analyzer = DagFaultAnalyzer::new(&dag);
         let (measurements, meas_ids) = analyzer.extract_measurements();
 
         assert_eq!(
             measurements.iter().map(|&(_, q, _)| q).collect::<Vec<_>>(),
-            vec![1, 0],
-            "qubit 1 holds the lower id, so it comes first despite being added second"
+            vec![2, 0, 1],
+            "extraction must follow the supplied ids, not insertion or topological order"
         );
         assert_eq!(
             meas_ids.iter().map(|id| id.index()).collect::<Vec<_>>(),
-            vec![4, 9]
+            vec![1, 5, 9]
         );
     }
 

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -534,6 +534,22 @@ impl DagCircuit {
         self.next_meas_id
     }
 
+    /// Check that `count` ids can still be minted, without minting them.
+    ///
+    /// Batch builders insert one gate per qubit, so without this a batch could
+    /// fail half way and leave the circuit partly mutated.
+    fn reserve_room_for_mints(&self, count: usize) -> Result<(), String> {
+        self.next_meas_id
+            .checked_add(count)
+            .map(|_| ())
+            .ok_or_else(|| {
+                format!(
+                    "measurement needs {count} ids but only {} remain below usize::MAX",
+                    usize::MAX - self.next_meas_id
+                )
+            })
+    }
+
     /// Give a measurement gate a [`MeasId`] per measured qubit, or reserve the
     /// ids it already carries.
     ///
@@ -1737,6 +1753,10 @@ impl DagCircuit {
     ///
     /// Returns an error if the circuit has no measurement ids left to mint.
     pub fn try_mz(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> Result<Vec<MeasRef>, String> {
+        // Each qubit becomes its own gate, so check the whole batch fits before
+        // inserting any of it. Failing part way would leave the circuit holding
+        // measurements the caller was told it did not get.
+        self.reserve_room_for_mints(qubits.len())?;
         qubits
             .iter()
             .map(|&q| {
@@ -1792,6 +1812,7 @@ impl DagCircuit {
     ///
     /// Returns an error if the circuit has no measurement ids left to mint.
     pub fn try_mz_free(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> Result<(), String> {
+        self.reserve_room_for_mints(qubits.len())?;
         for &q in qubits {
             self.try_add_gate_auto_wire(Gate::mz_free(&[q]))?;
         }
@@ -3386,6 +3407,37 @@ mod measurement_id_tests {
             circuit.gate(measured).unwrap().meas_ids[0],
             MeasId(1),
             "a MeasureFree consumes a record, so the next measurement follows it"
+        );
+    }
+
+    /// A batch builder inserts one gate per qubit. If the batch cannot fit
+    /// entirely it must insert none of it, or the caller is told the
+    /// measurement failed while the circuit holds part of it.
+    #[test]
+    fn a_batch_measurement_that_cannot_fit_inserts_nothing() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let gates_before = circuit.gate_count();
+        let mut near_max = Gate::mz(&[0usize]);
+        near_max.meas_ids = smallvec::smallvec![MeasId(usize::MAX - 2)];
+        circuit.add_gate_auto_wire(near_max);
+        let gates_after_setup = circuit.gate_count();
+        assert_eq!(gates_after_setup, gates_before + 1);
+
+        // One id slot remains; the batch needs two.
+        assert!(
+            circuit.try_mz(&[0usize, 1]).is_err(),
+            "two ids do not fit below usize::MAX"
+        );
+        assert_eq!(
+            circuit.gate_count(),
+            gates_after_setup,
+            "a rejected batch must leave no measurement behind"
+        );
+        assert_eq!(
+            circuit.num_measurement_ids(),
+            usize::MAX - 1,
+            "and must not move the counter"
         );
     }
 

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -23,7 +23,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use pecos_core::gate_type::GateType;
-use pecos_core::{Angle64, Gate, QubitId, TimeUnits};
+use pecos_core::{Angle64, Gate, MeasId, QubitId, TimeUnits};
 use pecos_num::dag::{DAG, DagWouldCycleError};
 
 use crate::circuit::{Circuit, CircuitMut, GateHandle, GateView};
@@ -436,6 +436,13 @@ pub struct DagCircuit {
     annotations: Vec<PauliAnnotation>,
     /// Measurement labels (`node_index` → label).
     measurement_labels: BTreeMap<usize, String>,
+    /// Next [`MeasId`] to hand out when a measurement arrives without one.
+    ///
+    /// `DagCircuit`'s builders previously created measurements carrying no
+    /// identity at all, so anything downstream that needs to name a specific
+    /// measurement had to fall back on node ids -- which cannot distinguish
+    /// measurements inside one batched gate (issue #387).
+    next_meas_id: usize,
 }
 
 impl DagCircuit {
@@ -449,6 +456,7 @@ impl DagCircuit {
             qubit_heads: BTreeMap::new(),
             last_node: None,
             max_qubit: 0,
+            next_meas_id: 0,
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -470,6 +478,7 @@ impl DagCircuit {
             qubit_heads: BTreeMap::new(),
             last_node: None,
             max_qubit: 0,
+            next_meas_id: 0,
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -506,7 +515,45 @@ impl DagCircuit {
         Ok(self.add_gate_unchecked(gate))
     }
 
-    fn add_gate_unchecked(&mut self, gate: Gate) -> usize {
+    /// Number of measurement records this circuit has allocated.
+    ///
+    /// Equivalently, the next [`MeasId`] that would be minted. With ids
+    /// supplied externally this is `max(id) + 1` rather than a count, which is
+    /// why it must not be used as one -- see #387.
+    #[must_use]
+    pub fn num_measurement_ids(&self) -> usize {
+        self.next_meas_id
+    }
+
+    /// Give a measurement gate a [`MeasId`] per measured qubit, or make room
+    /// for the ids it already carries.
+    ///
+    /// Every gate reaches the circuit through here, so this is the one place
+    /// that has to be right. Gates arriving with ids keep them -- they came
+    /// from a `TickCircuit` conversion or an external source that owns the
+    /// numbering -- and the counter is advanced past them so a later minted id
+    /// cannot collide.
+    fn assign_measurement_ids(&mut self, gate: &mut Gate) {
+        if !matches!(
+            gate.gate_type,
+            GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
+        ) {
+            return;
+        }
+        if gate.meas_ids.is_empty() {
+            for _ in &gate.qubits {
+                gate.meas_ids.push(MeasId(self.next_meas_id));
+                self.next_meas_id += 1;
+            }
+        } else {
+            for id in &gate.meas_ids {
+                self.next_meas_id = self.next_meas_id.max(id.index() + 1);
+            }
+        }
+    }
+
+    fn add_gate_unchecked(&mut self, mut gate: Gate) -> usize {
+        self.assign_measurement_ids(&mut gate);
         let node_idx = self.dag.add_node();
         // Ensure gates vector is large enough
         if node_idx >= self.gates.len() {
@@ -2917,5 +2964,92 @@ mod tests {
     fn test_add_gate_panics_on_invalid_gate_payload() {
         let mut circuit = DagCircuit::new();
         circuit.add_gate(Gate::cx(&[(0, 0)]));
+    }
+}
+
+#[cfg(test)]
+mod measurement_id_tests {
+    use super::*;
+
+    /// `DagCircuit`'s own builders created measurements with no identity at
+    /// all, so nothing downstream could name one measurement inside a batched
+    /// gate. Every measurement now carries a distinct `MeasId`.
+    #[test]
+    fn builders_mint_a_distinct_id_per_measurement() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let kept = circuit.mz(&[0, 1]);
+        circuit.mz_free(&[2]);
+
+        let ids: Vec<usize> = circuit
+            .gates
+            .iter()
+            .flatten()
+            .filter(|g| {
+                matches!(
+                    g.gate_type,
+                    GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
+                )
+            })
+            .flat_map(|g| g.meas_ids.iter().map(|id| id.index()))
+            .collect();
+
+        assert_eq!(ids, vec![0, 1, 2], "ids are minted in creation order");
+        assert_eq!(circuit.num_measurement_ids(), 3);
+        assert_eq!(kept.len(), 2);
+    }
+
+    /// A batched measurement gate gets one id per measured qubit, so the
+    /// instances inside it are individually nameable.
+    #[test]
+    fn a_batched_measurement_gets_one_id_per_qubit() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let node = circuit.add_gate_auto_wire(Gate::mz(&[0usize, 1, 2]));
+
+        let gate = circuit.gate(node).expect("gate exists");
+        assert_eq!(gate.qubits.len(), 3);
+        assert_eq!(
+            gate.meas_ids
+                .iter()
+                .map(|id| id.index())
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "each measured qubit in a batch needs its own id"
+        );
+    }
+
+    /// Gates arriving with ids own their numbering; the counter must move past
+    /// them so a later minted id cannot collide.
+    #[test]
+    fn supplied_ids_are_kept_and_do_not_collide_with_minted_ones() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut supplied = Gate::mz(&[0usize]);
+        supplied.meas_ids = smallvec::smallvec![MeasId(10)];
+        let supplied_node = circuit.add_gate_auto_wire(supplied);
+        let minted_node = circuit.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        assert_eq!(
+            circuit.gate(supplied_node).unwrap().meas_ids[0],
+            MeasId(10),
+            "a supplied id must be preserved"
+        );
+        let minted = circuit.gate(minted_node).unwrap().meas_ids[0];
+        assert_eq!(
+            minted,
+            MeasId(11),
+            "the counter must advance past supplied ids, not reuse 0"
+        );
+        assert_ne!(minted, MeasId(10), "minted ids must not collide");
+    }
+
+    /// Non-measurement gates are untouched.
+    #[test]
+    fn non_measurement_gates_get_no_ids() {
+        let mut circuit = DagCircuit::new();
+        let node = circuit.add_gate_auto_wire(Gate::h(&[0usize]));
+        assert!(circuit.gate(node).unwrap().meas_ids.is_empty());
+        assert_eq!(circuit.num_measurement_ids(), 0);
     }
 }

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -438,10 +438,8 @@ pub struct DagCircuit {
     measurement_labels: BTreeMap<usize, String>,
     /// Next [`MeasId`] to hand out when a measurement arrives without one.
     ///
-    /// `DagCircuit`'s builders previously created measurements carrying no
-    /// identity at all, so anything downstream that needs to name a specific
-    /// measurement had to fall back on node ids -- which cannot distinguish
-    /// measurements inside one batched gate (issue #387).
+    /// An id names one measurement. Node ids cannot: a batched measurement gate
+    /// is a single node covering several measurements.
     next_meas_id: usize,
     /// Every [`MeasId`] this circuit has minted or accepted.
     ///
@@ -528,9 +526,9 @@ impl DagCircuit {
 
     /// Number of measurement records this circuit has allocated.
     ///
-    /// Equivalently, the next [`MeasId`] that would be minted. With ids
-    /// supplied externally this is `max(id) + 1` rather than a count, which is
-    /// why it must not be used as one -- see #387.
+    /// Equivalently, the next [`MeasId`] that would be minted. This is not a
+    /// count of measurements: externally supplied ids may be sparse, in which
+    /// case it is `max(id) + 1`.
     #[must_use]
     pub fn num_measurement_ids(&self) -> usize {
         self.next_meas_id
@@ -545,15 +543,12 @@ impl DagCircuit {
     /// numbering -- and those ids are reserved so a later minted id cannot
     /// collide.
     ///
-    /// Ids are minted only for the gate types the rest of the codebase treats
-    /// as consuming a measurement record, `MZ | MeasureFree`. `MeasureLeaked`
-    /// is a measurement by `Gate::validate` and by `DagCircuit -> TickCircuit`,
-    /// but 46 other sites exclude it; minting here would stamp ids that the
-    /// `TickCircuit` side does not allocate records for, producing duplicates
-    /// at the boundary. Admitting `MeasureLeaked` is a repo-wide sweep tracked
-    /// in #387, not a decision for this one function. Ids supplied on a
-    /// `MeasureLeaked` are still reserved, so the sweep only has to change
-    /// which types get minted.
+    /// Ids are minted only for `MZ | MeasureFree`, the gate types that consume
+    /// a measurement record elsewhere in the codebase. `MeasureLeaked` is a
+    /// measurement to `Gate::validate`, but `TickCircuit` allocates it no
+    /// record, so minting one here would give it an id the two representations
+    /// disagree about. Ids *supplied* on a `MeasureLeaked` are still reserved,
+    /// so admitting it later means changing only which types are minted for.
     ///
     /// # Errors
     ///
@@ -3097,7 +3092,7 @@ mod measurement_id_tests {
     /// that decide which gates consume a measurement record exclude it. Minting
     /// here would hand out ids that `TickCircuit` allocates no record for, so
     /// the two sides would disagree about which id belongs to which
-    /// measurement. Admitting it is the repo-wide sweep in #387.
+    /// measurement.
     #[test]
     fn measure_leaked_is_not_minted_an_id() {
         let mut circuit = DagCircuit::new();
@@ -3118,8 +3113,8 @@ mod measurement_id_tests {
         assert_eq!(circuit.num_measurement_ids(), 1);
     }
 
-    /// An id supplied on a `MeasureLeaked` is still reserved, so the #387 sweep
-    /// only has to change which gate types are minted for.
+    /// An id supplied on a `MeasureLeaked` is still reserved, so admitting the
+    /// type later means changing only which gate types are minted for.
     #[test]
     fn a_supplied_measure_leaked_id_is_still_reserved() {
         let mut circuit = DagCircuit::new();

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -585,7 +585,7 @@ impl DagCircuit {
             return Ok(());
         }
 
-        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+        if !gate.gate_type.consumes_measurement_record() {
             return Ok(());
         }
         // Check the whole run fits before minting any of it. Minted ids are
@@ -1184,9 +1184,25 @@ impl DagCircuit {
     // - All methods return `&mut Self` for chaining
 
     /// Adds a gate and auto-wires it to previous gates on the same qubits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the gate is rejected -- see the `try_` variant for fallible
+    /// insertion.
     pub fn add_gate_auto_wire(&mut self, gate: Gate) -> usize {
+        self.try_add_gate_auto_wire(gate)
+            .unwrap_or_else(|err| panic!("Invalid gate: {err}"))
+    }
+
+    /// Adds a gate and wires it to the previous gate on each of its qubits,
+    /// reporting rejection instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if [`try_add_gate`](Self::try_add_gate) rejects the gate.
+    pub fn try_add_gate_auto_wire(&mut self, gate: Gate) -> Result<usize, String> {
         let qubits = gate.qubits.clone();
-        let node = self.add_gate(gate);
+        let node = self.try_add_gate(gate)?;
 
         // Connect to previous gates on each qubit
         for qubit in &qubits {
@@ -1201,7 +1217,7 @@ impl DagCircuit {
         // Track last added node for .meta() calls
         self.last_node = Some(node);
 
-        node
+        Ok(node)
     }
 
     /// Add metadata to the last added gate.
@@ -1705,13 +1721,28 @@ impl DagCircuit {
     /// let nodes = circuit.mz(&[0, 1]);
     /// assert_eq!(nodes.len(), 2);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the gate is rejected -- see the `try_` variant for fallible
+    /// insertion.
     pub fn mz(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> Vec<MeasRef> {
+        self.try_mz(qubits)
+            .unwrap_or_else(|err| panic!("Invalid gate: {err}"))
+    }
+
+    /// Measure qubits in the Z basis, reporting rejection instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the circuit has no measurement ids left to mint.
+    pub fn try_mz(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> Result<Vec<MeasRef>, String> {
         qubits
             .iter()
             .map(|&q| {
                 let qubit = q.into();
-                let node = self.add_gate_auto_wire(Gate::mz(&[qubit]));
-                MeasRef { node, qubit }
+                let node = self.try_add_gate_auto_wire(Gate::mz(&[qubit]))?;
+                Ok(MeasRef { node, qubit })
             })
             .collect()
     }
@@ -1744,11 +1775,27 @@ impl DagCircuit {
     }
 
     /// Measure and free qubit(s) (destructive measurement).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the gate is rejected -- see the `try_` variant for fallible
+    /// insertion.
     pub fn mz_free(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> &mut Self {
-        for &q in qubits {
-            self.add_gate_auto_wire(Gate::mz_free(&[q]));
-        }
+        self.try_mz_free(qubits)
+            .unwrap_or_else(|err| panic!("Invalid gate: {err}"));
         self
+    }
+
+    /// Measure and free qubits, reporting rejection instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the circuit has no measurement ids left to mint.
+    pub fn try_mz_free(&mut self, qubits: &[impl Into<QubitId> + Copy]) -> Result<(), String> {
+        for &q in qubits {
+            self.try_add_gate_auto_wire(Gate::mz_free(&[q]))?;
+        }
+        Ok(())
     }
 
     // ========================================================================
@@ -3303,6 +3350,42 @@ mod measurement_id_tests {
             circuit.gate(minted).unwrap().meas_ids[0],
             MeasId(11),
             "the counter must stay past the highest supplied id, not follow the latest"
+        );
+    }
+
+    /// Within one gate the counter must clear the *highest* id supplied, not the
+    /// last one. A batch of `[10, 3]` left the counter at 4, and the seventh
+    /// later mint silently re-issued `MeasId(10)`.
+    #[test]
+    fn a_batch_with_descending_ids_leaves_the_counter_past_the_highest() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let mut descending = Gate::mz(&[0usize, 1]);
+        descending.meas_ids = smallvec::smallvec![MeasId(10), MeasId(3)];
+        circuit.add_gate_auto_wire(descending);
+
+        assert_eq!(circuit.num_measurement_ids(), 11);
+        let minted = circuit.add_gate_auto_wire(Gate::mz(&[2usize]));
+        assert_eq!(
+            circuit.gate(minted).unwrap().meas_ids[0],
+            MeasId(11),
+            "the next mint must clear the highest id in the batch, not the last"
+        );
+    }
+
+    /// `MeasureFree` consumes a record, so it is minted for like `MZ`.
+    #[test]
+    fn measure_free_is_minted_an_id() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let freed = circuit.add_gate_auto_wire(Gate::mz_free(&[0usize]));
+        let measured = circuit.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        assert_eq!(circuit.gate(freed).unwrap().meas_ids[0], MeasId(0));
+        assert_eq!(
+            circuit.gate(measured).unwrap().meas_ids[0],
+            MeasId(1),
+            "a MeasureFree consumes a record, so the next measurement follows it"
         );
     }
 

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -543,48 +543,69 @@ impl DagCircuit {
     /// numbering -- and those ids are reserved so a later minted id cannot
     /// collide.
     ///
-    /// Ids are minted only for `MZ | MeasureFree`, the gate types that consume
-    /// a measurement record elsewhere in the codebase. `MeasureLeaked` is a
-    /// measurement to `Gate::validate`, but `TickCircuit` allocates it no
-    /// record, so minting one here would give it an id the two representations
-    /// disagree about. Ids *supplied* on a `MeasureLeaked` are still reserved,
-    /// so admitting it later means changing only which types are minted for.
+    /// Ids are minted only for `MZ | MeasureFree`, matching every site that
+    /// decides which gates consume a measurement record, `TickCircuit`
+    /// conversion in both directions included. Ids *supplied* on a
+    /// `MeasureLeaked` are still reserved, so admitting the type later means
+    /// changing only which types are minted for.
+    ///
+    /// Nothing is reserved until the whole gate has been checked: a rejected
+    /// gate must not leave its ids burned, or a later legitimate use of the same
+    /// id would be refused for a measurement that was never added.
     ///
     /// # Errors
     ///
-    /// Returns an error if a supplied id repeats one already in the circuit, or
-    /// if a supplied id is [`usize::MAX`] and so leaves no room for a successor.
+    /// Returns an error if a supplied id repeats one already in the circuit or
+    /// another in the same gate, or if the ids needed would run past
+    /// [`usize::MAX`].
     fn assign_measurement_ids(&mut self, gate: &mut Gate) -> Result<(), String> {
         if !gate.meas_ids.is_empty() {
+            let mut incoming = BTreeSet::new();
+            let mut highest_successor = 0;
             for id in &gate.meas_ids {
-                if !self.used_meas_ids.insert(id.index()) {
+                if self.used_meas_ids.contains(&id.index()) || !incoming.insert(id.index()) {
                     return Err(format!(
-                        "Measurement gate {:?} reuses MeasId({}), which another measurement in \
-                         this circuit already holds; measurement ids must be unique",
+                        "Measurement gate {:?} reuses MeasId({}), which another measurement \
+                         already holds; measurement ids must be unique",
                         gate.gate_type,
                         id.index()
                     ));
                 }
                 let successor = id.index().checked_add(1).ok_or_else(|| {
                     format!(
-                        "Measurement gate {:?} carries MeasId({}), leaving no room to mint further ids",
+                        "Measurement gate {:?} carries MeasId({}), leaving no room for a later id",
                         gate.gate_type,
                         id.index()
                     )
                 })?;
-                self.next_meas_id = self.next_meas_id.max(successor);
+                highest_successor = highest_successor.max(successor);
             }
+            self.used_meas_ids.append(&mut incoming);
+            self.next_meas_id = self.next_meas_id.max(highest_successor);
             return Ok(());
         }
 
         if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
             return Ok(());
         }
-        for _ in &gate.qubits {
-            gate.meas_ids.push(MeasId(self.next_meas_id));
-            self.used_meas_ids.insert(self.next_meas_id);
-            self.next_meas_id += 1;
+        // Check the whole run fits before minting any of it. Minted ids are
+        // always above every reserved id, so they cannot collide.
+        let after_last = self
+            .next_meas_id
+            .checked_add(gate.qubits.len())
+            .ok_or_else(|| {
+                format!(
+                    "Measurement gate {:?} needs {} ids but only {} remain below usize::MAX",
+                    gate.gate_type,
+                    gate.qubits.len(),
+                    usize::MAX - self.next_meas_id
+                )
+            })?;
+        for id in self.next_meas_id..after_last {
+            gate.meas_ids.push(MeasId(id));
+            self.used_meas_ids.insert(id);
         }
+        self.next_meas_id = after_last;
         Ok(())
     }
 
@@ -605,6 +626,10 @@ impl DagCircuit {
     /// Removes a gate from the circuit.
     ///
     /// Also removes all qubit wires connected to this gate.
+    ///
+    /// A removed measurement's [`MeasId`] stays reserved: an id names one
+    /// measurement for the life of the circuit, so handing it to a different one
+    /// later would make earlier references ambiguous.
     ///
     /// # Returns
     ///
@@ -632,6 +657,11 @@ impl DagCircuit {
     }
 
     /// Gets a mutable reference to the gate at the given node index.
+    ///
+    /// Editing `meas_ids` through this reference bypasses the uniqueness
+    /// bookkeeping in [`try_add_gate`](Self::try_add_gate), as editing `qubits`
+    /// bypasses [`max_qubit`](Self::max_qubit). Use it to change what a gate
+    /// does, not what it is identified by.
     pub fn gate_mut(&mut self, node: usize) -> Option<&mut Gate> {
         self.gates.get_mut(node).and_then(|g| g.as_mut())
     }
@@ -3177,6 +3207,102 @@ mod measurement_id_tests {
         assert!(
             circuit.try_add_gate(batch).is_err(),
             "a batch cannot name the same measurement twice"
+        );
+    }
+
+    /// A rejected gate must leave no trace. Reserving ids as they are checked
+    /// burned the first id of a batch whose second id was a duplicate, so a
+    /// later legitimate measurement could not use it.
+    #[test]
+    fn a_rejected_gate_reserves_nothing() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let mut clashing = Gate::mz(&[0usize, 1]);
+        clashing.meas_ids = smallvec::smallvec![MeasId(3), MeasId(3)];
+        assert!(circuit.try_add_gate(clashing).is_err());
+
+        let mut later = Gate::mz(&[2usize]);
+        later.meas_ids = smallvec::smallvec![MeasId(3)];
+        assert!(
+            circuit.try_add_gate(later).is_ok(),
+            "MeasId(3) never reached the circuit, so it must still be available"
+        );
+    }
+
+    /// The same applies to the id that triggered an overflow rejection.
+    #[test]
+    fn an_overflow_rejection_reserves_nothing() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut saturated = Gate::mz(&[0usize, 1]);
+        saturated.meas_ids = smallvec::smallvec![MeasId(4), MeasId(usize::MAX)];
+        assert!(circuit.try_add_gate(saturated).is_err());
+
+        let mut later = Gate::mz(&[0usize]);
+        later.meas_ids = smallvec::smallvec![MeasId(4)];
+        assert!(
+            circuit.try_add_gate(later).is_ok(),
+            "MeasId(4) shared a rejected gate, so it must still be available"
+        );
+    }
+
+    /// Minting must not run past `usize::MAX`. A supplied `usize::MAX - 1` puts
+    /// the counter one below the ceiling, so the next mint has no room.
+    #[test]
+    fn minting_past_the_ceiling_is_rejected_not_wrapped() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut near_max = Gate::mz(&[0usize]);
+        near_max.meas_ids = smallvec::smallvec![MeasId(usize::MAX - 1)];
+        circuit.add_gate_auto_wire(near_max);
+
+        let err = circuit
+            .try_add_gate(Gate::mz(&[1usize]))
+            .expect_err("the counter sits at usize::MAX, so nothing can be minted");
+        assert!(
+            err.contains("remain below usize::MAX"),
+            "the error must explain the exhaustion: {err}"
+        );
+    }
+
+    /// A batch must not be part-minted when it does not fit entirely.
+    #[test]
+    fn a_batch_that_does_not_fit_mints_nothing() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let mut near_max = Gate::mz(&[0usize]);
+        near_max.meas_ids = smallvec::smallvec![MeasId(usize::MAX - 2)];
+        circuit.add_gate_auto_wire(near_max);
+
+        assert!(
+            circuit.try_add_gate(Gate::mz(&[1usize, 2])).is_err(),
+            "two ids do not fit below usize::MAX, so neither may be minted"
+        );
+        assert_eq!(
+            circuit.num_measurement_ids(),
+            usize::MAX - 1,
+            "a rejected batch must not move the counter"
+        );
+    }
+
+    /// The counter only ever moves forward. A supplied id below it must not drag
+    /// it back, or a later mint would collide with an id already in use.
+    #[test]
+    fn a_lower_supplied_id_does_not_rewind_the_counter() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let mut high = Gate::mz(&[0usize]);
+        high.meas_ids = smallvec::smallvec![MeasId(10)];
+        circuit.add_gate_auto_wire(high);
+        let mut low = Gate::mz(&[1usize]);
+        low.meas_ids = smallvec::smallvec![MeasId(3)];
+        circuit.add_gate_auto_wire(low);
+
+        let minted = circuit.add_gate_auto_wire(Gate::mz(&[2usize]));
+        assert_eq!(
+            circuit.gate(minted).unwrap().meas_ids[0],
+            MeasId(11),
+            "the counter must stay past the highest supplied id, not follow the latest"
         );
     }
 

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -3424,21 +3424,28 @@ mod measurement_id_tests {
         let gates_after_setup = circuit.gate_count();
         assert_eq!(gates_after_setup, gates_before + 1);
 
-        // One id slot remains; the batch needs two.
-        assert!(
-            circuit.try_mz(&[0usize, 1]).is_err(),
-            "two ids do not fit below usize::MAX"
-        );
-        assert_eq!(
-            circuit.gate_count(),
-            gates_after_setup,
-            "a rejected batch must leave no measurement behind"
-        );
-        assert_eq!(
-            circuit.num_measurement_ids(),
-            usize::MAX - 1,
-            "and must not move the counter"
-        );
+        // One id slot remains; each batch below needs two.
+        for label in ["try_mz", "try_mz_free"] {
+            let rejected = if label == "try_mz" {
+                circuit.try_mz(&[0usize, 1]).map(|_| ())
+            } else {
+                circuit.try_mz_free(&[0usize, 1])
+            };
+            assert!(
+                rejected.is_err(),
+                "{label}: two ids do not fit below usize::MAX"
+            );
+            assert_eq!(
+                circuit.gate_count(),
+                gates_after_setup,
+                "{label}: a rejected batch must leave no measurement behind"
+            );
+            assert_eq!(
+                circuit.num_measurement_ids(),
+                usize::MAX - 1,
+                "{label}: and must not move the counter"
+            );
+        }
     }
 
     /// `usize::MAX` leaves no successor to mint, so it is refused rather than

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -443,6 +443,11 @@ pub struct DagCircuit {
     /// measurement had to fall back on node ids -- which cannot distinguish
     /// measurements inside one batched gate (issue #387).
     next_meas_id: usize,
+    /// Every [`MeasId`] this circuit has minted or accepted.
+    ///
+    /// `next_meas_id` alone cannot reject a supplied id that sits *below* the
+    /// counter, so duplicates need their own record.
+    used_meas_ids: BTreeSet<usize>,
 }
 
 impl DagCircuit {
@@ -457,6 +462,7 @@ impl DagCircuit {
             last_node: None,
             max_qubit: 0,
             next_meas_id: 0,
+            used_meas_ids: BTreeSet::new(),
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -479,6 +485,7 @@ impl DagCircuit {
             last_node: None,
             max_qubit: 0,
             next_meas_id: 0,
+            used_meas_ids: BTreeSet::new(),
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -498,8 +505,9 @@ impl DagCircuit {
     ///
     /// # Panics
     ///
-    /// Panics if [`Gate::validate`] rejects the gate payload. Use
-    /// [`try_add_gate`](Self::try_add_gate) for fallible insertion.
+    /// Panics if [`Gate::validate`] rejects the gate payload, or if the gate
+    /// carries a [`MeasId`] that another measurement in this circuit already
+    /// holds. Use [`try_add_gate`](Self::try_add_gate) for fallible insertion.
     pub fn add_gate(&mut self, gate: Gate) -> usize {
         self.try_add_gate(gate)
             .unwrap_or_else(|err| panic!("Invalid gate: {err}"))
@@ -509,9 +517,12 @@ impl DagCircuit {
     ///
     /// # Errors
     ///
-    /// Returns an error if [`Gate::validate`] rejects the gate payload.
-    pub fn try_add_gate(&mut self, gate: Gate) -> Result<usize, String> {
+    /// Returns an error if [`Gate::validate`] rejects the gate payload, or if
+    /// the gate carries a [`MeasId`] that another measurement in this circuit
+    /// already holds.
+    pub fn try_add_gate(&mut self, mut gate: Gate) -> Result<usize, String> {
         gate.validate()?;
+        self.assign_measurement_ids(&mut gate)?;
         Ok(self.add_gate_unchecked(gate))
     }
 
@@ -525,35 +536,64 @@ impl DagCircuit {
         self.next_meas_id
     }
 
-    /// Give a measurement gate a [`MeasId`] per measured qubit, or make room
-    /// for the ids it already carries.
+    /// Give a measurement gate a [`MeasId`] per measured qubit, or reserve the
+    /// ids it already carries.
     ///
     /// Every gate reaches the circuit through here, so this is the one place
     /// that has to be right. Gates arriving with ids keep them -- they came
     /// from a `TickCircuit` conversion or an external source that owns the
-    /// numbering -- and the counter is advanced past them so a later minted id
-    /// cannot collide.
-    fn assign_measurement_ids(&mut self, gate: &mut Gate) {
-        if !matches!(
-            gate.gate_type,
-            GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
-        ) {
-            return;
-        }
-        if gate.meas_ids.is_empty() {
-            for _ in &gate.qubits {
-                gate.meas_ids.push(MeasId(self.next_meas_id));
-                self.next_meas_id += 1;
-            }
-        } else {
+    /// numbering -- and those ids are reserved so a later minted id cannot
+    /// collide.
+    ///
+    /// Ids are minted only for the gate types the rest of the codebase treats
+    /// as consuming a measurement record, `MZ | MeasureFree`. `MeasureLeaked`
+    /// is a measurement by `Gate::validate` and by `DagCircuit -> TickCircuit`,
+    /// but 46 other sites exclude it; minting here would stamp ids that the
+    /// `TickCircuit` side does not allocate records for, producing duplicates
+    /// at the boundary. Admitting `MeasureLeaked` is a repo-wide sweep tracked
+    /// in #387, not a decision for this one function. Ids supplied on a
+    /// `MeasureLeaked` are still reserved, so the sweep only has to change
+    /// which types get minted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a supplied id repeats one already in the circuit, or
+    /// if a supplied id is [`usize::MAX`] and so leaves no room for a successor.
+    fn assign_measurement_ids(&mut self, gate: &mut Gate) -> Result<(), String> {
+        if !gate.meas_ids.is_empty() {
             for id in &gate.meas_ids {
-                self.next_meas_id = self.next_meas_id.max(id.index() + 1);
+                if !self.used_meas_ids.insert(id.index()) {
+                    return Err(format!(
+                        "Measurement gate {:?} reuses MeasId({}), which another measurement in \
+                         this circuit already holds; measurement ids must be unique",
+                        gate.gate_type,
+                        id.index()
+                    ));
+                }
+                let successor = id.index().checked_add(1).ok_or_else(|| {
+                    format!(
+                        "Measurement gate {:?} carries MeasId({}), leaving no room to mint further ids",
+                        gate.gate_type,
+                        id.index()
+                    )
+                })?;
+                self.next_meas_id = self.next_meas_id.max(successor);
             }
+            return Ok(());
         }
+
+        if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+            return Ok(());
+        }
+        for _ in &gate.qubits {
+            gate.meas_ids.push(MeasId(self.next_meas_id));
+            self.used_meas_ids.insert(self.next_meas_id);
+            self.next_meas_id += 1;
+        }
+        Ok(())
     }
 
-    fn add_gate_unchecked(&mut self, mut gate: Gate) -> usize {
-        self.assign_measurement_ids(&mut gate);
+    fn add_gate_unchecked(&mut self, gate: Gate) -> usize {
         let node_idx = self.dag.add_node();
         // Ensure gates vector is large enough
         if node_idx >= self.gates.len() {
@@ -3051,5 +3091,114 @@ mod measurement_id_tests {
         let node = circuit.add_gate_auto_wire(Gate::h(&[0usize]));
         assert!(circuit.gate(node).unwrap().meas_ids.is_empty());
         assert_eq!(circuit.num_measurement_ids(), 0);
+    }
+
+    /// `MeasureLeaked` is a measurement to `Gate::validate`, but the 46 sites
+    /// that decide which gates consume a measurement record exclude it. Minting
+    /// here would hand out ids that `TickCircuit` allocates no record for, so
+    /// the two sides would disagree about which id belongs to which
+    /// measurement. Admitting it is the repo-wide sweep in #387.
+    #[test]
+    fn measure_leaked_is_not_minted_an_id() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let leaked = circuit.add_gate_auto_wire(Gate::measure_leaked(&[0usize]));
+        let measured = circuit.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        assert!(
+            circuit.gate(leaked).unwrap().meas_ids.is_empty(),
+            "MeasureLeaked must not be minted an id while the record-bearing \
+             predicate elsewhere excludes it"
+        );
+        assert_eq!(
+            circuit.gate(measured).unwrap().meas_ids[0],
+            MeasId(0),
+            "and it must not consume an id that a real measurement needs"
+        );
+        assert_eq!(circuit.num_measurement_ids(), 1);
+    }
+
+    /// An id supplied on a `MeasureLeaked` is still reserved, so the #387 sweep
+    /// only has to change which gate types are minted for.
+    #[test]
+    fn a_supplied_measure_leaked_id_is_still_reserved() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut leaked = Gate::measure_leaked(&[0usize]);
+        leaked.meas_ids = smallvec::smallvec![MeasId(0)];
+        circuit.add_gate_auto_wire(leaked);
+        let measured = circuit.add_gate_auto_wire(Gate::mz(&[1usize]));
+
+        assert_eq!(
+            circuit.gate(measured).unwrap().meas_ids[0],
+            MeasId(1),
+            "minting must not reuse an id a MeasureLeaked already holds"
+        );
+    }
+
+    /// The counter cannot reject a supplied id that sits *below* it, so
+    /// duplicates need their own record. Mint 0..=2, then hand back `MeasId(1)`.
+    #[test]
+    fn a_supplied_id_below_the_counter_is_rejected() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2, 3]);
+        circuit.mz(&[0, 1, 2]);
+
+        let mut duplicate = Gate::mz(&[3usize]);
+        duplicate.meas_ids = smallvec::smallvec![MeasId(1)];
+        let err = circuit
+            .try_add_gate(duplicate)
+            .expect_err("MeasId(1) is already held by the earlier batch");
+        assert!(
+            err.contains("MeasId(1)") && err.contains("unique"),
+            "the error must name the duplicated id: {err}"
+        );
+    }
+
+    /// Two gates supplying the same id collide even when neither was minted.
+    #[test]
+    fn two_gates_supplying_the_same_id_are_rejected() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut first = Gate::mz(&[0usize]);
+        first.meas_ids = smallvec::smallvec![MeasId(7)];
+        circuit.add_gate_auto_wire(first);
+
+        let mut second = Gate::mz(&[1usize]);
+        second.meas_ids = smallvec::smallvec![MeasId(7)];
+        assert!(
+            circuit.try_add_gate(second).is_err(),
+            "a repeated supplied id must be rejected, not silently shadow the first"
+        );
+    }
+
+    /// A duplicate inside one batched gate is caught too.
+    #[test]
+    fn a_batch_repeating_an_id_is_rejected() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut batch = Gate::mz(&[0usize, 1]);
+        batch.meas_ids = smallvec::smallvec![MeasId(3), MeasId(3)];
+        assert!(
+            circuit.try_add_gate(batch).is_err(),
+            "a batch cannot name the same measurement twice"
+        );
+    }
+
+    /// `usize::MAX` leaves no successor to mint, so it is refused rather than
+    /// overflowing the counter.
+    #[test]
+    fn a_saturating_supplied_id_is_rejected() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let mut saturated = Gate::mz(&[0usize]);
+        saturated.meas_ids = smallvec::smallvec![MeasId(usize::MAX)];
+        let err = circuit
+            .try_add_gate(saturated)
+            .expect_err("usize::MAX leaves no room for a successor id");
+        assert!(
+            err.contains("no room"),
+            "the error must explain why the id is refused: {err}"
+        );
     }
 }

--- a/crates/pecos-quantum/src/pass.rs
+++ b/crates/pecos-quantum/src/pass.rs
@@ -1501,13 +1501,31 @@ pub struct AssignMissingMeasIds;
 
 impl CircuitPass for AssignMissingMeasIds {
     fn apply_tick(&self, circuit: &mut TickCircuit) {
-        let mut next_id = circuit.num_measurements();
+        // Count what needs an id and reserve the whole run before touching any
+        // gate, so an exhausted counter is reported rather than overflowing part
+        // way through the assignment.
+        let missing: usize = circuit
+            .iter_gate_batches()
+            .map(|batch| {
+                let gate = batch.as_gate();
+                if gate.gate_type.consumes_measurement_record() && gate.meas_ids.is_empty() {
+                    gate.qubits.len()
+                } else {
+                    0
+                }
+            })
+            .sum();
+        if missing == 0 {
+            return;
+        }
+        let mut next_id = circuit
+            .try_advance_meas_counter(missing)
+            .unwrap_or_else(|err| panic!("{err}"));
+
         for tick in circuit.ticks_mut() {
             for gate_idx in 0..tick.len() {
                 tick.update_gate_batch(gate_idx, |gate| {
-                    let is_measurement =
-                        matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree);
-                    if is_measurement && gate.meas_ids.is_empty() {
+                    if gate.gate_type.consumes_measurement_record() && gate.meas_ids.is_empty() {
                         for _ in &gate.qubits {
                             gate.meas_ids.push(pecos_core::MeasId(next_id));
                             next_id += 1;
@@ -1516,10 +1534,6 @@ impl CircuitPass for AssignMissingMeasIds {
                 })
                 .unwrap_or_else(|err| panic!("{err}"));
             }
-        }
-        let added = next_id - circuit.num_measurements();
-        if added > 0 {
-            circuit.advance_meas_counter(added);
         }
     }
 
@@ -3784,5 +3798,46 @@ mod tests {
         // X(0) can't merge with PZ (qubit 0 busy) or MZ (qubit 0 busy).
         assert_eq!(tc.num_ticks(), 3);
         assert_eq!(count_gate_batches(&tc), 3);
+    }
+
+    /// `AssignMissingMeasIds` fills in ids for measurements that arrived without
+    /// them, numbering from the circuit's current record counter.
+    #[test]
+    fn assign_missing_meas_ids_numbers_from_the_current_counter() {
+        let mut tc = TickCircuit::new();
+        let mut idless = Gate::mz(&[0usize, 1]);
+        idless.meas_ids.clear();
+        tc.tick().try_add_gate(idless).expect("gate is valid");
+
+        assign_missing_meas_ids(&mut tc);
+
+        let ids: Vec<usize> = tc
+            .iter_gate_batches()
+            .flat_map(|batch| {
+                batch
+                    .as_gate()
+                    .meas_ids
+                    .iter()
+                    .map(|id| id.index())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(ids, vec![0, 1]);
+        assert_eq!(tc.num_measurements(), 2);
+    }
+
+    /// The pass reserves the whole run before touching any gate, so an exhausted
+    /// counter is reported rather than overflowing part way through.
+    #[test]
+    #[should_panic(expected = "remain below usize::MAX")]
+    fn assign_missing_meas_ids_reports_an_exhausted_counter() {
+        let mut tc = TickCircuit::new();
+        tc.advance_meas_counter(usize::MAX);
+
+        let mut idless = Gate::mz(&[0usize]);
+        idless.meas_ids.clear();
+        tc.tick().try_add_gate(idless).expect("gate is valid");
+
+        assign_missing_meas_ids(&mut tc);
     }
 }

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1377,7 +1377,11 @@ impl TickCircuit {
         self.ticks.len()
     }
 
-    /// Total number of measurement results produced so far.
+    /// Next measurement record this circuit would hand out.
+    ///
+    /// This is not a count of measurements: externally supplied ids may be
+    /// sparse, in which case it is `max(id) + 1`. The last representable id is
+    /// never handed out, so the counter always has a valid successor.
     #[must_use]
     pub fn num_measurements(&self) -> usize {
         self.next_meas_record
@@ -3098,12 +3102,15 @@ impl<'a> TickHandle<'a> {
     pub fn mz(mut self, qubits: &[impl Into<QubitId> + Copy]) -> Vec<TickMeasRef> {
         let mut gate = Gate::mz(qubits);
         let mut refs = Vec::with_capacity(qubits.len());
-        for &q in qubits {
+        // Reserve the whole batch at once: reserving per qubit left the counter
+        // advanced for the qubits handled before an exhausted one.
+        let base = self
+            .circuit
+            .try_advance_meas_counter(qubits.len())
+            .unwrap_or_else(|err| panic!("{err}"));
+        for (offset, &q) in qubits.iter().enumerate() {
             let tick_idx = self.tick_idx;
-            let record_idx = self
-                .circuit
-                .try_advance_meas_counter(1)
-                .unwrap_or_else(|err| panic!("{err}"));
+            let record_idx = base + offset;
             let mr = MeasId(record_idx);
             gate.meas_ids.push(mr);
             refs.push(TickMeasRef {
@@ -3146,12 +3153,15 @@ impl<'a> TickHandle<'a> {
     pub fn mz_free(mut self, qubits: &[impl Into<QubitId> + Copy]) -> Vec<TickMeasRef> {
         let mut gate = Gate::mz_free(qubits);
         let mut refs = Vec::with_capacity(qubits.len());
-        for &q in qubits {
+        // Reserve the whole batch at once: reserving per qubit left the counter
+        // advanced for the qubits handled before an exhausted one.
+        let base = self
+            .circuit
+            .try_advance_meas_counter(qubits.len())
+            .unwrap_or_else(|err| panic!("{err}"));
+        for (offset, &q) in qubits.iter().enumerate() {
             let tick_idx = self.tick_idx;
-            let record_idx = self
-                .circuit
-                .try_advance_meas_counter(1)
-                .unwrap_or_else(|err| panic!("{err}"));
+            let record_idx = base + offset;
             let mr = MeasId(record_idx);
             gate.meas_ids.push(mr);
             refs.push(TickMeasRef {
@@ -3299,13 +3309,12 @@ impl From<&DagCircuit> for TickCircuit {
             for node_id in layer {
                 if let Some(gate) = dag.gate(node_id) {
                     let mut gate = gate.clone();
-                    // `MeasureLeaked` is excluded. Minting for it here while
-                    // `DagCircuit` does not gave an id-less `MeasureLeaked` the
-                    // same id as a real measurement. Every site that numbers
-                    // measurement records -- both conversions, `meas_ref`,
-                    // `AssignMissingMeasIds`, the fault extractors and the Pauli
-                    // frame lookup -- excludes it.
-                    if matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+                    // Which gates get a record is `consumes_measurement_record`
+                    // and nowhere else. Spelling the types out here let this site
+                    // mint for `MeasureLeaked` while `DagCircuit` did not, so an
+                    // id-less `MeasureLeaked` took the id a real measurement
+                    // already held.
+                    if gate.gate_type.consumes_measurement_record() {
                         if gate.meas_ids.is_empty() {
                             let mut records = Vec::with_capacity(gate.qubits.len());
                             for _ in &gate.qubits {
@@ -3491,7 +3500,7 @@ impl From<&TickCircuit> for DagCircuit {
                     // `MeasureLeaked` is a measurement too but is excluded
                     // here, matching every other site that decides which gates
                     // consume a record.
-                    if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
+                    if split_gate.gate_type.consumes_measurement_record() {
                         for _q in &split_gate.qubits {
                             meas_record_to_node.insert(meas_record_idx, node);
                             meas_record_idx += 1;
@@ -3579,6 +3588,26 @@ impl From<TickCircuit> for DagCircuit {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A batch reserves its records in one step. Reserving one per qubit left the
+    /// counter advanced for the qubits handled before it ran out, so a caller who
+    /// recovered saw records consumed by a measurement that never happened.
+    #[test]
+    fn a_batch_that_cannot_fit_reserves_no_records() {
+        let mut tc = TickCircuit::new();
+        tc.advance_meas_counter(usize::MAX - 1);
+
+        let attempt = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tc.tick().mz(&[0usize, 1]);
+        }));
+
+        assert!(attempt.is_err(), "two records do not fit below usize::MAX");
+        assert_eq!(
+            tc.num_measurements(),
+            usize::MAX - 1,
+            "a batch that cannot fit entirely must reserve none of it"
+        );
+    }
 
     /// `MeasureLeaked` must not be minted a `MeasId` on the way to a
     /// `TickCircuit` when `DagCircuit` does not mint one on the way in. It was,

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1384,8 +1384,35 @@ impl TickCircuit {
     }
 
     /// Advance the measurement counter by `n` (for external MZ gate construction).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the counter would run past [`usize::MAX`]. Use
+    /// [`try_advance_meas_counter`](Self::try_advance_meas_counter) to report
+    /// that instead.
     pub fn advance_meas_counter(&mut self, n: usize) {
-        self.next_meas_record += n;
+        self.try_advance_meas_counter(n)
+            .unwrap_or_else(|err| panic!("{err}"));
+    }
+
+    /// Reserve `n` measurement records, returning the first.
+    ///
+    /// Every record allocation goes through here so the counter has one place to
+    /// be checked. An unchecked `+=` here reached Python as an uncatchable panic
+    /// once a caller supplied an id near [`usize::MAX`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `n` records do not fit below [`usize::MAX`].
+    pub fn try_advance_meas_counter(&mut self, n: usize) -> Result<usize, String> {
+        let base = self.next_meas_record;
+        self.next_meas_record = base.checked_add(n).ok_or_else(|| {
+            format!(
+                "cannot reserve {n} more measurement records; only {} remain below usize::MAX",
+                usize::MAX - base
+            )
+        })?;
+        Ok(base)
     }
 
     /// Get the total number of individual gate applications across all ticks.
@@ -3063,13 +3090,20 @@ impl<'a> TickHandle<'a> {
     /// circuit.tick().mz(&[0]);           // Single qubit
     /// circuit.tick().mz(&[1, 2, 3]);     // Multiple qubits
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the circuit has no measurement records left below
+    /// [`usize::MAX`].
     pub fn mz(mut self, qubits: &[impl Into<QubitId> + Copy]) -> Vec<TickMeasRef> {
         let mut gate = Gate::mz(qubits);
         let mut refs = Vec::with_capacity(qubits.len());
         for &q in qubits {
             let tick_idx = self.tick_idx;
-            let record_idx = self.circuit.next_meas_record;
-            self.circuit.next_meas_record += 1;
+            let record_idx = self
+                .circuit
+                .try_advance_meas_counter(1)
+                .unwrap_or_else(|err| panic!("{err}"));
             let mr = MeasId(record_idx);
             gate.meas_ids.push(mr);
             refs.push(TickMeasRef {
@@ -3104,13 +3138,20 @@ impl<'a> TickHandle<'a> {
     /// let mut circuit = TickCircuit::new();
     /// circuit.tick().mz_free(&[0, 1]);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the circuit has no measurement records left below
+    /// [`usize::MAX`].
     pub fn mz_free(mut self, qubits: &[impl Into<QubitId> + Copy]) -> Vec<TickMeasRef> {
         let mut gate = Gate::mz_free(qubits);
         let mut refs = Vec::with_capacity(qubits.len());
         for &q in qubits {
             let tick_idx = self.tick_idx;
-            let record_idx = self.circuit.next_meas_record;
-            self.circuit.next_meas_record += 1;
+            let record_idx = self
+                .circuit
+                .try_advance_meas_counter(1)
+                .unwrap_or_else(|err| panic!("{err}"));
             let mr = MeasId(record_idx);
             gate.meas_ids.push(mr);
             refs.push(TickMeasRef {
@@ -3258,10 +3299,13 @@ impl From<&DagCircuit> for TickCircuit {
             for node_id in layer {
                 if let Some(gate) = dag.gate(node_id) {
                     let mut gate = gate.clone();
-                    if matches!(
-                        gate.gate_type,
-                        GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
-                    ) {
+                    // `MeasureLeaked` is excluded. Minting for it here while
+                    // `DagCircuit` does not gave an id-less `MeasureLeaked` the
+                    // same id as a real measurement. Every site that numbers
+                    // measurement records -- both conversions, `meas_ref`,
+                    // `AssignMissingMeasIds`, the fault extractors and the Pauli
+                    // frame lookup -- excludes it.
+                    if matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
                         if gate.meas_ids.is_empty() {
                             let mut records = Vec::with_capacity(gate.qubits.len());
                             for _ in &gate.qubits {
@@ -3535,6 +3579,36 @@ impl From<TickCircuit> for DagCircuit {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `MeasureLeaked` must not be minted a `MeasId` on the way to a
+    /// `TickCircuit` when `DagCircuit` does not mint one on the way in. It was,
+    /// so an id-less `MeasureLeaked` took the id a real measurement already
+    /// held, and converting back reported two measurements sharing an id.
+    #[test]
+    fn measure_leaked_survives_a_dag_tick_dag_round_trip() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        dag.add_gate_auto_wire(Gate::measure_leaked(&[0usize]));
+        let measured = dag.add_gate_auto_wire(Gate::mz(&[1usize]));
+        assert_eq!(dag.gate(measured).unwrap().meas_ids[0], MeasId(0));
+
+        let tc = TickCircuit::from(&dag);
+        let ids: Vec<usize> = tc
+            .iter_gate_batches()
+            .flat_map(|batch| {
+                batch
+                    .as_gate()
+                    .meas_ids
+                    .iter()
+                    .map(|id| id.index())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(ids, vec![0], "only the MZ carries an id");
+
+        let round_tripped = DagCircuit::from(&tc);
+        assert_eq!(round_tripped.num_measurement_ids(), 1);
+    }
 
     #[test]
     fn test_basic_tick_circuit() {

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1470,8 +1470,7 @@ impl TickCircuit {
         // Limitation: `mz_with_ids` lets callers supply external stable ids
         // (Guppy result ids) that are not positional, and for those the record
         // index and the id genuinely differ. `TickCircuit` does not store the
-        // positional ordinal separately, so that case cannot be resolved here;
-        // it is tracked in #387 along with the reverse-conversion conflation.
+        // positional ordinal separately, so that case cannot be resolved here.
         let batch = self.get_tick(tick)?.iter_gate_batches().nth(gate_idx)?;
         let gate = batch.as_gate();
         if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
@@ -3445,9 +3444,9 @@ impl From<&TickCircuit> for DagCircuit {
                     // here left later records unmappable, so annotations
                     // referencing them silently resolved to nothing.
                     //
-                    // `MeasureLeaked` is a measurement too and is still
-                    // excluded here; that inconsistency is tracked in #387
-                    // along with the remaining silent drops below.
+                    // `MeasureLeaked` is a measurement too but is excluded
+                    // here, matching every other site that decides which gates
+                    // consume a record.
                     if matches!(split_gate.gate_type, GateType::MZ | GateType::MeasureFree) {
                         for _q in &split_gate.qubits {
                             meas_record_to_node.insert(meas_record_idx, node);

--- a/exp/pecos-zx/src/dem.rs
+++ b/exp/pecos-zx/src/dem.rs
@@ -148,6 +148,9 @@ fn build_zx_body_circuit(body: &DagCircuit, num_rounds: usize) -> DagCircuit {
                     *q = new_q;
                 }
             }
+            // Each round measures a fresh ancilla, so it is a fresh
+            // measurement; carrying the body's id would name them all the same.
+            new_gate.meas_ids.clear();
             target.add_gate_auto_wire(new_gate);
         }
     }

--- a/exp/pecos-zx/src/tableau.rs
+++ b/exp/pecos-zx/src/tableau.rs
@@ -459,22 +459,23 @@ pub fn build_unrolled_circuit(
 ) -> DagCircuit {
     let mut target = DagCircuit::new();
 
-    // Replay init
-    for (_node, gate) in init.iter_gates_topo() {
-        target.add_gate_auto_wire(gate.clone());
-    }
-
-    // Replay body num_rounds times
-    for _ in 0..num_rounds {
-        for (_node, gate) in body.iter_gates_topo() {
-            target.add_gate_auto_wire(gate.clone());
+    // A replayed measurement is a new measurement: round 2's ancilla readout is
+    // not round 1's, and the three segments number their measurements from zero
+    // independently. Dropping the source id lets `target` mint one contiguous
+    // numbering of its own.
+    let mut replay = |source: &DagCircuit| {
+        for (_node, gate) in source.iter_gates_topo() {
+            let mut gate = gate.clone();
+            gate.meas_ids.clear();
+            target.add_gate_auto_wire(gate);
         }
-    }
+    };
 
-    // Replay finalize
-    for (_node, gate) in finalize.iter_gates_topo() {
-        target.add_gate_auto_wire(gate.clone());
+    replay(init);
+    for _ in 0..num_rounds {
+        replay(body);
     }
+    replay(finalize);
 
     target
 }

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -2698,9 +2698,11 @@ impl PyTickCircuit {
     ///     ValueError: Two measurements share a `MeasId`, so the ids cannot
     ///         name them apart.
     fn to_dag_circuit(&self) -> PyResult<PyDagCircuit> {
-        // `DagCircuit` enforces id uniqueness by panicking, which Python cannot
-        // catch as an ordinary exception. Check here, where the error can still
-        // be raised as one.
+        // `DagCircuit` rejects duplicate ids by panicking, which Python cannot
+        // catch as an ordinary exception, and no single `mz_with_ids` call can
+        // see a duplicate spread across calls. Check here, where the error can
+        // still be raised as one. Keep in step with `assign_measurement_ids`
+        // until the conversion itself can report failure.
         let mut seen = BTreeSet::new();
         for batch in self.inner.iter_gate_batches() {
             for id in &batch.as_gate().meas_ids {
@@ -3801,12 +3803,13 @@ impl PyTickHandle {
         // Assign MeasId values (SSA identity for each measurement)
         {
             let mut circuit = handle.circuit.borrow_mut(py);
-            let base = circuit.inner.num_measurements();
+            let base = circuit
+                .inner
+                .try_advance_meas_counter(qubits.len())
+                .map_err(pyo3::exceptions::PyValueError::new_err)?;
             for (i, _) in qubits.iter().enumerate() {
                 gate.meas_ids.push(pecos_core::MeasId(base + i));
             }
-            // Increment the measurement counter
-            circuit.inner.advance_meas_counter(qubits.len());
         }
         let gate_idx = handle.add_gate_get_idx(py, gate)?;
         let tick_idx = handle.tick_idx;
@@ -3844,6 +3847,19 @@ impl PyTickHandle {
                 )));
             }
         }
+        // The highest id has to leave room for a successor, or the record
+        // counter cannot advance past it.
+        let past_highest = meas_ids
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(
+                    "meas_ids contains the largest representable id, leaving no room for a later id",
+                )
+            })?;
         let mut handle = slf.borrow_mut(py);
         let mut gate = Gate::mz(&qubits);
         for &mid in &meas_ids {
@@ -3852,10 +3868,12 @@ impl PyTickHandle {
         {
             let mut circuit = handle.circuit.borrow_mut(py);
             // Advance counter to at least past the highest ID we're assigning
-            let max_id = meas_ids.iter().copied().max().unwrap_or(0);
             let current = circuit.inner.num_measurements();
-            if max_id >= current {
-                circuit.inner.advance_meas_counter(max_id + 1 - current);
+            if past_highest > current {
+                circuit
+                    .inner
+                    .try_advance_meas_counter(past_highest - current)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
             }
         }
         let gate_idx = handle.add_gate_get_idx(py, gate)?;
@@ -3877,11 +3895,13 @@ impl PyTickHandle {
         let mut gate = Gate::mz_free(&qubits);
         {
             let mut circuit = handle.circuit.borrow_mut(py);
-            let base = circuit.inner.num_measurements();
+            let base = circuit
+                .inner
+                .try_advance_meas_counter(qubits.len())
+                .map_err(pyo3::exceptions::PyValueError::new_err)?;
             for (i, _) in qubits.iter().enumerate() {
                 gate.meas_ids.push(pecos_core::MeasId(base + i));
             }
-            circuit.inner.advance_meas_counter(qubits.len());
         }
         let gate_idx = handle.add_gate_get_idx(py, gate)?;
         let tick_idx = handle.tick_idx;

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -1400,15 +1400,22 @@ impl PyDagCircuit {
     ///     >>> dag = `DagCircuit()`
     ///     >>> ms = dag.mz([0, 1])
     ///     >>> dag.detector(ms)
-    fn mz(slf: &Bound<'_, Self>, qubits: Vec<usize>) -> Vec<(usize, usize)> {
-        let refs = slf.borrow_mut().inner.mz(&qubits);
-        refs.iter().map(|r| (r.node, r.qubit.index())).collect()
+    fn mz(slf: &Bound<'_, Self>, qubits: Vec<usize>) -> PyResult<Vec<(usize, usize)>> {
+        let refs = slf
+            .borrow_mut()
+            .inner
+            .try_mz(&qubits)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+        Ok(refs.iter().map(|r| (r.node, r.qubit.index())).collect())
     }
 
     /// Measure and free qubits (destructive measurement).
-    fn mz_free(slf: Py<Self>, py: Python<'_>, qubits: Vec<usize>) -> Py<Self> {
-        slf.borrow_mut(py).inner.mz_free(&qubits);
-        slf
+    fn mz_free(slf: Py<Self>, py: Python<'_>, qubits: Vec<usize>) -> PyResult<Py<Self>> {
+        slf.borrow_mut(py)
+            .inner
+            .try_mz_free(&qubits)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+        Ok(slf)
     }
 
     /// Prepare qubits in the |0> state (Z-basis preparation).
@@ -3800,18 +3807,32 @@ impl PyTickHandle {
     ) -> PyResult<Vec<(usize, usize, usize)>> {
         let mut handle = slf.borrow_mut(py);
         let mut gate = Gate::mz(&qubits);
-        // Assign MeasId values (SSA identity for each measurement)
-        {
-            let mut circuit = handle.circuit.borrow_mut(py);
-            let base = circuit
-                .inner
-                .try_advance_meas_counter(qubits.len())
-                .map_err(pyo3::exceptions::PyValueError::new_err)?;
-            for (i, _) in qubits.iter().enumerate() {
-                gate.meas_ids.push(pecos_core::MeasId(base + i));
-            }
+        // Number the measurements from the current counter but do not commit the
+        // reservation until the gate is actually in: adding it can fail on a
+        // qubit conflict, and a caller that catches that must not be left with
+        // records consumed by a measurement the circuit never got.
+        let base = {
+            let circuit = handle.circuit.borrow(py);
+            let base = circuit.inner.num_measurements();
+            base.checked_add(qubits.len()).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "cannot reserve {} more measurement records; only {} remain below usize::MAX",
+                    qubits.len(),
+                    usize::MAX - base
+                ))
+            })?;
+            base
+        };
+        for (i, _) in qubits.iter().enumerate() {
+            gate.meas_ids.push(pecos_core::MeasId(base + i));
         }
         let gate_idx = handle.add_gate_get_idx(py, gate)?;
+        handle
+            .circuit
+            .borrow_mut(py)
+            .inner
+            .try_advance_meas_counter(qubits.len())
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
         let tick_idx = handle.tick_idx;
         Ok(qubits.iter().map(|&q| (tick_idx, gate_idx, q)).collect())
     }
@@ -3847,27 +3868,28 @@ impl PyTickHandle {
                 )));
             }
         }
-        // The highest id has to leave room for a successor, or the record
-        // counter cannot advance past it.
-        let past_highest = meas_ids
-            .iter()
-            .copied()
-            .max()
-            .unwrap_or(0)
-            .checked_add(1)
-            .ok_or_else(|| {
+        // The highest id has to leave room for a successor, or the record counter
+        // cannot advance past it. With no ids there is nothing to make room for --
+        // treating an empty list as id 0 reserved a record for a measurement that
+        // does not exist.
+        let past_highest = match meas_ids.iter().copied().max() {
+            Some(highest) => Some(highest.checked_add(1).ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(
                     "meas_ids contains the largest representable id, leaving no room for a later id",
                 )
-            })?;
+            })?),
+            None => None,
+        };
         let mut handle = slf.borrow_mut(py);
         let mut gate = Gate::mz(&qubits);
         for &mid in &meas_ids {
             gate.meas_ids.push(pecos_core::MeasId(mid));
         }
-        {
+        let gate_idx = handle.add_gate_get_idx(py, gate)?;
+        // Committed only once the gate is in, so a failed add leaves the counter
+        // where it was.
+        if let Some(past_highest) = past_highest {
             let mut circuit = handle.circuit.borrow_mut(py);
-            // Advance counter to at least past the highest ID we're assigning
             let current = circuit.inner.num_measurements();
             if past_highest > current {
                 circuit
@@ -3876,7 +3898,6 @@ impl PyTickHandle {
                     .map_err(pyo3::exceptions::PyValueError::new_err)?;
             }
         }
-        let gate_idx = handle.add_gate_get_idx(py, gate)?;
         let tick_idx = handle.tick_idx;
         Ok(qubits.iter().map(|&q| (tick_idx, gate_idx, q)).collect())
     }
@@ -3893,17 +3914,32 @@ impl PyTickHandle {
     ) -> PyResult<Vec<(usize, usize, usize)>> {
         let mut handle = slf.borrow_mut(py);
         let mut gate = Gate::mz_free(&qubits);
-        {
-            let mut circuit = handle.circuit.borrow_mut(py);
-            let base = circuit
-                .inner
-                .try_advance_meas_counter(qubits.len())
-                .map_err(pyo3::exceptions::PyValueError::new_err)?;
-            for (i, _) in qubits.iter().enumerate() {
-                gate.meas_ids.push(pecos_core::MeasId(base + i));
-            }
+        // Number the measurements from the current counter but do not commit the
+        // reservation until the gate is actually in: adding it can fail on a
+        // qubit conflict, and a caller that catches that must not be left with
+        // records consumed by a measurement the circuit never got.
+        let base = {
+            let circuit = handle.circuit.borrow(py);
+            let base = circuit.inner.num_measurements();
+            base.checked_add(qubits.len()).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "cannot reserve {} more measurement records; only {} remain below usize::MAX",
+                    qubits.len(),
+                    usize::MAX - base
+                ))
+            })?;
+            base
+        };
+        for (i, _) in qubits.iter().enumerate() {
+            gate.meas_ids.push(pecos_core::MeasId(base + i));
         }
         let gate_idx = handle.add_gate_get_idx(py, gate)?;
+        handle
+            .circuit
+            .borrow_mut(py)
+            .inner
+            .try_advance_meas_counter(qubits.len())
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
         let tick_idx = handle.tick_idx;
         Ok(qubits.iter().map(|&q| (tick_idx, gate_idx, q)).collect())
     }

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -31,6 +31,7 @@ use pecos_quantum::{
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
+use std::collections::BTreeSet;
 
 type PyMixedPauliTerm = (f64, Vec<(String, usize)>);
 
@@ -2692,10 +2693,28 @@ impl PyTickCircuit {
     ///
     /// Returns:
     ///     A new `DagCircuit` with the same gates and qubit wire connections.
-    fn to_dag_circuit(&self) -> PyDagCircuit {
-        PyDagCircuit {
-            inner: DagCircuit::from(&self.inner),
+    ///
+    /// Raises:
+    ///     ValueError: Two measurements share a `MeasId`, so the ids cannot
+    ///         name them apart.
+    fn to_dag_circuit(&self) -> PyResult<PyDagCircuit> {
+        // `DagCircuit` enforces id uniqueness by panicking, which Python cannot
+        // catch as an ordinary exception. Check here, where the error can still
+        // be raised as one.
+        let mut seen = BTreeSet::new();
+        for batch in self.inner.iter_gate_batches() {
+            for id in &batch.as_gate().meas_ids {
+                if !seen.insert(id.index()) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "two measurements share MeasId({}); each measurement needs a unique id",
+                        id.index()
+                    )));
+                }
+            }
         }
+        Ok(PyDagCircuit {
+            inner: DagCircuit::from(&self.inner),
+        })
     }
 
     /// Lower Clifford-angle rotations to named Clifford gates.
@@ -3812,6 +3831,18 @@ impl PyTickHandle {
                 meas_ids.len(),
                 qubits.len()
             )));
+        }
+        // A `MeasId` names one measurement, so a repeat inside a single call is
+        // never meaningful: stamped-id resolution would bind to whichever
+        // occurrence came first. Duplicates spread across calls are caught
+        // later, when the circuit is converted to a `DagCircuit`.
+        let mut seen = BTreeSet::new();
+        for &mid in &meas_ids {
+            if !seen.insert(mid) {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "meas_ids repeats MeasId({mid}); each measurement needs a unique id"
+                )));
+            }
         }
         let mut handle = slf.borrow_mut(py);
         let mut gate = Gate::mz(&qubits);

--- a/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
+++ b/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
@@ -59,7 +59,7 @@ def test_observable_over_two_measurements_uses_both() -> None:
 # takes detectors from the `detectors` metadata JSON, and
 # `InfluenceBuilder::with_circuit_annotations` routes detector annotations to the
 # sampler path instead. The binding fix corrects that path too, but exercising it
-# needs a sampler-level test; tracked with the rest of the annotation work in #387.
+# needs a sampler-level test.
 
 
 def test_measurement_ref_from_another_circuit_is_rejected() -> None:

--- a/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
+++ b/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
@@ -312,6 +312,34 @@ def test_mz_with_ids_rejects_a_repeated_id_in_one_call() -> None:
         tc.tick().mz_with_ids([0, 1], [7, 7])
 
 
+def test_mz_with_ids_rejects_an_id_with_no_room_for_a_successor() -> None:
+    """The largest representable id leaves the record counter nowhere to go. It
+    is refused as a ValueError rather than overflowing."""
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0])
+    with pytest.raises(ValueError, match=r"no room for a later id"):
+        tc.tick().mz_with_ids([0], [2**64 - 1])
+
+
+def test_a_high_supplied_id_does_not_let_a_later_measurement_overflow() -> None:
+    """A legal id just below the ceiling pushes the record counter onto it, so the
+    next measurement has nowhere to go. It is refused as a ValueError rather than
+    overflowing the counter into an uncatchable panic.
+
+    The last representable id is never handed out: the counter must always have a
+    valid successor.
+    """
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0, 1])
+    tc.tick().mz_with_ids([0], [2**64 - 2])
+    with pytest.raises(ValueError, match=r"remain below usize::MAX"):
+        tc.tick().mz([1])
+
+
 def test_duplicate_ids_across_calls_fail_at_dag_conversion() -> None:
     """A duplicate spread across two calls is invisible to either call, so it is
     caught when the circuit is converted."""

--- a/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
+++ b/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
@@ -300,24 +300,26 @@ def test_dem_sampler_builder_rejects_inconsistent_measurement_order() -> None:
         builder.build()
 
 
-def test_dem_sampler_builder_rejects_duplicate_stamped_meas_ids() -> None:
-    """Duplicate stable MeasIds make stamped-id resolution ambiguous (bind to
-    the first occurrence). DemBuilder rejects them; the sampler JSON path must
-    too, rather than silently binding."""
-    from pecos_rslib.qec import DemSamplerBuilder
+def test_mz_with_ids_rejects_a_repeated_id_in_one_call() -> None:
+    """Duplicate stable MeasIds make stamped-id resolution ambiguous (it binds
+    to the first occurrence). A repeat within one call is caught where the ids
+    are supplied, so it never reaches the circuit."""
     from pecos_rslib.quantum import TickCircuit
 
     tc = TickCircuit()
     tc.tick().pz([0, 1])
-    tc.tick().mz_with_ids([0, 1], [7, 7])  # duplicate stamped id 7
-    im = DagFaultAnalyzer(tc.to_dag_circuit()).build_influence_map()
+    with pytest.raises(ValueError, match=r"repeats MeasId\(7\)"):
+        tc.tick().mz_with_ids([0, 1], [7, 7])
 
-    builder = (
-        DemSamplerBuilder(im)
-        .with_noise(**_NOISE)
-        .with_detectors_json(
-            '[{"id": 0, "meas_ids": [7]}]',
-        )
-    )
-    with pytest.raises(ValueError, match=r"duplicate stable MeasId"):
-        builder.build()
+
+def test_duplicate_ids_across_calls_fail_at_dag_conversion() -> None:
+    """A duplicate spread across two calls is invisible to either call, so it is
+    caught when the circuit is converted."""
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0, 1])
+    tc.tick().mz_with_ids([0], [7])
+    tc.tick().mz_with_ids([1], [7])
+    with pytest.raises(ValueError, match=r"share MeasId\(7\)"):
+        tc.to_dag_circuit()

--- a/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
+++ b/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
@@ -312,6 +312,34 @@ def test_mz_with_ids_rejects_a_repeated_id_in_one_call() -> None:
         tc.tick().mz_with_ids([0, 1], [7, 7])
 
 
+def test_measuring_nothing_reserves_no_record() -> None:
+    """An empty measurement produces no results, so it must not consume a record.
+    Treating the empty id list as id 0 reserved one for a measurement that does
+    not exist."""
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().mz_with_ids([], [])
+    assert tc.num_measurements() == 0
+
+
+def test_a_rejected_measurement_does_not_consume_records() -> None:
+    """`mz` can fail on a qubit conflict. A caller that catches that must not be
+    left with records consumed by a measurement the circuit never got, or every
+    later measurement is misnumbered."""
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0])
+    tick = tc.tick()
+    with pytest.raises(ValueError, match=r"distinct qubits"):
+        tick.mz([0, 0])
+    assert tc.num_measurements() == 0
+
+    tick.mz([0])
+    assert tc.num_measurements() == 1
+
+
 def test_mz_with_ids_rejects_an_id_with_no_room_for_a_successor() -> None:
     """The largest representable id leaves the record counter nowhere to go. It
     is refused as a ValueError rather than overflowing."""
@@ -338,6 +366,21 @@ def test_a_high_supplied_id_does_not_let_a_later_measurement_overflow() -> None:
     tc.tick().mz_with_ids([0], [2**64 - 2])
     with pytest.raises(ValueError, match=r"remain below usize::MAX"):
         tc.tick().mz([1])
+
+
+def test_dag_circuit_measurement_reports_exhaustion_as_a_value_error() -> None:
+    """`DagCircuit.mz` mints ids, so it can run out. That has to arrive as a
+    catchable ValueError, not a panic Python cannot handle as an exception."""
+    from pecos_rslib.quantum import DagCircuit, TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0, 1])
+    tc.tick().mz_with_ids([0], [2**64 - 2])
+    dag = tc.to_dag_circuit()
+    assert isinstance(dag, DagCircuit)
+
+    with pytest.raises(ValueError, match=r"remain below usize::MAX"):
+        dag.mz([1])
 
 
 def test_duplicate_ids_across_calls_fail_at_dag_conversion() -> None:

--- a/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
+++ b/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
@@ -1385,14 +1385,28 @@ def test_result_tag_remap_validation_accepts_exact_traced_meas_ids() -> None:
 
 
 def test_result_tag_remap_validation_rejects_duplicate_traced_meas_ids() -> None:
-    from pecos_rslib.quantum import TickCircuit
+    # `mz_with_ids` rejects a repeated id, so a duplicate has to be supplied
+    # directly to reach this validator.
+    class FakeGate:
+        gate_type = "MZ"
+        qubits: ClassVar[list[int]] = [0, 1]
+        meas_ids: ClassVar[list[int]] = [7, 7]
 
-    tc = TickCircuit()
-    tc.tick().mz_with_ids([0, 1], [7, 7])
+    class FakeTick:
+        def gate_batches(self):
+            return [FakeGate()]
+
+    class FakeCircuit:
+        def num_ticks(self) -> int:
+            return 1
+
+        def get_tick(self, tick_idx: int):
+            assert tick_idx == 0
+            return FakeTick()
 
     with pytest.raises(ValueError, match="duplicate measured MeasId"):
         _validate_result_tag_remap_against_traced_measurements(
-            tc,
+            FakeCircuit(),
             {0: 7, 1: 8},
             expected_measurements=2,
         )


### PR DESCRIPTION
Every measurement in a `DagCircuit` now carries a unique `MeasId`. Step 1 of the plan in #387.

`meas_ids` appeared zero times in `dag_circuit.rs` before this: `mz`/`mz_free`/`mz_labeled` built measurements with no identity at all, so PECOS's own native DAG builder was the largest producer of id-less measurements. Anything downstream that needed to name one measurement had to fall back on node ids, which cannot distinguish the measurements inside a single batched gate.

Ids are assigned in `try_add_gate`, the one path every gate reaches the circuit through. Gates arriving with ids keep them -- they came from a `TickCircuit` conversion or an external source that owns the numbering.

## This changes measurement ordering, deliberately

The first revision of this PR claimed no downstream behaviour change. That was wrong, and two independent reviews refuted it by running.

Both `DagFaultAnalyzer::extract_measurements` and `InfluenceBuilder::extract_measurements` pick their sort key based on whether ids are present: topological position when absent, `MeasId` order when present. Minting ids everywhere therefore flips every `DagCircuit`-built circuit onto the id key. Existing tests did not catch it because minted ids coincide with topological order whenever a circuit is built in causal order, which every in-repo test does.

The new ordering is `MeasId` order. For minted ids that comes out as the order the program writes its measurements, which is what a measurement record means and the convention Stim's record offsets use. It is not the same thing as insertion order in general -- `mz_with_ids` accepts external Guppy ids that need not ascend, and there the supplier owns the numbering. The topological alternative is an artifact of how the DAG happens to be walked.

`measurements_extract_in_insertion_order_not_topological_order` pins it. On `dev` that test fails with `[1, 0]`; here it passes with `[0, 1]`.

The end-to-end DEM pipeline is unaffected: sampling a detector-bearing circuit over 50k shots gives identical detector rates and an identical mechanism count on both branches, because offset resolution lands on the same physical measurement either way.

## Uniqueness is enforced, and it found a real bug

A supplied id below the counter could previously duplicate a minted one. Ids are now tracked in a set and a repeat is rejected with a message naming the id, as is `usize::MAX`, which leaves no room for a successor.

That check failed five `pecos-zx` tests on its first run, all genuine: `build_unrolled_circuit` and `build_zx_body_circuit` replay a body segment N times by cloning its gates, so every round inherited the same `MeasId`. A replayed measurement is a new measurement -- round 2's ancilla readout is not round 1's -- so the replays now clear the source id and let the target mint its own numbering. Harmless before this PR only because the ids did not exist.

## MeasureLeaked is not minted for

The first revision included it, to avoid perpetuating the `MZ | MeasureFree` asymmetry. That was the wrong call, and the reasoning given for reversing it was also wrong: I claimed `TickCircuit` allocates `MeasureLeaked` no record. Review showed `DagCircuit -> TickCircuit` did mint for it, so an id-less `MeasureLeaked` took the id a real measurement already held, and `pauli_frame.rs` numbered it positionally while real measurements were numbered by `MeasId`.

Both now exclude it, so every site that numbers measurement records agrees: both conversions, `meas_ref`, `AssignMissingMeasIds`, the fault extractors and the Pauli frame lookup. Admitting `MeasureLeaked` across the remaining classification sites is a repo-wide sweep, not a decision for one function.

Ids *supplied* on a `MeasureLeaked` are still reserved, so the sweep only has to change which types are minted for.

## Verification

- Full workspace `cargo test`, exit 0. Cold `cargo clippy --locked --workspace --all-targets -- -D warnings`, exit 0, on a fresh target directory. `cargo fmt --check` clean.
- Nine mutations run against the new tests, all killed: readmitting `MeasureLeaked` to minting on either side, dropping duplicate rejection, dropping overflow rejection, dropping id reservation, ignoring `MeasureLeaked` entirely, reserving ids before validating the whole gate, dropping the mint-fits precheck, and making the counter follow the latest supplied id instead of the highest.
- Every dev-versus-branch comparison used a separate `CARGO_TARGET_DIR`. A shared warm one silently links stale rlibs across worktrees and makes such comparisons meaningless.

## Not in this PR

The dual sort key in both extractors is now dead on one side but still present. Removing it changes `extract_measurements`'s public contract (`meas_ids` becomes always-populated rather than empty-for-legacy) and touches the DEM consumers, so it is its own change with its own review.


## Correctness of the ordering change, verified end to end

Independent review sampled an ordering-adversarial circuit over 50k shots: the exact DEM emits `error(0.124397) D0`, matching the analytic 2q(1-q), with sampled D0 = 0.1215 and D1 exactly 0.0000. A record-order swap would have moved that mass to D1.

Three consumers that still order measurements topologically -- `hugr_executor.rs`, `noisy_symbolic.rs`, and `pecos-neo`'s DAG command conversion -- were checked and are inert: they keep their own histories in execution-index space and never join influence-map indices, and `pecos-neo` drops `meas_ids` entirely. Inside `pecos-qec` every cross-space join is content-based.
