### PR TITLE
Design: annotations should reference measurements by identity

### DIFF
--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -1,157 +1,208 @@
 # Annotations should reference measurements by identity
 
-Status: proposed. Step 3 of #387. Depends on #391 (merged), which made every
-`DagCircuit` measurement carry a unique `MeasId`.
+Status: proposed, revised after two adversarial design reviews (both
+NEEDS-ADJUSTMENT; core claim upheld, plan corrected). Step 3 of #387. Depends on
+#391 (merged as `cdfddba1b`), which made every `DagCircuit` measurement carry a
+unique `MeasId`.
 
 ## The defect
 
 `AnnotationKind::Detector` and `AnnotationKind::Observable` both store
-`measurement_nodes: Vec<usize>`. That field means two different things:
+`measurement_nodes: Vec<usize>`. That field means two different things: record
+indices in a `TickCircuit` (`tick_circuit.rs:2263`, storing
+`TickMeasRef::record_idx`) and DAG node ids in a `DagCircuit`
+(`dag_circuit.rs:1833`, storing `MeasRef::node`). One type, two meanings,
+translated on every conversion. Five separate fixes have each picked a key space
+and relocated the failure rather than removing it.
 
-- in a `TickCircuit` it holds **measurement record indices** (`tick_circuit.rs`,
-  `detector()` stores `TickMeasRef::record_idx`);
-- in a `DagCircuit` it holds **DAG node ids** (`dag_circuit.rs`, `detector()`
-  stores `MeasRef::node`).
+A node id also cannot name a measurement, because a batched measurement gate is
+one node covering several. Today that ambiguity is resolved three different
+wrong ways:
 
-One type, two meanings, translated on every conversion, with nothing in the type
-system distinguishing them. Five separate fixes have each picked a key space and
-relocated the failure rather than removing it. The conversion between the two
-spaces is where the defects keep appearing.
+- `dem_builder/builder.rs:3365` and `dem_builder/sampler.rs:1109` --
+  `node_to_meas_idx.entry(node).or_insert(...)`, first qubit wins, rest dropped.
+- `influence_builder.rs:200` -- **over-inclusion**: `PauliString::zs(&qubits)`
+  over *every* qubit on the node. (An earlier draft called this first-qubit-wins.
+  It is the opposite failure.)
+- `dag_circuit.rs:1928` `pauli_from_measurement_nodes` spreads Z over all qubits
+  of a batched node, so **the stored annotation Pauli is itself corrupted**, not
+  merely the readout list.
 
-A node id also cannot name a measurement. A batched measurement gate is one node
-covering several measurements, so `Detector { measurement_nodes: [n] }` is
-ambiguous whenever `n` measures more than one qubit. Three consumers resolve that
-ambiguity by taking the first qubit and silently discarding the rest:
-
-- `dem_builder/builder.rs:3367` -- `node_to_meas_idx.entry(node).or_insert(...)`
-- `dem_builder/sampler.rs:1141`
-- `influence_builder.rs:200`
+There is a live bug beyond ambiguity. `TickCircuit::meas_ref` fabricates
+`record_idx: meas_id.index()` (`tick_circuit.rs:1516`) and its own doc admits
+that for external ids "the record index and the id genuinely differ... that case
+cannot be resolved here" (`:1501`). Meanwhile `From<&TickCircuit>` builds
+`meas_record_to_node` by positional counting in **storage** order (`:3503`), so
+an annotation built from `mz_with_ids` misses the map and is silently dropped by
+the `filter_map` at `:3548`/`:3558`.
 
 ## The change
-
-Replace the field with an identity:
 
 ```rust
 Detector   { measurement_ids: Vec<MeasId>, coords: Vec<f64> },
 Observable { measurement_ids: Vec<MeasId> },
 ```
 
-`MeasId` means the same thing in both representations, so conversion **copies**
-the annotation instead of translating it. The translation step -- the thing that
-has produced a defect every time it has been touched -- stops existing.
+`MeasId` travels on the gate itself, and both conversions clone gates, so the id
+is invariant under conversion in both directions. The annotation becomes a copy
+and the translation step -- where a defect has appeared every time it has been
+touched -- stops existing.
 
