### PR TITLE
Make the TickCircuit to DagCircuit conversion fallible

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -271,7 +271,9 @@ impl<'a> DemBuilder<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if detector or observable metadata is malformed.
+    /// Returns an error if detector or observable metadata is malformed, or
+    /// if the `TickCircuit` cannot be converted to a `DagCircuit` (two
+    /// measurements sharing a `MeasId`).
     ///
     /// # Panics
     ///
@@ -301,7 +303,9 @@ impl<'a> DemBuilder<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if detector or observable metadata is malformed.
+    /// Returns an error if detector or observable metadata is malformed, or
+    /// if the `TickCircuit` cannot be converted to a `DagCircuit` (two
+    /// measurements sharing a `MeasId`).
     ///
     /// # Panics
     ///

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -288,7 +288,8 @@ impl<'a> DemBuilder<'a> {
         p_meas: f64,
         p_prep: f64,
     ) -> Result<DetectorErrorModel, DemBuilderError> {
-        let dag = pecos_quantum::DagCircuit::from(circuit);
+        let dag = pecos_quantum::DagCircuit::try_from(circuit)
+            .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?;
         build_dem_from_circuit(&dag, NoiseConfig::new(p1, p2, p_meas, p_prep))
     }
 
@@ -314,7 +315,8 @@ impl<'a> DemBuilder<'a> {
         circuit: &pecos_quantum::TickCircuit,
         noise: NoiseConfig,
     ) -> Result<DetectorErrorModel, DemBuilderError> {
-        let dag = pecos_quantum::DagCircuit::from(circuit);
+        let dag = pecos_quantum::DagCircuit::try_from(circuit)
+            .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?;
         build_dem_from_circuit(&dag, noise)
     }
 
