### PR TITLE
Pre-land the measurement-id resolution helpers

### DIFF
--- a/crates/pecos-core/src/meas_id.rs
+++ b/crates/pecos-core/src/meas_id.rs
@@ -21,7 +21,10 @@ use std::fmt;
 
 /// Unique identity of a measurement result.
 ///
-/// Lightweight (pointer-sized), `Copy`, directly usable as an array index.
+/// Lightweight (pointer-sized), `Copy`. An identity, **not an ordinal**:
+/// externally supplied ids may be sparse and out of order, so the numeric
+/// value must never be used to index an array. Boundaries that need a dense
+/// ordinal build their own `MeasId -> index` map.
 /// Analogous to [`QubitId`](crate::QubitId) but for measurement outcomes.
 ///
 /// # Example
@@ -29,13 +32,17 @@ use std::fmt;
 /// ```
 /// use pecos_core::MeasId;
 ///
+/// use std::collections::BTreeMap;
+///
 /// let m0 = MeasId(0);
 /// let m1 = MeasId(1);
 /// assert_ne!(m0, m1);
 ///
-/// // Direct array indexing
-/// let mut outcomes = vec![false; 10];
-/// outcomes[m0.0] = true;
+/// // Resolve through a map, never by the numeric value: externally supplied
+/// // ids (e.g. MeasId(9000)) are legal and would index out of bounds.
+/// let ordinal: BTreeMap<MeasId, usize> = [(m0, 0), (m1, 1)].into();
+/// let mut outcomes = vec![false; ordinal.len()];
+/// outcomes[ordinal[&m0]] = true;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MeasId(pub usize);

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -648,6 +648,13 @@ impl DagFaultInfluenceMap {
     /// once and build their own map.
     #[must_use]
     pub fn meas_index_of(&self, id: pecos_core::MeasId) -> Option<usize> {
+        // `extract_measurements` fills id-less entries of a mixed map with
+        // `MeasId(usize::MAX)` as a sentinel. No real gate can hold that id --
+        // insertion rejects it -- so a lookup for it must not "succeed" against
+        // the sentinel.
+        if id == pecos_core::MeasId(usize::MAX) {
+            return None;
+        }
         self.meas_ids.iter().position(|&held| held == id)
     }
 
@@ -2661,9 +2668,12 @@ mod tests {
         use pecos_core::MeasId;
         use pecos_quantum::Gate;
 
+        // Ids (7, 9, 4) on measurement nodes (3, 4, 5): no id equals its node,
+        // and no id equals its rank (sorted [4, 7, 9] -> ranks 0, 1, 2), so all
+        // three spaces are pairwise distinct for every entry.
         let mut dag = DagCircuit::new();
         dag.pz(&[0, 1, 2]);
-        for (qubit, id) in [(0usize, 9usize), (1, 1), (2, 5)] {
+        for (qubit, id) in [(0usize, 7usize), (1, 9), (2, 4)] {
             let mut gate = Gate::mz(&[qubit]);
             gate.meas_ids = smallvec::smallvec![MeasId(id)];
             dag.add_gate_auto_wire(gate);
@@ -2671,12 +2681,33 @@ mod tests {
 
         let map = DagFaultAnalyzer::new(&dag).build_influence_map();
         assert_eq!(
-            map.meas_index_of(MeasId(5)),
+            map.meas_index_of(MeasId(7)),
             Some(1),
-            "id-rank order is [1, 5, 9], so MeasId(5) is index 1"
+            "id-rank order is [4, 7, 9], so MeasId(7) is index 1"
         );
         assert_eq!(map.meas_index_of(MeasId(9)), Some(2));
+        assert_eq!(map.meas_index_of(MeasId(4)), Some(0));
         assert_eq!(map.meas_index_of(MeasId(2)), None, "absent id is None");
+    }
+
+    /// A mixed map -- some entries stamped, some id-less -- fills the id-less
+    /// slots with `MeasId(usize::MAX)` as a sentinel. Looking that value up
+    /// must not "find" the sentinel: no real gate can hold it.
+    #[test]
+    fn the_id_less_sentinel_never_resolves_as_a_held_id() {
+        use pecos_core::MeasId;
+        let mut map = DagFaultInfluenceMap::with_capacity(0);
+        map.meas_ids = vec![MeasId(4), MeasId(usize::MAX)];
+        assert_eq!(
+            map.meas_index_of(MeasId(usize::MAX)),
+            None,
+            "the sentinel occupies index 1, but it is not a held id"
+        );
+        assert_eq!(
+            map.meas_index_of(MeasId(4)),
+            Some(0),
+            "real ids still resolve"
+        );
     }
 
     /// Simple Z-stabilizer measurement circuit: measures Z0 Z1 parity

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -639,6 +639,18 @@ pub struct DagFaultInfluenceMap {
 }
 
 impl DagFaultInfluenceMap {
+    /// Index into `measurements` of the measurement holding `id`.
+    ///
+    /// This is the influence map's private ordinal (id-rank order). `None`
+    /// means the id is absent from this map -- the map cannot distinguish why;
+    /// resolve against the circuit with `DagCircuit::find_measurement` when the
+    /// reason matters. Callers resolving many ids should iterate `meas_ids`
+    /// once and build their own map.
+    #[must_use]
+    pub fn meas_index_of(&self, id: pecos_core::MeasId) -> Option<usize> {
+        self.meas_ids.iter().position(|&held| held == id)
+    }
+
     /// Creates a new `SoA` map with capacity for the given number of locations.
     #[must_use]
     pub fn with_capacity(num_locations: usize) -> Self {
@@ -2639,6 +2651,32 @@ mod tests {
             meas_ids.iter().map(|id| id.index()).collect::<Vec<_>>(),
             vec![1, 5, 9]
         );
+    }
+
+    /// `meas_index_of` resolves an id to the map's own ordinal (id-rank
+    /// order), which the scrambled supplied ids keep distinct from both the
+    /// id values and insertion order.
+    #[test]
+    fn meas_index_of_resolves_against_the_maps_own_ordering() {
+        use pecos_core::MeasId;
+        use pecos_quantum::Gate;
+
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1, 2]);
+        for (qubit, id) in [(0usize, 9usize), (1, 1), (2, 5)] {
+            let mut gate = Gate::mz(&[qubit]);
+            gate.meas_ids = smallvec::smallvec![MeasId(id)];
+            dag.add_gate_auto_wire(gate);
+        }
+
+        let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+        assert_eq!(
+            map.meas_index_of(MeasId(5)),
+            Some(1),
+            "id-rank order is [1, 5, 9], so MeasId(5) is index 1"
+        );
+        assert_eq!(map.meas_index_of(MeasId(9)), Some(2));
+        assert_eq!(map.meas_index_of(MeasId(2)), None, "absent id is None");
     }
 
     /// Simple Z-stabilizer measurement circuit: measures Z0 Z1 parity

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -379,22 +379,27 @@ impl From<MeasRef> for usize {
 
 /// Why a [`MeasId`] failed to resolve to a measurement.
 ///
-/// The three cases mean different things and need different reactions, so
+/// The four cases mean different things and need different reactions, so
 /// callers must be able to tell them apart -- an `Option` cannot:
 ///
 /// - an **unknown** id points at a caller bug (or a reference from a different
-///   circuit);
+///   circuit, though a colliding foreign id cannot be detected as foreign);
 /// - a **removed** id was real once, so the annotation that carries it went
-///   stale rather than being wrong from the start;
+///   stale rather than being wrong from the start. Removal is tracked with
+///   tombstones, so this genuinely means `remove_gate` ran;
 /// - a **record-less** id names a measurement that exists but produces no
 ///   classical result (`MeasureLeaked` with a supplied id), so nothing that
-///   reads records can use it.
+///   reads records can use it;
+/// - an **inconsistent** id means the circuit's bookkeeping and its gates
+///   disagree -- only reachable through `gate_mut` desync -- and the only safe
+///   reaction is to stop.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeasResolveError {
     /// The id was never minted or supplied in this circuit.
     Unknown(MeasId),
-    /// The id was reserved, but no gate holds it any more -- its measurement
-    /// was removed. Removed ids stay reserved forever, so this is unambiguous.
+    /// The id's measurement was removed via `remove_gate`. Tracked with a
+    /// tombstone, so this cannot be confused with a `gate_mut` edit that
+    /// merely overwrote the id -- that is [`Inconsistent`](Self::Inconsistent).
     Removed(MeasId),
     /// The id names a measurement that consumes no measurement record.
     RecordLess {
@@ -403,8 +408,10 @@ pub enum MeasResolveError {
         /// The node holding the record-less measurement.
         node: usize,
     },
-    /// The circuit's id bookkeeping disagrees with its gates: the id is held by
-    /// a gate but was never reserved, or is held by more than one gate.
+    /// The circuit's id bookkeeping disagrees with its gates: the id is held
+    /// but was never reserved, held more than once (across gates or within one
+    /// batch), held despite its measurement having been removed, or reserved
+    /// yet erased from every gate without a removal.
     ///
     /// Insertion validation makes both states unrepresentable, so reaching this
     /// means a [`gate_mut`](DagCircuit::gate_mut) edit desynced the circuit.
@@ -512,6 +519,13 @@ pub struct DagCircuit {
     /// `next_meas_id` alone cannot reject a supplied id that sits *below* the
     /// counter, so duplicates need their own record.
     used_meas_ids: BTreeSet<usize>,
+    /// Ids whose measurement was removed via [`remove_gate`](Self::remove_gate).
+    ///
+    /// A tombstone makes `Removed` mean what it says: without one, "reserved
+    /// but unheld" cannot distinguish a genuine removal from a `gate_mut` edit
+    /// that overwrote the id -- and a removed id forged onto a live gate would
+    /// resolve as if nothing happened.
+    removed_meas_ids: BTreeSet<usize>,
 }
 
 impl DagCircuit {
@@ -527,6 +541,7 @@ impl DagCircuit {
             max_qubit: 0,
             next_meas_id: 0,
             used_meas_ids: BTreeSet::new(),
+            removed_meas_ids: BTreeSet::new(),
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -550,6 +565,7 @@ impl DagCircuit {
             max_qubit: 0,
             next_meas_id: 0,
             used_meas_ids: BTreeSet::new(),
+            removed_meas_ids: BTreeSet::new(),
             annotations: Vec::new(),
             measurement_labels: BTreeMap::new(),
         }
@@ -615,10 +631,9 @@ impl DagCircuit {
     ///   numbers, and a foreign id that collides with a local one resolves to
     ///   the local measurement. Rejecting foreign references needs validation
     ///   at the point a reference enters a circuit, not here.
-    /// - [`MeasResolveError::Removed`] -- the id was reserved but no gate holds
-    ///   it. Usually its measurement was removed; a `gate_mut` edit that
-    ///   overwrote the id leaves the same state, and the two cannot be told
-    ///   apart without tombstones.
+    /// - [`MeasResolveError::Removed`] -- the id's measurement was removed via
+    ///   [`remove_gate`](Self::remove_gate), tracked with a tombstone. An id
+    ///   erased by a `gate_mut` edit is *not* this; it is `Inconsistent`.
     /// - [`MeasResolveError::Inconsistent`] -- the id is held but unreserved,
     ///   or held twice. Only reachable through `gate_mut` desync; stop trusting
     ///   the circuit.
@@ -649,14 +664,22 @@ impl DagCircuit {
             }
         }
         let Some((node, position)) = found else {
-            return if self.used_meas_ids.contains(&id.index()) {
+            return if self.removed_meas_ids.contains(&id.index()) {
                 Err(MeasResolveError::Removed(id))
+            } else if self.used_meas_ids.contains(&id.index()) {
+                // Reserved, never removed, yet no gate holds it: a gate_mut
+                // edit erased the id. Not a removal, so not `Removed`.
+                Err(MeasResolveError::Inconsistent(id))
             } else {
                 Err(MeasResolveError::Unknown(id))
             };
         };
-        if !self.used_meas_ids.contains(&id.index()) {
-            // Held but never reserved: a forged id written in through gate_mut.
+        if !self.used_meas_ids.contains(&id.index()) || self.removed_meas_ids.contains(&id.index())
+        {
+            // Held but never reserved (forged in through gate_mut), or held
+            // despite its measurement having been removed (a removed id forged
+            // onto a live gate). Either way the holder cannot legitimately own
+            // this id.
             return Err(MeasResolveError::Inconsistent(id));
         }
         let gate = self.gates[node].as_ref().expect("found above");
@@ -800,7 +823,13 @@ impl DagCircuit {
 
         self.dag.remove_node(node);
         if node < self.gates.len() {
-            self.gates[node].take()
+            let removed = self.gates[node].take();
+            if let Some(gate) = &removed {
+                for id in &gate.meas_ids {
+                    self.removed_meas_ids.insert(id.index());
+                }
+            }
+            removed
         } else {
             None
         }
@@ -3372,6 +3401,60 @@ mod measurement_id_tests {
             circuit.find_measurement(stolen),
             Err(MeasResolveError::Inconsistent(stolen)),
             "a duplicated id must not silently resolve to whichever gate scans first"
+        );
+    }
+
+    /// A removed id forged onto a live gate must not resolve: `used_meas_ids`
+    /// proves only that an id was reserved *once*, so without tombstones this
+    /// laundered a stale annotation onto a different measurement.
+    #[test]
+    fn a_removed_id_reassigned_by_gate_mut_does_not_resolve() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let refs = circuit.mz(&[0, 1]);
+        let dead = refs[0].meas_id;
+        circuit.remove_gate(refs[0].node);
+        circuit.gate_mut(refs[1].node).unwrap().meas_ids[0] = dead;
+
+        assert_eq!(
+            circuit.find_measurement(dead),
+            Err(MeasResolveError::Inconsistent(dead)),
+            "a removed id on a live gate is laundering, not a resolution"
+        );
+    }
+
+    /// An id erased from every gate without a removal is `Inconsistent`, not
+    /// `Removed` -- `Removed` now genuinely means `remove_gate` ran.
+    #[test]
+    fn an_id_erased_without_removal_is_inconsistent_not_removed() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let held = circuit.mz(&[0]);
+        circuit.gate_mut(held[0].node).unwrap().meas_ids[0] = MeasId(50);
+
+        assert_eq!(
+            circuit.find_measurement(held[0].meas_id),
+            Err(MeasResolveError::Inconsistent(held[0].meas_id)),
+            "the id vanished without remove_gate, so nothing about it can be trusted"
+        );
+    }
+
+    /// A duplicate *within one batched gate* is caught too, not only across
+    /// gates -- nothing previously pinned the per-position inner loop.
+    #[test]
+    fn a_duplicate_within_one_batch_is_inconsistent() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut batch = Gate::mz(&[0usize, 1]);
+        batch.meas_ids = smallvec::smallvec![MeasId(8), MeasId(2)];
+        let node = circuit.add_gate_auto_wire(batch);
+        let dup = MeasId(8);
+        circuit.gate_mut(node).unwrap().meas_ids[1] = dup;
+
+        assert_eq!(
+            circuit.find_measurement(dup),
+            Err(MeasResolveError::Inconsistent(dup)),
+            "one gate holding an id twice must not resolve to either position"
         );
     }
 

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -21,6 +21,7 @@
 //! flowing between gates, not just abstract dependencies.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 use pecos_core::gate_type::GateType;
 use pecos_core::{Angle64, Gate, MeasId, QubitId, TimeUnits};
@@ -376,6 +377,59 @@ impl From<MeasRef> for usize {
     }
 }
 
+/// Why a [`MeasId`] failed to resolve to a measurement.
+///
+/// The three cases mean different things and need different reactions, so
+/// callers must be able to tell them apart -- an `Option` cannot:
+///
+/// - an **unknown** id points at a caller bug (or a reference from a different
+///   circuit);
+/// - a **removed** id was real once, so the annotation that carries it went
+///   stale rather than being wrong from the start;
+/// - a **record-less** id names a measurement that exists but produces no
+///   classical result (`MeasureLeaked` with a supplied id), so nothing that
+///   reads records can use it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MeasResolveError {
+    /// The id was never minted or supplied in this circuit.
+    Unknown(MeasId),
+    /// The id was reserved, but no gate holds it any more -- its measurement
+    /// was removed. Removed ids stay reserved forever, so this is unambiguous.
+    Removed(MeasId),
+    /// The id names a measurement that consumes no measurement record.
+    RecordLess {
+        /// The id in question.
+        id: MeasId,
+        /// The node holding the record-less measurement.
+        node: usize,
+    },
+}
+
+impl fmt::Display for MeasResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unknown(id) => write!(
+                f,
+                "MeasId({}) does not name a measurement in this circuit",
+                id.index()
+            ),
+            Self::Removed(id) => write!(
+                f,
+                "MeasId({})'s measurement was removed from this circuit",
+                id.index()
+            ),
+            Self::RecordLess { id, node } => write!(
+                f,
+                "MeasId({}) names a measurement at node {node} that consumes no \
+                 measurement record",
+                id.index()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MeasResolveError {}
+
 /// The role of a Pauli annotation in the circuit.
 ///
 /// All three kinds track the same thing -- whether a Pauli string flips due to
@@ -530,6 +584,56 @@ impl DagCircuit {
     #[must_use]
     pub fn num_measurement_ids(&self) -> usize {
         self.next_meas_id
+    }
+
+    /// Resolve a [`MeasId`] to the measurement that holds it.
+    ///
+    /// A deliberate O(gates) scan rather than a maintained index: an index
+    /// would silently desync under [`gate_mut`](Self::gate_mut) edits, and
+    /// consumers that resolve many ids build their own map from one pass over
+    /// the circuit.
+    ///
+    /// # Errors
+    ///
+    /// - [`MeasResolveError::Unknown`] -- the id was never minted or supplied
+    ///   here. A reference from a different circuit lands in this case.
+    /// - [`MeasResolveError::Removed`] -- the id was reserved but no gate holds
+    ///   it; its measurement was removed. Ids stay reserved for the life of the
+    ///   circuit, so this cannot be confused with `Unknown`.
+    /// - [`MeasResolveError::RecordLess`] -- the id names a measurement that
+    ///   consumes no measurement record (`MeasureLeaked` carrying a supplied
+    ///   id). It is a real measurement, but nothing that reads records can
+    ///   resolve through it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a gate holds more ids than qubits. [`Gate::validate`] makes
+    /// that unrepresentable through every insertion path, so reaching it means
+    /// a [`gate_mut`](Self::gate_mut) edit desynced the gate.
+    pub fn find_measurement(&self, id: MeasId) -> Result<MeasRef, MeasResolveError> {
+        for (node, gate) in self.gates.iter().enumerate() {
+            let Some(gate) = gate.as_ref() else { continue };
+            let Some(position) = gate.meas_ids.iter().position(|&held| held == id) else {
+                continue;
+            };
+            if !gate.gate_type.consumes_measurement_record() {
+                return Err(MeasResolveError::RecordLess { id, node });
+            }
+            let qubit = *gate
+                .qubits
+                .get(position)
+                .expect("a validated measurement carries one id per qubit");
+            return Ok(MeasRef {
+                node,
+                qubit,
+                meas_id: id,
+            });
+        }
+        if self.used_meas_ids.contains(&id.index()) {
+            Err(MeasResolveError::Removed(id))
+        } else {
+            Err(MeasResolveError::Unknown(id))
+        }
     }
 
     /// Check that `count` ids can still be minted, without minting them.
@@ -3202,6 +3306,65 @@ mod measurement_id_tests {
         let node = circuit.add_gate_auto_wire(Gate::h(&[0usize]));
         assert!(circuit.gate(node).unwrap().meas_ids.is_empty());
         assert_eq!(circuit.num_measurement_ids(), 0);
+    }
+
+    /// `find_measurement` resolves an id to the exact measurement inside a
+    /// batched node -- the thing a node index cannot express.
+    ///
+    /// De-aliased on purpose: supplied ids (9, 4) match neither node indices
+    /// nor qubit positions, so resolving by anything except the id fails.
+    #[test]
+    fn find_measurement_names_one_measurement_inside_a_batch() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let mut batch = Gate::mz(&[0usize, 1]);
+        batch.meas_ids = smallvec::smallvec![MeasId(9), MeasId(4)];
+        let node = circuit.add_gate_auto_wire(batch);
+
+        let mref = circuit.find_measurement(MeasId(4)).expect("id 4 exists");
+        assert_eq!(mref.node, node);
+        assert_eq!(
+            mref.qubit.index(),
+            1,
+            "MeasId(4) is the batch's second measurement, so qubit 1"
+        );
+        assert_eq!(mref.meas_id, MeasId(4));
+    }
+
+    /// The three failure cases are distinct errors, because they mean different
+    /// things: a caller bug, a stale annotation, and a measurement with no
+    /// classical result.
+    #[test]
+    fn find_measurement_distinguishes_unknown_removed_and_record_less() {
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1, 2]);
+        let refs = circuit.mz(&[0]);
+        let mut leaked = Gate::measure_leaked(&[1usize]);
+        leaked.meas_ids = smallvec::smallvec![MeasId(7)];
+        let leaked_node = circuit.add_gate_auto_wire(leaked);
+
+        assert_eq!(
+            circuit.find_measurement(MeasId(999)),
+            Err(MeasResolveError::Unknown(MeasId(999))),
+            "an id never minted or supplied is Unknown"
+        );
+
+        assert_eq!(
+            circuit.find_measurement(MeasId(7)),
+            Err(MeasResolveError::RecordLess {
+                id: MeasId(7),
+                node: leaked_node,
+            }),
+            "a MeasureLeaked's supplied id names a real but record-less measurement"
+        );
+
+        let held = refs[0].meas_id;
+        circuit.remove_gate(refs[0].node);
+        assert_eq!(
+            circuit.find_measurement(held),
+            Err(MeasResolveError::Removed(held)),
+            "a reserved id whose gate is gone is Removed, not Unknown"
+        );
     }
 
     /// A `MeasRef` carries the identity of the measurement, not just its node.

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -403,6 +403,14 @@ pub enum MeasResolveError {
         /// The node holding the record-less measurement.
         node: usize,
     },
+    /// The circuit's id bookkeeping disagrees with its gates: the id is held by
+    /// a gate but was never reserved, or is held by more than one gate.
+    ///
+    /// Insertion validation makes both states unrepresentable, so reaching this
+    /// means a [`gate_mut`](DagCircuit::gate_mut) edit desynced the circuit.
+    /// Nothing resolved through such a circuit can be trusted; the only safe
+    /// reaction is to stop.
+    Inconsistent(MeasId),
 }
 
 impl fmt::Display for MeasResolveError {
@@ -422,6 +430,12 @@ impl fmt::Display for MeasResolveError {
                 f,
                 "MeasId({}) names a measurement at node {node} that consumes no \
                  measurement record",
+                id.index()
+            ),
+            Self::Inconsistent(id) => write!(
+                f,
+                "MeasId({})'s bookkeeping is inconsistent -- held but unreserved, or \
+                 held by more than one gate; a gate_mut edit has desynced this circuit",
                 id.index()
             ),
         }
@@ -596,10 +610,18 @@ impl DagCircuit {
     /// # Errors
     ///
     /// - [`MeasResolveError::Unknown`] -- the id was never minted or supplied
-    ///   here. A reference from a different circuit lands in this case.
+    ///   here. A bare id carries no provenance, so a reference from a
+    ///   *different* circuit is NOT reliably detected: ids are circuit-local
+    ///   numbers, and a foreign id that collides with a local one resolves to
+    ///   the local measurement. Rejecting foreign references needs validation
+    ///   at the point a reference enters a circuit, not here.
     /// - [`MeasResolveError::Removed`] -- the id was reserved but no gate holds
-    ///   it; its measurement was removed. Ids stay reserved for the life of the
-    ///   circuit, so this cannot be confused with `Unknown`.
+    ///   it. Usually its measurement was removed; a `gate_mut` edit that
+    ///   overwrote the id leaves the same state, and the two cannot be told
+    ///   apart without tombstones.
+    /// - [`MeasResolveError::Inconsistent`] -- the id is held but unreserved,
+    ///   or held twice. Only reachable through `gate_mut` desync; stop trusting
+    ///   the circuit.
     /// - [`MeasResolveError::RecordLess`] -- the id names a measurement that
     ///   consumes no measurement record (`MeasureLeaked` carrying a supplied
     ///   id). It is a real measurement, but nothing that reads records can
@@ -611,29 +633,45 @@ impl DagCircuit {
     /// that unrepresentable through every insertion path, so reaching it means
     /// a [`gate_mut`](Self::gate_mut) edit desynced the gate.
     pub fn find_measurement(&self, id: MeasId) -> Result<MeasRef, MeasResolveError> {
+        // Scan the whole circuit rather than stopping at the first hit, so a
+        // duplicate holder is reported instead of silently winning.
+        let mut found: Option<(usize, usize)> = None;
         for (node, gate) in self.gates.iter().enumerate() {
             let Some(gate) = gate.as_ref() else { continue };
-            let Some(position) = gate.meas_ids.iter().position(|&held| held == id) else {
-                continue;
-            };
-            if !gate.gate_type.consumes_measurement_record() {
-                return Err(MeasResolveError::RecordLess { id, node });
+            for (position, &held) in gate.meas_ids.iter().enumerate() {
+                if held != id {
+                    continue;
+                }
+                if found.is_some() {
+                    return Err(MeasResolveError::Inconsistent(id));
+                }
+                found = Some((node, position));
             }
-            let qubit = *gate
-                .qubits
-                .get(position)
-                .expect("a validated measurement carries one id per qubit");
-            return Ok(MeasRef {
-                node,
-                qubit,
-                meas_id: id,
-            });
         }
-        if self.used_meas_ids.contains(&id.index()) {
-            Err(MeasResolveError::Removed(id))
-        } else {
-            Err(MeasResolveError::Unknown(id))
+        let Some((node, position)) = found else {
+            return if self.used_meas_ids.contains(&id.index()) {
+                Err(MeasResolveError::Removed(id))
+            } else {
+                Err(MeasResolveError::Unknown(id))
+            };
+        };
+        if !self.used_meas_ids.contains(&id.index()) {
+            // Held but never reserved: a forged id written in through gate_mut.
+            return Err(MeasResolveError::Inconsistent(id));
         }
+        let gate = self.gates[node].as_ref().expect("found above");
+        if !gate.gate_type.consumes_measurement_record() {
+            return Err(MeasResolveError::RecordLess { id, node });
+        }
+        let qubit = *gate
+            .qubits
+            .get(position)
+            .expect("a validated measurement carries one id per qubit");
+        Ok(MeasRef {
+            node,
+            qubit,
+            meas_id: id,
+        })
     }
 
     /// Check that `count` ids can still be minted, without minting them.
@@ -3306,6 +3344,35 @@ mod measurement_id_tests {
         let node = circuit.add_gate_auto_wire(Gate::h(&[0usize]));
         assert!(circuit.gate(node).unwrap().meas_ids.is_empty());
         assert_eq!(circuit.num_measurement_ids(), 0);
+    }
+
+    /// A `gate_mut` edit can hold an id the circuit never reserved, or hold
+    /// one id twice. Both are `Inconsistent` -- the one variant whose only
+    /// safe reaction is to stop -- not a successful resolution.
+    #[test]
+    fn find_measurement_reports_desynced_circuits_as_inconsistent() {
+        // Forged: a held id that was never reserved.
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0]);
+        let node = circuit.mz(&[0])[0].node;
+        circuit.gate_mut(node).unwrap().meas_ids[0] = MeasId(7);
+        assert_eq!(
+            circuit.find_measurement(MeasId(7)),
+            Err(MeasResolveError::Inconsistent(MeasId(7))),
+            "a forged id must not resolve to a real measurement"
+        );
+
+        // Duplicated: one id held by two gates.
+        let mut circuit = DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        let refs = circuit.mz(&[0, 1]);
+        let stolen = refs[0].meas_id;
+        circuit.gate_mut(refs[1].node).unwrap().meas_ids[0] = stolen;
+        assert_eq!(
+            circuit.find_measurement(stolen),
+            Err(MeasResolveError::Inconsistent(stolen)),
+            "a duplicated id must not silently resolve to whichever gate scans first"
+        );
     }
 
     /// `find_measurement` resolves an id to the exact measurement inside a

--- a/crates/pecos-quantum/src/lib.rs
+++ b/crates/pecos-quantum/src/lib.rs
@@ -82,8 +82,8 @@ pub mod hugr_convert;
 
 pub use circuit::{Circuit, CircuitMut, GateHandle, GateView};
 pub use dag_circuit::{
-    AnnotationKind, Attribute, DagCircuit, DagTraversalIndex, MeasRef, PauliAnnotation,
-    TraversalWorkBuffers,
+    AnnotationKind, Attribute, DagCircuit, DagTraversalIndex, MeasRef, MeasResolveError,
+    PauliAnnotation, TraversalWorkBuffers,
 };
 pub use tick_circuit::{
     CustomGateError, GateSignatureMismatchError, PHYSICAL_DURATION_META_KEY, QubitConflictError,

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -203,23 +203,44 @@ Nothing to migrate on disk: no serde derives on `PauliAnnotation`,
 `AnnotationKind`, or `MeasId`, and the detectors/observables JSON already speaks
 both `records` and `meas_ids` with a consistency check.
 
+## Resolved by the helper round (PR #403 review)
+
+- **The error taxonomy** is now code: `MeasResolveError::{Unknown, Removed,
+  RecordLess, Inconsistent}`. `Inconsistent` was added by the review -- a
+  `gate_mut` edit can leave an id held-but-unreserved or held twice, and a
+  resolver that silently returned the first holder would launder the desync.
+  Honesty limits are documented on the resolver: a bare id cannot detect a
+  reference from a *different* circuit (ids are circuit-local numbers; a
+  colliding foreign id resolves to the local measurement), and `Removed`
+  cannot be told apart from an id overwritten via `gate_mut`. Rejecting
+  foreign references needs validation where a reference *enters* a circuit.
+- **The forgery seam: close it.** The review's verdict, judged against the
+  helpers rather than on paper: they make forgery **more** dangerous, because a
+  forged `MeasId(x)` that collides with a real id now resolves to a real
+  `MeasRef`. Resolution rejects absent numbers but silently accepts the common
+  collision case, so the seam cannot be left open. Closing it -- private tuple
+  field, constructor-controlled creation, opaque Python references instead of
+  integer tuples -- is a **pivot prerequisite**, done as its own change (it
+  touches every `MeasId(x)` constructor in the tree).
+
+## Pivot API consequences (from the same review)
+
+- Annotation construction and the DEM builder must reject all four resolver
+  variants loudly, wrapped with annotation label/index context.
+- `DemSampler::with_circuit_annotations` returns `Self`; it must become
+  fallible or hold a pending error for `build`.
+- `InfluenceBuilder::with_circuit_annotations` and `build` are infallible and
+  need an error channel. Its separate circuit argument should also go, so
+  annotations cannot come from a circuit other than `self.dag`.
+- eeg needs its own `UnsupportedMeasurementKind`-style error: its expansion is
+  `MZ`-only, so an absent id is ambiguous between unknown and unsupported until
+  `build`/`build_dem_string`/`summary` can report.
+- The influence map's mixed-stamping sentinel (`MeasId(usize::MAX)` for id-less
+  entries) is guarded at `meas_index_of`, but the representation itself should
+  become explicit (`Option<MeasId>`) when the pivot touches those types.
+
 ## Unresolved, deliberately
 
-Two questions did not settle on paper because they are about code that does not
-exist yet, and a third is a separate defect:
-
-- **How far to close the `MeasId` forgery seam.** Removing `From<usize>` does not
-  close it -- `MeasId(x)` and `.0` stay public. Closing it properly means private
-  fields, an opaque `MeasRef`, and an opaque Python reference object instead of
-  integer tuples. Whether that is worth its churn is a judgement to make against
-  the pivot, not before it.
-- **The resolver's error taxonomy.** The design wants unknown, removed, and
-  record-less to be distinct errors, but `find_measurement -> Option<MeasRef>`
-  cannot distinguish unknown from removed; only the circuit's private
-  `used_meas_ids` knows. Several consumer APIs also have no error channel at all
-  (`InfluenceBuilder::with_circuit_annotations` and the sampler equivalent both
-  return `Self`). The resolver must be result-bearing and those APIs fallible
-  before the pivot, or the pivot is not mechanical.
 - **`InfluenceBuilder::run_symbolic_simulation` measures only `qubits[0]` of a
   batched gate** and maps a node to one measurement index. That is a live defect
   independent of this design and is filed as #398; the identity pivot does not

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -29,6 +29,17 @@ pub struct ExpandedCircuit {
     /// original_measured_qubit[k] = the qubit in the original circuit that
     /// the k-th MZ gate acted on.
     pub original_measured_qubit: Vec<usize>,
+    /// Expansion rank of each stamped measurement id.
+    ///
+    /// `meas_id_rank[&id] = k` means the measurement holding `id` is the k-th
+    /// one this expansion recorded -- an index into `measurement_qubit` and
+    /// `original_measured_qubit`. Only measurements whose gates carry
+    /// `meas_ids` appear; a legacy id-less circuit yields an empty map.
+    ///
+    /// This is eeg's private ordinal. It is expansion order, not id-rank order
+    /// and not any other component's ordering; resolve ids through this map
+    /// rather than assuming an id's numeric value indexes anything.
+    pub meas_id_rank: std::collections::BTreeMap<pecos_core::MeasId, usize>,
 }
 
 /// Expand a circuit by deferring mid-circuit measurements.
@@ -52,6 +63,7 @@ pub fn expand_circuit(gates: &[Gate]) -> ExpandedCircuit {
     let mut next_aux = num_original;
 
     let mut expanded = Vec::with_capacity(gates.len() * 2);
+    let mut meas_id_rank = std::collections::BTreeMap::new();
     let mut measurement_qubit = Vec::new();
     let mut original_measured_qubit = Vec::new();
 
@@ -89,8 +101,11 @@ pub fn expand_circuit(gates: &[Gate]) -> ExpandedCircuit {
         match gate.gate_type {
             GateType::MZ => {
                 // For each qubit in this MZ gate, create CX to auxiliary
-                for q in &gate.qubits {
+                for (position, q) in gate.qubits.iter().enumerate() {
                     let q_idx = q.index();
+                    if let Some(&id) = gate.meas_ids.get(position) {
+                        meas_id_rank.insert(id, measurement_qubit.len());
+                    }
                     let aux = next_aux;
                     next_aux += 1;
 
@@ -144,6 +159,7 @@ pub fn expand_circuit(gates: &[Gate]) -> ExpandedCircuit {
         num_original_qubits: num_original,
         measurement_qubit,
         original_measured_qubit,
+        meas_id_rank,
     }
 }
 
@@ -265,6 +281,35 @@ pub fn make_gate(gt: GateType, qubits: &[usize]) -> Gate {
 
 #[cfg(test)]
 mod tests {
+    /// `meas_id_rank` records expansion order, keyed by the id the gate holds.
+    ///
+    /// De-aliased: the ids arrive in descending order (9 before 3), so
+    /// expansion rank disagrees with numeric id order and with the id values
+    /// themselves -- ranking by anything except the walk fails.
+    #[test]
+    fn meas_id_rank_follows_expansion_order_not_id_order() {
+        use pecos_core::MeasId;
+        let mut first = super::make_gate(super::GateType::MZ, &[0]);
+        first.meas_ids.push(MeasId(9));
+        let mut second = super::make_gate(super::GateType::MZ, &[1]);
+        second.meas_ids.push(MeasId(3));
+        let gates = vec![
+            super::make_gate(super::GateType::PZ, &[0]),
+            super::make_gate(super::GateType::PZ, &[1]),
+            first,
+            second,
+        ];
+
+        let expanded = super::expand_circuit(&gates);
+        assert_eq!(expanded.meas_id_rank.get(&MeasId(9)), Some(&0));
+        assert_eq!(expanded.meas_id_rank.get(&MeasId(3)), Some(&1));
+        assert_eq!(
+            expanded.meas_id_rank.len(),
+            2,
+            "only stamped measurements appear"
+        );
+    }
+
     use super::*;
 
     fn gate(gt: GateType, qubits: &[usize]) -> Gate {

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -33,8 +33,14 @@ pub struct ExpandedCircuit {
     ///
     /// `meas_id_rank[&id] = k` means the measurement holding `id` is the k-th
     /// one this expansion recorded -- an index into `measurement_qubit` and
-    /// `original_measured_qubit`. Only measurements whose gates carry
-    /// `meas_ids` appear; a legacy id-less circuit yields an empty map.
+    /// `original_measured_qubit`.
+    ///
+    /// **`MZ` only.** The expansion walk handles no other measurement type, so
+    /// a stamped `MeasureFree` -- record-bearing and valid -- does not appear
+    /// here, exactly as its measurement does not appear in `measurement_qubit`.
+    /// An absent id is therefore ambiguous between "unknown" and "unsupported
+    /// measurement type"; resolving that needs an error channel on the eeg
+    /// builder, tracked in #387. Id-less legacy circuits yield an empty map.
     ///
     /// This is eeg's private ordinal. It is expansion order, not id-rank order
     /// and not any other component's ordering; resolve ids through this map
@@ -289,25 +295,32 @@ mod tests {
     #[test]
     fn meas_id_rank_follows_expansion_order_not_id_order() {
         use pecos_core::MeasId;
-        let mut first = super::make_gate(super::GateType::MZ, &[0]);
-        first.meas_ids.push(MeasId(9));
-        let mut second = super::make_gate(super::GateType::MZ, &[1]);
-        second.meas_ids.push(MeasId(3));
+        // One BATCHED MZ: two measurements inside a single gate, ids scrambled
+        // (9 then 3) so rank disagrees with id order, and id values (9, 3)
+        // coincide with no gate index (0..=1) or rank (0..=1). Ranking by the
+        // first id, by id value, or by anything except the per-position walk
+        // fails.
+        let mut batch = super::make_gate(super::GateType::MZ, &[0, 1]);
+        batch.meas_ids.push(MeasId(9));
+        batch.meas_ids.push(MeasId(3));
         let gates = vec![
             super::make_gate(super::GateType::PZ, &[0]),
             super::make_gate(super::GateType::PZ, &[1]),
-            first,
-            second,
+            batch,
         ];
 
         let expanded = super::expand_circuit(&gates);
-        assert_eq!(expanded.meas_id_rank.get(&MeasId(9)), Some(&0));
-        assert_eq!(expanded.meas_id_rank.get(&MeasId(3)), Some(&1));
         assert_eq!(
-            expanded.meas_id_rank.len(),
-            2,
-            "only stamped measurements appear"
+            expanded.meas_id_rank.get(&MeasId(9)),
+            Some(&0),
+            "first batch member is expansion rank 0"
         );
+        assert_eq!(
+            expanded.meas_id_rank.get(&MeasId(3)),
+            Some(&1),
+            "second batch member is rank 1 -- per-position, not first-id"
+        );
+        assert_eq!(expanded.meas_id_rank.len(), 2);
     }
 
     use super::*;


### PR DESCRIPTION
Pre-lands the id-resolution helpers from `design/measurement-id-annotations.md` (step 3 of the revised migration order), so the eventual field pivot is a mechanical swap onto tested helpers rather than the judgment-laden commit where this subsystem's defects have historically bred.

This also settles the design's open error-taxonomy question against real code rather than on paper.

## The three helpers

**`DagCircuit::find_measurement(MeasId) -> Result<MeasRef, MeasResolveError>`.** The error enum distinguishes the three failure meanings the design required, which an `Option` cannot:

- `Unknown` -- never minted or supplied here (a caller bug, or a reference from another circuit);
- `Removed` -- reserved in `used_meas_ids` but no gate holds it. Removed ids stay reserved for the life of the circuit, so this cannot be confused with `Unknown`;
- `RecordLess { id, node }` -- a `MeasureLeaked` carrying a supplied id: a real measurement, but nothing that reads records can resolve through it.

Deliberately an O(gates) scan, not a maintained index -- an index would silently desync under `gate_mut` edits, and consumers resolving many ids build their own map from one pass.

**`DagFaultInfluenceMap::meas_index_of(MeasId) -> Option<usize>`** -- id to the map's own ordinal (id-rank order), documented as private to that boundary. `None` means absent; the map cannot know why, and the doc points callers at `find_measurement` when the reason matters.

**`ExpandedCircuit::meas_id_rank: BTreeMap<MeasId, usize>`** -- eeg's private ordinal (expansion order), built in the same walk that populates `measurement_qubit`. Empty for id-less legacy circuits. This is the map that will replace the silent `record_idx < num_meas` skip in `builder.rs` when consumers migrate.

Per the design's ordering rule: each boundary computes its own ordinal from an explicit map, ordinals are never interchanged, and nothing is `Vec`-indexed by a raw `MeasId`.

## Tests, all de-aliased

Every fixture uses scrambled, non-contiguous supplied ids so node index, id value, and ordinal cannot coincide -- in nearly every pre-existing test in this subsystem the three are the same number, which is why conflation bugs stayed invisible.

Five mutations run and killed: resolving by first qubit instead of the id's position, collapsing `Removed` into `Unknown`, dropping the `RecordLess` check, ranking eeg's map by id value, and indexing the influence map by id value. The last two are this bug class's signature shape.

## Observed, not fixed here

eeg's expansion matches `GateType::MZ` only; a `MeasureFree` passes through unchanged, silently dropping its measurement from the expansion. Pre-existing and independent of this change -- recorded on #387's ledger.

## Verification

Cold `cargo clippy --locked --workspace --all-targets -- -D warnings` exit 0 on a fresh target directory. `cargo fmt --check` clean. `cargo test` with the `pecos-cli` exclusion set exit 0. The Rust doc-test crate exit 0. `pre-commit run --all-files` exit 0.