-Ordinals do not disappear; they move to where they belong. A DEM record offset
-is an export format, computed at the boundary that emits it and never read back
-to identify a measurement. That is the direction `design/measurement-id-system.md`
-already settled on: values carry their identity through the transformation, and
-the negative-offset convention becomes import/export only.
+## Why not the cheaper newtype
 
-## Why the migration is safe to attempt
+Keeping `Vec<usize>` and decreeing it always means record indices, with a
+`RecordIdx` newtype, fails on a concrete witness: "record index" is *itself* two
+different numbers inside `TickCircuit`. Allocation order (the `mz` counter) and
+storage order (tick/batch iteration) diverge under `tick_at` out-of-order filling
+and compatible-batch merging -- documented at `tick_circuit.rs:1495` and live in
+the conversion, which counts storage order while annotations store
+allocation-order indices. A `RecordIdx` newtype would type-bless both disagreeing
+numbers as one space. Identity on the gate is the minimal construct invariant
+under both reorderings.
 
-Changing the field's type is a compile error at every consumer. There is no
-partial state that builds, so nothing can silently keep using the old meaning.
-That property is what the five incremental fixes lacked.
+## Ordering: there is no single canonical order, and that is fine
+
+An earlier draft claimed ordinals retreat to export boundaries. That was wrong.
+Dense ordinals already exist *inside* the analysis:
+
+- `DagFaultInfluenceMap.measurements` is dense and ordered by `MeasId` rank
+  (`propagator/dag.rs:619`, extraction at `:1921`).
+- eeg's `expanded.measurement_qubit` is dense in **expansion** order
+  (`exp/pecos-eeg/src/expand.rs:79`).
+- The Guppy binding documents `runtime_meas_ids` as ids in **runtime execution
+  order** (`dag_circuit_bindings.rs:1841`), which is not numeric id order.
+
+External ids `[10, 3]` therefore give id-rank order `[3, 10]` in the influence
+map and storage order `[10, 3]` in eeg. Both are correct for their own purpose.
+
+**Rule:** every boundary that needs an ordinal computes its own, privately, from
+an explicit `MeasId -> ordinal` map. Ordinals are never interchanged between
+boundaries and never inferred from an id's numeric value. Nothing is ever
+`Vec`-indexed by a raw `MeasId`.
+
+`MeasId`'s own doc currently says it is "directly usable as an array index"
+(`meas_id.rs:24`) and its example does `outcomes[m0.0]`. That contract is false
+for external ids and must be corrected in this series, or it will seed the next
+round of the same bug.
 
 ## What has to change with it
 
 **1. The annotation API must stop discarding the qubit.**
+`DagCircuit::detector(&[impl Into<usize>])` plus `MeasRef: Deref<Target = usize>`
+loses the qubit at the call boundary. It becomes `&[MeasRef]`, `MeasRef` gains
+`meas_id`, and the `Deref` goes -- it is what let a node id stand in for a
+measurement. Dropping `Deref` compiles today because `From<MeasRef> for usize`
+(`dag_circuit.rs:375`) already satisfies the existing bound.
 
-`DagCircuit::detector(&[impl Into<usize>])` accepts anything convertible to
-`usize`, and `MeasRef: Deref<Target = usize>` derefs to the *node*. The qubit is
-lost at the call boundary, so the batched-node fix is unreachable without
-changing this signature. It becomes:
+`TickMeasRef.record_idx` is **removed**, not kept. It is a documented lie for
+external ids, and two callers already do `record_idx - num_measurements`
+arithmetic on it (`crates/pecos/tests/neo_surface_ler_test.rs:211`,
+`crates/benchmarks/benches/modules/fault_catalog.rs:453`) which is already wrong
+for those ids. They migrate to the meas_ids JSON path.
 
-```rust
-pub fn detector(&mut self, measurements: &[MeasRef]) -> usize
-```
+**2. `From<&TickCircuit> for DagCircuit` is removed, not supplemented.**
+Keeping it alongside `TryFrom` is not a preference -- it does not compile. std's
+blanket `impl<T, U: Into<T>> TryFrom<U> for T` makes the pair a coherence error
+(E0119, verified). `From<&DagCircuit> for TickCircuit` -- the other direction --
+becomes a genuine copy and stays infallible.
 