@@ -3772,7 +3774,8 @@ mod tests {
         circuit
             .add_observable_metadata(&[-1], Some(0), Some("L0"))
             .unwrap();
-        let round_tripped = TickCircuit::from(&DagCircuit::from(&circuit));
+        let round_tripped =
+            TickCircuit::from(&DagCircuit::try_from(&circuit).expect("valid circuit"));
         let dem = DemBuilder::from_tick_circuit(&round_tripped, 0.03, 0.0, 0.02, 0.0);
 
         assert_eq!(dem.num_detectors(), 1);

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -375,6 +375,8 @@ impl DemSampler {
     ///
     /// Returns [`DetectorValidationError`] if any detector references a
     /// non-deterministic measurement or the detectors are linearly dependent.
+    /// Also returned when the `TickCircuit` cannot be converted to a
+    /// `DagCircuit` (two measurements sharing a `MeasId`).
     ///
     /// # Example
     ///

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -401,7 +401,11 @@ impl DemSampler {
         circuit: &pecos_quantum::TickCircuit,
         noise: &super::types::NoiseConfig,
     ) -> Result<Self, DetectorValidationError> {
-        let dag = pecos_quantum::DagCircuit::from(circuit);
+        let dag = pecos_quantum::DagCircuit::try_from(circuit).map_err(|err| {
+            DetectorValidationError::InvalidMetadata {
+                message: err.to_string(),
+            }
+        })?;
         Self::from_circuit(&dag, noise)
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -3159,7 +3159,8 @@ mod tests {
             .unwrap();
         tc.tracked_pauli_labeled("tracked_z1", PauliString::z(1));
 
-        let round_tripped = TickCircuit::from(&pecos_quantum::DagCircuit::from(&tc));
+        let round_tripped =
+            TickCircuit::from(&pecos_quantum::DagCircuit::try_from(&tc).expect("valid circuit"));
         assert_eq!(round_tripped.annotations().len(), 1);
         assert!(matches!(
             round_tripped.annotations()[0].kind,

--- a/crates/pecos-qec/src/fault_tolerance/symbolic_replay.rs
+++ b/crates/pecos-qec/src/fault_tolerance/symbolic_replay.rs
@@ -56,7 +56,7 @@ pub(crate) enum ArityError {
 /// entry, two-qubit gates to every consecutive pair. A `DagCircuit` node may
 /// genuinely carry several gate instances -- `DagCircuit::gate_count` counts
 /// them individually -- so applying only the first would silently drop gates.
-/// Only `DagCircuit::from(&TickCircuit)` and the `DagCircuit` builder helpers
+/// Only `DagCircuit::try_from(&TickCircuit)` and the `DagCircuit` builder helpers
 /// split batches; `add_gate_auto_wire` stores a batched `Gate` unchanged.
 ///
 /// # Errors

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3442,7 +3442,33 @@ impl From<DagCircuit> for TickCircuit {
     }
 }
 
-impl From<&TickCircuit> for DagCircuit {
+/// Error converting a [`TickCircuit`] into a [`DagCircuit`].
+///
+/// The conversion inserts every gate into a `DagCircuit`, which enforces
+/// measurement-id uniqueness. A `TickCircuit` can hold ids that violate it --
+/// nothing on that side checks -- so the conversion has to be able to say so
+/// rather than panic partway through.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TickToDagError {
+    /// Tick the rejected gate came from.
+    pub tick: usize,
+    /// Why `DagCircuit` refused it.
+    pub reason: String,
+}
+
+impl fmt::Display for TickToDagError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "cannot convert TickCircuit to DagCircuit: gate at tick {} was rejected: {}",
+            self.tick, self.reason
+        )
+    }
+}
+
+impl std::error::Error for TickToDagError {}
+
+impl TryFrom<&TickCircuit> for DagCircuit {
     /// Convert a `TickCircuit` to a `DagCircuit`.
     ///
     /// Gates are added in tick order, with qubit wires connecting
@@ -3457,11 +3483,19 @@ impl From<&TickCircuit> for DagCircuit {
     /// tc.tick().h(&[0]);
     /// tc.tick().cx(&[(0, 1)]);
     ///
-    /// let dag = DagCircuit::from(&tc);
+    /// let dag = DagCircuit::try_from(&tc).expect("valid circuit");
     /// assert_eq!(dag.gate_count(), 2);
     /// assert_eq!(dag.wire_count(), 1); // H->CX on qubit 0
     /// ```
-    fn from(tc: &TickCircuit) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TickToDagError`] if `DagCircuit` refuses a gate -- in practice,
+    /// two measurements sharing a [`MeasId`], which nothing on the `TickCircuit`
+    /// side prevents.
+    type Error = TickToDagError;
+
+    fn try_from(tc: &TickCircuit) -> Result<Self, Self::Error> {
         let mut dag = DagCircuit::new();
 
         // Track the last node for each qubit to connect wires
@@ -3488,7 +3522,12 @@ impl From<&TickCircuit> for DagCircuit {
 
                 let mut split_nodes = Vec::with_capacity(split_gates.len());
                 for split_gate in &split_gates {
-                    let node = dag.add_gate(split_gate.clone());
+                    let node =
+                        dag.try_add_gate(split_gate.clone())
+                            .map_err(|reason| TickToDagError {
+                                tick: tick_idx,
+                                reason,
+                            })?;
                     split_nodes.push(node);
 
                     // Every measurement consumes a record, `MeasureFree`
@@ -3575,19 +3614,48 @@ impl From<&TickCircuit> for DagCircuit {
             }
         }
 
-        dag
+        Ok(dag)
     }
 }
 
-impl From<TickCircuit> for DagCircuit {
-    fn from(tc: TickCircuit) -> Self {
-        DagCircuit::from(&tc)
+impl TryFrom<TickCircuit> for DagCircuit {
+    type Error = TickToDagError;
+
+    fn try_from(tc: TickCircuit) -> Result<Self, Self::Error> {
+        DagCircuit::try_from(&tc)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Conversion reports a circuit it cannot represent instead of panicking
+    /// partway through building the DAG. `TickCircuit` does not enforce
+    /// measurement-id uniqueness, so it can hold ids `DagCircuit` refuses.
+    #[test]
+    fn converting_a_circuit_with_duplicate_ids_reports_the_tick() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        let mut first = Gate::mz(&[0usize]);
+        first.meas_ids = smallvec::smallvec![MeasId(4)];
+        tc.tick().try_add_gate(first).expect("gate is valid");
+        let mut second = Gate::mz(&[1usize]);
+        second.meas_ids = smallvec::smallvec![MeasId(4)];
+        tc.tick().try_add_gate(second).expect("gate is valid");
+
+        let err = DagCircuit::try_from(&tc)
+            .expect_err("two measurements share MeasId(4), which DagCircuit refuses");
+        assert_eq!(
+            err.tick, 2,
+            "the error must name the tick that was rejected"
+        );
+        assert!(
+            err.reason.contains("MeasId(4)"),
+            "and carry the reason: {}",
+            err.reason
+        );
+    }
 
     /// A batch reserves its records in one step. Reserving one per qubit left the
     /// counter advanced for the qubits handled before it ran out, so a caller who
@@ -3635,7 +3703,7 @@ mod tests {
             .collect();
         assert_eq!(ids, vec![0], "only the MZ carries an id");
 
-        let round_tripped = DagCircuit::from(&tc);
+        let round_tripped = DagCircuit::try_from(&tc).expect("valid circuit");
         assert_eq!(round_tripped.num_measurement_ids(), 1);
     }
 
@@ -3998,7 +4066,7 @@ mod tests {
         assert_eq!(tc1.gate_count(), 3);
         assert_eq!(tc1.gate_batch_count(), 2);
 
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         assert_eq!(dag.gate_count(), 3);
         assert_eq!(dag.gate_node_count(), 3);
         assert_eq!(dag.gate_type_count(GateType::RZ), 3);
@@ -4151,7 +4219,7 @@ mod tests {
         tc.tick().cx(&[(0, 1)]); // Tick 1: CX
         tc.tick().h(&[0]); // Tick 2: H
 
-        let dag = DagCircuit::from(&tc);
+        let dag = DagCircuit::try_from(&tc).expect("valid circuit");
 
         // Check gate counts
         assert_eq!(dag.gate_count(), 4);
@@ -4226,7 +4294,7 @@ mod tests {
                 let mut tc = TickCircuit::new();
                 add_gate(&mut tc, gate_type, &pairs);
 
-                let dag = DagCircuit::from(&tc);
+                let dag = DagCircuit::try_from(&tc).expect("valid circuit");
                 let gates: Vec<_> = dag.iter_gates().map(|(_, gate)| gate).collect();
                 assert_eq!(gates.len(), 2, "{gate_type:?} {pairs:?}");
                 assert!(
@@ -4290,7 +4358,7 @@ mod tests {
         tc1.tick().h(&[1]);
 
         // Convert to DAG and back
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         let tc2 = TickCircuit::from(&dag);
 
         // Should have same structure
@@ -4323,7 +4391,7 @@ mod tests {
         assert_eq!(ms[0].meas_id, MeasId(0));
         assert_eq!(ms[1].meas_id, MeasId(1));
 
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         assert_eq!(dag.gate_count(), 6);
         assert_eq!(dag.gate_node_count(), 6);
         assert_eq!(dag.gate_type_count(GateType::H), 2);
@@ -4438,7 +4506,7 @@ mod tests {
             Attribute::String("Z".into()),
         );
 
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         assert_eq!(dag.gate_count(), 2);
         assert_eq!(dag.gate_node_count(), 2);
         for (node, gate) in dag.iter_gates() {
@@ -4486,7 +4554,7 @@ mod tests {
             &[QubitId::from(0), QubitId::from(1)]
         );
 
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         assert_eq!(dag.gate_count(), 1);
         assert_eq!(dag.gate_node_count(), 1);
         let (_, gate) = dag.iter_gates().next().unwrap();
@@ -4514,7 +4582,7 @@ mod tests {
         tc1.detector_labeled("det01", &ms);
         tc1.observable_labeled("obs1", &[ms[1]]);
 
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         let tc2 = TickCircuit::from(&dag);
 
         assert_eq!(tc2.num_measurements(), 2);
@@ -4610,7 +4678,7 @@ mod tests {
         tc1.observable_labeled("observable", &[ms[1]]);
         tc1.tracked_pauli_labeled("tracked", X(0) & Z(2));
 
-        let tc2 = TickCircuit::from(&DagCircuit::from(&tc1));
+        let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
         assert_eq!(tc2.annotations().len(), 3);
 
         assert_eq!(tc2.annotations()[0].label.as_deref(), Some("detector"));
@@ -4693,7 +4761,7 @@ mod tests {
                 tc1.observable_labeled("obs", &ms);
             }
 
-            let tc2 = TickCircuit::from(&DagCircuit::from(&tc1));
+            let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
             assert_eq!(tc2.gate_count(), tc1.gate_count());
             assert_eq!(tc2.num_measurements(), tc1.num_measurements());
             assert_eq!(tc2.gate_counts_by_type(), tc1.gate_counts_by_type());
@@ -4753,7 +4821,7 @@ mod tests {
             tc1.observable_labeled(&format!("obs-{case_idx}"), &observable_records);
             tc1.tracked_pauli_labeled(&format!("track-{case_idx}"), tracked.clone());
 
-            let tc2 = TickCircuit::from(&DagCircuit::from(&tc1));
+            let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
             assert_eq!(tc2.gate_count(), tc1.gate_count(), "case {case_idx}");
             assert_eq!(
                 tc2.num_measurements(),
@@ -4865,7 +4933,7 @@ mod tests {
         tc1.observable_labeled("obs-all-gates", &[ms[1]]);
         tc1.tracked_pauli_labeled("tracked-all-gates", X(70) & Z(71));
 
-        let tc2 = TickCircuit::from(&DagCircuit::from(&tc1));
+        let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
 
         assert_eq!(tc2.gate_count(), tc1.gate_count());
         assert_eq!(tc2.num_measurements(), tc1.num_measurements());
@@ -5068,7 +5136,7 @@ mod tests {
             };
             tc1.tracked_pauli_labeled(&format!("tracked-{case_idx}"), tracked.clone());
 
-            let tc2 = TickCircuit::from(&DagCircuit::from(&tc1));
+            let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
 
             assert_eq!(
                 tc2.get_meta("case"),
@@ -5185,7 +5253,7 @@ mod tests {
         tc1.tick().meta("round", Attribute::Int(1)).cx(&[(0, 1)]);
 
         // Convert to DAG
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
 
         // Check tick-level attrs are stored with prefix
         assert_eq!(dag.get_attr("tick[0].round"), Some(&Attribute::Int(0)));
@@ -5643,7 +5711,7 @@ mod tests {
         ));
         tc.tick().mz(&[0]);
 
-        let dag = DagCircuit::from(&tc);
+        let dag = DagCircuit::try_from(&tc).expect("valid circuit");
 
         assert_eq!(
             dag.gate_count(),
@@ -6251,7 +6319,7 @@ mod tests {
         tc.observable_labeled("obs0", &ms);
         tc.tracked_pauli_labeled("op0", Z(0) & Z(1));
 
-        let dag = DagCircuit::from(&tc);
+        let dag = DagCircuit::try_from(&tc).expect("valid circuit");
 
         // Annotations should transfer
         assert_eq!(dag.annotations().len(), 3);
@@ -6310,7 +6378,7 @@ mod tests {
         tc1.tracked_pauli_labeled("log_X", X(0) & X(1));
 
         // TickCircuit -> DagCircuit -> TickCircuit
-        let dag = DagCircuit::from(&tc1);
+        let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         let tc2 = TickCircuit::from(&dag);
 
         // Annotation count and labels preserved
@@ -6905,7 +6973,7 @@ mod tests {
         );
         circuit.observable(&kept);
 
-        let dag = crate::DagCircuit::from(&circuit);
+        let dag = crate::DagCircuit::try_from(&circuit).expect("valid circuit");
         let nodes: Vec<Vec<usize>> = dag
             .annotations()
             .iter()

--- a/docs/user-guide/circuit-representation.md
+++ b/docs/user-guide/circuit-representation.md
@@ -508,12 +508,14 @@ TickCircuit can be converted to and from DagCircuit:
     ```rust
     use pecos::quantum::{DagCircuit, TickCircuit};
 
-    // TickCircuit -> DagCircuit
+    // TickCircuit -> DagCircuit. Fallible: a TickCircuit can hold
+    // measurement ids that DagCircuit refuses (duplicates), so the
+    // conversion reports that instead of panicking.
     let mut tick_circuit = TickCircuit::new();
     tick_circuit.tick().h(&[0, 1]);
     tick_circuit.tick().cx(&[(0, 1)]);
 
-    let dag_circuit = DagCircuit::from(tick_circuit);
+    let dag_circuit = DagCircuit::try_from(tick_circuit).expect("no duplicate measurement ids");
 
     // DagCircuit -> TickCircuit
     let tick_circuit2 = TickCircuit::from(dag_circuit);

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -2702,28 +2702,12 @@ impl PyTickCircuit {
     ///     A new `DagCircuit` with the same gates and qubit wire connections.
     ///
     /// Raises:
-    ///     ValueError: Two measurements share a `MeasId`, so the ids cannot
-    ///         name them apart.
+    ///     ValueError: The circuit cannot be converted -- in practice, two
+    ///         measurements sharing a `MeasId`.
     fn to_dag_circuit(&self) -> PyResult<PyDagCircuit> {
-        // `DagCircuit` rejects duplicate ids by panicking, which Python cannot
-        // catch as an ordinary exception, and no single `mz_with_ids` call can
-        // see a duplicate spread across calls. Check here, where the error can
-        // still be raised as one. Keep in step with `assign_measurement_ids`
-        // until the conversion itself can report failure.
-        let mut seen = BTreeSet::new();
-        for batch in self.inner.iter_gate_batches() {
-            for id in &batch.as_gate().meas_ids {
-                if !seen.insert(id.index()) {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "two measurements share MeasId({}); each measurement needs a unique id",
-                        id.index()
-                    )));
-                }
-            }
-        }
-        Ok(PyDagCircuit {
-            inner: DagCircuit::from(&self.inner),
-        })
+        let inner = DagCircuit::try_from(&self.inner)
+            .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+        Ok(PyDagCircuit { inner })
     }
 
     /// Lower Clifford-angle rotations to named Clifford gates.

--- a/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_circuit_representation.rs
+++ b/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_circuit_representation.rs
@@ -218,12 +218,14 @@ fn test_user_guide_circuit_representation_rust_9() {
     use pecos::digraph::DiGraph;
     use pecos::quantum::{Attribute, DagCircuit, TickCircuit};
 
-// TickCircuit -> DagCircuit
+// TickCircuit -> DagCircuit. Fallible: a TickCircuit can hold
+// measurement ids that DagCircuit refuses (duplicates), so the
+// conversion reports that instead of panicking.
 let mut tick_circuit = TickCircuit::new();
 tick_circuit.tick().h(&[0, 1]);
 tick_circuit.tick().cx(&[(0, 1)]);
 
-let dag_circuit = DagCircuit::from(tick_circuit);
+let dag_circuit = DagCircuit::try_from(tick_circuit).expect("no duplicate measurement ids");
 
 // DagCircuit -> TickCircuit
 let tick_circuit2 = TickCircuit::from(dag_circuit);

--- a/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
+++ b/python/quantum-pecos/tests/qec/test_dem_metadata_fail_loud.py
@@ -383,6 +383,25 @@ def test_dag_circuit_measurement_reports_exhaustion_as_a_value_error() -> None:
         dag.mz([1])
 
 
+def test_an_idless_and_a_stamped_measurement_collide_loudly() -> None:
+    """The generic ``add_gate`` reserves no measurement record, so its MZ is
+    id-less until conversion mints one -- which then collides with a measurement
+    that already holds that id.
+
+    A pre-conversion scan cannot catch this: it sees only *supplied* ids, and the
+    colliding id does not exist until the conversion runs. Only the conversion
+    itself can report it.
+    """
+    from pecos_rslib.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().add_gate("MZ", [0])
+    tc.tick().mz([1])
+
+    with pytest.raises(ValueError, match=r"reuses MeasId"):
+        tc.to_dag_circuit()
+
+
 def test_duplicate_ids_across_calls_fail_at_dag_conversion() -> None:
     """A duplicate spread across two calls is invisible to either call, so it is
     caught when the circuit is converted."""
@@ -392,5 +411,5 @@ def test_duplicate_ids_across_calls_fail_at_dag_conversion() -> None:
     tc.tick().pz([0, 1])
     tc.tick().mz_with_ids([0], [7])
     tc.tick().mz_with_ids([1], [7])
-    with pytest.raises(ValueError, match=r"share MeasId\(7\)"):
+    with pytest.raises(ValueError, match=r"reuses MeasId\(7\)"):
         tc.to_dag_circuit()


### PR DESCRIPTION
Step 2 of #387's annotation-identity work (design: #400; step 1: #397). Both reviewers asked for this in three consecutive rounds of #391.

`impl From<&TickCircuit> for DagCircuit` becomes `TryFrom`, returning a `TickToDagError` that names the rejected tick and the reason. The owned `From<TickCircuit>` is removed too -- it delegated to the borrowed impl, so leaving it would have preserved exactly the panic being removed behind one `.unwrap()`.

## What this deletes

The Python binding's `to_dag_circuit` pre-scan: a second implementation of the measurement-id uniqueness invariant, kept "in step with `assign_measurement_ids`" by comment alone. It had already drifted once (disagreeing about `usize::MAX`), and it was structurally incomplete -- it saw only *supplied* ids, so a collision involving an id minted during conversion was invisible to it:

```python
tc = TickCircuit()
tc.tick().add_gate("MZ", [0])   # generic add: reserves no record, id-less
tc.tick().mz([1])               # mints record 0
tc.to_dag_circuit()             # was: PanicException (uncatchable)
```

That case now raises `ValueError: cannot convert TickCircuit to DagCircuit: gate at tick 1 was rejected: Measurement gate MZ reuses MeasId(0)...` -- verified by running. The invariant now lives in one place, and the conversion reports its own failures.

## Migration cost

Smaller than planned for. All three production callers (`DemSampler::from_tick_circuit`, `DetectorErrorModel::try_from_tick_circuit`, `..._with_noise_config`) already return `Result`, so the error maps into their existing enums and **no public signature changed**. The remaining call sites were test round-trips, now `try_from(...).expect(...)`.

One pre-existing test updated: it pinned the deleted pre-scan's error message ("share MeasId(7)"); the conversion's own message ("reuses MeasId(7)") is what survives. Same behaviour, same exception type.

## What this deliberately does not claim

The reverse direction, `From<&DagCircuit> for TickCircuit`, stays infallible-by-signature but is **not proven total**. Two panic sites are reachable from public API: `tick_circuit.rs:3349` unwraps on an invalid gate (reachable if `gate_mut` desyncs a gate's qubits), and `:3432` panics on an annotation referencing a non-measurement node (the public annotation API accepts arbitrary node numbers). Recorded on #387 rather than asserted away; fixing it is its own change, and this PR's scope is the direction with the live defect.

## Verification

Cold `cargo clippy --locked --workspace --all-targets -- -D warnings` exit 0 on a fresh target directory. `cargo fmt --check` clean. `cargo test` with the exclusion set `pecos-cli` applies exit 0, 297 suites. Full Python lane 4371 passed / 68 skipped exit 0 (one more than before -- the new conversion test). `pre-commit run --all-files` exit 0.

New tests: the Rust conversion error carries the offending tick and reason (`converting_a_circuit_with_duplicate_ids_reports_the_tick`), and the Python case above that the pre-scan structurally could not catch (`test_an_idless_and_a_stamped_measurement_collide_loudly`).
