### PR TITLE
Make annotation ingestion fallible across the three DEM consumers

### DIFF
--- a/crates/benchmarks/benches/modules/gpu_influence_sampler.rs
+++ b/crates/benchmarks/benches/modules/gpu_influence_sampler.rs
@@ -107,7 +107,7 @@ fn build_influence_maps(
 ) -> (DagFaultInfluenceMap, GpuInfluenceMapData) {
     let tracked_pauli_qubits: Vec<usize> = (0..num_data).collect();
     let builder = InfluenceBuilder::new(circuit).with_z(&tracked_pauli_qubits);
-    let influence_map = builder.build();
+    let influence_map = builder.build().expect("circuit is replayable");
 
     let (
         num_loc,

--- a/crates/pecos-gpu-sims/examples/cpu_vs_gpu_comparison.rs
+++ b/crates/pecos-gpu-sims/examples/cpu_vs_gpu_comparison.rs
@@ -93,7 +93,7 @@ fn main() {
         // Build influence map
         let tracked_pauli_qubits: Vec<usize> = (0..num_data).collect();
         let builder = InfluenceBuilder::new(&circuit).with_z(&tracked_pauli_qubits);
-        let influence_map = builder.build();
+        let influence_map = builder.build().expect("circuit is replayable");
 
         let num_locations = influence_map.locations.len();
 
@@ -181,7 +181,7 @@ fn main() {
 
         let tracked_pauli_qubits: Vec<usize> = (0..num_data).collect();
         let builder = InfluenceBuilder::new(&circuit).with_z(&tracked_pauli_qubits);
-        let influence_map = builder.build();
+        let influence_map = builder.build().expect("circuit is replayable");
 
         let (
             num_loc,

--- a/crates/pecos-gpu-sims/examples/full_pipeline_example.rs
+++ b/crates/pecos-gpu-sims/examples/full_pipeline_example.rs
@@ -86,7 +86,7 @@ fn main() {
     // Build influence map with a tracked Z Pauli (sensitive to X errors)
     let builder = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]);
 
-    let influence_map = builder.build();
+    let influence_map = builder.build().expect("circuit is replayable");
     println!("   Locations: {}", influence_map.locations.len());
     println!("   Detectors: {}", influence_map.detectors.len());
     println!("   Measurements: {}", influence_map.measurements.len());
@@ -161,7 +161,7 @@ fn main() {
     // Build influence map with a tracked X Pauli (sensitive to Z errors on this plaquette)
     let builder = InfluenceBuilder::new(&circuit).with_x(&[0, 1, 2, 3]);
 
-    let influence_map = builder.build();
+    let influence_map = builder.build().expect("circuit is replayable");
     println!("   Locations: {}", influence_map.locations.len());
     println!("   Detectors: {}", influence_map.detectors.len());
 
@@ -224,7 +224,7 @@ fn main() {
     for num_rounds in [1, 2, 4, 8] {
         let circuit = build_repetition_code_circuit(num_rounds);
         let builder = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]);
-        let influence_map = builder.build();
+        let influence_map = builder.build().expect("circuit is replayable");
 
         let (
             num_locations,

--- a/crates/pecos-gpu-sims/examples/pipeline_benchmark.rs
+++ b/crates/pecos-gpu-sims/examples/pipeline_benchmark.rs
@@ -158,7 +158,7 @@ fn benchmark_circuit(
     // Build influence map (common to both pipelines)
     let build_start = Instant::now();
     let builder = InfluenceBuilder::new(circuit).with_z(tracked_pauli_qubits);
-    let influence_map = builder.build();
+    let influence_map = builder.build().expect("circuit is replayable");
     let build_time = build_start.elapsed();
 
     let num_locations = influence_map.locations.len();

--- a/crates/pecos-gpu-sims/examples/profile_samplers.rs
+++ b/crates/pecos-gpu-sims/examples/profile_samplers.rs
@@ -514,7 +514,7 @@ fn main() {
         // Build influence map
         let tracked_pauli_qubits: Vec<usize> = (0..num_data).collect();
         let builder = InfluenceBuilder::new(&circuit).with_z(&tracked_pauli_qubits);
-        let influence_map = builder.build();
+        let influence_map = builder.build().expect("circuit is replayable");
         let num_locations = influence_map.locations.len();
 
         // Export for GPU

--- a/crates/pecos-qec/examples/influence_builder_example.rs
+++ b/crates/pecos-qec/examples/influence_builder_example.rs
@@ -57,7 +57,7 @@ fn main() {
     // =========================================================================
     let builder = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]); // Z logical on all data qubits
 
-    let influence_map = builder.build();
+    let influence_map = builder.build().expect("circuit is replayable");
 
     println!("\n2. Influence map built:");
     println!("   Fault locations: {}", influence_map.locations.len());

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -1251,8 +1251,10 @@ impl<'a> DemBuilder<'a> {
     ) -> Result<FaultMechanism, DemBuilderError> {
         use crate::fault_tolerance::influence_builder::InfluenceBuilder;
 
-        let ideal_history = self.exact_ideal_measurement_history(context);
-        let branch_info = InfluenceBuilder::new(branch).run_symbolic_simulation();
+        let ideal_history = self.exact_ideal_measurement_history(context)?;
+        let branch_info = InfluenceBuilder::new(branch)
+            .run_symbolic_simulation()
+            .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?;
         let mut triggered_dets: SmallVec<[u32; 4]> = SmallVec::new();
         let mut triggered_obs: SmallVec<[u32; 2]> = SmallVec::new();
 
@@ -1294,20 +1296,21 @@ impl<'a> DemBuilder<'a> {
     fn exact_ideal_measurement_history(
         &self,
         context: ExactBranchReplayContext<'_>,
-    ) -> Rc<MeasurementHistory> {
+    ) -> Result<Rc<MeasurementHistory>, DemBuilderError> {
         use crate::fault_tolerance::influence_builder::InfluenceBuilder;
 
         if let Some(cached) = self.exact_ideal_history_cache.borrow().as_ref().cloned() {
-            return cached;
+            return Ok(cached);
         }
 
         let history = Rc::new(
             InfluenceBuilder::new(context.circuit)
                 .run_symbolic_simulation()
+                .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?
                 .history,
         );
         *self.exact_ideal_history_cache.borrow_mut() = Some(history.clone());
-        history
+        Ok(history)
     }
 
     fn exact_branch_analysis(
@@ -3274,7 +3277,8 @@ fn build_dem_from_circuit(
     let annotation_map = InfluenceBuilder::new(circuit)
         .with_circuit_annotations()
         .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?
-        .build();
+        .build()
+        .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?;
     influence_map.merge_dem_outputs_from(&annotation_map);
 
     // Extract metadata before building (to avoid borrow issues)

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -3272,7 +3272,8 @@ fn build_dem_from_circuit(
     let mut influence_map = DagFaultAnalyzer::new(circuit).build_influence_map();
     let annotated_observable_records = observable_records_from_annotations(circuit, &influence_map);
     let annotation_map = InfluenceBuilder::new(circuit)
-        .with_circuit_annotations(circuit)
+        .with_circuit_annotations()
+        .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?
         .build();
     influence_map.merge_dem_outputs_from(&annotation_map);
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -452,7 +452,10 @@ impl DemSampler {
             .map_err(|err| DetectorValidationError::InvalidMetadata {
                 message: err.to_string(),
             })?
-            .build();
+            .build()
+            .map_err(|err| DetectorValidationError::InvalidMetadata {
+                message: err.to_string(),
+            })?;
         influence_map.merge_dem_outputs_from(&annotation_map);
 
         // Extract metadata before building (avoids ownership issues with builder methods)
@@ -1159,28 +1162,13 @@ impl<'a> DemSamplerBuilder<'a> {
         let detectors: Vec<&pecos_quantum::PauliAnnotation> = circuit.detectors().collect();
         let observables: Vec<&pecos_quantum::PauliAnnotation> = circuit.observables().collect();
 
-        // Map user-defined detector annotations to auto-detected detector indices
+        // Map each user detector directly to absolute raw-measurement indices --
+        // the coordinate space `detector_records_abs` documents and `sample_dual`
+        // XORs. An earlier version routed through a first-match-by-qubit/basis
+        // auto-detector lookup, which both stored the wrong coordinate space and
+        // rejected legitimate detectors on circuits that measure one qubit more
+        // than once.
         if !detectors.is_empty() {
-            // For each IM measurement index, find which auto-detector contains it
-            let mut meas_idx_to_auto_det: Vec<Option<usize>> =
-                vec![None; self.influence_map.measurements.len()];
-            for (det_idx, det) in self.influence_map.detectors.iter().enumerate() {
-                for meas_id in &det.measurements {
-                    for (im_idx, &(_node, qubit, basis)) in
-                        self.influence_map.measurements.iter().enumerate()
-                    {
-                        if qubit == meas_id.qubit
-                            && basis == meas_id.basis
-                            && meas_idx_to_auto_det[im_idx].is_none()
-                        {
-                            meas_idx_to_auto_det[im_idx] = Some(det_idx);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Map each user detector: measurement_nodes → IM meas index → auto-detector index
             let mut det_records_abs: Vec<Vec<usize>> = Vec::with_capacity(detectors.len());
             for (annotation_index, ann) in detectors.iter().enumerate() {
                 let AnnotationKind::Detector {
@@ -1192,17 +1180,14 @@ impl<'a> DemSamplerBuilder<'a> {
                 };
                 let mut resolved = Vec::with_capacity(measurement_nodes.len());
                 for &node in measurement_nodes {
-                    let record = node_to_meas_idx
-                        .get(&node)
-                        .and_then(|&im_idx| meas_idx_to_auto_det[im_idx]);
-                    let Some(det_idx) = record else {
+                    let Some(&im_idx) = node_to_meas_idx.get(&node) else {
                         return Err(DetectorValidationError::UnresolvableAnnotationRef {
                             output_kind: "detector",
                             annotation_index,
                             node,
                         });
                     };
-                    resolved.push(det_idx);
+                    resolved.push(im_idx);
                 }
                 det_records_abs.push(resolved);
             }
@@ -1560,8 +1545,8 @@ mod tests {
         let err = DemSamplerBuilder::new(&im)
             .with_uniform_noise(0.01)
             .with_circuit_annotations(&dag)
-            .err()
-            .expect("node 99 resolves to no measurement");
+            .map(|_| ())
+            .expect_err("node 99 resolves to no measurement");
         assert!(matches!(
             err,
             DetectorValidationError::UnresolvableAnnotationRef {
@@ -1595,7 +1580,10 @@ mod tests {
     #[test]
     fn raw_mode_output_length_matches_measurements() {
         let circuit = repetition_code(2);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_uniform_noise(0.01)
@@ -1613,7 +1601,10 @@ mod tests {
     #[test]
     fn zero_noise_raw_mode_deterministic_measurements_are_zero() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_uniform_noise(0.0)
@@ -1632,7 +1623,10 @@ mod tests {
     #[test]
     fn raw_mode_matches_dem_sampler_from_influence_map() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         let p = 0.01;
         let num_shots = 20_000;
@@ -1662,7 +1656,9 @@ mod tests {
     #[test]
     fn detector_mode_output_length_matches_definitions() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .build()
+            .expect("circuit is replayable");
 
         // Define 2 simple detectors (last two measurements)
         let detector_records = vec![vec![-1i32], vec![-2]];
@@ -1685,7 +1681,9 @@ mod tests {
     #[test]
     fn detector_mode_accepts_observable_aliases() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .build()
+            .expect("circuit is replayable");
 
         let records_sampler = DemSamplerBuilder::new(&im)
             .with_detector_records(vec![vec![-1]])
@@ -1755,7 +1753,8 @@ mod tests {
         let im = InfluenceBuilder::new(&circuit)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_noise(0.03, 0.0, 0.02, 0.0)
@@ -1787,7 +1786,8 @@ mod tests {
         let im = InfluenceBuilder::new(&circuit)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_noise(0.0, 0.0, 1.0, 0.0)
@@ -1930,7 +1930,8 @@ mod tests {
         let influence_map = InfluenceBuilder::new(&circuit)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
         let from_builder = DemSamplerBuilder::new(&influence_map)
             .with_noise(0.0, 0.0, 1.0, 0.0)
             .with_detector_records(vec![vec![-1]])
@@ -2014,7 +2015,9 @@ mod tests {
         circuit.pz(&[0]);
         circuit.h(&[0]);
         circuit.mz(&[0]);
-        let im = InfluenceBuilder::new(&circuit).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_uniform_noise(0.01)
@@ -2112,7 +2115,10 @@ mod tests {
     #[test]
     fn high_noise_produces_nonzero_rates_both_modes() {
         let circuit = repetition_code(2);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         let p = 0.1;
         let num_shots = 5_000;
@@ -2147,7 +2153,10 @@ mod tests {
     #[test]
     fn dual_output_returns_none_without_definitions() {
         let circuit = repetition_code(2);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         let sampler = DemSamplerBuilder::new(&im)
             .with_uniform_noise(0.01)
@@ -2162,7 +2171,10 @@ mod tests {
     #[test]
     fn dual_output_produces_both_views() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         // Define detectors: first and second measurements
         let det_defs = vec![vec![0usize], vec![1]];
@@ -2186,7 +2198,10 @@ mod tests {
     #[test]
     fn dual_output_detector_events_consistent_with_raw() {
         let circuit = repetition_code(3);
-        let im = InfluenceBuilder::new(&circuit).with_z(&[0, 1, 2]).build();
+        let im = InfluenceBuilder::new(&circuit)
+            .with_z(&[0, 1, 2])
+            .build()
+            .expect("circuit is replayable");
 
         // Detector = XOR of measurements 0 and 1
         let det_defs = vec![vec![0usize, 1]];

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -60,6 +60,16 @@ pub enum DetectorValidationError {
     UnsupportedGateForDeterminismAnalysis { gate_type: String },
     /// Circuit detector/observable metadata is malformed.
     InvalidMetadata { message: String },
+    /// A detector or observable annotation references a node that cannot be
+    /// resolved to a measurement in the influence map.
+    UnresolvableAnnotationRef {
+        /// "detector" or "observable".
+        output_kind: &'static str,
+        /// Index among that kind's annotations.
+        annotation_index: usize,
+        /// The unresolvable node reference.
+        node: usize,
+    },
 }
 
 impl std::fmt::Display for DetectorValidationError {
@@ -97,6 +107,15 @@ impl std::fmt::Display for DetectorValidationError {
             Self::InvalidMetadata { message } => {
                 write!(f, "Invalid detector/observable metadata: {message}")
             }
+            Self::UnresolvableAnnotationRef {
+                output_kind,
+                annotation_index,
+                node,
+            } => write!(
+                f,
+                "{output_kind} annotation {annotation_index} references node {node}, which \
+                 does not resolve to a measurement in the influence map"
+            ),
         }
     }
 }
@@ -429,7 +448,10 @@ impl DemSampler {
 
         let mut influence_map = DagFaultAnalyzer::new(circuit).build_influence_map();
         let annotation_map = InfluenceBuilder::new(circuit)
-            .with_circuit_annotations(circuit)
+            .with_circuit_annotations()
+            .map_err(|err| DetectorValidationError::InvalidMetadata {
+                message: err.to_string(),
+            })?
             .build();
         influence_map.merge_dem_outputs_from(&annotation_map);
 
@@ -1108,8 +1130,22 @@ impl<'a> DemSamplerBuilder<'a> {
     /// Observables are converted to measurement-record outputs. Tracked
     /// Paulis remain unmeasured Pauli annotations and are carried
     /// through PECOS metadata only.
-    #[must_use]
-    pub fn with_circuit_annotations(mut self, circuit: &pecos_quantum::DagCircuit) -> Self {
+    /// # Errors
+    ///
+    /// Returns [`DetectorValidationError::UnresolvableAnnotationRef`] when a
+    /// detector or observable annotation references a node that does not
+    /// resolve to a measurement in the influence map. Such references used to
+    /// be dropped silently, producing outputs with missing terms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a resolved measurement index exceeds `i32` while the
+    /// measurement count fits -- impossible, since every index is below the
+    /// count, which is checked first.
+    pub fn with_circuit_annotations(
+        mut self,
+        circuit: &pecos_quantum::DagCircuit,
+    ) -> Result<Self, DetectorValidationError> {
         use pecos_quantum::AnnotationKind;
 
         let mut node_to_meas_idx: std::collections::BTreeMap<usize, usize> =
@@ -1145,55 +1181,68 @@ impl<'a> DemSamplerBuilder<'a> {
             }
 
             // Map each user detector: measurement_nodes → IM meas index → auto-detector index
-            let det_records_abs: Vec<Vec<usize>> = detectors
-                .iter()
-                .map(|ann| {
-                    if let AnnotationKind::Detector {
-                        measurement_nodes, ..
-                    } = &ann.kind
-                    {
-                        measurement_nodes
-                            .iter()
-                            .filter_map(|&node| {
-                                let im_idx = node_to_meas_idx.get(&node)?;
-                                meas_idx_to_auto_det[*im_idx]
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    }
-                })
-                .collect();
+            let mut det_records_abs: Vec<Vec<usize>> = Vec::with_capacity(detectors.len());
+            for (annotation_index, ann) in detectors.iter().enumerate() {
+                let AnnotationKind::Detector {
+                    measurement_nodes, ..
+                } = &ann.kind
+                else {
+                    det_records_abs.push(Vec::new());
+                    continue;
+                };
+                let mut resolved = Vec::with_capacity(measurement_nodes.len());
+                for &node in measurement_nodes {
+                    let record = node_to_meas_idx
+                        .get(&node)
+                        .and_then(|&im_idx| meas_idx_to_auto_det[im_idx]);
+                    let Some(det_idx) = record else {
+                        return Err(DetectorValidationError::UnresolvableAnnotationRef {
+                            output_kind: "detector",
+                            annotation_index,
+                            node,
+                        });
+                    };
+                    resolved.push(det_idx);
+                }
+                det_records_abs.push(resolved);
+            }
 
             self.labels.dual_detectors = detectors.iter().map(|a| a.label.clone()).collect();
             self.detector_records_abs = Some(det_records_abs);
         }
 
         if !observables.is_empty() && self.observable_records.is_none() {
-            let records = if let Ok(num_measurements) =
-                i32::try_from(self.influence_map.measurements.len())
-            {
-                observables
-                    .iter()
-                    .map(|ann| {
-                        if let AnnotationKind::Observable { measurement_nodes } = &ann.kind {
-                            measurement_nodes
-                                .iter()
-                                .filter_map(|node| node_to_meas_idx.get(node).copied())
-                                .filter_map(|meas_idx| {
-                                    i32::try_from(meas_idx)
-                                        .ok()
-                                        .map(|meas_idx| meas_idx - num_measurements)
-                                })
-                                .collect()
-                        } else {
-                            Vec::new()
-                        }
-                    })
-                    .collect()
-            } else {
-                vec![Vec::new(); observables.len()]
-            };
+            let num_measurements =
+                i32::try_from(self.influence_map.measurements.len()).map_err(|_| {
+                    DetectorValidationError::InvalidMetadata {
+                        message: format!(
+                            "{} measurements exceed the i32 record-offset range",
+                            self.influence_map.measurements.len()
+                        ),
+                    }
+                })?;
+            let mut records: Vec<Vec<i32>> = Vec::with_capacity(observables.len());
+            for (annotation_index, ann) in observables.iter().enumerate() {
+                let AnnotationKind::Observable { measurement_nodes } = &ann.kind else {
+                    records.push(Vec::new());
+                    continue;
+                };
+                let mut resolved = Vec::with_capacity(measurement_nodes.len());
+                for &node in measurement_nodes {
+                    let Some(&meas_idx) = node_to_meas_idx.get(&node) else {
+                        return Err(DetectorValidationError::UnresolvableAnnotationRef {
+                            output_kind: "observable",
+                            annotation_index,
+                            node,
+                        });
+                    };
+                    let meas_idx = i32::try_from(meas_idx)
+                        .expect("meas_idx < measurements.len(), which fits in i32");
+                    resolved.push(meas_idx - num_measurements);
+                }
+                records.push(resolved);
+            }
+            let records = records;
             self.observable_records = Some(records);
         }
 
@@ -1213,7 +1262,7 @@ impl<'a> DemSamplerBuilder<'a> {
             self.labels.tracked_pauli_labels = tracked_pauli_labels;
         }
 
-        self
+        Ok(self)
     }
 
     /// Set the measurement order for legacy circuits without `MeasId` on gates.
@@ -1489,6 +1538,40 @@ pub(crate) fn gate_location_prob_from_locations(
 
 #[cfg(test)]
 mod tests {
+    /// An observable annotation referencing a node absent from the influence
+    /// map used to be silently dropped, thinning the observable. It is now an
+    /// error naming the annotation and the node.
+    #[test]
+    fn an_unresolvable_observable_ref_is_an_error() {
+        use pecos_quantum::DagCircuit;
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.mz(&[0]);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: pecos_core::PauliString::zs(&[0usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_nodes: vec![99],
+            },
+            label: None,
+        });
+        let im =
+            crate::fault_tolerance::propagator::DagFaultAnalyzer::new(&dag).build_influence_map();
+
+        let err = DemSamplerBuilder::new(&im)
+            .with_uniform_noise(0.01)
+            .with_circuit_annotations(&dag)
+            .err()
+            .expect("node 99 resolves to no measurement");
+        assert!(matches!(
+            err,
+            DetectorValidationError::UnresolvableAnnotationRef {
+                output_kind: "observable",
+                node: 99,
+                ..
+            }
+        ));
+    }
+
     use super::*;
     use crate::fault_tolerance::InfluenceBuilder;
     use pecos_quantum::DagCircuit;
@@ -1670,7 +1753,8 @@ mod tests {
         circuit.mz(&[0]);
 
         let im = InfluenceBuilder::new(&circuit)
-            .with_circuit_annotations(&circuit)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         let sampler = DemSamplerBuilder::new(&im)
@@ -1701,7 +1785,8 @@ mod tests {
         circuit.observable_labeled("obs0", &[meas[0]]);
 
         let im = InfluenceBuilder::new(&circuit)
-            .with_circuit_annotations(&circuit)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         let sampler = DemSamplerBuilder::new(&im)
@@ -1843,7 +1928,8 @@ mod tests {
         assert_eq!(sample_once(&from_dem), (vec![true], vec![true]));
 
         let influence_map = InfluenceBuilder::new(&circuit)
-            .with_circuit_annotations(&circuit)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
         let from_builder = DemSamplerBuilder::new(&influence_map)
             .with_noise(0.0, 0.0, 1.0, 0.0)

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1523,6 +1523,60 @@ pub(crate) fn gate_location_prob_from_locations(
 
 #[cfg(test)]
 mod tests {
+    /// The reviewer's happy-path witness for the rewritten detector mapping:
+    /// `detector_records_abs` must hold absolute raw-measurement indices, so a
+    /// single-measurement detector's event equals that measurement's flip on
+    /// every shot. The old auto-detector hop stored detector ids in the field,
+    /// which reads the wrong measurement whenever the numberings differ.
+    ///
+    /// `raw_measurements` is FLIP space, so the discriminator is statistical:
+    /// noise makes the two measurements' flips independent, and the test
+    /// asserts its own non-vacuity by requiring measurement 1's flip to vary
+    /// AND to disagree with measurement 0's on at least one shot. A fixture
+    /// where the compared streams never differ proves nothing -- the first
+    /// version of this test had exactly that hole, twice.
+    #[test]
+    fn dual_output_detector_events_xor_the_named_raw_measurements() {
+        use pecos_quantum::DagCircuit;
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.mz(&[0]); // raw measurement 0
+        dag.pz(&[1]);
+        let named = dag.mz(&[1]); // raw measurement 1 -- the detector's target
+        dag.detector(&named);
+
+        let im =
+            crate::fault_tolerance::propagator::DagFaultAnalyzer::new(&dag).build_influence_map();
+        let sampler = DemSamplerBuilder::new(&im)
+            .with_uniform_noise(0.3)
+            .raw_measurements()
+            .with_circuit_annotations(&dag)
+            .expect("the annotation resolves")
+            .build()
+            .expect("the detector is valid");
+
+        let mut rng = PecosRng::seed_from_u64(42);
+        let (mut saw_one_flip, mut saw_one_clear, mut saw_disagreement) = (false, false, false);
+        for _ in 0..64 {
+            let shot = sampler
+                .sample_dual(&mut rng)
+                .expect("annotations enable dual output");
+            assert_eq!(
+                shot.detector_events[0], shot.raw_measurements[1],
+                "the detector names raw measurement 1; reading any other \
+                 numbering lands on a different flip stream"
+            );
+            saw_one_flip |= shot.raw_measurements[1];
+            saw_one_clear |= !shot.raw_measurements[1];
+            saw_disagreement |= shot.raw_measurements[0] != shot.raw_measurements[1];
+        }
+        assert!(
+            saw_one_flip && saw_one_clear && saw_disagreement,
+            "vacuity check: measurement 1's flip must vary and must disagree \
+             with measurement 0 at least once, or the equality above proves nothing"
+        );
+    }
+
     /// An observable annotation referencing a node absent from the influence
     /// map used to be silently dropped, thinning the observable. It is now an
     /// error naming the annotation and the node.

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -81,6 +81,65 @@ struct PauliPropagationTerm {
     start_node: Option<usize>,
 }
 
+/// Why circuit annotations could not be ingested into the influence map.
+///
+/// An annotation that loses references silently becomes an output with no
+/// propagation terms -- not merely empty, but wrong: it suppresses the
+/// record-based fallback downstream. So unresolvable references are errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnnotationIngestError {
+    /// An observable annotation references a node that does not exist.
+    ObservableRefNotFound {
+        /// Index of the annotation among the circuit's annotations.
+        annotation_index: usize,
+        /// The nonexistent node.
+        node: usize,
+    },
+    /// An observable annotation references a node whose gate consumes no
+    /// measurement record, so it cannot contribute a readout term.
+    ObservableRefNotAMeasurement {
+        /// Index of the annotation among the circuit's annotations.
+        annotation_index: usize,
+        /// The referenced node.
+        node: usize,
+    },
+    /// A tracked-Pauli annotation has no matching `TrackedPauliMeta` gate.
+    TrackedPauliWithoutMetaNode {
+        /// Index of the annotation among the circuit's annotations.
+        annotation_index: usize,
+    },
+}
+
+impl std::fmt::Display for AnnotationIngestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ObservableRefNotFound {
+                annotation_index,
+                node,
+            } => write!(
+                f,
+                "annotation {annotation_index}: observable references node {node}, \
+                 which does not exist in the circuit"
+            ),
+            Self::ObservableRefNotAMeasurement {
+                annotation_index,
+                node,
+            } => write!(
+                f,
+                "annotation {annotation_index}: observable references node {node}, \
+                 whose gate consumes no measurement record"
+            ),
+            Self::TrackedPauliWithoutMetaNode { annotation_index } => write!(
+                f,
+                "annotation {annotation_index}: tracked Pauli has no matching \
+                 TrackedPauliMeta gate in the circuit"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AnnotationIngestError {}
+
 pub struct InfluenceBuilder<'a> {
     dag: &'a pecos_quantum::DagCircuit,
     /// Non-detector parity outputs to track for flipping.
@@ -184,8 +243,20 @@ impl<'a> InfluenceBuilder<'a> {
     /// Detector annotations are NOT handled here -- they are processed
     /// by `DemSamplerBuilder::with_circuit_annotations` which maps them
     /// to auto-detected detectors.
-    #[must_use]
-    pub fn with_circuit_annotations(mut self, circuit: &pecos_quantum::DagCircuit) -> Self {
+    ///
+    /// The circuit is `self.dag` -- the one this builder was constructed with.
+    /// It used to be a parameter, which let annotations come from a *different*
+    /// circuit than the one being analyzed, silently producing nonsense.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationIngestError`] when an annotation cannot be resolved
+    /// against the circuit: an observable referencing a missing node or a
+    /// non-measurement gate, or a tracked Pauli with no meta gate. Dropping
+    /// such references silently produced outputs with missing propagation
+    /// terms.
+    pub fn with_circuit_annotations(mut self) -> Result<Self, AnnotationIngestError> {
+        let circuit = self.dag;
         // Find TrackedPauliMeta nodes in topological order.
         // The nth meta-gate corresponds to the nth tracked-Pauli annotation.
         let meta_nodes: Vec<usize> = circuit
@@ -195,41 +266,63 @@ impl<'a> InfluenceBuilder<'a> {
             .collect();
 
         let mut operator_idx = 0;
-        for ann in circuit.annotations() {
+        let mut ingested = Vec::new();
+        for (annotation_index, ann) in circuit.annotations().iter().enumerate() {
             match &ann.kind {
                 pecos_quantum::AnnotationKind::Observable { measurement_nodes } => {
                     let mut terms = Vec::new();
                     for &meas_node in measurement_nodes {
-                        if let Some(gate) = circuit.gate(meas_node) {
-                            let qubits: Vec<usize> =
-                                gate.qubits.iter().map(pecos_core::QubitId::index).collect();
-                            terms.push(PauliPropagationTerm {
-                                pauli: PauliString::zs(&qubits),
-                                start_node: Some(meas_node),
+                        let Some(gate) = circuit.gate(meas_node) else {
+                            return Err(AnnotationIngestError::ObservableRefNotFound {
+                                annotation_index,
+                                node: meas_node,
+                            });
+                        };
+                        if !gate.gate_type.consumes_measurement_record() {
+                            return Err(AnnotationIngestError::ObservableRefNotAMeasurement {
+                                annotation_index,
+                                node: meas_node,
                             });
                         }
+                        let qubits: Vec<usize> =
+                            gate.qubits.iter().map(pecos_core::QubitId::index).collect();
+                        terms.push(PauliPropagationTerm {
+                            pauli: PauliString::zs(&qubits),
+                            start_node: Some(meas_node),
+                        });
                     }
-                    self.non_detector_outputs.push(NonDetectorOutputTarget {
+                    ingested.push(NonDetectorOutputTarget {
                         metadata: DemOutputMetadata::observable(ann.pauli.clone())
                             .with_optional_label(ann.label.clone()),
                         terms,
                     });
                 }
                 pecos_quantum::AnnotationKind::TrackedPauli => {
-                    let meta_node = meta_nodes.get(operator_idx).copied();
+                    let Some(meta_node) = meta_nodes.get(operator_idx).copied() else {
+                        return Err(AnnotationIngestError::TrackedPauliWithoutMetaNode {
+                            annotation_index,
+                        });
+                    };
                     operator_idx += 1;
-                    self.push_single_term_output(
-                        DemOutputMetadata::tracked_pauli(ann.pauli.clone())
-                            .with_optional_label(ann.label.clone()),
-                        meta_node,
-                    );
+                    let metadata = DemOutputMetadata::tracked_pauli(ann.pauli.clone())
+                        .with_optional_label(ann.label.clone());
+                    ingested.push(NonDetectorOutputTarget {
+                        terms: vec![PauliPropagationTerm {
+                            pauli: metadata.pauli.clone(),
+                            start_node: Some(meta_node),
+                        }],
+                        metadata,
+                    });
                 }
                 pecos_quantum::AnnotationKind::Detector { .. } => {
                     // Detectors handled separately by DemSamplerBuilder
                 }
             }
         }
-        self
+        // Nothing is committed until every annotation resolved: a rejected
+        // ingest must not leave the builder holding half the outputs.
+        self.non_detector_outputs.extend(ingested);
+        Ok(self)
     }
 
     /// Build the influence map.
@@ -1078,7 +1171,8 @@ mod tests {
         dag.tracked_pauli_labeled("track_x", X(0));
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         // 1 observable (record_obs) + 1 tracked Pauli (track_x) = 2 DEM outputs
@@ -1111,7 +1205,8 @@ mod tests {
         dag.observable_labeled("split_time_obs", &[early[0], late[0]]);
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         assert_eq!(map.num_observables(), 1);
@@ -1154,7 +1249,8 @@ mod tests {
         dag.observable_labeled("split_obs", &[early[0], late[0]]);
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         assert_eq!(map.num_observables(), 1);
@@ -1198,7 +1294,8 @@ mod tests {
         dag.observable_labeled("split_obs", &[early[0], late[0]]);
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         assert_eq!(map.num_observables(), 1);
@@ -1228,6 +1325,92 @@ mod tests {
         );
     }
 
+    /// An observable referencing a missing node is an error, not a silently
+    /// thinner observable. De-aliased: node 99 exists in no space.
+    #[test]
+    fn an_observable_ref_to_a_missing_node_is_an_error() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.mz(&[0]);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: PauliString::zs(&[0usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_nodes: vec![99],
+            },
+            label: None,
+        });
+
+        let Err(err) = InfluenceBuilder::new(&dag).with_circuit_annotations() else {
+            panic!("node 99 does not exist, so ingest must fail");
+        };
+        assert_eq!(
+            err,
+            AnnotationIngestError::ObservableRefNotFound {
+                annotation_index: 0,
+                node: 99,
+            }
+        );
+    }
+
+    /// A reference to a real gate that consumes no measurement record cannot
+    /// contribute a readout term, so it is an error rather than a Z-spray over
+    /// the gate's qubits.
+    #[test]
+    fn an_observable_ref_to_a_non_measurement_gate_is_an_error() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        let h_node = dag.gate_count(); // next node index is the H below
+        dag.h(&[0]);
+        dag.mz(&[0]);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: PauliString::zs(&[0usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_nodes: vec![h_node],
+            },
+            label: None,
+        });
+
+        let Err(err) = InfluenceBuilder::new(&dag).with_circuit_annotations() else {
+            panic!("an H gate holds no measurement record, so ingest must fail");
+        };
+        assert!(matches!(
+            err,
+            AnnotationIngestError::ObservableRefNotAMeasurement { .. }
+        ));
+    }
+
+    /// A rejected ingest commits nothing observable-side: a caller who catches
+    /// the error and rebuilds sees no half-state.
+    #[test]
+    fn a_rejected_ingest_leaves_no_partial_outputs() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        let good = dag.mz(&[0]);
+        dag.mz(&[1]);
+        dag.observable_labeled("resolves_fine", &good);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: PauliString::zs(&[1usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_nodes: vec![99],
+            },
+            label: None,
+        });
+
+        assert!(
+            InfluenceBuilder::new(&dag)
+                .with_circuit_annotations()
+                .is_err(),
+            "the second annotation cannot resolve"
+        );
+        let clean = InfluenceBuilder::new(&dag).build();
+        let fresh = InfluenceBuilder::new(&dag).build();
+        assert_eq!(
+            clean.num_observables(),
+            fresh.num_observables(),
+            "a fresh build is unaffected by the failed ingest"
+        );
+    }
+
     #[test]
     fn test_duplicate_observable_terms_cancel_in_influence_map() {
         let mut dag = DagCircuit::new();
@@ -1237,7 +1420,8 @@ mod tests {
         dag.observable_labeled("duplicate_record_obs", &[meas[0], meas[0]]);
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
 
         assert_eq!(map.num_observables(), 1);

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -456,9 +456,16 @@ impl<'a> InfluenceBuilder<'a> {
                         meas_idx += 1;
                     }
                     // A leaked measurement collapses its qubit but consumes no
-                    // measurement record, so it gets no measurement index.
+                    // record -- and this replay cannot express that: `sim.mz`
+                    // advances the simulator's internal history index, so a
+                    // record-less collapse desyncs symbolic indices from
+                    // records and manufactures phantom detectors. Refused,
+                    // exactly as `symbolic_measurement_history` refuses it.
                     pecos_quantum::GateType::MeasureLeaked => {
-                        sim.mz(&qubits);
+                        return Err(InfluenceBuildError::UnsupportedGate {
+                            node,
+                            gate_type: op.gate_type,
+                        });
                     }
                     // Resets project onto |0>. Skipping them treated a reused
                     // qubit as still carrying its pre-reset correlations.
@@ -1459,6 +1466,25 @@ mod tests {
         ));
     }
 
+    /// A leaked measurement cannot be represented in this replay: collapsing
+    /// it via `sim.mz` advances the simulator's internal history index without
+    /// a matching record, desyncing symbolic indices from records. The witness
+    /// circuit manufactured a phantom detector on the visible measurement.
+    #[test]
+    fn a_leaked_measurement_is_refused_not_desynced() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.h(&[0]);
+        dag.add_gate_auto_wire(pecos_quantum::Gate::measure_leaked(&[0usize]));
+        dag.mz(&[0]);
+
+        let err = InfluenceBuilder::new(&dag)
+            .build()
+            .map(|_| ())
+            .expect_err("a leaked measurement has no record this replay can express");
+        assert!(matches!(err, InfluenceBuildError::UnsupportedGate { .. }));
+    }
+
     /// A mid-circuit reset must reach the simulator: skipping it treated a
     /// reused qubit as still carrying its pre-reset correlations, so the
     /// re-measurement looked like a deterministic repeat instead of fresh.
@@ -1478,6 +1504,18 @@ mod tests {
             map.detectors.len(),
             1,
             "the post-reset measurement is deterministic on its own"
+        );
+        // Skipping the reset ALSO yields one detector -- the parity of both
+        // measurements -- so counting alone distinguishes nothing. The
+        // detector must contain exactly the post-reset measurement.
+        assert_eq!(
+            map.detectors[0].measurements.len(),
+            1,
+            "one measurement, not a two-measurement parity"
+        );
+        assert_eq!(
+            map.detectors[0].measurements[0].qubit, 0,
+            "and it is the post-reset measurement on qubit 0"
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -22,7 +22,7 @@
 //!
 //! // Build influence map with automatic detector discovery
 //! let builder = InfluenceBuilder::new(&dag);
-//! let influence_map = builder.build();
+//! let influence_map = builder.build().expect("circuit is replayable");
 //!
 //! // Build a fast DemSampler from the influence map
 //! let num_locations = influence_map.locations.len();
@@ -140,6 +140,54 @@ impl std::fmt::Display for AnnotationIngestError {
 
 impl std::error::Error for AnnotationIngestError {}
 
+/// Why the influence map could not be built from the circuit.
+///
+/// The forward symbolic replay used to skip anything it did not recognize --
+/// including mid-circuit resets and non-Clifford rotations -- and to measure
+/// only the first qubit of a batched measurement node. All of those produced
+/// silently wrong detector analyses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InfluenceBuildError {
+    /// A gate the symbolic replay cannot represent.
+    UnsupportedGate {
+        /// The DAG node holding the gate.
+        node: usize,
+        /// The offending gate type.
+        gate_type: pecos_core::gate_type::GateType,
+    },
+    /// A single node carrying more than one measurement.
+    ///
+    /// The measurement-info model maps a node to one measurement index, so a
+    /// batched node cannot be represented yet (issue #398 tracks per-measurement
+    /// mapping). Refused rather than analyzed as if only the first qubit were
+    /// measured.
+    BatchedMeasurementUnsupported {
+        /// The DAG node holding the batched measurement.
+        node: usize,
+        /// How many measurements it carries.
+        count: usize,
+    },
+}
+
+impl std::fmt::Display for InfluenceBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedGate { node, gate_type } => write!(
+                f,
+                "symbolic replay cannot represent {gate_type:?} at node {node}; lower it to \
+                 supported Cliffords first"
+            ),
+            Self::BatchedMeasurementUnsupported { node, count } => write!(
+                f,
+                "node {node} carries {count} measurements in one gate; the influence map \
+                 cannot yet represent a batched measurement node"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for InfluenceBuildError {}
+
 pub struct InfluenceBuilder<'a> {
     dag: &'a pecos_quantum::DagCircuit,
     /// Non-detector parity outputs to track for flipping.
@@ -212,7 +260,7 @@ impl<'a> InfluenceBuilder<'a> {
     /// let builder = InfluenceBuilder::new(&dag).with_tracked_pauli(
     ///     PauliString::from_paulis(&[Pauli::X, Pauli::Z, Pauli::Z]),
     /// );
-    /// let _map = builder.build();
+    /// let _map = builder.build().expect("circuit is replayable");
     /// ```
     #[must_use]
     pub fn with_tracked_pauli(mut self, pauli: PauliString) -> Self {
@@ -319,8 +367,11 @@ impl<'a> InfluenceBuilder<'a> {
                 }
             }
         }
-        // Nothing is committed until every annotation resolved: a rejected
-        // ingest must not leave the builder holding half the outputs.
+        // Staged so interleaved observables and tracked Paulis keep annotation
+        // order in one place. Partial state cannot escape an `Err` regardless:
+        // the method consumes `self`, so a failed ingest drops the builder --
+        // which also means transactionality here is structural and untestable,
+        // not a behavior a test could pin.
         self.non_detector_outputs.extend(ingested);
         Ok(self)
     }
@@ -331,20 +382,30 @@ impl<'a> InfluenceBuilder<'a> {
     /// 1. Forward symbolic simulation to get measurement correlations
     /// 2. Detector extraction from deterministic measurements
     /// 3. Backward propagation from detectors and DEM outputs
-    #[must_use]
-    pub fn build(&self) -> DagFaultInfluenceMap {
+    /// # Errors
+    ///
+    /// Returns [`InfluenceBuildError`] when the circuit contains a gate the
+    /// symbolic replay cannot represent, or a batched measurement node. Both
+    /// used to be analyzed silently wrong -- an ignored rotation manufactured
+    /// phantom detectors, and a batched node was treated as measuring only its
+    /// first qubit.
+    pub fn build(&self) -> Result<DagFaultInfluenceMap, InfluenceBuildError> {
         // Step 1: Run forward symbolic simulation
-        let measurement_info = self.run_symbolic_simulation();
+        let measurement_info = self.run_symbolic_simulation()?;
 
         // Step 2: Extract detectors from deterministic measurements
         let detectors = Self::extract_detectors(&measurement_info);
 
         // Step 3: Build influence map with backward propagation
-        self.build_influence_map_with_detectors(&measurement_info, &detectors)
+        Ok(self.build_influence_map_with_detectors(&measurement_info, &detectors))
     }
 
     /// Run symbolic simulation to get measurement correlations.
-    pub(crate) fn run_symbolic_simulation(&self) -> MeasurementInfo {
+    ///
+    /// # Errors
+    ///
+    /// See [`build`](Self::build).
+    pub(crate) fn run_symbolic_simulation(&self) -> Result<MeasurementInfo, InfluenceBuildError> {
         let topo_order = self.dag.topological_order();
 
         // Determine number of qubits from the circuit
@@ -384,23 +445,55 @@ impl<'a> InfluenceBuilder<'a> {
 
                 match op.gate_type {
                     pecos_quantum::GateType::MZ | pecos_quantum::GateType::MeasureFree => {
+                        if qubits.len() > 1 {
+                            return Err(InfluenceBuildError::BatchedMeasurementUnsupported {
+                                node,
+                                count: qubits.len(),
+                            });
+                        }
                         sim.mz(&[qubits[0]]);
                         node_to_meas_idx[node] = Some(meas_idx);
                         meas_idx += 1;
                     }
-                    // Skip other gates (identity, barriers, Prep, etc.)
-                    _ => {}
+                    // A leaked measurement collapses its qubit but consumes no
+                    // measurement record, so it gets no measurement index.
+                    pecos_quantum::GateType::MeasureLeaked => {
+                        sim.mz(&qubits);
+                    }
+                    // Resets project onto |0>. Skipping them treated a reused
+                    // qubit as still carrying its pre-reset correlations.
+                    pecos_quantum::GateType::PZ | pecos_quantum::GateType::QAlloc => {
+                        for &q in &qubits {
+                            sim.pz(q);
+                        }
+                    }
+                    // No effect on stabilizer correlations.
+                    pecos_quantum::GateType::I
+                    | pecos_quantum::GateType::Idle
+                    | pecos_quantum::GateType::QFree
+                    | pecos_quantum::GateType::MeasCrosstalkGlobalPayload
+                    | pecos_quantum::GateType::MeasCrosstalkLocalPayload
+                    | pecos_quantum::GateType::TrackedPauliMeta => {}
+                    // Anything else would be silently mis-analyzed: an ignored
+                    // rotation manufactures detectors its backward propagation
+                    // then contradicts.
+                    other => {
+                        return Err(InfluenceBuildError::UnsupportedGate {
+                            node,
+                            gate_type: other,
+                        });
+                    }
                 }
             }
         }
 
         let history = sim.measurement_history().clone();
 
-        MeasurementInfo {
+        Ok(MeasurementInfo {
             history,
             node_to_meas_idx,
             num_measurements: meas_idx,
-        }
+        })
     }
 
     /// Extract detectors from deterministic measurements.
@@ -1074,7 +1167,7 @@ mod tests {
         dag.mz(&[0]);
 
         let builder = InfluenceBuilder::new(&dag);
-        let map = builder.build();
+        let map = builder.build().expect("circuit is replayable");
 
         // Should have some locations and at least one detector
         assert!(!map.locations.is_empty());
@@ -1096,7 +1189,7 @@ mod tests {
         dag.mz(&[2]);
 
         let builder = InfluenceBuilder::new(&dag);
-        let map = builder.build();
+        let map = builder.build().expect("circuit is replayable");
 
         assert!(!map.locations.is_empty());
         assert!(!map.measurements.is_empty());
@@ -1120,7 +1213,7 @@ mod tests {
         dag.mz(&[2]);
 
         let builder = InfluenceBuilder::new(&dag);
-        let map = builder.build();
+        let map = builder.build().expect("circuit is replayable");
 
         // Should have multiple measurements
         assert!(map.measurements.len() >= 2);
@@ -1139,7 +1232,7 @@ mod tests {
 
         let builder = InfluenceBuilder::new(&dag).with_z(&[0]); // Track Z logical on qubit 0
 
-        let map = builder.build();
+        let map = builder.build().expect("circuit is replayable");
 
         // Should track the logical
         assert!(map.influences.max_dem_output_index().is_some());
@@ -1173,7 +1266,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         // 1 observable (record_obs) + 1 tracked Pauli (track_x) = 2 DEM outputs
         assert_eq!(map.num_dem_outputs(), 1, "1 observable");
@@ -1207,7 +1301,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         assert_eq!(map.num_observables(), 1);
 
@@ -1251,7 +1346,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         assert_eq!(map.num_observables(), 1);
 
@@ -1296,7 +1392,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         assert_eq!(map.num_observables(), 1);
 
@@ -1322,6 +1419,65 @@ mod tests {
                     .get_observable_indices(h_q1, Pauli::Z.as_u8())
                     .is_empty(),
             "at least one Pauli fault between measurements should flip the late term"
+        );
+    }
+
+    /// An ignored rotation used to manufacture phantom detectors: forward
+    /// replay skipped `RZ` while backward propagation simplified it, so the two
+    /// halves of the analysis disagreed. Reviewer witness on #408.
+    #[test]
+    fn an_unrepresentable_gate_is_refused_not_skipped() {
+        use pecos_core::Angle64;
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.rz(Angle64::QUARTER_TURN, &[0]);
+        dag.mz(&[0]);
+
+        let err = InfluenceBuilder::new(&dag)
+            .build()
+            .map(|_| ())
+            .expect_err("RZ is not representable in the symbolic replay");
+        assert!(matches!(err, InfluenceBuildError::UnsupportedGate { .. }));
+    }
+
+    /// A batched measurement node used to be analyzed as measuring only its
+    /// first qubit, silently undercounting detectors. Refused until the
+    /// per-measurement model (#398) can represent it.
+    #[test]
+    fn a_batched_measurement_node_is_refused_not_undercounted() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        dag.add_gate_auto_wire(pecos_quantum::Gate::mz(&[0usize, 1]));
+
+        let err = InfluenceBuilder::new(&dag)
+            .build()
+            .map(|_| ())
+            .expect_err("a batched measurement node cannot be represented");
+        assert!(matches!(
+            err,
+            InfluenceBuildError::BatchedMeasurementUnsupported { count: 2, .. }
+        ));
+    }
+
+    /// A mid-circuit reset must reach the simulator: skipping it treated a
+    /// reused qubit as still carrying its pre-reset correlations, so the
+    /// re-measurement looked like a deterministic repeat instead of fresh.
+    #[test]
+    fn a_mid_circuit_reset_reaches_the_simulator() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        dag.h(&[0]);
+        dag.mz(&[0]); // random
+        dag.pz(&[0]); // reset -- was silently skipped
+        dag.mz(&[0]); // deterministic |0>, NOT a repeat of the first
+
+        let map = InfluenceBuilder::new(&dag)
+            .build()
+            .expect("all gates representable");
+        assert_eq!(
+            map.detectors.len(),
+            1,
+            "the post-reset measurement is deterministic on its own"
         );
     }
 
@@ -1379,38 +1535,6 @@ mod tests {
         ));
     }
 
-    /// A rejected ingest commits nothing observable-side: a caller who catches
-    /// the error and rebuilds sees no half-state.
-    #[test]
-    fn a_rejected_ingest_leaves_no_partial_outputs() {
-        let mut dag = DagCircuit::new();
-        dag.pz(&[0, 1]);
-        let good = dag.mz(&[0]);
-        dag.mz(&[1]);
-        dag.observable_labeled("resolves_fine", &good);
-        dag.add_annotation(pecos_quantum::PauliAnnotation {
-            pauli: PauliString::zs(&[1usize]),
-            kind: pecos_quantum::AnnotationKind::Observable {
-                measurement_nodes: vec![99],
-            },
-            label: None,
-        });
-
-        assert!(
-            InfluenceBuilder::new(&dag)
-                .with_circuit_annotations()
-                .is_err(),
-            "the second annotation cannot resolve"
-        );
-        let clean = InfluenceBuilder::new(&dag).build();
-        let fresh = InfluenceBuilder::new(&dag).build();
-        assert_eq!(
-            clean.num_observables(),
-            fresh.num_observables(),
-            "a fresh build is unaffected by the failed ingest"
-        );
-    }
-
     #[test]
     fn test_duplicate_observable_terms_cancel_in_influence_map() {
         let mut dag = DagCircuit::new();
@@ -1422,7 +1546,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         assert_eq!(map.num_observables(), 1);
         for loc_idx in 0..map.locations.len() {
@@ -1469,12 +1594,14 @@ mod batched_node_tests {
 
         let batched_det: Vec<bool> = InfluenceBuilder::new(&batched)
             .run_symbolic_simulation()
+            .expect("circuit is replayable")
             .history
             .iter()
             .map(|result| result.is_deterministic)
             .collect();
         let split_det: Vec<bool> = InfluenceBuilder::new(&split)
             .run_symbolic_simulation()
+            .expect("circuit is replayable")
             .history
             .iter()
             .map(|result| result.is_deterministic)

--- a/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
@@ -484,7 +484,8 @@ mod tests {
         dag.observable_labeled("obs0", &[meas[0]]);
 
         let map = InfluenceBuilder::new(&dag)
-            .with_circuit_annotations(&dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve against the circuit")
             .build();
         assert_eq!(map.num_tracked_paulis(), 1);
         assert_eq!(map.num_observables(), 1);

--- a/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
@@ -486,7 +486,8 @@ mod tests {
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
             .expect("annotations resolve against the circuit")
-            .build();
+            .build()
+            .expect("circuit is replayable");
         assert_eq!(map.num_tracked_paulis(), 1);
         assert_eq!(map.num_observables(), 1);
 
@@ -502,7 +503,9 @@ mod tests {
         let meas = dag.mz(&[1]);
         dag.detector(&[meas[0]]);
 
-        let map = InfluenceBuilder::new(&dag).build();
+        let map = InfluenceBuilder::new(&dag)
+            .build()
+            .expect("circuit is replayable");
         assert_eq!(map.num_observables(), 0);
 
         let decoder = LookupDecoder::build(&map, &NoiseConfig::uniform(0.01), 0);

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -3038,7 +3038,8 @@ mod tests {
 
         let map = crate::fault_tolerance::InfluenceBuilder::new(&dag)
             .with_z(&[0])
-            .build();
+            .build()
+            .expect("circuit is replayable");
 
         assert_eq!(map.num_dem_outputs(), 0);
         assert_eq!(map.num_tracked_paulis(), 1);

--- a/crates/pecos-qec/tests/fault_enumeration_example.rs
+++ b/crates/pecos-qec/tests/fault_enumeration_example.rs
@@ -122,7 +122,8 @@ fn repetition_code_fault_enumeration() {
 
     // Build influence map (InfluenceBuilder handles annotations)
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     let locs = map.gate_fault_locations();
@@ -286,7 +287,8 @@ fn repetition_code_fault_enumeration() {
 fn repetition_code_labels() {
     let dag = build_repetition_code(1); // 1 round for simplicity
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Check DEM-output labels are populated (observables + tracked Paulis)
@@ -325,7 +327,8 @@ fn repetition_code_labels() {
 fn repetition_code_lookup_table() {
     let dag = build_repetition_code(3);
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Build lookup: syndrome pattern -> list of possible logical effects
@@ -368,7 +371,8 @@ fn repetition_code_ml_decoder() {
 
     // Build influence map
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Build ML decoder from fault enumeration up to weight 3
@@ -445,7 +449,8 @@ fn decoder_empty_syndrome() {
     let dag = build_repetition_code(1);
     let noise = NoiseConfig::uniform(0.01);
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     let decoder = LookupDecoder::build(&map, &noise, 2);
@@ -469,7 +474,8 @@ fn decoder_table_size_and_truncation() {
     let dag = build_repetition_code(1);
     let noise = NoiseConfig::uniform(0.001);
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     let d1 = LookupDecoder::build(&map, &noise, 1);
@@ -636,7 +642,8 @@ fn code_422_fault_enumeration() {
 
     // Build influence map
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     let locs = map.gate_fault_locations();
@@ -711,7 +718,8 @@ fn code_422_ml_decoder() {
     let noise = NoiseConfig::uniform(0.001);
 
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Build ML decoder up to weight 2

--- a/crates/pecos-qec/tests/fault_enumeration_example.rs
+++ b/crates/pecos-qec/tests/fault_enumeration_example.rs
@@ -124,7 +124,8 @@ fn repetition_code_fault_enumeration() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     let locs = map.gate_fault_locations();
     println!(
@@ -289,7 +290,8 @@ fn repetition_code_labels() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Check DEM-output labels are populated (observables + tracked Paulis)
     println!("DEM output labels: {:?}", map.dem_output_labels);
@@ -329,7 +331,8 @@ fn repetition_code_lookup_table() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Build lookup: syndrome pattern -> list of possible logical effects
     let mut lookup: std::collections::BTreeMap<Vec<u32>, Vec<pecos_core::PauliString>> =
@@ -373,7 +376,8 @@ fn repetition_code_ml_decoder() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Build ML decoder from fault enumeration up to weight 3
     let decoder = LookupDecoder::build(&map, &noise, 3);
@@ -451,7 +455,8 @@ fn decoder_empty_syndrome() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     let decoder = LookupDecoder::build(&map, &noise, 2);
 
@@ -476,7 +481,8 @@ fn decoder_table_size_and_truncation() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     let d1 = LookupDecoder::build(&map, &noise, 1);
     let d2 = LookupDecoder::build(&map, &noise, 2);
@@ -644,7 +650,8 @@ fn code_422_fault_enumeration() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     let locs = map.gate_fault_locations();
     println!(
@@ -720,7 +727,8 @@ fn code_422_ml_decoder() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Build ML decoder up to weight 2
     let decoder = LookupDecoder::build(&map, &noise, 2);

--- a/crates/pecos-qec/tests/targeted_tests.rs
+++ b/crates/pecos-qec/tests/targeted_tests.rs
@@ -133,7 +133,8 @@ fn custom_p1_weights_affect_decoder() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Uniform weights
     let noise_uniform = NoiseConfig::uniform(0.001);
@@ -208,7 +209,8 @@ fn prep_gate_stops_propagation() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     // Find the H gate's after-location
     let mut h_has_influence = false;
@@ -315,7 +317,8 @@ fn probability_sums_to_one() {
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
         .expect("annotations resolve against the circuit")
-        .build();
+        .build()
+        .expect("circuit is replayable");
 
     let noise = NoiseConfig::uniform(0.001);
     let decoder = LookupDecoder::build(&map, &noise, 3);

--- a/crates/pecos-qec/tests/targeted_tests.rs
+++ b/crates/pecos-qec/tests/targeted_tests.rs
@@ -131,7 +131,8 @@ fn custom_p1_weights_affect_decoder() {
     dag.observable(&[ms[0], ms[1]]);
 
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Uniform weights
@@ -205,7 +206,8 @@ fn prep_gate_stops_propagation() {
     dag.mz(&[0]);
 
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     // Find the H gate's after-location
@@ -311,7 +313,8 @@ fn probability_sums_to_one() {
     dag.observable(&[ms[0], ms[1]]);
 
     let map = InfluenceBuilder::new(&dag)
-        .with_circuit_annotations(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve against the circuit")
         .build();
 
     let noise = NoiseConfig::uniform(0.001);

--- a/crates/pecos-qec/tests/unified_sampler_tests.rs
+++ b/crates/pecos-qec/tests/unified_sampler_tests.rs
@@ -457,6 +457,7 @@ fn circuit_annotation_dual_output() {
     let sampler = DemSamplerBuilder::new(&influence_map)
         .with_uniform_noise(0.05) // high noise for visible effect
         .with_circuit_annotations(&dag)
+        .expect("annotations resolve against the influence map")
         .build()
         .unwrap();
 

--- a/crates/pecos-qec/tests/unified_sampler_tests.rs
+++ b/crates/pecos-qec/tests/unified_sampler_tests.rs
@@ -44,7 +44,10 @@ fn repetition_code_circuit(num_rounds: usize) -> DagCircuit {
 fn build_influence_map(
     circuit: &DagCircuit,
 ) -> pecos_qec::fault_tolerance::propagator::DagFaultInfluenceMap {
-    InfluenceBuilder::new(circuit).with_z(&[0, 1, 2]).build()
+    InfluenceBuilder::new(circuit)
+        .with_z(&[0, 1, 2])
+        .build()
+        .expect("circuit is replayable")
 }
 
 // ============================================================================

--- a/exp/pecos-eeg/examples/profile_heisenberg.rs
+++ b/exp/pecos-eeg/examples/profile_heisenberg.rs
@@ -49,7 +49,7 @@ fn main() {
     let num_rounds = 8;
     let gates = build_weight4_circuit(num_rounds);
     let noise = pecos_eeg::noise::UniformNoise::coherent_only(0.05);
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates).expect("supported circuit");
     let na = 1; // one ancilla
 
     let mut detectors = Vec::new();

--- a/exp/pecos-eeg/src/builder.rs
+++ b/exp/pecos-eeg/src/builder.rs
@@ -12,46 +12,7 @@ use crate::stabilizer::StabilizerGroup;
 use pecos_core::pauli::pauli_bitmask::BitmaskStorage;
 use pecos_quantum::{AnnotationKind, TickCircuit};
 
-/// Why an EEG DEM could not be built from the circuit.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EegBuildError {
-    /// The circuit contains a measurement type the EEG expansion does not
-    /// handle. Expansion is `MZ`-only; any other measurement would silently
-    /// vanish from the deferred-measurement circuit, taking its record with it.
-    UnsupportedMeasurement {
-        /// The offending gate type.
-        gate_type: pecos_core::gate_type::GateType,
-    },
-    /// An annotation references a measurement record the circuit does not have.
-    UnresolvableAnnotationRecord {
-        /// The out-of-range record index.
-        record_idx: usize,
-        /// How many measurement records the expansion produced.
-        num_measurements: usize,
-    },
-}
-
-impl std::fmt::Display for EegBuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnsupportedMeasurement { gate_type } => write!(
-                f,
-                "circuit contains {gate_type:?}, which the MZ-only EEG expansion cannot \
-                 represent; its measurement record would silently vanish"
-            ),
-            Self::UnresolvableAnnotationRecord {
-                record_idx,
-                num_measurements,
-            } => write!(
-                f,
-                "annotation references measurement record {record_idx}, but the expansion \
-                 produced only {num_measurements}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for EegBuildError {}
+pub use crate::expand::EegBuildError;
 
 pub struct EegDemBuilder<'a> {
     tc: &'a TickCircuit,
@@ -96,26 +57,6 @@ impl<'a> EegDemBuilder<'a> {
         self
     }
 
-    fn collect_supported_gates(&self) -> Result<Vec<pecos_core::Gate>, EegBuildError> {
-        let mut gates = Vec::new();
-        for batch in self.tc.iter_gate_batches() {
-            let gate = batch.as_gate();
-            let is_measurement = matches!(
-                gate.gate_type,
-                pecos_core::gate_type::GateType::MZ
-                    | pecos_core::gate_type::GateType::MeasureFree
-                    | pecos_core::gate_type::GateType::MeasureLeaked
-            );
-            if is_measurement && gate.gate_type != pecos_core::gate_type::GateType::MZ {
-                return Err(EegBuildError::UnsupportedMeasurement {
-                    gate_type: gate.gate_type,
-                });
-            }
-            gates.push(gate.clone());
-        }
-        Ok(gates)
-    }
-
     /// # Errors
     ///
     /// Returns [`EegBuildError`] when the circuit contains a measurement type
@@ -123,8 +64,12 @@ impl<'a> EegDemBuilder<'a> {
     /// a measurement record the expansion did not produce. Both used to be
     /// silent -- the measurement vanished, or the reference was skipped.
     pub fn build(&self) -> Result<Vec<DemEntry>, EegBuildError> {
-        let gates = self.collect_supported_gates()?;
-        let expanded = expand::expand_circuit(&gates);
+        let gates: Vec<pecos_core::Gate> = self
+            .tc
+            .iter_gate_batches()
+            .map(|batch| batch.as_gate().clone())
+            .collect();
+        let expanded = expand::expand_circuit(&gates)?;
         let result = circuit::analyze_expanded(&expanded.gates, &self.noise);
         let (detectors, observables) = build_detectors(self.tc, &expanded)?;
 
@@ -155,8 +100,12 @@ impl<'a> EegDemBuilder<'a> {
     ///
     /// Same conditions as [`build`](Self::build).
     pub fn summary(&self) -> Result<EegSummary, EegBuildError> {
-        let gates = self.collect_supported_gates()?;
-        let expanded = expand::expand_circuit(&gates);
+        let gates: Vec<pecos_core::Gate> = self
+            .tc
+            .iter_gate_batches()
+            .map(|batch| batch.as_gate().clone())
+            .collect();
+        let expanded = expand::expand_circuit(&gates)?;
         let result = circuit::analyze_expanded(&expanded.gates, &self.noise);
         let (detectors, observables) = build_detectors(self.tc, &expanded)?;
 
@@ -295,16 +244,10 @@ fn measurement_nodes_to_aux_bitmask(
 ) -> Result<Bm, EegBuildError> {
     let mut bitmask = Bm::default();
 
+    let _ = num_meas;
     for &record_idx in measurement_nodes {
-        // An out-of-range record used to be skipped, thinning the annotation
-        // without a word.
-        if record_idx >= num_meas {
-            return Err(EegBuildError::UnresolvableAnnotationRecord {
-                record_idx,
-                num_measurements: num_meas,
-            });
-        }
-        let aux_qubit = expanded.measurement_qubit[record_idx];
+        // Single resolver: an out-of-range record is an error, never a skip.
+        let aux_qubit = expanded.aux_qubit_for_record(record_idx)?;
         bitmask.z_bits.xor_bit(aux_qubit);
     }
 
@@ -410,7 +353,7 @@ mod tests {
             .iter_gate_batches()
             .map(|batch| batch.as_gate().clone())
             .collect();
-        let expanded = expand::expand_circuit(&gates);
+        let expanded = expand::expand_circuit(&gates).expect("MZ-only circuit");
         let result = circuit::analyze_expanded(&expanded.gates, &noise);
 
         let expanded_pre = exclude_final_mz(&expanded.gates);

--- a/exp/pecos-eeg/src/builder.rs
+++ b/exp/pecos-eeg/src/builder.rs
@@ -258,19 +258,50 @@ fn measurement_nodes_to_aux_bitmask(
 mod tests {
     use super::*;
 
-    /// A `MeasureFree` used to pass through the MZ-only expansion unchanged,
-    /// silently deleting its measurement record. It is now refused.
+    /// A `MeasureFree` used to pass through the expansion unchanged, silently
+    /// deleting its measurement record. It now lowers to `MZ`.
     #[test]
-    fn a_measure_free_circuit_is_refused_not_silently_thinned() {
+    fn a_measure_free_circuit_expands_with_its_record_intact() {
+        // Surface-code circuits read every ancilla with `mz_free`; refusing it
+        // was a regression, not a guard. It lowers to `MZ` -- the record is
+        // real, the free has no stabilizer effect.
         let mut tc = TickCircuit::new();
         tc.tick().pz(&[0, 1]);
         tc.tick().mz_free(&[0]);
         tc.tick().mz(&[1]);
 
+        EegDemBuilder::from_tick_circuit(&tc)
+            .noise(NoiseModel::coherent_only(0.01))
+            .build()
+            .expect("MeasureFree lowers to MZ in the expansion");
+
+        let gates: Vec<pecos_core::Gate> = tc
+            .iter_gate_batches()
+            .map(|batch| batch.as_gate().clone())
+            .collect();
+        let expanded = crate::expand::expand_circuit(&gates).expect("supported");
+        assert_eq!(
+            expanded.measurement_qubit.len(),
+            2,
+            "both the MeasureFree and the MZ keep their measurement records"
+        );
+    }
+
+    /// `MeasureLeaked` stays refused: it consumes no record, so the
+    /// record-aligned expansion genuinely cannot represent it.
+    #[test]
+    fn a_measure_leaked_circuit_is_refused() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick()
+            .try_add_gate(pecos_core::Gate::measure_leaked(&[0usize]))
+            .expect("gate is valid");
+        tc.tick().mz(&[1]);
+
         let err = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::coherent_only(0.01))
             .build()
-            .expect_err("MeasureFree cannot be represented by the MZ-only expansion");
+            .expect_err("MeasureLeaked consumes no record");
         assert!(matches!(err, EegBuildError::UnsupportedMeasurement { .. }));
     }
 

--- a/exp/pecos-eeg/src/builder.rs
+++ b/exp/pecos-eeg/src/builder.rs
@@ -12,6 +12,47 @@ use crate::stabilizer::StabilizerGroup;
 use pecos_core::pauli::pauli_bitmask::BitmaskStorage;
 use pecos_quantum::{AnnotationKind, TickCircuit};
 
+/// Why an EEG DEM could not be built from the circuit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EegBuildError {
+    /// The circuit contains a measurement type the EEG expansion does not
+    /// handle. Expansion is `MZ`-only; any other measurement would silently
+    /// vanish from the deferred-measurement circuit, taking its record with it.
+    UnsupportedMeasurement {
+        /// The offending gate type.
+        gate_type: pecos_core::gate_type::GateType,
+    },
+    /// An annotation references a measurement record the circuit does not have.
+    UnresolvableAnnotationRecord {
+        /// The out-of-range record index.
+        record_idx: usize,
+        /// How many measurement records the expansion produced.
+        num_measurements: usize,
+    },
+}
+
+impl std::fmt::Display for EegBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedMeasurement { gate_type } => write!(
+                f,
+                "circuit contains {gate_type:?}, which the MZ-only EEG expansion cannot \
+                 represent; its measurement record would silently vanish"
+            ),
+            Self::UnresolvableAnnotationRecord {
+                record_idx,
+                num_measurements,
+            } => write!(
+                f,
+                "annotation references measurement record {record_idx}, but the expansion \
+                 produced only {num_measurements}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EegBuildError {}
+
 pub struct EegDemBuilder<'a> {
     tc: &'a TickCircuit,
     noise: NoiseModel,
@@ -55,16 +96,37 @@ impl<'a> EegDemBuilder<'a> {
         self
     }
 
-    #[must_use]
-    pub fn build(&self) -> Vec<DemEntry> {
-        let gates: Vec<pecos_core::Gate> = self
-            .tc
-            .iter_gate_batches()
-            .map(|batch| batch.as_gate().clone())
-            .collect();
+    fn collect_supported_gates(&self) -> Result<Vec<pecos_core::Gate>, EegBuildError> {
+        let mut gates = Vec::new();
+        for batch in self.tc.iter_gate_batches() {
+            let gate = batch.as_gate();
+            let is_measurement = matches!(
+                gate.gate_type,
+                pecos_core::gate_type::GateType::MZ
+                    | pecos_core::gate_type::GateType::MeasureFree
+                    | pecos_core::gate_type::GateType::MeasureLeaked
+            );
+            if is_measurement && gate.gate_type != pecos_core::gate_type::GateType::MZ {
+                return Err(EegBuildError::UnsupportedMeasurement {
+                    gate_type: gate.gate_type,
+                });
+            }
+            gates.push(gate.clone());
+        }
+        Ok(gates)
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`EegBuildError`] when the circuit contains a measurement type
+    /// the MZ-only expansion cannot represent, or when an annotation references
+    /// a measurement record the expansion did not produce. Both used to be
+    /// silent -- the measurement vanished, or the reference was skipped.
+    pub fn build(&self) -> Result<Vec<DemEntry>, EegBuildError> {
+        let gates = self.collect_supported_gates()?;
         let expanded = expand::expand_circuit(&gates);
         let result = circuit::analyze_expanded(&expanded.gates, &self.noise);
-        let (detectors, observables) = build_detectors(self.tc, &expanded);
+        let (detectors, observables) = build_detectors(self.tc, &expanded)?;
 
         // Compute stabilizer group from the EXPANDED circuit (pre-readout).
         // This includes auxiliary qubits, so beta function checks happen
@@ -73,30 +135,30 @@ impl<'a> EegDemBuilder<'a> {
         let expanded_pre_readout = exclude_final_mz(&expanded.gates);
         let stab_group = StabilizerGroup::from_circuit(&expanded_pre_readout, expanded.num_qubits);
 
-        dem_mapping::build_dem_configured(
+        Ok(dem_mapping::build_dem_configured(
             &result.generators,
             &detectors,
             &observables,
             Some(&stab_group),
             &self.config,
-        )
+        ))
     }
 
-    #[must_use]
-    pub fn build_dem_string(&self) -> String {
-        dem_mapping::format_dem(&self.build())
+    /// # Errors
+    ///
+    /// Same conditions as [`build`](Self::build).
+    pub fn build_dem_string(&self) -> Result<String, EegBuildError> {
+        Ok(dem_mapping::format_dem(&self.build()?))
     }
 
-    #[must_use]
-    pub fn summary(&self) -> EegSummary {
-        let gates: Vec<pecos_core::Gate> = self
-            .tc
-            .iter_gate_batches()
-            .map(|batch| batch.as_gate().clone())
-            .collect();
+    /// # Errors
+    ///
+    /// Same conditions as [`build`](Self::build).
+    pub fn summary(&self) -> Result<EegSummary, EegBuildError> {
+        let gates = self.collect_supported_gates()?;
         let expanded = expand::expand_circuit(&gates);
         let result = circuit::analyze_expanded(&expanded.gates, &self.noise);
-        let (detectors, observables) = build_detectors(self.tc, &expanded);
+        let (detectors, observables) = build_detectors(self.tc, &expanded)?;
 
         let expanded_pre = exclude_final_mz(&expanded.gates);
         let stab_group = StabilizerGroup::from_circuit(&expanded_pre, expanded.num_qubits);
@@ -119,7 +181,7 @@ impl<'a> EegDemBuilder<'a> {
             .filter(|g| g.eeg_type == crate::eeg::EegType::S)
             .count();
 
-        EegSummary {
+        Ok(EegSummary {
             num_original_gates: gates.len(),
             num_expanded_gates: expanded.gates.len(),
             num_expanded_qubits: expanded.num_qubits,
@@ -129,7 +191,7 @@ impl<'a> EegDemBuilder<'a> {
             num_observables: observables.len(),
             num_dem_events: entries.len(),
             generator_fidelity: result.generator_fidelity(),
-        }
+        })
     }
 }
 
@@ -174,7 +236,7 @@ fn exclude_final_mz(gates: &[pecos_core::Gate]) -> Vec<pecos_core::Gate> {
 fn build_detectors(
     tc: &TickCircuit,
     expanded: &expand::ExpandedCircuit,
-) -> (Vec<Detector>, Vec<Observable>) {
+) -> Result<(Vec<Detector>, Vec<Observable>), EegBuildError> {
     let mut detectors = Vec::new();
     let mut observables = Vec::new();
     let num_meas = expanded.measurement_qubit.len();
@@ -197,7 +259,7 @@ fn build_detectors(
                 // measurement_node is a gate index — we find which measurement
                 // records that gate produced.
                 let bitmask =
-                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas);
+                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas)?;
                 detectors.push(Detector {
                     id: detectors.len(),
                     stabilizer: bitmask,
@@ -207,7 +269,7 @@ fn build_detectors(
                 measurement_nodes, ..
             } => {
                 let bitmask =
-                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas);
+                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas)?;
                 observables.push(Observable {
                     id: observables.len(),
                     pauli: bitmask,
@@ -217,7 +279,7 @@ fn build_detectors(
         }
     }
 
-    (detectors, observables)
+    Ok((detectors, observables))
 }
 
 /// Map measurement record indices to a Z bitmask on auxiliary qubits.
@@ -230,22 +292,74 @@ fn measurement_nodes_to_aux_bitmask(
     _tc: &TickCircuit,
     expanded: &expand::ExpandedCircuit,
     num_meas: usize,
-) -> Bm {
+) -> Result<Bm, EegBuildError> {
     let mut bitmask = Bm::default();
 
     for &record_idx in measurement_nodes {
-        if record_idx < num_meas {
-            let aux_qubit = expanded.measurement_qubit[record_idx];
-            bitmask.z_bits.xor_bit(aux_qubit);
+        // An out-of-range record used to be skipped, thinning the annotation
+        // without a word.
+        if record_idx >= num_meas {
+            return Err(EegBuildError::UnresolvableAnnotationRecord {
+                record_idx,
+                num_measurements: num_meas,
+            });
         }
+        let aux_qubit = expanded.measurement_qubit[record_idx];
+        bitmask.z_bits.xor_bit(aux_qubit);
     }
 
-    bitmask
+    Ok(bitmask)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `MeasureFree` used to pass through the MZ-only expansion unchanged,
+    /// silently deleting its measurement record. It is now refused.
+    #[test]
+    fn a_measure_free_circuit_is_refused_not_silently_thinned() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        tc.tick().mz_free(&[0]);
+        tc.tick().mz(&[1]);
+
+        let err = EegDemBuilder::from_tick_circuit(&tc)
+            .noise(NoiseModel::coherent_only(0.01))
+            .build()
+            .expect_err("MeasureFree cannot be represented by the MZ-only expansion");
+        assert!(matches!(err, EegBuildError::UnsupportedMeasurement { .. }));
+    }
+
+    /// An annotation referencing a record the expansion never produced used to
+    /// be skipped, thinning the observable. It is now an error naming both
+    /// sides of the mismatch.
+    #[test]
+    fn an_out_of_range_record_annotation_is_an_error() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0]);
+        let refs = tc.tick().mz(&[0]);
+        tc.detector(&refs);
+        // Forge a measurement ref onto record 7 of a 1-record circuit.
+        // TickMeasRef fields are public, so a caller can construct exactly this.
+        let forged = pecos_quantum::TickMeasRef {
+            record_idx: 7,
+            ..refs[0]
+        };
+        tc.observable(&[forged]);
+
+        let err = EegDemBuilder::from_tick_circuit(&tc)
+            .noise(NoiseModel::coherent_only(0.01))
+            .build()
+            .expect_err("record 7 does not exist");
+        assert_eq!(
+            err,
+            EegBuildError::UnresolvableAnnotationRecord {
+                record_idx: 7,
+                num_measurements: 1,
+            }
+        );
+    }
 
     #[test]
     fn test_empty_no_noise() {
@@ -254,7 +368,8 @@ mod tests {
         tc.tick().mz(&[0]);
         let entries = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::coherent_only(0.0))
-            .build();
+            .build()
+            .expect("circuit is MZ-only with in-range records");
         assert!(entries.is_empty());
     }
 
@@ -267,7 +382,8 @@ mod tests {
         tc.tick().mz(&[0, 1]);
         let summary = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::coherent_only(0.1))
-            .summary();
+            .summary()
+            .expect("circuit is MZ-only with in-range records");
         assert!(summary.num_h_generators > 0);
         assert_eq!(summary.num_s_generators, 0);
     }
@@ -286,7 +402,8 @@ mod tests {
         // Builder path
         let builder_entries = EegDemBuilder::from_tick_circuit(&tc)
             .noise(noise.clone())
-            .build();
+            .build()
+            .expect("circuit is MZ-only with in-range records");
 
         // Manual path
         let gates: Vec<pecos_core::Gate> = tc
@@ -299,7 +416,7 @@ mod tests {
         let expanded_pre = exclude_final_mz(&expanded.gates);
         let stab_group = StabilizerGroup::from_circuit(&expanded_pre, expanded.num_qubits);
 
-        let (detectors, observables) = build_detectors(&tc, &expanded);
+        let (detectors, observables) = build_detectors(&tc, &expanded).expect("records in range");
         let manual_entries = dem_mapping::build_dem_with_stabilizers(
             &result.generators,
             &detectors,
@@ -337,7 +454,8 @@ mod tests {
 
         let entries = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::depolarizing(0.01))
-            .build();
+            .build()
+            .expect("circuit is MZ-only with in-range records");
 
         assert!(
             entries.is_empty(),
@@ -370,7 +488,8 @@ mod tests {
 
         let entries = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::depolarizing(0.01))
-            .build();
+            .build()
+            .expect("circuit is MZ-only with in-range records");
 
         assert!(
             !entries.is_empty(),
@@ -392,7 +511,8 @@ mod tests {
 
         let summary = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::depolarizing(0.01).with_idle_rz(0.05))
-            .summary();
+            .summary()
+            .expect("circuit is MZ-only with in-range records");
 
         assert!(
             summary.num_h_generators > 0,

--- a/exp/pecos-eeg/src/circuit.rs
+++ b/exp/pecos-eeg/src/circuit.rs
@@ -647,7 +647,7 @@ mod tests {
             gate(GateType::MZ, &[1]), // last round
             gate(GateType::MZ, &[0]),
         ];
-        let expanded = crate::expand::expand_circuit(&original_gates);
+        let expanded = crate::expand::expand_circuit(&original_gates).expect("MZ-only circuit");
 
         // Count PZ gates in expanded circuit (originals + expansion projections)
         let all_pz: Vec<_> = expanded
@@ -698,7 +698,7 @@ mod tests {
             gate(GateType::MZ, &[0]),
             gate(GateType::MZ, &[1]),
         ];
-        let expanded = crate::expand::expand_circuit(&gates);
+        let expanded = crate::expand::expand_circuit(&gates).expect("MZ-only circuit");
         let noise = NoiseModel::coherent_only(0.1);
         let result = analyze_expanded(&expanded.gates, &noise);
 

--- a/exp/pecos-eeg/src/dem_simulator.rs
+++ b/exp/pecos-eeg/src/dem_simulator.rs
@@ -137,7 +137,7 @@ fn stochastic_path(
     seed: u64,
 ) -> Result<DemSimulationResult, DemSimulationError> {
     // Build TickCircuit using typed API (proper measurement record tracking)
-    let mut tc = build_tick_circuit(gates, meta);
+    let mut tc = build_tick_circuit(gates, meta)?;
 
     // Compact ticks to reduce DAG complexity (critical for performance)
     tc.compact_ticks();
@@ -177,7 +177,31 @@ fn stochastic_path(
 /// After building all gates, creates detector/observable annotations using
 /// the stored measurement references. This ensures the DagCircuit conversion
 /// and DagFaultAnalyzer see proper structured annotations.
-fn build_tick_circuit(gates: &[Gate], meta: &CircuitMeasurementMeta) -> TickCircuit {
+/// Resolve one Stim-style record offset to its measurement ref, loudly.
+fn resolve_record_offset_ref(
+    offset: i32,
+    meta: &CircuitMeasurementMeta,
+    all_meas_refs: &[pecos_quantum::TickMeasRef],
+) -> Result<pecos_quantum::TickMeasRef, DemSimulationError> {
+    record_offset_to_absolute_index(meta.num_measurements, offset)
+        .and_then(|abs_idx| all_meas_refs.get(abs_idx).copied())
+        .ok_or_else(|| {
+            DemSimulationError::FaultTable(format!(
+                "record offset {offset} does not resolve against {} measurements",
+                meta.num_measurements
+            ))
+        })
+}
+
+/// # Errors
+///
+/// Returns [`DemSimulationError`] when a detector or observable record offset
+/// does not resolve against the circuit's measurements. Unresolvable offsets
+/// used to be silently dropped, thinning the annotation.
+fn build_tick_circuit(
+    gates: &[Gate],
+    meta: &CircuitMeasurementMeta,
+) -> Result<TickCircuit, DemSimulationError> {
     use pecos_quantum::{Attribute, TickMeasRef};
 
     let mut tc = TickCircuit::default();
@@ -202,15 +226,13 @@ fn build_tick_circuit(gates: &[Gate], meta: &CircuitMeasurementMeta) -> TickCirc
         }
     }
 
-    // Create detector annotations from record definitions
+    // Create detector annotations from record definitions. An offset that
+    // does not resolve is an error, not a silently thinner annotation.
     for records in &meta.detector_records {
-        let det_refs: Vec<TickMeasRef> = records
-            .iter()
-            .filter_map(|&rec| {
-                let abs_idx = (meta.num_measurements as i32 + rec) as usize;
-                all_meas_refs.get(abs_idx).copied()
-            })
-            .collect();
+        let mut det_refs: Vec<TickMeasRef> = Vec::with_capacity(records.len());
+        for &rec in records {
+            det_refs.push(resolve_record_offset_ref(rec, meta, &all_meas_refs)?);
+        }
         if !det_refs.is_empty() {
             tc.detector(&det_refs);
         }
@@ -218,13 +240,10 @@ fn build_tick_circuit(gates: &[Gate], meta: &CircuitMeasurementMeta) -> TickCirc
 
     // Create observable annotations from record definitions
     for records in &meta.observable_records {
-        let obs_refs: Vec<TickMeasRef> = records
-            .iter()
-            .filter_map(|&rec| {
-                let abs_idx = (meta.num_measurements as i32 + rec) as usize;
-                all_meas_refs.get(abs_idx).copied()
-            })
-            .collect();
+        let mut obs_refs: Vec<TickMeasRef> = Vec::with_capacity(records.len());
+        for &rec in records {
+            obs_refs.push(resolve_record_offset_ref(rec, meta, &all_meas_refs)?);
+        }
         if !obs_refs.is_empty() {
             tc.observable(&obs_refs);
         }
@@ -256,7 +275,7 @@ fn build_tick_circuit(gates: &[Gate], meta: &CircuitMeasurementMeta) -> TickCirc
         tc.set_meta("observables", Attribute::String(obs_json));
     }
 
-    tc
+    Ok(tc)
 }
 
 /// EEG path: DEM generation + ParsedDem sampling + measurement synthesis.
@@ -319,12 +338,13 @@ fn build_detectors_from_meta(
     for (id, records) in meta.detector_records.iter().enumerate() {
         let mut bm = crate::Bm::default();
         for &rec in records {
-            let meas_idx = record_offset_to_absolute_index(meta.num_measurements, rec).ok_or(
-                crate::expand::EegBuildError::UnresolvableAnnotationRecord {
-                    record_idx: usize::MAX,
-                    num_measurements: meta.num_measurements,
-                },
-            )?;
+            let meas_idx =
+                record_offset_to_absolute_index(meta.num_measurements, rec).ok_or_else(|| {
+                    DemSimulationError::FaultTable(format!(
+                        "record offset {rec} does not resolve against {} measurements",
+                        meta.num_measurements
+                    ))
+                })?;
             // Single resolver: out-of-range is an error, never a skip.
             let q = expanded.aux_qubit_for_record(meas_idx)?;
             bm.z_bits.set_bit(q);
@@ -343,12 +363,13 @@ fn build_observables_from_meta(
     for (id, records) in meta.observable_records.iter().enumerate() {
         let mut bm = crate::Bm::default();
         for &rec in records {
-            let meas_idx = record_offset_to_absolute_index(meta.num_measurements, rec).ok_or(
-                crate::expand::EegBuildError::UnresolvableAnnotationRecord {
-                    record_idx: usize::MAX,
-                    num_measurements: meta.num_measurements,
-                },
-            )?;
+            let meas_idx =
+                record_offset_to_absolute_index(meta.num_measurements, rec).ok_or_else(|| {
+                    DemSimulationError::FaultTable(format!(
+                        "record offset {rec} does not resolve against {} measurements",
+                        meta.num_measurements
+                    ))
+                })?;
             let q = expanded.aux_qubit_for_record(meas_idx)?;
             bm.z_bits.set_bit(q);
         }

--- a/exp/pecos-eeg/src/dem_simulator.rs
+++ b/exp/pecos-eeg/src/dem_simulator.rs
@@ -31,6 +31,7 @@ use pecos_core::Gate;
 use pecos_core::gate_type::GateType;
 use pecos_core::pauli::pauli_bitmask::BitmaskStorage;
 use pecos_qec::fault_tolerance::dem_builder::ParsedDem;
+use pecos_qec::fault_tolerance::dem_builder::record_offset_to_absolute_index;
 use pecos_qec::fault_tolerance::fault_sampler::{
     RawMeasurementPlan, StochasticNoiseParams, symbolic_measurement_history,
 };
@@ -53,6 +54,38 @@ pub struct CircuitMeasurementMeta {
 pub struct DemSimulationResult {
     /// Per-shot measurement bitstrings (same format as gate-by-gate simulators).
     pub measurements: Vec<Vec<u8>>,
+}
+/// Why a DEM simulation could not run.
+///
+/// Every variant carries the underlying diagnostic. This replaces an
+/// `Option`/`.ok()?` chain that erased the cause and an `expect` that turned
+/// any failure into a generic panic blaming the wrong layer.
+#[derive(Debug, Clone)]
+pub enum DemSimulationError {
+    /// The circuit cannot be expanded or its annotations resolved.
+    Eeg(crate::expand::EegBuildError),
+    /// The circuit cannot produce a record-aligned measurement history.
+    History(pecos_qec::fault_tolerance::fault_sampler::MeasurementHistoryError),
+    /// The fault table could not be built.
+    FaultTable(String),
+}
+
+impl std::fmt::Display for DemSimulationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eeg(err) => write!(f, "DEM simulation: {err}"),
+            Self::History(err) => write!(f, "DEM simulation: {err}"),
+            Self::FaultTable(msg) => write!(f, "DEM simulation: fault table: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for DemSimulationError {}
+
+impl From<crate::expand::EegBuildError> for DemSimulationError {
+    fn from(err: crate::expand::EegBuildError) -> Self {
+        Self::Eeg(err)
+    }
 }
 
 /// Run DEM-based simulation: build DEM, sample, produce measurement bitstrings.
@@ -78,15 +111,14 @@ pub fn run_dem_simulation(
     generator: &dyn DemGenerator,
     shots: usize,
     seed: u64,
-) -> DemSimulationResult {
+) -> Result<DemSimulationResult, DemSimulationError> {
     // Coherent noise: use EEG path (Heisenberg walks handle idle_rz)
     if noise.idle_rz.abs() > 1e-15 {
         return run_eeg_path(gates, noise, meta, generator, shots, seed);
     }
 
     // Stochastic: use proper DemSampler with raw measurement output
-    try_stochastic_path(gates, noise, meta, shots, seed)
-        .expect("DEM simulation failed: could not build TickCircuit or DemSampler from circuit")
+    stochastic_path(gates, noise, meta, shots, seed)
 }
 
 /// Stochastic raw measurement path via RawMeasurementPlan.
@@ -97,26 +129,20 @@ pub fn run_dem_simulation(
 /// - Geometric/O(fired) fault sampling
 /// - Raw measurement output matching gate-by-gate simulators
 ///
-/// Returns None if idle_rz > 0 (needs EEG path for coherent noise).
-fn try_stochastic_path(
+fn stochastic_path(
     gates: &[Gate],
     noise: &UniformNoise,
     meta: &CircuitMeasurementMeta,
     shots: usize,
     seed: u64,
-) -> Option<DemSimulationResult> {
-    // Only use stochastic path when no coherent noise
-    if noise.idle_rz.abs() > 1e-15 {
-        return None;
-    }
-
+) -> Result<DemSimulationResult, DemSimulationError> {
     // Build TickCircuit using typed API (proper measurement record tracking)
     let mut tc = build_tick_circuit(gates, meta);
 
     // Compact ticks to reduce DAG complexity (critical for performance)
     tc.compact_ticks();
 
-    let history = symbolic_measurement_history(&tc).ok()?;
+    let history = symbolic_measurement_history(&tc).map_err(DemSimulationError::History)?;
 
     let noise_params = StochasticNoiseParams {
         p1: noise.p1,
@@ -125,7 +151,8 @@ fn try_stochastic_path(
         p_prep: noise.p_prep,
     };
     let mechanisms =
-        pecos_qec::fault_tolerance::fault_sampler::build_fault_table(&tc, &noise_params).ok()?;
+        pecos_qec::fault_tolerance::fault_sampler::build_fault_table(&tc, &noise_params)
+            .map_err(|err| DemSimulationError::FaultTable(err.to_string()))?;
     let plan = RawMeasurementPlan::new(&history, mechanisms);
 
     // Sample raw measurements (columnar, then extract rows)
@@ -140,7 +167,7 @@ fn try_stochastic_path(
         measurements.push(meas);
     }
 
-    Some(DemSimulationResult { measurements })
+    Ok(DemSimulationResult { measurements })
 }
 
 /// Build a TickCircuit from flat gates + metadata using the typed API.
@@ -243,14 +270,14 @@ fn run_eeg_path(
     generator: &dyn DemGenerator,
     shots: usize,
     seed: u64,
-) -> DemSimulationResult {
+) -> Result<DemSimulationResult, DemSimulationError> {
     // Expand circuit for EEG analysis
-    let expanded = crate::expand::expand_circuit(gates);
+    let expanded = crate::expand::expand_circuit(gates)?;
     let gate_index = GateIndex::build(&expanded.gates, expanded.num_qubits);
 
     // Build detectors and observables from metadata
-    let detectors = build_detectors_from_meta(meta, &expanded);
-    let observables = build_observables_from_meta(meta, &expanded);
+    let detectors = build_detectors_from_meta(meta, &expanded)?;
+    let observables = build_observables_from_meta(meta, &expanded)?;
 
     // Generate DEM via trait
     let ctx = DemContext {
@@ -280,51 +307,54 @@ fn run_eeg_path(
         measurements.push(meas);
     }
 
-    DemSimulationResult { measurements }
+    Ok(DemSimulationResult { measurements })
 }
 
 /// Build EEG Detector structs from circuit metadata.
 fn build_detectors_from_meta(
     meta: &CircuitMeasurementMeta,
     expanded: &ExpandedCircuit,
-) -> Vec<crate::dem_mapping::Detector> {
-    meta.detector_records
-        .iter()
-        .enumerate()
-        .map(|(id, records)| {
-            let mut bm = crate::Bm::default();
-            for &rec in records {
-                let meas_idx = (meta.num_measurements as i32 + rec) as usize;
-                if meas_idx < expanded.measurement_qubit.len() {
-                    let q = expanded.measurement_qubit[meas_idx];
-                    bm.z_bits.set_bit(q);
-                }
-            }
-            crate::dem_mapping::Detector { id, stabilizer: bm }
-        })
-        .collect()
+) -> Result<Vec<crate::dem_mapping::Detector>, DemSimulationError> {
+    let mut detectors = Vec::with_capacity(meta.detector_records.len());
+    for (id, records) in meta.detector_records.iter().enumerate() {
+        let mut bm = crate::Bm::default();
+        for &rec in records {
+            let meas_idx = record_offset_to_absolute_index(meta.num_measurements, rec).ok_or(
+                crate::expand::EegBuildError::UnresolvableAnnotationRecord {
+                    record_idx: usize::MAX,
+                    num_measurements: meta.num_measurements,
+                },
+            )?;
+            // Single resolver: out-of-range is an error, never a skip.
+            let q = expanded.aux_qubit_for_record(meas_idx)?;
+            bm.z_bits.set_bit(q);
+        }
+        detectors.push(crate::dem_mapping::Detector { id, stabilizer: bm });
+    }
+    Ok(detectors)
 }
 
 /// Build EEG Observable structs from circuit metadata.
 fn build_observables_from_meta(
     meta: &CircuitMeasurementMeta,
     expanded: &ExpandedCircuit,
-) -> Vec<crate::dem_mapping::Observable> {
-    meta.observable_records
-        .iter()
-        .enumerate()
-        .map(|(id, records)| {
-            let mut bm = crate::Bm::default();
-            for &rec in records {
-                let meas_idx = (meta.num_measurements as i32 + rec) as usize;
-                if meas_idx < expanded.measurement_qubit.len() {
-                    let q = expanded.measurement_qubit[meas_idx];
-                    bm.z_bits.set_bit(q);
-                }
-            }
-            crate::dem_mapping::Observable { id, pauli: bm }
-        })
-        .collect()
+) -> Result<Vec<crate::dem_mapping::Observable>, DemSimulationError> {
+    let mut observables = Vec::with_capacity(meta.observable_records.len());
+    for (id, records) in meta.observable_records.iter().enumerate() {
+        let mut bm = crate::Bm::default();
+        for &rec in records {
+            let meas_idx = record_offset_to_absolute_index(meta.num_measurements, rec).ok_or(
+                crate::expand::EegBuildError::UnresolvableAnnotationRecord {
+                    record_idx: usize::MAX,
+                    num_measurements: meta.num_measurements,
+                },
+            )?;
+            let q = expanded.aux_qubit_for_record(meas_idx)?;
+            bm.z_bits.set_bit(q);
+        }
+        observables.push(crate::dem_mapping::Observable { id, pauli: bm });
+    }
+    Ok(observables)
 }
 
 /// Precomputed info for synthesizing measurements from detection events.

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -14,6 +14,47 @@ use pecos_core::pauli::pauli_bitmask::BitmaskStorage;
 use pecos_core::{Gate, GateAngles, GateParams, QubitId};
 
 /// Result of circuit expansion.
+/// Why an EEG DEM could not be built from the circuit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EegBuildError {
+    /// The circuit contains a measurement type the EEG expansion does not
+    /// handle. Expansion is `MZ`-only; any other measurement would silently
+    /// vanish from the deferred-measurement circuit, taking its record with it.
+    UnsupportedMeasurement {
+        /// The offending gate type.
+        gate_type: pecos_core::gate_type::GateType,
+    },
+    /// An annotation references a measurement record the circuit does not have.
+    UnresolvableAnnotationRecord {
+        /// The out-of-range record index.
+        record_idx: usize,
+        /// How many measurement records the expansion produced.
+        num_measurements: usize,
+    },
+}
+
+impl std::fmt::Display for EegBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedMeasurement { gate_type } => write!(
+                f,
+                "circuit contains {gate_type:?}, which the MZ-only EEG expansion cannot \
+                 represent; its measurement record would silently vanish"
+            ),
+            Self::UnresolvableAnnotationRecord {
+                record_idx,
+                num_measurements,
+            } => write!(
+                f,
+                "annotation references measurement record {record_idx}, but the expansion \
+                 produced only {num_measurements}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EegBuildError {}
+
 pub struct ExpandedCircuit {
     /// The expanded gate sequence (purely Clifford, no mid-circuit measurements).
     pub gates: Vec<Gate>,
@@ -57,7 +98,25 @@ pub struct ExpandedCircuit {
 /// All auxiliary qubits are measured at the end via MZ.
 /// Final data measurements (MZ not followed by PZ) are also deferred
 /// to auxiliary qubits for uniformity.
-pub fn expand_circuit(gates: &[Gate]) -> ExpandedCircuit {
+/// # Errors
+///
+/// Returns [`EegBuildError::UnsupportedMeasurement`] when the circuit contains
+/// a measurement type this MZ-only expansion cannot represent -- passing it
+/// through would silently delete its measurement record. This is THE checked
+/// entrance: every consumer (builder, simulator, bindings) routes through it,
+/// so the check cannot drift across copies.
+pub fn expand_circuit(gates: &[Gate]) -> Result<ExpandedCircuit, EegBuildError> {
+    for gate in gates {
+        let is_measurement = matches!(
+            gate.gate_type,
+            GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
+        );
+        if is_measurement && gate.gate_type != GateType::MZ {
+            return Err(EegBuildError::UnsupportedMeasurement {
+                gate_type: gate.gate_type,
+            });
+        }
+    }
     // First pass: find the max qubit index to know where auxiliaries start
     let max_qubit = gates
         .iter()
@@ -159,14 +218,14 @@ pub fn expand_circuit(gates: &[Gate]) -> ExpandedCircuit {
         expanded.push(make_gate(GateType::MZ, &[aux]));
     }
 
-    ExpandedCircuit {
+    Ok(ExpandedCircuit {
         gates: expanded,
         num_qubits: next_aux,
         num_original_qubits: num_original,
         measurement_qubit,
         original_measured_qubit,
         meas_id_rank,
-    }
+    })
 }
 
 impl ExpandedCircuit {
@@ -285,6 +344,26 @@ pub fn make_gate(gt: GateType, qubits: &[usize]) -> Gate {
     }
 }
 
+impl ExpandedCircuit {
+    /// The auxiliary qubit whose final Z-measurement carries `record_idx`.
+    ///
+    /// The one implementation of record resolution: an out-of-range record is
+    /// an error naming both sides of the mismatch, never a silent skip.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EegBuildError::UnresolvableAnnotationRecord`] when the record
+    /// does not exist.
+    pub fn aux_qubit_for_record(&self, record_idx: usize) -> Result<usize, EegBuildError> {
+        self.measurement_qubit.get(record_idx).copied().ok_or(
+            EegBuildError::UnresolvableAnnotationRecord {
+                record_idx,
+                num_measurements: self.measurement_qubit.len(),
+            },
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     /// `meas_id_rank` records expansion order, keyed by the id the gate holds.
@@ -309,7 +388,7 @@ mod tests {
             batch,
         ];
 
-        let expanded = super::expand_circuit(&gates);
+        let expanded = super::expand_circuit(&gates).expect("MZ-only circuit");
         assert_eq!(
             expanded.meas_id_rank.get(&MeasId::from_raw(9)),
             Some(&0),
@@ -342,7 +421,7 @@ mod tests {
             gate(GateType::MZ, &[0]), // → CX(0, aux1)
         ];
 
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         // Should have 3 qubits: original 0, aux 1, aux 2
         assert_eq!(expanded.num_original_qubits, 1);
@@ -374,7 +453,7 @@ mod tests {
             gate(GateType::CX, &[0, 1]),
         ];
 
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         // No measurements → no expansion needed
         assert_eq!(expanded.num_qubits, 2);
@@ -393,7 +472,7 @@ mod tests {
             gate(GateType::MZ, &[1]), // meas record 1 → aux 3
         ];
 
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         assert_eq!(expanded.measurement_qubit, vec![2, 3]);
         assert_eq!(expanded.num_qubits, 4);
@@ -406,7 +485,7 @@ mod tests {
             gate(GateType::PZ, &[0]),
             gate(GateType::MZ, &[0]), // meas 0 → aux 1
         ];
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         // X on aux 1 maps to X on original qubit 0
         let p = Bm::x(1); // aux qubit
@@ -418,7 +497,7 @@ mod tests {
     fn test_map_to_original_frame_z_on_aux_dropped() {
         // Z on auxiliary is dropped (measurement projection absorbs it)
         let gates = vec![gate(GateType::PZ, &[0]), gate(GateType::MZ, &[0])];
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         let p = Bm::z(1); // Z on aux
         let mapped = expanded.map_to_original_frame(&p);
@@ -429,7 +508,7 @@ mod tests {
     fn test_map_to_original_frame_original_passthrough() {
         // Components on original qubits pass through unchanged
         let gates = vec![gate(GateType::PZ, &[0, 1]), gate(GateType::MZ, &[0])];
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         let p = Bm::x(0).multiply(&Bm::z(1)); // X0 Z1
         let mapped = expanded.map_to_original_frame(&p);
@@ -444,7 +523,7 @@ mod tests {
             gate(GateType::H, &[0]),
             gate(GateType::MZ, &[0]),
         ];
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         // Still creates one aux qubit for the final MZ
         assert_eq!(expanded.num_qubits, 2);
@@ -470,7 +549,7 @@ mod tests {
             gate(GateType::MZ, &[0]), // data readout
         ];
 
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         // Count PZ/QAlloc gates on qubit 1 in the expanded circuit
         let resets_on_1: Vec<_> = expanded
@@ -518,7 +597,7 @@ mod tests {
             gate(GateType::PZ, &[0]),
             gate(GateType::MZ, &[0]),
         ];
-        let expanded = expand_circuit(&gates);
+        let expanded = expand_circuit(&gates).expect("MZ-only circuit");
 
         assert_eq!(expanded.measurement_qubit.len(), 2);
         assert_eq!(expanded.original_measured_qubit, vec![0, 0]);

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -76,12 +76,10 @@ pub struct ExpandedCircuit {
     /// one this expansion recorded -- an index into `measurement_qubit` and
     /// `original_measured_qubit`.
     ///
-    /// **`MZ` only.** The expansion walk handles no other measurement type, so
-    /// a stamped `MeasureFree` -- record-bearing and valid -- does not appear
-    /// here, exactly as its measurement does not appear in `measurement_qubit`.
-    /// An absent id is therefore ambiguous between "unknown" and "unsupported
-    /// measurement type"; resolving that needs an error channel on the eeg
-    /// builder, tracked in #387. Id-less legacy circuits yield an empty map.
+    /// `MZ` and `MeasureFree` both appear -- `MeasureFree` lowers to `MZ` in
+    /// this expansion, since the free has no stabilizer effect and its record
+    /// is real. `MeasureLeaked` is refused at the entrance, so an absent id
+    /// here means unknown. Id-less legacy circuits yield an empty map.
     ///
     /// This is eeg's private ordinal. It is expansion order, not id-rank order
     /// and not any other component's ordering; resolve ids through this map
@@ -107,11 +105,12 @@ pub struct ExpandedCircuit {
 /// so the check cannot drift across copies.
 pub fn expand_circuit(gates: &[Gate]) -> Result<ExpandedCircuit, EegBuildError> {
     for gate in gates {
-        let is_measurement = matches!(
-            gate.gate_type,
-            GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
-        );
-        if is_measurement && gate.gate_type != GateType::MZ {
+        // `MeasureFree` is record-bearing and lowers to `MZ` below -- the
+        // "free" is resource bookkeeping with no stabilizer effect, and a
+        // reused qubit reappears behind an explicit prep the expansion keeps.
+        // Only `MeasureLeaked` is refused: it consumes no record, so this
+        // record-aligned expansion cannot represent it.
+        if gate.gate_type == GateType::MeasureLeaked {
             return Err(EegBuildError::UnsupportedMeasurement {
                 gate_type: gate.gate_type,
             });
@@ -164,7 +163,7 @@ pub fn expand_circuit(gates: &[Gate]) -> Result<ExpandedCircuit, EegBuildError> 
         let gate = &gates[i];
 
         match gate.gate_type {
-            GateType::MZ => {
+            GateType::MZ | GateType::MeasureFree => {
                 // For each qubit in this MZ gate, create CX to auxiliary
                 for (position, q) in gate.qubits.iter().enumerate() {
                     let q_idx = q.index();

--- a/exp/pecos-eeg/src/heisenberg.rs
+++ b/exp/pecos-eeg/src/heisenberg.rs
@@ -1764,8 +1764,8 @@ pub fn heisenberg_detection_probability_from_circuit(
     noise: &dyn NoiseSpec,
     num_original_qubits: usize,
     prune_threshold: f64,
-) -> f64 {
-    let expanded = crate::expand::expand_circuit(original_gates);
+) -> Result<f64, crate::expand::EegBuildError> {
+    let expanded = crate::expand::expand_circuit(original_gates)?;
 
     let mut detector = Bm::default();
     for &m in detector_meas_indices {
@@ -1779,7 +1779,13 @@ pub fn heisenberg_detection_probability_from_circuit(
         .collect();
     let stab = StabilizerGroup::from_circuit(&init_gates, expanded.num_qubits);
 
-    heisenberg_detection_probability(&expanded.gates, &detector, noise, &stab, prune_threshold)
+    Ok(heisenberg_detection_probability(
+        &expanded.gates,
+        &detector,
+        noise,
+        &stab,
+        prune_threshold,
+    ))
 }
 
 /// Exact detection probability via matrix-based backward Heisenberg.
@@ -1793,8 +1799,8 @@ pub fn heisenberg_exact_from_circuit(
     detector_meas_indices: &[usize],
     noise: &dyn NoiseSpec,
     _num_original_qubits: usize,
-) -> f64 {
-    let expanded = crate::expand::expand_circuit(original_gates);
+) -> Result<f64, crate::expand::EegBuildError> {
+    let expanded = crate::expand::expand_circuit(original_gates)?;
     let n = expanded.num_qubits;
 
     assert!(
@@ -1874,7 +1880,7 @@ pub fn heisenberg_exact_from_circuit(
     // ⟨0...0|O_backward|0...0⟩ = obs_re[0]
     let expectation = obs_re[0];
     let prob = 0.5 * (1.0 - expectation);
-    prob.clamp(0.0, 1.0)
+    Ok(prob.clamp(0.0, 1.0))
 }
 
 // --- Matrix helpers for exact Heisenberg ---
@@ -2098,7 +2104,7 @@ mod tests {
             gate(GateType::MZ, &[3]),
         ];
 
-        let expanded = expand::expand_circuit(&gates_orig);
+        let expanded = expand::expand_circuit(&gates_orig).expect("supported circuit");
         let theta = 0.05;
         let noise = UniformNoise::coherent_only(theta);
 
@@ -2273,7 +2279,8 @@ mod tests {
 
         for &theta in &[0.01, 0.05, 0.1, 0.2, 0.5] {
             let noise = crate::noise::UniformNoise::coherent_only(theta);
-            let p = heisenberg_exact_from_circuit(&gates, &[0, 1], &noise, 2);
+            let p = heisenberg_exact_from_circuit(&gates, &[0, 1], &noise, 2)
+                .expect("supported circuit");
             let exact = theta.sin().powi(2);
             assert!(
                 (p - exact).abs() < 1e-10,
@@ -2305,7 +2312,8 @@ mod tests {
 
         for &theta in &[0.01, 0.05, 0.1, 0.2] {
             let noise = crate::noise::UniformNoise::coherent_only(theta);
-            let p = heisenberg_exact_from_circuit(&gates, &[0, 1], &noise, 3);
+            let p = heisenberg_exact_from_circuit(&gates, &[0, 1], &noise, 3)
+                .expect("supported circuit");
             let exact = (2.0 - (6.0 * theta).cos() - (2.0 * theta).cos()) / 4.0;
             eprintln!("theta={theta:.2}: exact_heisenberg={p:.10}, analytical={exact:.10}");
             assert!(
@@ -2368,7 +2376,7 @@ mod tests {
             gate(GateType::MZ, &[6]),
         ];
 
-        let expanded = crate::expand::expand_circuit(&gates_orig);
+        let expanded = crate::expand::expand_circuit(&gates_orig).expect("supported circuit");
         let gate_index = crate::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
 
         let init_gates: Vec<Gate> = (0..7).map(|q| gate(GateType::PZ, &[q])).collect();
@@ -2548,7 +2556,7 @@ mod tests {
                 gates.push(gate(GateType::MZ, &[q]));
             }
 
-            let expanded = crate::expand::expand_circuit(&gates);
+            let expanded = crate::expand::expand_circuit(&gates).expect("supported circuit");
             let gate_index = crate::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
             let noise_map = build_noise_map(&expanded.gates, &noise, &gate_index.expansion_gates);
 
@@ -2674,7 +2682,7 @@ mod tests {
                 gates.push(gate(GateType::MZ, &[q]));
             }
 
-            let expanded = crate::expand::expand_circuit(&gates);
+            let expanded = crate::expand::expand_circuit(&gates).expect("supported circuit");
             let gate_index = crate::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
             let noise_map = build_noise_map(&expanded.gates, &noise, &gate_index.expansion_gates);
 

--- a/exp/pecos-eeg/src/heisenberg.rs
+++ b/exp/pecos-eeg/src/heisenberg.rs
@@ -1769,9 +1769,9 @@ pub fn heisenberg_detection_probability_from_circuit(
 
     let mut detector = Bm::default();
     for &m in detector_meas_indices {
-        if m < expanded.measurement_qubit.len() {
-            detector.z_bits.set_bit(expanded.measurement_qubit[m]);
-        }
+        // Single resolver: an out-of-range record is an error, never a
+        // silently thinner detector.
+        detector.z_bits.set_bit(expanded.aux_qubit_for_record(m)?);
     }
 
     let init_gates: Vec<Gate> = (0..num_original_qubits)
@@ -1813,11 +1813,16 @@ pub fn heisenberg_exact_from_circuit(
     // Build detector matrix: diagonal with Z eigenvalues on the detector aux qubits.
     let mut obs_re = vec![0.0f64; dim * dim];
     let obs_im = vec![0.0f64; dim * dim];
+    // Pre-resolve outside the matrix loop: out-of-range is an error, and the
+    // resolver must not run 2^n times.
+    let mut detector_aux = Vec::with_capacity(detector_meas_indices.len());
+    for &m in detector_meas_indices {
+        detector_aux.push(expanded.aux_qubit_for_record(m)?);
+    }
     for i in 0..dim {
         let mut eigenvalue = 1.0f64;
-        for &m in detector_meas_indices {
-            if m < expanded.measurement_qubit.len() {
-                let aux = expanded.measurement_qubit[m];
+        for &aux in &detector_aux {
+            {
                 if (i >> aux) & 1 == 1 {
                     eigenvalue = -eigenvalue;
                 }

--- a/exp/pecos-eeg/tests/beta_investigation.rs
+++ b/exp/pecos-eeg/tests/beta_investigation.rs
@@ -53,7 +53,7 @@ fn build_minimal_zbasis() -> Vec<Gate> {
 #[test]
 fn test_zbasis_generator_labels() {
     let gates = build_minimal_zbasis();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
 
     eprintln!(
         "Expanded circuit: {} qubits ({} original + {} aux)",

--- a/exp/pecos-eeg/tests/generator_trace.rs
+++ b/exp/pecos-eeg/tests/generator_trace.rs
@@ -87,7 +87,7 @@ fn build_d2_zbasis() -> Vec<Gate> {
 #[test]
 fn trace_d2_zbasis_generators() {
     let gates = build_d2_zbasis();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(0.01);
     let result = analyze_expanded(&expanded.gates, &noise);
 

--- a/exp/pecos-eeg/tests/statevec_comparison.rs
+++ b/exp/pecos-eeg/tests/statevec_comparison.rs
@@ -53,7 +53,7 @@ fn bit_to_f64(value: usize) -> f64 {
 
 /// Run EEG on a gate list with a parity detector over all measurements.
 fn eeg_detection_prob(gates: &[Gate], theta: f64) -> f64 {
-    let expanded = expand::expand_circuit(gates);
+    let expanded = expand::expand_circuit(gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(theta);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -85,7 +85,7 @@ fn eeg_detection_prob(gates: &[Gate], theta: f64) -> f64 {
 
 /// Run EEG with per-round detectors, return per-detector probabilities.
 fn eeg_per_round_probs(gates: &[Gate], theta: f64, num_rounds: usize) -> Vec<f64> {
-    let expanded = expand::expand_circuit(gates);
+    let expanded = expand::expand_circuit(gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(theta);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -145,7 +145,7 @@ fn test_eeg_vs_statevec_bell_parity() {
         gate(GateType::MZ, &[1]),
     ];
 
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(theta);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -236,7 +236,7 @@ fn test_eeg_vs_statevec_larger_angle() {
         gate(GateType::MZ, &[1]),
     ];
 
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(theta);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -475,7 +475,7 @@ fn bench_z_basis_check() {
     ];
 
     for &theta in &[0.01, 0.05, 0.1, 0.2, 0.3] {
-        let expanded = expand::expand_circuit(&gates);
+        let expanded = expand::expand_circuit(&gates).expect("supported circuit");
         let noise = NoiseModel::coherent_only(theta);
         let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -606,7 +606,7 @@ fn bench_repetition_code_comparison() {
             );
 
             // --- EEG forward ---
-            let expanded = expand::expand_circuit(&gates);
+            let expanded = expand::expand_circuit(&gates).expect("supported circuit");
             let noise_model = NoiseModel::coherent_only(theta);
             let noise_spec = UniformNoise::coherent_only(theta);
             let result = analyze_expanded(&expanded.gates, &noise_model);
@@ -668,7 +668,8 @@ fn bench_repetition_code_comparison() {
                         &noise_spec,
                         num_qubits,
                         1e-12,
-                    );
+                    )
+                    .expect("supported circuit");
                 }
             }
 
@@ -783,7 +784,7 @@ fn bench_expansion_equivalence() {
     ];
 
     // Expand the circuit
-    let expanded = expand::expand_circuit(&gates_orig);
+    let expanded = expand::expand_circuit(&gates_orig).expect("supported circuit");
     eprintln!(
         "Expanded: {} gates, {} qubits",
         expanded.gates.len(),
@@ -797,7 +798,8 @@ fn bench_expansion_equivalence() {
 
     // --- Heisenberg on expanded circuit ---
     let noise = UniformNoise::coherent_only(theta);
-    let h_p = heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0);
+    let h_p = heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0)
+        .expect("supported circuit");
 
     // --- StateVec on ORIGINAL circuit (with mid-circuit measurements) ---
     let mut orig_det = 0u64;
@@ -947,7 +949,7 @@ fn bench_matrix_heisenberg() {
         gate(GateType::H, &[2]),
         gate(GateType::MZ, &[2]),
     ];
-    let expanded = expand::expand_circuit(&gates_orig);
+    let expanded = expand::expand_circuit(&gates_orig).expect("supported circuit");
 
     // Build the detector matrix: Z_3 * Z_4
     // Z_q has eigenvalue +1 for |0> and -1 for |1>
@@ -1094,7 +1096,8 @@ fn bench_matrix_heisenberg() {
 
     // Heisenberg backward walk
     let noise = UniformNoise::coherent_only(theta);
-    let h_p = heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0);
+    let h_p = heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0)
+        .expect("supported circuit");
 
     // Exact analytical
     let exact = (2.0 - (6.0 * theta).cos() - (2.0 * theta).cos()) / 4.0;
@@ -1270,7 +1273,7 @@ fn bench_per_noise_attribution() {
         gate(GateType::H, &[2]),
         gate(GateType::MZ, &[2]),
     ];
-    let expanded = expand::expand_circuit(&gates_orig);
+    let expanded = expand::expand_circuit(&gates_orig).expect("supported circuit");
 
     // Noise source locations in expanded circuit:
     // Gate 4: CX(2,0) R1 → noise on q2 and q0
@@ -1379,7 +1382,8 @@ fn bench_per_noise_attribution() {
     let matrix_all = 0.5 * (1.0 - obs_re[0]);
     let noise = UniformNoise::coherent_only(theta);
     let walk_all =
-        heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0);
+        heisenberg_detection_probability_from_circuit(&gates_orig, &[0, 1], &noise, 3, 0.0)
+            .expect("supported circuit");
     eprintln!(
         "{:>25} {:>12.8} {:>12.8} {:>8.4}",
         "ALL",
@@ -1414,7 +1418,8 @@ fn bench_weight_isolation() {
             gate(GateType::MZ, &[2]),
         ];
         let noise = UniformNoise::coherent_only(theta);
-        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0], &noise, 3, 0.0);
+        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0], &noise, 3, 0.0)
+            .expect("supported circuit");
 
         let mut det = 0u64;
         let mut sim = StateVec::new(3);
@@ -1459,7 +1464,8 @@ fn bench_weight_isolation() {
             gate(GateType::MZ, &[2]),
         ];
         let noise = UniformNoise::coherent_only(theta);
-        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 3, 0.0);
+        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 3, 0.0)
+            .expect("supported circuit");
 
         let mut det = 0u64;
         let mut sim = StateVec::new(3);
@@ -1509,7 +1515,8 @@ fn bench_weight_isolation() {
             gate(GateType::MZ, &[4]),
         ];
         let noise = UniformNoise::coherent_only(theta);
-        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0], &noise, 5, 0.0);
+        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0], &noise, 5, 0.0)
+            .expect("supported circuit");
 
         let mut det = 0u64;
         let mut sim = StateVec::new(5);
@@ -1559,7 +1566,8 @@ fn bench_weight_isolation() {
             gate(GateType::MZ, &[4]),
         ];
         let noise = UniformNoise::coherent_only(theta);
-        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 5, 0.0);
+        let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 5, 0.0)
+            .expect("supported circuit");
 
         let mut det = 0u64;
         let mut sim = StateVec::new(5);
@@ -1626,8 +1634,10 @@ fn bench_weight_isolation() {
             gate(GateType::MZ, &[4]),
         ];
         let noise = UniformNoise::coherent_only(theta);
-        let h_a0 = heisenberg_detection_probability_from_circuit(&gates, &[0, 2], &noise, 5, 0.0);
-        let h_a1 = heisenberg_detection_probability_from_circuit(&gates, &[1, 3], &noise, 5, 0.0);
+        let h_a0 = heisenberg_detection_probability_from_circuit(&gates, &[0, 2], &noise, 5, 0.0)
+            .expect("supported circuit");
+        let h_a1 = heisenberg_detection_probability_from_circuit(&gates, &[1, 3], &noise, 5, 0.0)
+            .expect("supported circuit");
 
         let mut a0 = 0u64;
         let mut a1 = 0u64;
@@ -1708,7 +1718,7 @@ fn bench_heisenberg_scaling() {
         let num_ancilla = d - 1;
         let num_detectors = num_ancilla; // rounds-1 == 1 comparison per ancilla
 
-        let expanded = expand::expand_circuit(&gates);
+        let expanded = expand::expand_circuit(&gates).expect("supported circuit");
         let noise = UniformNoise::coherent_only(theta);
 
         let mut max_prob = 0.0f64;
@@ -1730,7 +1740,8 @@ fn bench_heisenberg_scaling() {
                 &noise,
                 num_qubits,
                 0.0,
-            );
+            )
+            .expect("supported circuit");
             let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
             eprintln!("    {i:>6} {prob:>18.10} {elapsed_ms:>12.2}");
@@ -1768,7 +1779,7 @@ fn bench_heisenberg_scaling() {
         // Round comparison detectors: (num_rounds - 1) comparisons per ancilla
         let num_detectors = num_ancilla * (num_rounds - 1);
 
-        let expanded = expand::expand_circuit(&gates);
+        let expanded = expand::expand_circuit(&gates).expect("supported circuit");
         let noise = UniformNoise::coherent_only(theta);
 
         let mut max_prob = 0.0f64;
@@ -1790,7 +1801,8 @@ fn bench_heisenberg_scaling() {
                     &noise,
                     num_qubits,
                     0.0,
-                );
+                )
+                .expect("supported circuit");
                 let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
                 eprintln!("    R{round}A{i} {prob:>18.10} {elapsed_ms:>12.2}");
@@ -1862,11 +1874,13 @@ fn bench_combined_noise() {
         p_prep: 0.0,
     };
     // Detector = Z on meas[0] * Z on meas[1] (round comparison)
-    let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 3, 0.0);
+    let h_p = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise, 3, 0.0)
+        .expect("supported circuit");
 
     // ---- Also compute coherent-only and meas-only for decomposition ----
     let noise_coh = UniformNoise::coherent_only(idle_rz);
-    let h_coh = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise_coh, 3, 0.0);
+    let h_coh = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise_coh, 3, 0.0)
+        .expect("supported circuit");
 
     let noise_meas = UniformNoise {
         idle_rz: 0.0,
@@ -1876,7 +1890,8 @@ fn bench_combined_noise() {
         p_prep: 0.0,
     };
     let h_meas =
-        heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise_meas, 3, 0.0);
+        heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &noise_meas, 3, 0.0)
+            .expect("supported circuit");
 
     // ---- StateVec simulation with matching noise ----
     let mut rng = PecosRng::seed_from_u64(12345);
@@ -1937,7 +1952,8 @@ fn bench_combined_noise() {
             p_meas: pm,
             p_prep: 0.0,
         };
-        let hp = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &n, 3, 0.0);
+        let hp = heisenberg_detection_probability_from_circuit(&gates, &[0, 1], &n, 3, 0.0)
+            .expect("supported circuit");
 
         let pm_threshold = rng.probability_threshold(pm);
         let mut d = 0u64;

--- a/exp/pecos-eeg/tests/surface_code.rs
+++ b/exp/pecos-eeg/tests/surface_code.rs
@@ -62,7 +62,7 @@ fn build_repetition_code() -> (Vec<Gate>, Vec<Detector>, Vec<Observable>) {
 #[test]
 fn test_repetition_code_no_noise() {
     let (gates, _, _) = build_repetition_code();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(0.0);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -72,7 +72,7 @@ fn test_repetition_code_no_noise() {
 #[test]
 fn test_repetition_code_coherent_noise() {
     let (gates, detectors, observables) = build_repetition_code();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::coherent_only(0.1);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -106,7 +106,7 @@ fn test_repetition_code_coherent_noise() {
 #[test]
 fn test_repetition_code_depolarizing_noise() {
     let (gates, detectors, observables) = build_repetition_code();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::depolarizing(0.003);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -132,7 +132,7 @@ fn test_repetition_code_depolarizing_noise() {
 #[test]
 fn test_repetition_code_combined_noise() {
     let (gates, detectors, observables) = build_repetition_code();
-    let expanded = expand::expand_circuit(&gates);
+    let expanded = expand::expand_circuit(&gates).expect("supported circuit");
     let noise = NoiseModel::depolarizing(0.003).with_idle_rz(0.1);
     let result = analyze_expanded(&expanded.gates, &noise);
 
@@ -175,7 +175,7 @@ fn test_eeg_generator_count_scales_linearly() {
             .iter_gate_batches()
             .map(|batch| batch.as_gate().clone())
             .collect();
-        let expanded = expand::expand_circuit(&gates);
+        let expanded = expand::expand_circuit(&gates).expect("supported circuit");
         let noise = NoiseModel::coherent_only(0.1);
         let result = analyze_expanded(&expanded.gates, &noise);
 

--- a/python/pecos-rslib-exp/src/eeg_bindings.rs
+++ b/python/pecos-rslib-exp/src/eeg_bindings.rs
@@ -110,7 +110,8 @@ pub fn eeg_summary(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let result = circuit::analyze_expanded(&expanded.gates, &noise);
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
     let h = result
@@ -148,7 +149,8 @@ pub fn eeg_event_diagnostics(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let result = circuit::analyze_expanded(&expanded.gates, &noise);
     let (detectors, _observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
@@ -214,7 +216,8 @@ pub fn eeg_per_detector(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let result = circuit::analyze_expanded(&expanded.gates, &noise);
     let (detectors, _observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
@@ -402,7 +405,8 @@ pub fn exact_detection_rates(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, _observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
     // Build initial stabilizer group: Z on each original qubit
@@ -477,7 +481,8 @@ pub fn exact_pairwise_rates(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, _observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
     let init_gates: Vec<Gate> = (0..expanded.num_original_qubits)
@@ -557,7 +562,8 @@ pub fn coherent_dem_exact(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
     let gate_index = pecos_eeg::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
 
@@ -650,7 +656,8 @@ pub fn coherent_dem_decomposed(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
     let gate_index = pecos_eeg::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
 
@@ -757,7 +764,8 @@ pub fn exact_correlation_table(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
     let init_gates: Vec<Gate> = (0..expanded.num_original_qubits)
@@ -821,7 +829,8 @@ pub fn correlation_matching_dem(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
     let init_gates: Vec<Gate> = (0..expanded.num_original_qubits)
@@ -871,7 +880,8 @@ pub fn compress_noise(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let gate_index = pecos_eeg::expand::GateIndex::build(&expanded.gates, expanded.num_qubits);
 
     let result = pecos_eeg::noise_compression::compress_noise_to_boundaries(
@@ -913,7 +923,8 @@ pub fn noise_characterization(
         p_prep,
     };
     let gates = extract_gates(tick_circuit)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let (detectors, observables) = extract_detectors_expanded(tick_circuit, &expanded)?;
 
     let init_gates: Vec<Gate> = (0..expanded.num_original_qubits)
@@ -998,7 +1009,8 @@ fn run_eeg(
     let gates = extract_gates(py_tc)?;
 
     // Step 1: Expand circuit (defer measurements)
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
 
     // Step 2: Propagate through expanded circuit
     let result = pecos_eeg::circuit::analyze_expanded(&expanded.gates, &noise);
@@ -1054,7 +1066,8 @@ fn run_eeg_decomposable(
         p_prep,
     };
     let gates = extract_gates(py_tc)?;
-    let expanded = pecos_eeg::expand::expand_circuit(&gates);
+    let expanded = pecos_eeg::expand::expand_circuit(&gates)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     let result = pecos_eeg::circuit::analyze_expanded(&expanded.gates, &noise);
     let (detectors, observables) = extract_detectors_expanded(py_tc, &expanded)?;
     let expanded_pre_readout = exclude_final_mz(&expanded.gates);
@@ -1260,11 +1273,18 @@ fn extract_detectors_expanded(
         for (id, records) in det_list {
             let mut bm = Bm::default();
             for &rec in &records {
-                if let Some(abs_idx) = measurement_record_index(rec, num_meas) {
-                    // Map to AUXILIARY qubit in expanded circuit
-                    let aux_qubit = expanded.measurement_qubit[abs_idx];
-                    bm.z_bits.xor_bit(aux_qubit);
-                }
+                // Single resolver: an unresolvable record is an error, not a
+                // silently thinner detector.
+                let abs_idx = measurement_record_index(rec, num_meas).ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "detector {id} references record offset {rec}, which does not \
+                         resolve against {num_meas} measurements"
+                    ))
+                })?;
+                let aux_qubit = expanded
+                    .aux_qubit_for_record(abs_idx)
+                    .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+                bm.z_bits.xor_bit(aux_qubit);
             }
             detectors.push(Detector { id, stabilizer: bm });
         }
@@ -1278,10 +1298,16 @@ fn extract_detectors_expanded(
         for (id, records) in obs_list {
             let mut bm = Bm::default();
             for &rec in &records {
-                if let Some(abs_idx) = measurement_record_index(rec, num_meas) {
-                    let aux_qubit = expanded.measurement_qubit[abs_idx];
-                    bm.z_bits.xor_bit(aux_qubit);
-                }
+                let abs_idx = measurement_record_index(rec, num_meas).ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "observable {id} references record offset {rec}, which does not \
+                         resolve against {num_meas} measurements"
+                    ))
+                })?;
+                let aux_qubit = expanded
+                    .aux_qubit_for_record(abs_idx)
+                    .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+                bm.z_bits.xor_bit(aux_qubit);
             }
             observables.push(Observable { id, pauli: bm });
         }

--- a/python/pecos-rslib-exp/src/eeg_bindings.rs
+++ b/python/pecos-rslib-exp/src/eeg_bindings.rs
@@ -1203,7 +1203,11 @@ fn extract_gates(py_tc: &Bound<'_, PyAny>) -> PyResult<Vec<Gate>> {
                 // MZ: keep multi-qubit (expansion handles per-qubit)
                 _ => {
                     let gt = match name.as_str() {
-                        "MZ" | "MeasureFree" => pecos_core::gate_type::GateType::MZ,
+                        "MZ" => pecos_core::gate_type::GateType::MZ,
+                        // Preserved, NOT normalized to MZ: the MZ-only EEG
+                        // expansion must see and refuse it, or its measurement
+                        // record silently vanishes.
+                        "MeasureFree" => pecos_core::gate_type::GateType::MeasureFree,
                         "RZ" => pecos_core::gate_type::GateType::RZ,
                         "Idle" | "I" => pecos_core::gate_type::GateType::Idle,
                         other => {

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -1585,9 +1585,12 @@ fn build_rust_tick_circuit_from_gates(
                 qubits.iter().map(|&q| pecos_core::QubitId(q)).collect();
 
             match gate_name.as_str() {
+                // MeasureFree lowers to MZ here: record-bearing, and the free
+                // has no stabilizer effect. The expansion accepts it either way.
                 "MZ" | "Measure" | "MeasureFree" => {
                     mz_qubits.extend(qubit_ids);
                 }
+
                 "QAlloc" | "PZ" | "Prep" => {
                     pz_qubits.extend(qubit_ids);
                 }

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -1446,7 +1446,8 @@ impl PySimNeoBuilder {
             generator.as_ref(),
             shots,
             self.resolved_seed_u64(),
-        );
+        )
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
         Ok(result.measurements)
     }
 }

--- a/python/pecos-rslib/src/fault_tolerance_bindings.rs
+++ b/python/pecos-rslib/src/fault_tolerance_bindings.rs
@@ -1057,7 +1057,9 @@ impl PyInfluenceBuilder {
             builder = builder.with_tracked_pauli(pauli.clone());
         }
 
-        let inner = builder.build();
+        let inner = builder
+            .build()
+            .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
         Ok(PyDagFaultInfluenceMap { inner })
     }
 

--- a/python/pecos-rslib/src/fault_tolerance_bindings.rs
+++ b/python/pecos-rslib/src/fault_tolerance_bindings.rs
@@ -1033,7 +1033,12 @@ impl PyInfluenceBuilder {
     ///
     /// Returns:
     ///     `DagFaultInfluenceMap` with proper detector definitions and tracked Paulis.
-    fn build(&self) -> PyDagFaultInfluenceMap {
+    ///
+    /// Raises:
+    ///     ValueError: A circuit annotation cannot be resolved -- an observable
+    ///         referencing a missing node or a non-measurement gate, or a
+    ///         tracked Pauli with no meta gate.
+    fn build(&self) -> PyResult<PyDagFaultInfluenceMap> {
         let mut builder = RustInfluenceBuilder::new(&self.dag);
 
         if !self.tracked_x_qubits.is_empty() {
@@ -1044,14 +1049,16 @@ impl PyInfluenceBuilder {
         }
 
         if self.use_circuit_tracked_paulis {
-            builder = builder.with_circuit_annotations(&self.dag);
+            builder = builder
+                .with_circuit_annotations()
+                .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
         }
         for pauli in &self.tracked_paulis {
             builder = builder.with_tracked_pauli(pauli.clone());
         }
 
         let inner = builder.build();
-        PyDagFaultInfluenceMap { inner }
+        Ok(PyDagFaultInfluenceMap { inner })
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
The fallible consumer APIs from `design/measurement-id-annotations.md`'s pivot checklist (recorded there by #403's adversarial round). With this, every annotation-ingestion path reports failure instead of silently thinning its outputs, and the pivot can swap node-based resolution for id-based resolution inside error channels that already exist.

## InfluenceBuilder

`with_circuit_annotations()` no longer takes a circuit: it ingests `self.dag`, the circuit the builder was constructed with. The parameter let annotations come from a *different* circuit than the one under analysis, silently producing nonsense; every in-repo caller passed the same circuit, verified before removal.

It returns `Result<Self, AnnotationIngestError>`: an observable referencing a missing node, an observable referencing a gate that consumes no measurement record, or a tracked Pauli with no `TrackedPauliMeta` gate. All three were silent skips. Ingestion is transactional and order-preserving -- a rejected ingest commits nothing, and interleaved observables and tracked Paulis keep their annotation order (the first draft of this change deferred one kind and committed the other, which would have reordered outputs consumers index positionally; caught before it compiled).

`build` stays infallible, deliberately deviating from the review checklist: post-pivot, resolution failures all surface at ingestion, so `build` has nothing honest to fail on, and an always-`Ok` `Result` is a fallback-shaped lie. The review round for this PR should attack that reasoning.

## DemSamplerBuilder

`with_circuit_annotations` returns `Result`, with a new `DetectorValidationError::UnresolvableAnnotationRef { output_kind, annotation_index, node }`. Four silent shapes closed: a detector node absent from the influence map, a detector measurement outside every auto-detector, an observable node absent from the map, and the `i32`-overflow branch that returned silently *empty* records.

## eeg

`EegBuildError`, and `build`/`build_dem_string`/`summary` all return `Result`:

- `UnsupportedMeasurement` -- a `MeasureFree` used to pass through the MZ-only expansion *unchanged*, silently deleting its measurement record from the deferred circuit. This closes the ledger item filed on #387 when the expansion map was built.
- `UnresolvableAnnotationRecord` -- the `record_idx < num_meas` silent skip is dead; the error names both sides of the mismatch.

`EegDemBuilder` has no callers outside its own crate, so the signature changes ripple nowhere.

## Behavioral evidence

The entire `pecos-qec` and `pecos-eeg` suites pass under the strict errors -- no legitimate in-repo circuit trips any of them, so every new rejection is fail-loud gain rather than a behavior tax. Python binding (`InfluenceBuilder.build`) raises `ValueError` with the resolver's message.

Six new tests, each mutation-killed with asserted anchors: the three `AnnotationIngestError` variants, the transactionality guarantee, the sampler's observable drop, and both eeg errors.

## Verification

Cold `cargo clippy --locked --workspace --all-targets -- -D warnings` exit 0 on a fresh target directory (it caught two stray `#[must_use]` attributes and a missing `# Panics` section the suite passed over). `cargo fmt --check` clean. `cargo test` with the `pecos-cli` exclusion set exit 0. Rust doc-test crate exit 0. Full Python lane 4390 passed / 68 skipped exit 0, run with `CARGO_TARGET_DIR` unset. `pre-commit run --all-files` exit 0.