-`MeasRef` already carries `{ node, qubit }` and needs `meas_id` added. The
-`Deref<Target = usize>` impl should go: it is what let a node id be used where a
-measurement was meant.
+This also deletes the `to_dag_circuit` pre-scan, a second implementation of the
+uniqueness invariant that has already drifted once and is structurally
+incomplete: it sees only *supplied* ids, so `add_gate("MZ",[0])` followed by
+`tick().mz([1])` still panics.
 
-The `TickCircuit` side is easier than it looks. `TickCircuit::detector` already
-takes `&[TickMeasRef]`, and `TickMeasRef` already carries `meas_id` -- it stores
-`record_idx` and throws the id away. It only has to keep what it already has.
+**3. Resolution distinguishes three failures, all loud.**
+An id may be unknown, may name a *removed* measurement (`remove_gate` reserves
+the id forever, `dag_circuit.rs:646`, so this is unambiguous), or may name a
+measurement that consumes **no record** -- a `MeasureLeaked` carrying a supplied
+id is accepted and reserved today. Each needs its own error.
 
-**2. `From<&TickCircuit> for DagCircuit` must become fallible.**
+Validation must also reject a record-consuming gate where
+`meas_ids.len() != qubits.len()` and non-empty: the batch merge machinery permits
+it, and position-based lookup (`tick_circuit.rs:1511`) then pairs the wrong id
+with the wrong qubit silently.
 
-Both reviewers asked for this in three consecutive rounds of #391 while it stayed
-out of scope. It is now blocking:
+**4. Silent drops become errors** at `tick_circuit.rs:3548`/`:3558`,
+`dem_builder/builder.rs:3376`, `dem_builder/sampler.rs:1151`, and
+`exp/pecos-eeg/src/builder.rs:236` (`if record_idx < num_meas`).
 
-- the conversion cannot report failure, so `DagCircuit`'s uniqueness check
-  panics, and Python sees a `PanicException` (a `BaseException`, which
-  `except Exception` does not catch);
-- the binding therefore pre-scans for duplicates in front of the conversion,
-  which is a **second implementation of the same invariant**. It has already
-  drifted once, disagreeing about `usize::MAX`;
-- the pre-scan is also structurally incomplete. It sees only *supplied* ids, so
-  a circuit mixing an id-less measurement with a stamped one still panics:
+**5. The Python boundary needs its own migration.** The compile-error safety
+argument is void there -- everything is `usize`.
+`dag_circuit_bindings.rs:996` `extract_measurement_nodes` accepts plain ints as
+raw node indices; after the pivot an int would be silently reinterpreted from
+node space to id space, so the plain-int path is **rejected** and the py `mz()`
+return shape changes (breaking 2-tuple destructuring).
+`PyDagCircuit::annotations()` (`:1522`) omits the field today and must not gain
+it in the old space mid-migration.
 
-```python
-tc.add_gate("MZ", [0])   # generic add_gate reserves no record
-tc.tick().mz([1])        # mints record 0
-tc.to_dag_circuit()      # PanicException: reuses MeasId(0)
-```
+## Migration order
 
-`TryFrom<&TickCircuit> for DagCircuit` lets the binding return `ValueError` and
-deletes the duplicate. Open question below on whether `From` should remain.
+1. `MeasRef` gains `meas_id`, drops `Deref`; `TickMeasRef` drops `record_idx`.
+2. Remove `From<&TickCircuit> for DagCircuit`, add `TryFrom`; bindings route
+   through it; delete the pre-scan.
+3. **Pre-land the id-resolution helpers, tested, alongside the existing
+   node-based paths**: `DagCircuit::find_measurement(MeasId) -> Option<MeasRef>`
+   (an O(gates) scan, deliberately *not* a maintained index, which `gate_mut`
+   could desync -- `dag_circuit.rs:677`); id -> influence-map index via
+   `influence_map.meas_ids`; eeg's id -> expansion-rank map.
+4. **The pivot, one commit:** the field type, the `detector`/`observable`
+   signatures, every consumer switched to the step-3 helpers, fail-loud
+   validation, the Python boundary, and eeg -- all together. These cannot be
+   separated: the consumers pattern-match the field and cannot compile without
+   new resolution, so splitting them means either a huge judgment-laden commit or
+   mechanical `MeasId(x)` fixes that compile and are wrong.
+5. Presentation: each export boundary computes its own ordinal.
 
