### PR TITLE
Give MeasRef the measurement identity and drop its node Deref

### DIFF
--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -363,13 +363,11 @@ pub struct MeasRef {
     pub node: usize,
     /// Qubit that was measured.
     pub qubit: QubitId,
-}
-
-impl std::ops::Deref for MeasRef {
-    type Target = usize;
-    fn deref(&self) -> &usize {
-        &self.node
-    }
+    /// Stable identity of the measurement result.
+    ///
+    /// A node cannot name a measurement: a batched measurement gate is one node
+    /// covering several. This is what identifies the individual measurement.
+    pub meas_id: MeasId,
 }
 
 impl From<MeasRef> for usize {
@@ -1762,7 +1760,12 @@ impl DagCircuit {
             .map(|&q| {
                 let qubit = q.into();
                 let node = self.try_add_gate_auto_wire(Gate::mz(&[qubit]))?;
-                Ok(MeasRef { node, qubit })
+                let meas_id = self.minted_meas_id(node);
+                Ok(MeasRef {
+                    node,
+                    qubit,
+                    meas_id,
+                })
             })
             .collect()
     }
@@ -1776,11 +1779,26 @@ impl DagCircuit {
             .map(|&(q, label)| {
                 let qubit = q.into();
                 let node = self.add_gate_auto_wire(Gate::mz(&[qubit]));
-                let mref = MeasRef { node, qubit };
+                let mref = MeasRef {
+                    node,
+                    qubit,
+                    meas_id: self.minted_meas_id(node),
+                };
                 self.set_measurement_label(node, label);
                 mref
             })
             .collect()
+    }
+
+    /// The id minted for a single-qubit measurement node just inserted.
+    ///
+    /// Every measurement reaches the circuit through `try_add_gate`, which mints
+    /// one id per measured qubit, so a node created here always carries exactly
+    /// one.
+    fn minted_meas_id(&self, node: usize) -> MeasId {
+        self.gate(node)
+            .and_then(|gate| gate.meas_ids.first().copied())
+            .expect("a measurement node inserted here always carries a minted id")
     }
 
     /// Set a label on a measurement node.
@@ -3184,6 +3202,36 @@ mod measurement_id_tests {
         let node = circuit.add_gate_auto_wire(Gate::h(&[0usize]));
         assert!(circuit.gate(node).unwrap().meas_ids.is_empty());
         assert_eq!(circuit.num_measurement_ids(), 0);
+    }
+
+    /// A `MeasRef` carries the identity of the measurement, not just its node.
+    ///
+    /// The fixture keeps node index and `MeasId` deliberately different -- the
+    /// preps occupy the low node numbers -- so wiring `meas_id` to the node
+    /// would fail rather than coincide.
+    #[test]
+    fn a_measurement_ref_carries_the_id_the_gate_holds() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let refs = circuit.mz(&[0, 1]);
+
+        assert_eq!(refs.len(), 2);
+        for (offset, mref) in refs.iter().enumerate() {
+            assert_eq!(
+                mref.meas_id,
+                MeasId(offset),
+                "ids are minted in order from zero"
+            );
+            assert_ne!(
+                mref.node, offset,
+                "node and id must not coincide, or this test proves nothing"
+            );
+            assert_eq!(
+                circuit.gate(mref.node).unwrap().meas_ids[0],
+                mref.meas_id,
+                "the ref must carry the id the gate actually holds"
+            );
+        }
     }
 
     /// `MeasureLeaked` is a measurement to `Gate::validate`, but the 46 sites


### PR DESCRIPTION
First step of #387's annotation-identity work (design on `measurement-id-annotations-design`). Deliberately small and independent of the contested parts.

`MeasRef` gains `meas_id`, and its `Deref<Target = usize>` is removed.

A DAG node cannot name a measurement -- a batched measurement gate is one node covering several -- so a reference that derefs to the node lets a node id stand in wherever a measurement is meant. That is the substitution the wider change exists to make impossible, and this is the smallest piece of it.

Nothing broke from dropping `Deref`: `From<MeasRef> for usize` already satisfies the `Into<usize>` bound that `detector()` and friends take, so every existing call site still compiles unchanged.

## The plan said to do more, and trying it showed the plan was wrong

The design's step 1 also said `TickMeasRef` should drop `record_idx`. It cannot, yet. `TickCircuit::detector` stores `record_idx` into `measurement_nodes: Vec<usize>`, so removing the field forces storing `meas_id.index()` as a bare `usize` -- exactly the record-index/identity conflation the change exists to remove. It moves into the pivot commit, where the field it feeds changes type at the same time. The design is corrected accordingly.

## Test

`a_measurement_ref_carries_the_id_the_gate_holds` is deliberately de-aliased: the preps occupy the low node numbers, so node index and `MeasId` cannot coincide and a test that passed by accident would be visible. Mutating `minted_meas_id` to return `MeasId(node)` fails it.

That matters more than usual here. In nearly every existing test in this subsystem `meas_id == record_idx == rank` -- three spaces, one number -- which is why this class of bug has stayed invisible.

## Verification

Cold `cargo clippy --locked --workspace --all-targets -- -D warnings` exit 0 on a fresh target directory. `cargo fmt --check` clean. `cargo test` with the exclusion set `pecos-cli` applies (`rust_cmd.rs`) exit 0, 297 suites. Python lane exit 0. `pre-commit run --all-files` exit 0.