-**3. Silent drops at annotation resolution must become loud.**
+The compile barrier is weaker than an earlier draft claimed. `MeasId` is
+`pub struct MeasId(pub usize)` with `From<usize>` (`meas_id.rs:41,58`), so the
+mechanical fix at each error site is `MeasId(x)` or `.0`, which compiles and
+silently re-conflates. Remove `From<usize> for MeasId`, keep an explicit
+constructor, and rely on the de-aliased tests below rather than on the compiler.
 
-`filter_map` currently discards unresolvable references at `tick_circuit.rs:3483`
-(both arms), `dem_builder/builder.rs:3315`, and `dem_builder/sampler.rs:1149`
-and `:1173`. An annotation that loses all of its references becomes an output
-with no propagation terms -- not merely empty, but also suppressing the correct
-record-based fallback in `build_dem_from_circuit`.
+Scope cut, stated explicitly: the DEM builder's id plumbing stays untyped --
+`influence_map.meas_ids: Vec<usize>`, `resolve_result_tags(&[usize], &[usize])`
+(`builder.rs:3413`), JSON `meas_ids: Vec<usize>`. Conflation can persist there
+and the tests must cover it.
 
-Under identity references an unresolvable id is unambiguously a bug, so these
-become errors at the boundaries that can report: `build_dem_from_circuit`, the
-sampler, and the new `TryFrom`.
+## Test strategy
 
-`exp/pecos-eeg/src/builder.rs:236` has the same shape (`if record_idx < num_meas`
-silently skips) and should follow.
+The reason conflation bugs have been invisible: in virtually every existing test
+`meas_id == record_idx == rank`. Three spaces, one number.
 
-## Migration, in order
+Every tier needs at least one case with **non-positional, non-contiguous** ids
+(the `mz_with_ids` pattern, e.g. 9, 1, 5):
 
-1. `MeasRef` gains `meas_id`; drop its `Deref`. `TickMeasRef` already has one.
-2. `TryFrom<&TickCircuit> for DagCircuit`; bindings route through it; delete the
-   `to_dag_circuit` pre-scan.
-3. The pivot, one commit: `measurement_nodes: Vec<usize>` becomes
-   `measurement_ids: Vec<MeasId>`; fix every compile error; conversions copy.
-4. Consumers resolve by id. The three first-qubit-wins sites become correct for
-   batched nodes as a consequence, not as separate work.
-5. Silent drops become errors.
-6. Presentation: record offsets computed at export only.
+- Tick <-> Dag round-trip preserving annotation ids.
+- DEM build equivalence: the same physical circuit with positional ids and with
+  scrambled ids must produce byte-identical DEMs.
+- Sampler, `InfluenceBuilder`, and eeg agreement on the same circuit.
+- A batched `Gate::mz(&[0,1])` added via `add_gate`, with a detector referencing
+  exactly one of its measurements -- the case that was previously inexpressible.
+- Duplicate ids within one annotation still **cancel**, not error and not
+  dedupe: `influence_builder.rs:1232` asserts this deliberately, matching the
+  stim XOR convention. `Vec`, not a set.
+- Removed, unknown, and record-less (`MeasureLeaked`) references each producing
+  their own error.
+- Python: `mz_with_ids` annotations, and `ValueError` rather than
+  `PanicException` on every rejection path.
+- A regression proving a sparse id causes no id-sized allocation.
 
-## Open questions for review
+**Acceptance gate:** the end-to-end DEM verification harness from #391, re-run at
+the merge commit. It is the only demonstrated detector of resolution-semantics
+drift in this subsystem.
 
-**Q1.** Should `From<&TickCircuit> for DagCircuit` be kept alongside `TryFrom`,
-panicking as today, or removed outright? Keeping both preserves callers but
-leaves a panicking path; removing it is a breaking change to an std trait impl
-that several call sites use.
+Nothing to migrate on disk: no serde derives on `PauliAnnotation`,
+`AnnotationKind`, or `MeasId`, and the detectors/observables JSON already speaks
+both `records` and `meas_ids` with a consistency check.
 
-**Q2.** Is `Vec<MeasId>` right, or should it be an ordered set? Duplicate ids in
-one annotation are meaningless (XOR of a value with itself), and nothing
-currently rejects them.
+## Out of scope
 
-**Q3.** What happens to an annotation whose measurement is removed by
-`remove_gate`? Today the reference dangles and is silently dropped. Options:
-reject the removal, invalidate the annotation, or make resolution fail loudly.
+#394 (Pauli clearing at non-destructive measurements), #395 (leakage-aware
+history), #396 (channel conventions). None blocks this, and folding any in would
+make the DEM comparisons that validate this change impossible to interpret.
 
-**Q4.** `exp/pecos-eeg` treats `measurement_nodes` as record indices and indexes
-`expanded.measurement_qubit[record_idx]` -- a dense array sized by the
-high-water record count. Legal sparse ids (external Guppy ids up to
-`usize::MAX - 1`) would make that an enormous allocation. Does eeg migrate to
-ids, or keep an explicit export-boundary ordinal?
+## Related
 
-**Q5.** Is there a consumer that genuinely needs the *node*, not the
-measurement? If so, `MeasRef` carrying both is the answer, but the annotation
-should still store only the id.
-
-## Explicitly out of scope
-
-#394 (clearing a propagating Pauli at a non-destructive measurement is wrong,
-pre-existing, four sites hold three opinions), #395 (leakage-aware history where
-a record depends on a leaked result), #396 (DemBuilder vs fault-sampler channel
-conventions). None blocks this and folding any of them in would make the DEM
-comparisons that validate this change impossible to interpret.
+`measurement-id-system.md` in the pecos-docs vault (`~/Repos/pecos-docs/design/`)
+is the origin of the identity-over-ordering direction. It is not in this repo;
+an earlier draft cited it as though it were.

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -1,9 +1,9 @@
 # Annotations should reference measurements by identity
 
-Status: proposed, revised after two adversarial design reviews (both
-NEEDS-ADJUSTMENT; core claim upheld, plan corrected). Step 3 of #387. Depends on
-#391 (merged as `cdfddba1b`), which made every `DagCircuit` measurement carry a
-unique `MeasId`.
+Status: in progress. Revised after three adversarial design reviews (core
+claim upheld, plan corrected twice). Step 3 of #387. Depends on #391 (merged as
+`cdfddba1b`), which made every `DagCircuit` measurement carry a unique `MeasId`.
+Steps 1 and 2 below are merged (#397, #401); the pivot itself is not started.
 
 ## The defect
 
@@ -145,7 +145,9 @@ it in the old space mid-migration.
    would force storing `meas_id.index()` as a bare `usize` -- the exact
    conflation this change removes. It moves into the pivot (step 4).
 2. Remove `From<&TickCircuit> for DagCircuit`, add `TryFrom`; bindings route
-   through it; delete the pre-scan.
+   through it; delete the pre-scan. **Done, PR #401.** The owned
+   `From<TickCircuit>` went with it, and all three production callers already
+   returned `Result`, so no public signature changed.
 3. **Pre-land the id-resolution helpers, tested, alongside the existing
    node-based paths**: `DagCircuit::find_measurement(MeasId) -> Option<MeasRef>`
    (an O(gates) scan, deliberately *not* a maintained index, which `gate_mut`

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -117,10 +117,11 @@ the id forever, `dag_circuit.rs:646`, so this is unambiguous), or may name a
 measurement that consumes **no record** -- a `MeasureLeaked` carrying a supplied
 id is accepted and reserved today. Each needs its own error.
 
-Validation must also reject a record-consuming gate where
-`meas_ids.len() != qubits.len()` and non-empty: the batch merge machinery permits
-it, and position-based lookup (`tick_circuit.rs:1511`) then pairs the wrong id
-with the wrong qubit silently.
+(An earlier draft claimed batch merging permits a gate where
+`meas_ids.len() != qubits.len()`. That is false: `Gate::validate` rejects it and
+`gates.rs:153` refuses to merge such gates. The claim came from a reviewer
+finding explicitly labelled as reasoned rather than verified, and was written in
+without checking.)
 
 **4. Silent drops become errors** at `tick_circuit.rs:3548`/`:3558`,
 `dem_builder/builder.rs:3376`, `dem_builder/sampler.rs:1151`, and
@@ -137,7 +138,12 @@ it in the old space mid-migration.
 
 ## Migration order
 
-1. `MeasRef` gains `meas_id`, drops `Deref`; `TickMeasRef` drops `record_idx`.
+1. `MeasRef` gains `meas_id`, drops `Deref`. **Done, PR #397.**
+   `TickMeasRef` cannot drop `record_idx` here, as an earlier draft said it
+   could: `TickCircuit::detector` stores that field into
+   `measurement_nodes: Vec<usize>`, so removing it before the field changes type
+   would force storing `meas_id.index()` as a bare `usize` -- the exact
+   conflation this change removes. It moves into the pivot (step 4).
 2. Remove `From<&TickCircuit> for DagCircuit`, add `TryFrom`; bindings route
    through it; delete the pre-scan.
 3. **Pre-land the id-resolution helpers, tested, alongside the existing
@@ -160,7 +166,7 @@ silently re-conflates. Remove `From<usize> for MeasId`, keep an explicit
 constructor, and rely on the de-aliased tests below rather than on the compiler.
 
 Scope cut, stated explicitly: the DEM builder's id plumbing stays untyped --
-`influence_map.meas_ids: Vec<usize>`, `resolve_result_tags(&[usize], &[usize])`
+`resolve_result_tags(&[usize], &[usize])`
 (`builder.rs:3413`), JSON `meas_ids: Vec<usize>`. Conflation can persist there
 and the tests must cover it.
 
@@ -194,6 +200,33 @@ drift in this subsystem.
 Nothing to migrate on disk: no serde derives on `PauliAnnotation`,
 `AnnotationKind`, or `MeasId`, and the detectors/observables JSON already speaks
 both `records` and `meas_ids` with a consistency check.
+
+## Unresolved, deliberately
+
+Two questions did not settle on paper because they are about code that does not
+exist yet, and a third is a separate defect:
+
+- **How far to close the `MeasId` forgery seam.** Removing `From<usize>` does not
+  close it -- `MeasId(x)` and `.0` stay public. Closing it properly means private
+  fields, an opaque `MeasRef`, and an opaque Python reference object instead of
+  integer tuples. Whether that is worth its churn is a judgement to make against
+  the pivot, not before it.
+- **The resolver's error taxonomy.** The design wants unknown, removed, and
+  record-less to be distinct errors, but `find_measurement -> Option<MeasRef>`
+  cannot distinguish unknown from removed; only the circuit's private
+  `used_meas_ids` knows. Several consumer APIs also have no error channel at all
+  (`InfluenceBuilder::with_circuit_annotations` and the sampler equivalent both
+  return `Self`). The resolver must be result-bearing and those APIs fallible
+  before the pivot, or the pivot is not mechanical.
+- **`InfluenceBuilder::run_symbolic_simulation` measures only `qubits[0]` of a
+  batched gate** and maps a node to one measurement index. That is a live defect
+  independent of this design and is filed as #398; the identity pivot does not
+  fix it, contrary to what an earlier draft implied.
+
+Also carried forward: removing `From<&TickCircuit> for DagCircuit` must remove
+the owned `From<TickCircuit>` at `tick_circuit.rs:3582` too, and
+`From<&DagCircuit> for TickCircuit` is not proven infallible -- `gate_mut` can
+desync invariants the conversion then unwraps on.
 
 ## Out of scope
 

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -1,0 +1,157 @@
+# Annotations should reference measurements by identity
+
+Status: proposed. Step 3 of #387. Depends on #391 (merged), which made every
+`DagCircuit` measurement carry a unique `MeasId`.
+
+## The defect
+
+`AnnotationKind::Detector` and `AnnotationKind::Observable` both store
+`measurement_nodes: Vec<usize>`. That field means two different things:
+
+- in a `TickCircuit` it holds **measurement record indices** (`tick_circuit.rs`,
+  `detector()` stores `TickMeasRef::record_idx`);
+- in a `DagCircuit` it holds **DAG node ids** (`dag_circuit.rs`, `detector()`
+  stores `MeasRef::node`).
+
+One type, two meanings, translated on every conversion, with nothing in the type
+system distinguishing them. Five separate fixes have each picked a key space and
+relocated the failure rather than removing it. The conversion between the two
+spaces is where the defects keep appearing.
+
+A node id also cannot name a measurement. A batched measurement gate is one node
+covering several measurements, so `Detector { measurement_nodes: [n] }` is
+ambiguous whenever `n` measures more than one qubit. Three consumers resolve that
+ambiguity by taking the first qubit and silently discarding the rest:
+
+- `dem_builder/builder.rs:3367` -- `node_to_meas_idx.entry(node).or_insert(...)`
+- `dem_builder/sampler.rs:1141`
+- `influence_builder.rs:200`
+
+## The change
+
+Replace the field with an identity:
+
+```rust
+Detector   { measurement_ids: Vec<MeasId>, coords: Vec<f64> },
+Observable { measurement_ids: Vec<MeasId> },
+```
+
+`MeasId` means the same thing in both representations, so conversion **copies**
+the annotation instead of translating it. The translation step -- the thing that
+has produced a defect every time it has been touched -- stops existing.
+
+Ordinals do not disappear; they move to where they belong. A DEM record offset
+is an export format, computed at the boundary that emits it and never read back
+to identify a measurement. That is the direction `design/measurement-id-system.md`
+already settled on: values carry their identity through the transformation, and
+the negative-offset convention becomes import/export only.
+
+## Why the migration is safe to attempt
+
+Changing the field's type is a compile error at every consumer. There is no
+partial state that builds, so nothing can silently keep using the old meaning.
+That property is what the five incremental fixes lacked.
+
+## What has to change with it
+
+**1. The annotation API must stop discarding the qubit.**
+
+`DagCircuit::detector(&[impl Into<usize>])` accepts anything convertible to
+`usize`, and `MeasRef: Deref<Target = usize>` derefs to the *node*. The qubit is
+lost at the call boundary, so the batched-node fix is unreachable without
+changing this signature. It becomes:
+
+```rust
+pub fn detector(&mut self, measurements: &[MeasRef]) -> usize
+```
+
+`MeasRef` already carries `{ node, qubit }` and needs `meas_id` added. The
+`Deref<Target = usize>` impl should go: it is what let a node id be used where a
+measurement was meant.
+
+The `TickCircuit` side is easier than it looks. `TickCircuit::detector` already
+takes `&[TickMeasRef]`, and `TickMeasRef` already carries `meas_id` -- it stores
+`record_idx` and throws the id away. It only has to keep what it already has.
+
+**2. `From<&TickCircuit> for DagCircuit` must become fallible.**
+
+Both reviewers asked for this in three consecutive rounds of #391 while it stayed
+out of scope. It is now blocking:
+
+- the conversion cannot report failure, so `DagCircuit`'s uniqueness check
+  panics, and Python sees a `PanicException` (a `BaseException`, which
+  `except Exception` does not catch);
+- the binding therefore pre-scans for duplicates in front of the conversion,
+  which is a **second implementation of the same invariant**. It has already
+  drifted once, disagreeing about `usize::MAX`;
+- the pre-scan is also structurally incomplete. It sees only *supplied* ids, so
+  a circuit mixing an id-less measurement with a stamped one still panics:
+
+```python
+tc.add_gate("MZ", [0])   # generic add_gate reserves no record
+tc.tick().mz([1])        # mints record 0
+tc.to_dag_circuit()      # PanicException: reuses MeasId(0)
+```
+
+`TryFrom<&TickCircuit> for DagCircuit` lets the binding return `ValueError` and
+deletes the duplicate. Open question below on whether `From` should remain.
+
+**3. Silent drops at annotation resolution must become loud.**
+
+`filter_map` currently discards unresolvable references at `tick_circuit.rs:3483`
+(both arms), `dem_builder/builder.rs:3315`, and `dem_builder/sampler.rs:1149`
+and `:1173`. An annotation that loses all of its references becomes an output
+with no propagation terms -- not merely empty, but also suppressing the correct
+record-based fallback in `build_dem_from_circuit`.
+
+Under identity references an unresolvable id is unambiguously a bug, so these
+become errors at the boundaries that can report: `build_dem_from_circuit`, the
+sampler, and the new `TryFrom`.
+
+`exp/pecos-eeg/src/builder.rs:236` has the same shape (`if record_idx < num_meas`
+silently skips) and should follow.
+
+## Migration, in order
+
+1. `MeasRef` gains `meas_id`; drop its `Deref`. `TickMeasRef` already has one.
+2. `TryFrom<&TickCircuit> for DagCircuit`; bindings route through it; delete the
+   `to_dag_circuit` pre-scan.
+3. The pivot, one commit: `measurement_nodes: Vec<usize>` becomes
+   `measurement_ids: Vec<MeasId>`; fix every compile error; conversions copy.
+4. Consumers resolve by id. The three first-qubit-wins sites become correct for
+   batched nodes as a consequence, not as separate work.
+5. Silent drops become errors.
+6. Presentation: record offsets computed at export only.
+
+## Open questions for review
+
+**Q1.** Should `From<&TickCircuit> for DagCircuit` be kept alongside `TryFrom`,
+panicking as today, or removed outright? Keeping both preserves callers but
+leaves a panicking path; removing it is a breaking change to an std trait impl
+that several call sites use.
+
+**Q2.** Is `Vec<MeasId>` right, or should it be an ordered set? Duplicate ids in
+one annotation are meaningless (XOR of a value with itself), and nothing
+currently rejects them.
+
+**Q3.** What happens to an annotation whose measurement is removed by
+`remove_gate`? Today the reference dangles and is silently dropped. Options:
+reject the removal, invalidate the annotation, or make resolution fail loudly.
+
+**Q4.** `exp/pecos-eeg` treats `measurement_nodes` as record indices and indexes
+`expanded.measurement_qubit[record_idx]` -- a dense array sized by the
+high-water record count. Legal sparse ids (external Guppy ids up to
+`usize::MAX - 1`) would make that an enormous allocation. Does eeg migrate to
+ids, or keep an explicit export-boundary ordinal?
+
+**Q5.** Is there a consumer that genuinely needs the *node*, not the
+measurement? If so, `MeasRef` carrying both is the answer, but the annotation
+should still store only the id.
+
+## Explicitly out of scope
+
+#394 (clearing a propagating Pauli at a non-destructive measurement is wrong,
+pre-existing, four sites hold three opinions), #395 (leakage-aware history where
+a record depends on a leaked result), #396 (DemBuilder vs fault-sampler channel
+conventions). None blocks this and folding any of them in would make the DEM
+comparisons that validate this change impossible to interpret.


### PR DESCRIPTION
Design record for step 3 of #387, landing as a document so the reasoning survives independently of whoever implements it.

It has been through two rounds of independent adversarial review plus a re-review of the revision, all before any implementation. Every round found something, including two false claims I wrote into revision 2.

## What it proposes

`AnnotationKind::{Detector,Observable}` reference measurements by `MeasId` rather than by `measurement_nodes: Vec<usize>` -- a field that means record indices in a `TickCircuit` and DAG node ids in a `DagCircuit`. One type, two meanings, translated on every conversion, and the translation is where a defect has appeared every time it has been touched.

## Why it is worth reading even if you do not implement it

The document records several things that are true today and were not obvious:

- "Record index" is itself two different numbers inside `TickCircuit` -- allocation order and storage order -- which diverge under `tick_at` out-of-order filling and compatible-batch merging. That is why newtyping the two spaces separately does not work: a `RecordIdx` newtype would type-bless both disagreeing numbers as one space.
- There is no single canonical measurement order and there should not be. Three exist and are each correct for their purpose: id-rank in the influence map, expansion order in eeg, and runtime execution order at the Guppy binding.
- `MeasId`'s own documentation says it is "directly usable as an array index", which is false for externally supplied ids and needs correcting.
- In nearly every existing test in this subsystem, `meas_id == record_idx == rank` -- three spaces, one number. That is why this class of bug stays invisible, and why the test strategy requires deliberately de-aliased fixtures.

## What is deliberately unresolved

Two questions did not settle on paper and are recorded as open: how far to close the `MeasId` forgery seam, and the resolver's error taxonomy. Both are about code that does not exist yet -- `Option<MeasRef>` cannot distinguish an unknown id from a removed one, and two consumer APIs have no error channel at all. They get decided against the pivot, not before it.

A third item turned out to be a live defect rather than a design question and is filed as #398.

## Status

Step 1 is #397. The document's own step 1 was wrong about `TickMeasRef::record_idx`, which implementation immediately falsified; the correction is in the text.
