### PR TITLE
Pivot annotations to measurement identity (measurement_ids: Vec<MeasId>)

### DIFF
--- a/crates/benchmarks/benches/modules/fault_catalog.rs
+++ b/crates/benchmarks/benches/modules/fault_catalog.rs
@@ -383,13 +383,13 @@ fn build_rotated_z_memory_circuit(distance: usize, rounds: usize) -> Result<Memo
     let final_data_measurements = circuit.tick().mz(&data_qubits);
     let num_measurements = circuit.num_measurements();
 
-    let mut detectors: Vec<Vec<i32>> = Vec::new();
+    let mut detectors: Vec<Vec<usize>> = Vec::new();
 
     for &meas_ref in z_round_measurements[0]
         .iter()
         .take(code.num_z_stabilizers())
     {
-        detectors.push(relative_records(num_measurements, &[meas_ref]));
+        detectors.push(ref_meas_ids(&[meas_ref]));
     }
 
     for round in 1..rounds {
@@ -398,14 +398,14 @@ fn build_rotated_z_memory_circuit(distance: usize, rounds: usize) -> Result<Memo
             .zip(x_round_measurements[round - 1].iter())
             .take(code.num_x_stabilizers())
         {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
         for (&current, &previous) in z_round_measurements[round]
             .iter()
             .zip(z_round_measurements[round - 1].iter())
             .take(code.num_z_stabilizers())
         {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
     }
 
@@ -418,7 +418,7 @@ fn build_rotated_z_memory_circuit(distance: usize, rounds: usize) -> Result<Memo
                 .into_iter()
                 .map(|q| final_data_measurements[q]),
         );
-        detectors.push(relative_records(num_measurements, &refs));
+        detectors.push(ref_meas_ids(&refs));
     }
 
     let logical_z_refs: Vec<TickMeasRef> = code
@@ -427,14 +427,17 @@ fn build_rotated_z_memory_circuit(distance: usize, rounds: usize) -> Result<Memo
         .iter()
         .map(|&q| final_data_measurements[q])
         .collect();
-    let observables = vec![relative_records(num_measurements, &logical_z_refs)];
+    let observables = vec![ref_meas_ids(&logical_z_refs)];
 
     circuit.set_meta(
         "num_measurements",
         Attribute::String(num_measurements.to_string()),
     );
-    circuit.set_meta("detectors", Attribute::String(records_json(&detectors)));
-    circuit.set_meta("observables", Attribute::String(records_json(&observables)));
+    circuit.set_meta("detectors", Attribute::String(meas_ids_json(&detectors)));
+    circuit.set_meta(
+        "observables",
+        Attribute::String(meas_ids_json(&observables)),
+    );
 
     Ok(MemoryCircuit {
         circuit,
@@ -446,26 +449,20 @@ fn build_rotated_z_memory_circuit(distance: usize, rounds: usize) -> Result<Memo
     })
 }
 
-fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
-    let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
-    refs.iter()
-        .map(|meas_ref| {
-            i32::try_from(meas_ref.meas_id.index()).expect("measurement record index fits in i32")
-                - num_measurements
-        })
-        .collect()
+fn ref_meas_ids(refs: &[TickMeasRef]) -> Vec<usize> {
+    refs.iter().map(|m| m.meas_id.index()).collect()
 }
 
-fn records_json(records: &[Vec<i32>]) -> String {
-    let entries: Vec<String> = records
+fn meas_ids_json(annotations: &[Vec<usize>]) -> String {
+    let entries: Vec<String> = annotations
         .iter()
-        .map(|records| {
-            let values = records
+        .map(|ids| {
+            let values = ids
                 .iter()
-                .map(i32::to_string)
+                .map(usize::to_string)
                 .collect::<Vec<_>>()
                 .join(",");
-            format!(r#"{{"records":[{values}]}}"#)
+            format!(r#"{{"meas_ids":[{values}]}}"#)
         })
         .collect();
     format!("[{}]", entries.join(","))

--- a/crates/benchmarks/benches/modules/fault_catalog.rs
+++ b/crates/benchmarks/benches/modules/fault_catalog.rs
@@ -450,7 +450,7 @@ fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
     let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
     refs.iter()
         .map(|meas_ref| {
-            i32::try_from(meas_ref.record_idx).expect("measurement record index fits in i32")
+            i32::try_from(meas_ref.meas_id.index()).expect("measurement record index fits in i32")
                 - num_measurements
         })
         .collect()

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -3273,7 +3273,8 @@ fn build_dem_from_circuit(
     use pecos_num::graph::Attribute;
 
     let mut influence_map = DagFaultAnalyzer::new(circuit).build_influence_map();
-    let annotated_observable_records = observable_records_from_annotations(circuit, &influence_map);
+    let annotated_observable_records =
+        observable_records_from_annotations(circuit, &influence_map)?;
     let annotation_map = InfluenceBuilder::new(circuit)
         .with_circuit_annotations()
         .map_err(|err| DemBuilderError::ConfigurationError(err.to_string()))?
@@ -3365,36 +3366,36 @@ fn circuit_with_omitted_two_qubit_gate(
 fn observable_records_from_annotations(
     circuit: &pecos_quantum::DagCircuit,
     influence_map: &DagFaultInfluenceMap,
-) -> Vec<Vec<i32>> {
+) -> Result<Vec<Vec<i32>>, DemBuilderError> {
     use pecos_quantum::AnnotationKind;
 
     let num_measurements = influence_map.measurements.len();
     if num_measurements == 0 {
-        return Vec::new();
-    }
-
-    let mut node_to_meas_idx: BTreeMap<usize, usize> = BTreeMap::new();
-    for (meas_idx, &(node, _qubit, _basis)) in influence_map.measurements.iter().enumerate() {
-        node_to_meas_idx.entry(node).or_insert(meas_idx);
+        return Ok(Vec::new());
     }
 
     circuit
         .observables()
-        .map(|ann| {
-            if let AnnotationKind::Observable { measurement_nodes } = &ann.kind {
-                measurement_nodes
-                    .iter()
-                    .filter_map(|node| node_to_meas_idx.get(node).copied())
-                    .map(|meas_idx| {
-                        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
-                        {
-                            meas_idx as i32 - num_measurements as i32
-                        }
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            }
+        .enumerate()
+        .map(|(annotation_index, ann)| {
+            let AnnotationKind::Observable { measurement_ids } = &ann.kind else {
+                return Ok(Vec::new());
+            };
+            measurement_ids
+                .iter()
+                .map(|&meas_id| {
+                    let meas_idx = influence_map.meas_index_of(meas_id).ok_or_else(|| {
+                        DemBuilderError::ConfigurationError(format!(
+                            "observable annotation {annotation_index} references \
+                                 MeasId({}), which does not resolve to a measurement \
+                                 in the influence map",
+                            meas_id.index()
+                        ))
+                    })?;
+                    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+                    Ok(meas_idx as i32 - num_measurements as i32)
+                })
+                .collect()
         })
         .collect()
 }
@@ -3834,7 +3835,9 @@ mod tests {
         let mut circuit = DagCircuit::new();
         circuit.pz(&[0]);
         let meas = circuit.mz(&[0]);
-        circuit.observable_labeled("obs0", &[meas[0]]);
+        circuit
+            .observable_labeled("obs0", &[meas[0]])
+            .expect("refs are from this circuit");
 
         let dem = DemBuilder::from_circuit(&circuit, 0.0, 0.0, 1.0, 0.0);
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -773,14 +773,16 @@ impl<'a> DemBuilder<'a> {
                 )));
             }
         }
-        // With stamped ids the measurement mapping is defined by the ids;
-        // a supplied order feeds the qubit-occurrence heuristic, which
-        // silently mis-binds on non-positional ids. Legacy id-less circuits
-        // are the only clients of the escape hatch.
-        if self.measurement_order.is_some() && !self.influence_map.meas_ids.is_empty() {
+        // A supplied order feeds the qubit-occurrence heuristic, which needs
+        // per-qubit chronology on both sides. Minted (positional) ids keep it
+        // -- that combination is routine in the surface pipeline -- but
+        // external non-positional ids can reorder a qubit's measurements in
+        // the map, and no heuristic can recover the caller's record order.
+        if self.measurement_order.is_some() && !stamped_ids_are_positional(&self.influence_map) {
             return Err(DemBuilderError::ConfigurationError(
-                "measurement_order cannot be combined with a circuit that carries \
-                 stable MeasIds; the ids already define the measurement mapping"
+                "measurement_order cannot be combined with a circuit whose stable \
+                 MeasIds are non-positional; the caller's record order is not \
+                 recoverable"
                     .to_string(),
             ));
         }
@@ -2236,9 +2238,16 @@ impl<'a> DemBuilder<'a> {
         for det in &self.detectors {
             if det.records.is_empty() {
                 for &meas_id in &det.meas_ids {
-                    if let Some(tc_idx) = self.resolve_meas_id_to_tc_index(meas_id)
-                        && let Some(&influence_idx) = tc_to_influence.get(&tc_idx)
-                    {
+                    // Stamped resolution already yields the influence-map
+                    // index; only the legacy positional branch speaks tick
+                    // order and needs the occurrence mapping.
+                    let resolved = self.resolve_meas_id_to_tc_index(meas_id);
+                    let influence_idx = if self.influence_map.meas_ids.is_empty() {
+                        resolved.and_then(|tc_idx| tc_to_influence.get(&tc_idx).copied())
+                    } else {
+                        resolved
+                    };
+                    if let Some(influence_idx) = influence_idx {
                         meas_to_detectors
                             .entry(influence_idx)
                             .or_default()
@@ -2266,9 +2275,14 @@ impl<'a> DemBuilder<'a> {
             }
             if obs.records.is_empty() {
                 for &meas_id in &obs.meas_ids {
-                    if let Some(tc_idx) = self.resolve_meas_id_to_tc_index(meas_id)
-                        && let Some(&influence_idx) = tc_to_influence.get(&tc_idx)
-                    {
+                    // Same split as the detector branch above.
+                    let resolved = self.resolve_meas_id_to_tc_index(meas_id);
+                    let influence_idx = if self.influence_map.meas_ids.is_empty() {
+                        resolved.and_then(|tc_idx| tc_to_influence.get(&tc_idx).copied())
+                    } else {
+                        resolved
+                    };
+                    if let Some(influence_idx) = influence_idx {
                         meas_to_observables
                             .entry(influence_idx)
                             .or_default()
@@ -2804,6 +2818,23 @@ pub(crate) fn parse_observable_record_vectors(
 /// bug, not bad caller input. Mirrors the guard in
 /// `DemBuilder::validate_measurement_count` so the sampler JSON path rejects
 /// exactly what `DemBuilder` does.
+/// Whether the map's stamped ids are exactly the positional set `0..n`.
+///
+/// True for every circuit whose ids were minted by `mz()`; false for external
+/// (Guppy/traced) ids. An empty id list counts as positional -- the legacy
+/// id-less case.
+fn stamped_ids_are_positional(influence_map: &DagFaultInfluenceMap) -> bool {
+    let n = influence_map.meas_ids.len();
+    let mut seen = vec![false; n];
+    for mid in &influence_map.meas_ids {
+        let Some(slot) = seen.get_mut(mid.index()) else {
+            return false;
+        };
+        *slot = true;
+    }
+    seen.into_iter().all(|s| s)
+}
+
 fn reject_duplicate_stamped_meas_ids(
     influence_map: &DagFaultInfluenceMap,
 ) -> Result<(), DemBuilderError> {
@@ -5021,6 +5052,55 @@ mod tests {
         assert!(
             result.is_err(),
             "a duplicate stable MeasId must fail loud, not bind to the first",
+        );
+    }
+
+    /// The stamped branch of `build_measurement_mappings` must use the
+    /// resolved index directly: it is already an influence-map index, and
+    /// composing it with the tick-to-influence occurrence mapping re-binds
+    /// annotations whenever the two orders differ.
+    #[test]
+    fn stamped_meas_id_mapping_is_not_recomposed_through_the_order() {
+        let mut influence_map = DagFaultInfluenceMap::with_capacity(0);
+        // Map order disagrees with tick record order: the map holds q1's
+        // measurement (id 1) first, q0's (id 0) second. The id SET is
+        // positional, so the order combination is accepted.
+        influence_map.meas_ids = vec![
+            pecos_core::MeasId::from_raw(1),
+            pecos_core::MeasId::from_raw(0),
+        ];
+        influence_map.measurements = vec![(5, 1, 0), (2, 0, 0)];
+        let builder = DemBuilder::new(&influence_map)
+            .with_measurement_order(vec![0, 1])
+            .with_detectors_json(r#"[{"id": 0, "meas_ids": [1]}]"#)
+            .unwrap();
+        let (meas_to_detectors, _) = builder.build_measurement_mappings();
+        assert_eq!(
+            meas_to_detectors.keys().copied().collect::<Vec<_>>(),
+            vec![0],
+            "id 1 lives at influence index 0; composing through the order \
+             re-bound it to index 1"
+        );
+    }
+
+    /// Positional (minted) ids with a supplied order is the routine surface
+    /// pipeline combination and must keep building.
+    #[test]
+    fn measurement_order_is_accepted_with_positional_ids() {
+        let mut influence_map = DagFaultInfluenceMap::with_capacity(0);
+        influence_map.meas_ids = vec![
+            pecos_core::MeasId::from_raw(0),
+            pecos_core::MeasId::from_raw(1),
+        ];
+        influence_map.measurements = vec![(2, 0, 0), (5, 1, 0)];
+        let result = DemBuilder::new(&influence_map)
+            .with_measurement_order(vec![0, 1])
+            .with_detectors_json(r#"[{"id": 0, "meas_ids": [1]}]"#)
+            .unwrap()
+            .try_build();
+        assert!(
+            result.is_ok(),
+            "minted ids keep per-qubit chronology; the combination is benign: {result:?}"
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -778,7 +778,7 @@ impl<'a> DemBuilder<'a> {
         // -- that combination is routine in the surface pipeline -- but
         // external non-positional ids can reorder a qubit's measurements in
         // the map, and no heuristic can recover the caller's record order.
-        if self.measurement_order.is_some() && !stamped_ids_are_positional(&self.influence_map) {
+        if self.measurement_order.is_some() && !stamped_ids_are_positional(self.influence_map) {
             return Err(DemBuilderError::ConfigurationError(
                 "measurement_order cannot be combined with a circuit whose stable \
                  MeasIds are non-positional; the caller's record order is not \

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -773,6 +773,17 @@ impl<'a> DemBuilder<'a> {
                 )));
             }
         }
+        // With stamped ids the measurement mapping is defined by the ids;
+        // a supplied order feeds the qubit-occurrence heuristic, which
+        // silently mis-binds on non-positional ids. Legacy id-less circuits
+        // are the only clients of the escape hatch.
+        if self.measurement_order.is_some() && !self.influence_map.meas_ids.is_empty() {
+            return Err(DemBuilderError::ConfigurationError(
+                "measurement_order cannot be combined with a circuit that carries \
+                 stable MeasIds; the ids already define the measurement mapping"
+                    .to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -5010,6 +5021,26 @@ mod tests {
         assert!(
             result.is_err(),
             "a duplicate stable MeasId must fail loud, not bind to the first",
+        );
+    }
+
+    #[test]
+    fn test_validate_measurement_count_rejects_order_with_stamped_ids() {
+        let mut influence_map = DagFaultInfluenceMap::with_capacity(0);
+        influence_map.meas_ids = vec![
+            pecos_core::MeasId::from_raw(9),
+            pecos_core::MeasId::from_raw(4),
+        ];
+        influence_map.measurements = vec![(0, 0, 0), (1, 1, 0)];
+        let result = DemBuilder::new(&influence_map)
+            .with_measurement_order(vec![0, 1])
+            .with_detectors_json(r#"[{"id": 0, "meas_ids": [9]}]"#)
+            .unwrap()
+            .try_build();
+        assert!(
+            result.is_err(),
+            "measurement_order on a stamped-id circuit silently mis-binds; it \
+             must fail loud",
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1152,6 +1152,22 @@ impl<'a> DemSamplerBuilder<'a> {
     ) -> Result<Self, DetectorValidationError> {
         use pecos_quantum::AnnotationKind;
 
+        // A duplicate stamped id would make `meas_index_of` bind to the first
+        // holder -- an ambiguous, silently-wrong bind. Mirrors the guard on
+        // the JSON path (`reject_duplicate_stamped_meas_ids`).
+        let mut seen = std::collections::BTreeSet::new();
+        for mid in &self.influence_map.meas_ids {
+            if !seen.insert(mid.index()) {
+                return Err(DetectorValidationError::InvalidMetadata {
+                    message: format!(
+                        "duplicate stable MeasId {} in the circuit; each \
+                         measurement must have a unique stamped id",
+                        mid.index()
+                    ),
+                });
+            }
+        }
+
         let detectors: Vec<&pecos_quantum::PauliAnnotation> = circuit.detectors().collect();
         let observables: Vec<&pecos_quantum::PauliAnnotation> = circuit.observables().collect();
 
@@ -1265,6 +1281,18 @@ impl<'a> DemSamplerBuilder<'a> {
         // measurement count would resolve in a different (shorter/longer) frame
         // at sample time and silently misbind. (See sampler-JSON validation.)
         if let Some(ref order) = self.measurement_order {
+            // With stamped ids the order is derivable from the ids, and the
+            // qubit-occurrence heuristic behind a supplied order silently
+            // mis-binds on non-positional ids. The escape hatch is for id-less
+            // legacy circuits only.
+            if !self.influence_map.meas_ids.is_empty() {
+                return Err(DetectorValidationError::InvalidMetadata {
+                    message: "measurement_order cannot be combined with a circuit \
+                              that carries stable MeasIds; the ids already define \
+                              the measurement mapping"
+                        .to_string(),
+                });
+            }
             let expected = self.influence_map.measurements.len();
             if order.len() != expected {
                 return Err(DetectorValidationError::InvalidMetadata {

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1281,15 +1281,24 @@ impl<'a> DemSamplerBuilder<'a> {
         // measurement count would resolve in a different (shorter/longer) frame
         // at sample time and silently misbind. (See sampler-JSON validation.)
         if let Some(ref order) = self.measurement_order {
-            // With stamped ids the order is derivable from the ids, and the
-            // qubit-occurrence heuristic behind a supplied order silently
-            // mis-binds on non-positional ids. The escape hatch is for id-less
-            // legacy circuits only.
-            if !self.influence_map.meas_ids.is_empty() {
+            // A supplied order feeds the qubit-occurrence heuristic, which
+            // needs per-qubit chronology on both sides. Minted (positional)
+            // ids keep it; external non-positional ids can reorder a qubit's
+            // measurements in the map, and the caller's record order is then
+            // not recoverable.
+            let n = self.influence_map.meas_ids.len();
+            let mut seen = vec![false; n];
+            let positional = self
+                .influence_map
+                .meas_ids
+                .iter()
+                .all(|mid| seen.get_mut(mid.index()).map(|slot| *slot = true).is_some())
+                && seen.into_iter().all(|s| s);
+            if !positional {
                 return Err(DetectorValidationError::InvalidMetadata {
                     message: "measurement_order cannot be combined with a circuit \
-                              that carries stable MeasIds; the ids already define \
-                              the measurement mapping"
+                              whose stable MeasIds are non-positional; the \
+                              caller's record order is not recoverable"
                         .to_string(),
                 });
             }

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -67,8 +67,8 @@ pub enum DetectorValidationError {
         output_kind: &'static str,
         /// Index among that kind's annotations.
         annotation_index: usize,
-        /// The unresolvable node reference.
-        node: usize,
+        /// The unresolvable measurement id.
+        meas_id: pecos_core::MeasId,
     },
 }
 
@@ -110,11 +110,12 @@ impl std::fmt::Display for DetectorValidationError {
             Self::UnresolvableAnnotationRef {
                 output_kind,
                 annotation_index,
-                node,
+                meas_id,
             } => write!(
                 f,
-                "{output_kind} annotation {annotation_index} references node {node}, which \
-                 does not resolve to a measurement in the influence map"
+                "{output_kind} annotation {annotation_index} references MeasId({}), which \
+                 does not resolve to a measurement in the influence map",
+                meas_id.index()
             ),
         }
     }
@@ -1151,14 +1152,6 @@ impl<'a> DemSamplerBuilder<'a> {
     ) -> Result<Self, DetectorValidationError> {
         use pecos_quantum::AnnotationKind;
 
-        let mut node_to_meas_idx: std::collections::BTreeMap<usize, usize> =
-            std::collections::BTreeMap::new();
-        for (meas_idx, &(node, _qubit, _basis)) in
-            self.influence_map.measurements.iter().enumerate()
-        {
-            node_to_meas_idx.entry(node).or_insert(meas_idx);
-        }
-
         let detectors: Vec<&pecos_quantum::PauliAnnotation> = circuit.detectors().collect();
         let observables: Vec<&pecos_quantum::PauliAnnotation> = circuit.observables().collect();
 
@@ -1172,19 +1165,19 @@ impl<'a> DemSamplerBuilder<'a> {
             let mut det_records_abs: Vec<Vec<usize>> = Vec::with_capacity(detectors.len());
             for (annotation_index, ann) in detectors.iter().enumerate() {
                 let AnnotationKind::Detector {
-                    measurement_nodes, ..
+                    measurement_ids, ..
                 } = &ann.kind
                 else {
                     det_records_abs.push(Vec::new());
                     continue;
                 };
-                let mut resolved = Vec::with_capacity(measurement_nodes.len());
-                for &node in measurement_nodes {
-                    let Some(&im_idx) = node_to_meas_idx.get(&node) else {
+                let mut resolved = Vec::with_capacity(measurement_ids.len());
+                for &meas_id in measurement_ids {
+                    let Some(im_idx) = self.influence_map.meas_index_of(meas_id) else {
                         return Err(DetectorValidationError::UnresolvableAnnotationRef {
                             output_kind: "detector",
                             annotation_index,
-                            node,
+                            meas_id,
                         });
                     };
                     resolved.push(im_idx);
@@ -1208,17 +1201,17 @@ impl<'a> DemSamplerBuilder<'a> {
                 })?;
             let mut records: Vec<Vec<i32>> = Vec::with_capacity(observables.len());
             for (annotation_index, ann) in observables.iter().enumerate() {
-                let AnnotationKind::Observable { measurement_nodes } = &ann.kind else {
+                let AnnotationKind::Observable { measurement_ids } = &ann.kind else {
                     records.push(Vec::new());
                     continue;
                 };
-                let mut resolved = Vec::with_capacity(measurement_nodes.len());
-                for &node in measurement_nodes {
-                    let Some(&meas_idx) = node_to_meas_idx.get(&node) else {
+                let mut resolved = Vec::with_capacity(measurement_ids.len());
+                for &meas_id in measurement_ids {
+                    let Some(meas_idx) = self.influence_map.meas_index_of(meas_id) else {
                         return Err(DetectorValidationError::UnresolvableAnnotationRef {
                             output_kind: "observable",
                             annotation_index,
-                            node,
+                            meas_id,
                         });
                     };
                     let meas_idx = i32::try_from(meas_idx)
@@ -1543,7 +1536,7 @@ mod tests {
         dag.mz(&[0]); // raw measurement 0
         dag.pz(&[1]);
         let named = dag.mz(&[1]); // raw measurement 1 -- the detector's target
-        dag.detector(&named);
+        dag.detector(&named).expect("refs are from this circuit");
 
         let im =
             crate::fault_tolerance::propagator::DagFaultAnalyzer::new(&dag).build_influence_map();
@@ -1577,9 +1570,9 @@ mod tests {
         );
     }
 
-    /// An observable annotation referencing a node absent from the influence
+    /// An observable annotation referencing an id absent from the influence
     /// map used to be silently dropped, thinning the observable. It is now an
-    /// error naming the annotation and the node.
+    /// error naming the annotation and the id.
     #[test]
     fn an_unresolvable_observable_ref_is_an_error() {
         use pecos_quantum::DagCircuit;
@@ -1589,7 +1582,7 @@ mod tests {
         dag.add_annotation(pecos_quantum::PauliAnnotation {
             pauli: pecos_core::PauliString::zs(&[0usize]),
             kind: pecos_quantum::AnnotationKind::Observable {
-                measurement_nodes: vec![99],
+                measurement_ids: vec![pecos_core::MeasId::from_raw(99)],
             },
             label: None,
         });
@@ -1605,9 +1598,9 @@ mod tests {
             err,
             DetectorValidationError::UnresolvableAnnotationRef {
                 output_kind: "observable",
-                node: 99,
+                meas_id,
                 ..
-            }
+            } if meas_id == pecos_core::MeasId::from_raw(99)
         ));
     }
 
@@ -1835,7 +1828,9 @@ mod tests {
         let mut circuit = DagCircuit::new();
         circuit.pz(&[0]);
         let meas = circuit.mz(&[0]);
-        circuit.observable_labeled("obs0", &[meas[0]]);
+        circuit
+            .observable_labeled("obs0", &[meas[0]])
+            .expect("refs are from this circuit");
 
         let im = InfluenceBuilder::new(&circuit)
             .with_circuit_annotations()
@@ -1954,8 +1949,12 @@ mod tests {
         let mut circuit = DagCircuit::new();
         circuit.pz(&[0]);
         let meas = circuit.mz(&[0]);
-        circuit.detector_labeled("det0", &[meas[0]]);
-        circuit.observable_labeled("obs0", &[meas[0]]);
+        circuit
+            .detector_labeled("det0", &[meas[0]])
+            .expect("refs are from this circuit");
+        circuit
+            .observable_labeled("obs0", &[meas[0]])
+            .expect("refs are from this circuit");
         circuit.tracked_pauli_labeled("tracked_x0", X(0));
         circuit.set_attr("num_measurements", Attribute::String("1".to_string()));
         circuit.set_attr(

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -88,20 +88,15 @@ struct PauliPropagationTerm {
 /// record-based fallback downstream. So unresolvable references are errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AnnotationIngestError {
-    /// An observable annotation references a node that does not exist.
-    ObservableRefNotFound {
+    /// An observable annotation references a measurement id that does not
+    /// resolve against the circuit.
+    ObservableRefUnresolved {
         /// Index of the annotation among the circuit's annotations.
         annotation_index: usize,
-        /// The nonexistent node.
-        node: usize,
-    },
-    /// An observable annotation references a node whose gate consumes no
-    /// measurement record, so it cannot contribute a readout term.
-    ObservableRefNotAMeasurement {
-        /// Index of the annotation among the circuit's annotations.
-        annotation_index: usize,
-        /// The referenced node.
-        node: usize,
+        /// The unresolved id.
+        meas_id: pecos_core::MeasId,
+        /// Why resolution failed.
+        source: pecos_quantum::MeasResolveError,
     },
     /// A tracked-Pauli annotation has no matching `TrackedPauliMeta` gate.
     TrackedPauliWithoutMetaNode {
@@ -113,21 +108,15 @@ pub enum AnnotationIngestError {
 impl std::fmt::Display for AnnotationIngestError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ObservableRefNotFound {
+            Self::ObservableRefUnresolved {
                 annotation_index,
-                node,
+                meas_id,
+                source,
             } => write!(
                 f,
-                "annotation {annotation_index}: observable references node {node}, \
-                 which does not exist in the circuit"
-            ),
-            Self::ObservableRefNotAMeasurement {
-                annotation_index,
-                node,
-            } => write!(
-                f,
-                "annotation {annotation_index}: observable references node {node}, \
-                 whose gate consumes no measurement record"
+                "annotation {annotation_index}: observable references MeasId({}), which \
+                 does not resolve against the circuit: {source}",
+                meas_id.index()
             ),
             Self::TrackedPauliWithoutMetaNode { annotation_index } => write!(
                 f,
@@ -317,26 +306,22 @@ impl<'a> InfluenceBuilder<'a> {
         let mut ingested = Vec::new();
         for (annotation_index, ann) in circuit.annotations().iter().enumerate() {
             match &ann.kind {
-                pecos_quantum::AnnotationKind::Observable { measurement_nodes } => {
+                pecos_quantum::AnnotationKind::Observable { measurement_ids } => {
                     let mut terms = Vec::new();
-                    for &meas_node in measurement_nodes {
-                        let Some(gate) = circuit.gate(meas_node) else {
-                            return Err(AnnotationIngestError::ObservableRefNotFound {
+                    for &meas_id in measurement_ids {
+                        // Each id names one measurement, so each term is Z on
+                        // that measurement's own qubit -- not a Z-spray over
+                        // every qubit of a batched node.
+                        let mref = circuit.find_measurement(meas_id).map_err(|source| {
+                            AnnotationIngestError::ObservableRefUnresolved {
                                 annotation_index,
-                                node: meas_node,
-                            });
-                        };
-                        if !gate.gate_type.consumes_measurement_record() {
-                            return Err(AnnotationIngestError::ObservableRefNotAMeasurement {
-                                annotation_index,
-                                node: meas_node,
-                            });
-                        }
-                        let qubits: Vec<usize> =
-                            gate.qubits.iter().map(pecos_core::QubitId::index).collect();
+                                meas_id,
+                                source,
+                            }
+                        })?;
                         terms.push(PauliPropagationTerm {
-                            pauli: PauliString::zs(&qubits),
-                            start_node: Some(meas_node),
+                            pauli: PauliString::zs(&[mref.qubit.index()]),
+                            start_node: Some(mref.node),
                         });
                     }
                     ingested.push(NonDetectorOutputTarget {
@@ -552,10 +537,33 @@ impl<'a> InfluenceBuilder<'a> {
         // Copy locations from analyzer
         map.locations = Self::extract_locations(propagator);
 
-        // Build measurement node lookup
-        let (measurements, meas_ids) = Self::extract_measurements(propagator);
+        // One order per map: measurements, meas_ids, detectors, and the
+        // backward-propagation recorder all number measurements by the replay
+        // ordinal, so `meas_index_of` is the ordinal the influence data (and
+        // the sampler's raw channels) actually use. Re-sorting measurements by
+        // id rank here while the detectors kept replay order gave one map two
+        // internal orderings, which only agreed while ids were positional.
+        let mut measurements = vec![(0usize, 0usize, 0u8); info.num_measurements];
+        let mut meas_ids = vec![pecos_core::MeasId::from_raw(usize::MAX); info.num_measurements];
+        let mut any_id = false;
+        for (node, opt) in info.node_to_meas_idx.iter().enumerate() {
+            if let Some(meas_idx) = *opt {
+                let gate = self
+                    .dag
+                    .gate(node)
+                    .expect("a replayed measurement node holds a gate");
+                // Batched measurement nodes are refused by the replay, so the
+                // node holds exactly one measurement.
+                let qubit = gate.qubits.first().map_or(0, pecos_core::QubitId::index);
+                measurements[meas_idx] = (node, qubit, 0);
+                if let Some(&id) = gate.meas_ids.first() {
+                    meas_ids[meas_idx] = id;
+                    any_id = true;
+                }
+            }
+        }
         map.measurements.clone_from(&measurements);
-        map.meas_ids = meas_ids;
+        map.meas_ids = if any_id { meas_ids } else { Vec::new() };
 
         // Create DetectorId entries for each detector
         for detector in detectors {
@@ -563,21 +571,12 @@ impl<'a> InfluenceBuilder<'a> {
                 .measurement_indices
                 .iter()
                 .filter_map(|&meas_idx| {
-                    // Find the node for this measurement index
-                    info.node_to_meas_idx
-                        .iter()
-                        .position(|&opt| opt == Some(meas_idx))
-                        .map(|node| {
-                            // Find qubit for this measurement
-                            let qubit = measurements
-                                .iter()
-                                .find(|&&(n, _, _)| n == node)
-                                .map_or(0, |&(_, q, _)| q);
-                            MeasurementId {
-                                tick: node,
-                                qubit,
-                                basis: 0, // Z-basis
-                            }
+                    measurements
+                        .get(meas_idx)
+                        .map(|&(node, qubit, basis)| MeasurementId {
+                            tick: node,
+                            qubit,
+                            basis,
                         })
                 })
                 .collect();
@@ -669,54 +668,6 @@ impl<'a> InfluenceBuilder<'a> {
         }
 
         locations
-    }
-
-    /// Extract measurements from the propagator.
-    fn extract_measurements(
-        propagator: &DagPropagator<'_>,
-    ) -> (Vec<(usize, usize, u8)>, Vec<pecos_core::MeasId>) {
-        let mut entries: Vec<(usize, usize, usize, u8, Option<pecos_core::MeasId>)> = Vec::new();
-
-        for &node in propagator.topo_order() {
-            if let Some(gate) = propagator.gate(node) {
-                let basis = match gate.gate_type {
-                    pecos_quantum::GateType::MZ | pecos_quantum::GateType::MeasureFree => 0,
-                    _ => continue,
-                };
-
-                if gate.meas_ids.is_empty() {
-                    let topo_pos = propagator.topo_position(node);
-                    for qubit in &gate.qubits {
-                        entries.push((topo_pos, node, qubit.index(), basis, None));
-                    }
-                } else {
-                    for (i, qubit) in gate.qubits.iter().enumerate() {
-                        let mr = gate.meas_ids.get(i).copied();
-                        let sort_key = mr.map_or(usize::MAX, pecos_core::MeasId::index);
-                        entries.push((sort_key, node, qubit.index(), basis, mr));
-                    }
-                }
-            }
-        }
-
-        entries.sort_by_key(|&(sort_key, _, qubit, _, _)| (sort_key, qubit));
-
-        let has_meas_ids = entries.iter().any(|(_, _, _, _, mr)| mr.is_some());
-        let meas_ids = if has_meas_ids {
-            entries
-                .iter()
-                .map(|(_, _, _, _, mr)| mr.unwrap_or(pecos_core::MeasId::from_raw(usize::MAX)))
-                .collect()
-        } else {
-            Vec::new()
-        };
-
-        let measurements = entries
-            .into_iter()
-            .map(|(_, node, qubit, basis, _)| (node, qubit, basis))
-            .collect();
-
-        (measurements, meas_ids)
     }
 
     /// Propagate backward from all detectors.
@@ -1267,7 +1218,8 @@ mod tests {
         dag.pz(&[0]);
         dag.h(&[0]);
         let meas = dag.mz(&[0]);
-        dag.observable_labeled("record_obs", &[meas[0]]);
+        dag.observable_labeled("record_obs", &[meas[0]])
+            .expect("refs are from this circuit");
         dag.tracked_pauli_labeled("track_x", X(0));
 
         let map = InfluenceBuilder::new(&dag)
@@ -1303,7 +1255,8 @@ mod tests {
         let early = dag.mz(&[0]);
         dag.h(&[0]);
         let late = dag.mz(&[1]);
-        dag.observable_labeled("split_time_obs", &[early[0], late[0]]);
+        dag.observable_labeled("split_time_obs", &[early[0], late[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
@@ -1348,7 +1301,8 @@ mod tests {
         let early = dag.mz(&[0]);
         dag.h(&[1]);
         let late = dag.mz(&[1]);
-        dag.observable_labeled("split_obs", &[early[0], late[0]]);
+        dag.observable_labeled("split_obs", &[early[0], late[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
@@ -1394,7 +1348,8 @@ mod tests {
         let early = dag.mz(&[0]);
         dag.h(&[1]);
         let late = dag.mz(&[1]);
-        dag.observable_labeled("split_obs", &[early[0], late[0]]);
+        dag.observable_labeled("split_obs", &[early[0], late[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
@@ -1519,57 +1474,62 @@ mod tests {
         );
     }
 
-    /// An observable referencing a missing node is an error, not a silently
-    /// thinner observable. De-aliased: node 99 exists in no space.
+    /// An observable referencing an unknown id is an error, not a silently
+    /// thinner observable. De-aliased: id 99 exists in no space.
     #[test]
-    fn an_observable_ref_to_a_missing_node_is_an_error() {
+    fn an_observable_ref_to_an_unknown_id_is_an_error() {
         let mut dag = DagCircuit::new();
         dag.pz(&[0]);
         dag.mz(&[0]);
         dag.add_annotation(pecos_quantum::PauliAnnotation {
             pauli: PauliString::zs(&[0usize]),
             kind: pecos_quantum::AnnotationKind::Observable {
-                measurement_nodes: vec![99],
+                measurement_ids: vec![pecos_core::MeasId::from_raw(99)],
             },
             label: None,
         });
 
         let Err(err) = InfluenceBuilder::new(&dag).with_circuit_annotations() else {
-            panic!("node 99 does not exist, so ingest must fail");
-        };
-        assert_eq!(
-            err,
-            AnnotationIngestError::ObservableRefNotFound {
-                annotation_index: 0,
-                node: 99,
-            }
-        );
-    }
-
-    /// A reference to a real gate that consumes no measurement record cannot
-    /// contribute a readout term, so it is an error rather than a Z-spray over
-    /// the gate's qubits.
-    #[test]
-    fn an_observable_ref_to_a_non_measurement_gate_is_an_error() {
-        let mut dag = DagCircuit::new();
-        dag.pz(&[0]);
-        let h_node = dag.gate_count(); // next node index is the H below
-        dag.h(&[0]);
-        dag.mz(&[0]);
-        dag.add_annotation(pecos_quantum::PauliAnnotation {
-            pauli: PauliString::zs(&[0usize]),
-            kind: pecos_quantum::AnnotationKind::Observable {
-                measurement_nodes: vec![h_node],
-            },
-            label: None,
-        });
-
-        let Err(err) = InfluenceBuilder::new(&dag).with_circuit_annotations() else {
-            panic!("an H gate holds no measurement record, so ingest must fail");
+            panic!("id 99 was never minted, so ingest must fail");
         };
         assert!(matches!(
             err,
-            AnnotationIngestError::ObservableRefNotAMeasurement { .. }
+            AnnotationIngestError::ObservableRefUnresolved {
+                annotation_index: 0,
+                source: pecos_quantum::MeasResolveError::Unknown(_),
+                ..
+            }
+        ));
+    }
+
+    /// An id held by a gate that consumes no measurement record cannot
+    /// contribute a readout term, so it is an error rather than a Z-spray over
+    /// the gate's qubits.
+    #[test]
+    fn an_observable_ref_to_a_record_less_measurement_is_an_error() {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0, 1]);
+        let mut leaked = pecos_core::Gate::measure_leaked(&[0usize]);
+        leaked.meas_ids = smallvec::smallvec![pecos_core::MeasId::from_raw(7)];
+        dag.try_add_gate(leaked).expect("gate is valid");
+        dag.mz(&[1]);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: PauliString::zs(&[0usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_ids: vec![pecos_core::MeasId::from_raw(7)],
+            },
+            label: None,
+        });
+
+        let Err(err) = InfluenceBuilder::new(&dag).with_circuit_annotations() else {
+            panic!("MeasureLeaked consumes no record, so ingest must fail");
+        };
+        assert!(matches!(
+            err,
+            AnnotationIngestError::ObservableRefUnresolved {
+                source: pecos_quantum::MeasResolveError::RecordLess { .. },
+                ..
+            }
         ));
     }
 
@@ -1579,7 +1539,8 @@ mod tests {
         dag.pz(&[0]);
         dag.h(&[0]);
         let meas = dag.mz(&[0]);
-        dag.observable_labeled("duplicate_record_obs", &[meas[0], meas[0]]);
+        dag.observable_labeled("duplicate_record_obs", &[meas[0], meas[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()

--- a/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/lookup_decoder.rs
@@ -481,7 +481,8 @@ mod tests {
         dag.pz(&[0]);
         dag.tracked_pauli_labeled("track_x", X(0));
         let meas = dag.mz(&[0]);
-        dag.observable_labeled("obs0", &[meas[0]]);
+        dag.observable_labeled("obs0", &[meas[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .with_circuit_annotations()
@@ -501,7 +502,8 @@ mod tests {
         dag.pz(&[0, 1]);
         dag.cx(&[(0, 1)]);
         let meas = dag.mz(&[1]);
-        dag.detector(&[meas[0]]);
+        dag.detector(&[meas[0]])
+            .expect("refs are from this circuit");
 
         let map = InfluenceBuilder::new(&dag)
             .build()

--- a/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/dag.rs
@@ -617,7 +617,12 @@ pub struct DagFaultInfluenceMap {
     pub detectors: Vec<DetectorId>,
 
     /// All measurements in the circuit (node, qubit, basis).
-    /// Ordered by `MeasId` when gates carry `MeasId` values.
+    ///
+    /// The order is this map's single private ordinal, shared by `meas_ids`,
+    /// `detectors`, and the influence data. Which order that is depends on the
+    /// builder (`DagFaultAnalyzer` uses id rank; `InfluenceBuilder` uses
+    /// replay order) -- resolve through `meas_index_of`, never by assuming a
+    /// particular ordering.
     pub measurements: Vec<(usize, usize, u8)>,
 
     /// `MeasId` IDs for each measurement, in the same order as `measurements`.
@@ -641,7 +646,8 @@ pub struct DagFaultInfluenceMap {
 impl DagFaultInfluenceMap {
     /// Index into `measurements` of the measurement holding `id`.
     ///
-    /// This is the influence map's private ordinal (id-rank order). `None`
+    /// This is the influence map's private ordinal -- the one order shared by
+    /// every array in the map, whichever the builder chose. `None`
     /// means the id is absent from this map -- the map cannot distinguish why;
     /// resolve against the circuit with `DagCircuit::find_measurement` when the
     /// reason matters. Callers resolving many ids should iterate `meas_ids`

--- a/crates/pecos-qec/tests/fault_enumeration_example.rs
+++ b/crates/pecos-qec/tests/fault_enumeration_example.rs
@@ -68,12 +68,16 @@ fn build_repetition_code(num_rounds: usize) -> DagCircuit {
         // Detectors
         if round == 0 {
             // First round: each measurement should be 0 (fresh code state)
-            dag.detector_labeled(&format!("Z01_r{round}"), &[ms_01[0]]);
-            dag.detector_labeled(&format!("Z12_r{round}"), &[ms_12[0]]);
+            dag.detector_labeled(&format!("Z01_r{round}"), &[ms_01[0]])
+                .expect("refs are from this circuit");
+            dag.detector_labeled(&format!("Z12_r{round}"), &[ms_12[0]])
+                .expect("refs are from this circuit");
         } else {
             // Subsequent rounds: compare with previous round
-            dag.detector_labeled(&format!("Z01_r{round}"), &[prev_meas_01.unwrap(), ms_01[0]]);
-            dag.detector_labeled(&format!("Z12_r{round}"), &[prev_meas_12.unwrap(), ms_12[0]]);
+            dag.detector_labeled(&format!("Z01_r{round}"), &[prev_meas_01.unwrap(), ms_01[0]])
+                .expect("refs are from this circuit");
+            dag.detector_labeled(&format!("Z12_r{round}"), &[prev_meas_12.unwrap(), ms_12[0]])
+                .expect("refs are from this circuit");
         }
 
         prev_meas_01 = Some(ms_01[0]);
@@ -88,15 +92,18 @@ fn build_repetition_code(num_rounds: usize) -> DagCircuit {
     dag.detector_labeled(
         "Z01_final",
         &[ms_data[0], ms_data[1], prev_meas_01.unwrap()],
-    );
+    )
+    .expect("refs are from this circuit");
     // Z_1 Z_2 from data should match last ancilla measurement
     dag.detector_labeled(
         "Z12_final",
         &[ms_data[1], ms_data[2], prev_meas_12.unwrap()],
-    );
+    )
+    .expect("refs are from this circuit");
 
     // Observable: logical Z readout = Z_0 (any single data qubit works for rep code)
-    dag.observable_labeled("logical_Z", &[ms_data[0]]);
+    dag.observable_labeled("logical_Z", &[ms_data[0]])
+        .expect("refs are from this circuit");
 
     // Pauli operator: track logical X = X_0 X_1 X_2
     dag.tracked_pauli_labeled("logical_X", X(0) & X(1) & X(2));
@@ -583,13 +590,16 @@ fn build_422_code(num_rounds: usize) -> DagCircuit {
         // Detectors
         if round == 0 {
             // Z stabilizer is deterministic on |0000⟩ (Z eigenstate)
-            dag.detector_labeled(&format!("Sz_r{round}"), &[ms_z[0]]);
+            dag.detector_labeled(&format!("Sz_r{round}"), &[ms_z[0]])
+                .expect("refs are from this circuit");
             // X stabilizer is NOT deterministic on |0000⟩ -- no standalone detector.
             // First X measurement is a random coin flip; only round-to-round
             // comparisons are valid detectors.
         } else {
-            dag.detector_labeled(&format!("Sx_r{round}"), &[prev_meas_x.unwrap(), ms_x[0]]);
-            dag.detector_labeled(&format!("Sz_r{round}"), &[prev_meas_z.unwrap(), ms_z[0]]);
+            dag.detector_labeled(&format!("Sx_r{round}"), &[prev_meas_x.unwrap(), ms_x[0]])
+                .expect("refs are from this circuit");
+            dag.detector_labeled(&format!("Sz_r{round}"), &[prev_meas_z.unwrap(), ms_z[0]])
+                .expect("refs are from this circuit");
         }
 
         prev_meas_x = Some(ms_x[0]);
@@ -610,15 +620,18 @@ fn build_422_code(num_rounds: usize) -> DagCircuit {
             ms_data[3],
             prev_meas_z.unwrap(),
         ],
-    );
+    )
+    .expect("refs are from this circuit");
     // No final X-stabilizer detector: Z-basis data measurements cannot
     // reconstruct X_0 X_1 X_2 X_3 parity.
 
     // Observables: logical Z readouts
     // Logical Z_1 = Z_0 Z_1
-    dag.observable_labeled("logical_Z1", &[ms_data[0], ms_data[1]]);
+    dag.observable_labeled("logical_Z1", &[ms_data[0], ms_data[1]])
+        .expect("refs are from this circuit");
     // Logical Z_2 = Z_0 Z_2
-    dag.observable_labeled("logical_Z2", &[ms_data[0], ms_data[2]]);
+    dag.observable_labeled("logical_Z2", &[ms_data[0], ms_data[2]])
+        .expect("refs are from this circuit");
 
     // Tracked Paulis: logical X operators
     // Logical X_1 = X_0 X_2

--- a/crates/pecos-qec/tests/meas_id_pivot_tests.rs
+++ b/crates/pecos-qec/tests/meas_id_pivot_tests.rs
@@ -1,0 +1,393 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! De-aliased measurement-identity tests.
+//!
+//! In most circuits `meas_id == record index == rank`, so three different
+//! number spaces collapse into one and conflation bugs are invisible. Every
+//! test here uses non-positional, non-contiguous ids (the `mz_with_ids`
+//! pattern, e.g. 9, 1, 5) so that using the wrong space produces a wrong
+//! answer instead of a coincidentally right one.
+
+use pecos_core::{Gate, MeasId, QubitId};
+use pecos_qec::fault_tolerance::InfluenceBuilder;
+use pecos_qec::fault_tolerance::dem_builder::DemSamplerBuilder;
+use pecos_qec::fault_tolerance::propagator::types::Pauli;
+use pecos_quantum::{AnnotationKind, DagCircuit, TickCircuit};
+
+/// `Gate::mz` on one qubit carrying a chosen id.
+fn mz_with_id(qubit: usize, id: usize) -> Gate {
+    let mut gate = Gate::mz(&[qubit]);
+    gate.meas_ids = smallvec::smallvec![MeasId::from_raw(id)];
+    gate
+}
+
+/// The same physical parity-check circuit, ids chosen by the caller.
+///
+/// Prep 0..=2, entangle data 0,1 onto ancilla 2, measure the ancilla and both
+/// data qubits. `ids[0]` names the ancilla measurement, `ids[1]`/`ids[2]` the
+/// data measurements.
+fn parity_check_with_ids(ids: [usize; 3]) -> DagCircuit {
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1, 2]);
+    dag.cx(&[(0, 2)]);
+    dag.cx(&[(1, 2)]);
+    for (qubit, id) in [(2, ids[0]), (0, ids[1]), (1, ids[2])] {
+        dag.try_add_gate_auto_wire(mz_with_id(qubit, id))
+            .expect("gate is valid and id is fresh");
+    }
+    let refs: Vec<_> = ids
+        .iter()
+        .map(|&id| {
+            dag.find_measurement(MeasId::from_raw(id))
+                .expect("the id was just supplied")
+        })
+        .collect();
+    // Detector: ancilla XOR both data readouts is deterministic.
+    dag.detector(&refs).expect("refs are from this circuit");
+    // Observable: logical Z read from data qubit 0's measurement.
+    dag.observable(&[refs[1]])
+        .expect("refs are from this circuit");
+    dag
+}
+
+/// Scrambled ids must produce the same fault-to-output relationships as
+/// positional ids: identity is a name, not a coordinate.
+#[test]
+fn scrambled_ids_build_the_same_influence_relations_as_positional_ids() {
+    let positional = parity_check_with_ids([0, 1, 2]);
+    let scrambled = parity_check_with_ids([9, 1, 5]);
+
+    let map_pos = InfluenceBuilder::new(&positional)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+    let map_scr = InfluenceBuilder::new(&scrambled)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+
+    assert_eq!(map_pos.locations.len(), map_scr.locations.len());
+    assert_eq!(map_pos.num_observables(), map_scr.num_observables());
+    // Location order is itself a per-build ordinal, so locations are matched
+    // by their physical coordinates, never by index.
+    let scr_by_key = location_index_by_key(&map_scr);
+    let mut influence_seen = false;
+    for (pos_idx, loc) in map_pos.locations.iter().enumerate() {
+        let scr_idx = scr_by_key[&location_key(loc)];
+        for pauli in [Pauli::X, Pauli::Y, Pauli::Z] {
+            let pos = map_pos.get_observable_indices(pos_idx, pauli.as_u8());
+            let scr = map_scr.get_observable_indices(scr_idx, pauli.as_u8());
+            assert_eq!(
+                pos, scr,
+                "fault at {loc:?} pauli {pauli:?} must flip the same \
+                 observables regardless of id values"
+            );
+            influence_seen |= !pos.is_empty();
+        }
+    }
+    assert!(
+        influence_seen,
+        "the comparison is vacuous unless some fault influences some observable"
+    );
+}
+
+type LocationKey = (usize, Vec<usize>, bool, pecos_core::gate_type::GateType);
+
+fn location_key(
+    loc: &pecos_qec::fault_tolerance::propagator::dag::DagSpacetimeLocation,
+) -> LocationKey {
+    (
+        loc.node,
+        loc.qubits.iter().map(|q| q.index()).collect(),
+        loc.before,
+        loc.gate_type,
+    )
+}
+
+fn location_index_by_key(
+    map: &pecos_qec::fault_tolerance::propagator::DagFaultInfluenceMap,
+) -> std::collections::BTreeMap<LocationKey, usize> {
+    let index: std::collections::BTreeMap<LocationKey, usize> = map
+        .locations
+        .iter()
+        .enumerate()
+        .map(|(idx, loc)| (location_key(loc), idx))
+        .collect();
+    assert_eq!(
+        index.len(),
+        map.locations.len(),
+        "location keys must be unique for by-key matching to be sound"
+    );
+    index
+}
+
+/// The per-measurement fault influence must be the same physical relation
+/// under both id sets: each fault flips the same *named* measurements, with
+/// indices compared through each map's own `meas_index_of` ordinal.
+///
+/// Shot-by-shot stream comparison at a shared seed is NOT a valid probe here:
+/// mechanism tables are keyed by detector indices, so re-labeling ids reorders
+/// the table and the same seed draws different faults. The structure is the
+/// invariant; the streams are only equal in distribution.
+#[test]
+fn scrambled_ids_influence_the_same_named_measurements() {
+    let positional = parity_check_with_ids([0, 1, 2]);
+    let scrambled = parity_check_with_ids([9, 1, 5]);
+
+    let build = |dag: &DagCircuit| {
+        InfluenceBuilder::new(dag)
+            .with_circuit_annotations()
+            .expect("annotations resolve")
+            .build()
+            .expect("circuit is replayable")
+    };
+    let map_pos = build(&positional);
+    let map_scr = build(&scrambled);
+
+    // scr-index -> pos-index for the same physical measurement: ids[i] of one
+    // circuit names the same physical measurement as ids[i] of the other.
+    let mut scr_to_pos = vec![usize::MAX; 3];
+    for (pos_id, scr_id) in [(0usize, 9usize), (1, 1), (2, 5)] {
+        let pi = map_pos
+            .meas_index_of(MeasId::from_raw(pos_id))
+            .expect("id is in the positional map");
+        let si = map_scr
+            .meas_index_of(MeasId::from_raw(scr_id))
+            .expect("id is in the scrambled map");
+        scr_to_pos[si] = pi;
+    }
+
+    assert_eq!(map_pos.locations.len(), map_scr.locations.len());
+    let scr_by_key = location_index_by_key(&map_scr);
+    let mut influence_seen = false;
+    for (pos_idx, loc) in map_pos.locations.iter().enumerate() {
+        let scr_idx = scr_by_key[&location_key(loc)];
+        for pauli in [Pauli::X, Pauli::Y, Pauli::Z] {
+            let mut pos: Vec<u32> = map_pos
+                .get_detector_indices(pos_idx, pauli.as_u8())
+                .to_vec();
+            let mut scr_mapped: Vec<u32> = map_scr
+                .get_detector_indices(scr_idx, pauli.as_u8())
+                .iter()
+                .map(|&si| u32::try_from(scr_to_pos[si as usize]).expect("index fits"))
+                .collect();
+            pos.sort_unstable();
+            scr_mapped.sort_unstable();
+            assert_eq!(
+                pos, scr_mapped,
+                "fault at {loc:?} pauli {pauli:?} must flip the same \
+                 named measurements regardless of id values"
+            );
+            influence_seen |= !pos.is_empty();
+        }
+    }
+    assert!(
+        influence_seen,
+        "the comparison is vacuous unless some fault flips some measurement"
+    );
+}
+
+/// Under scrambled ids, `sample_dual` detector events must XOR exactly the
+/// raw channels that `meas_index_of` names -- the sampler witness for the
+/// one-order-per-map invariant. FLIP space: with a noiseless deterministic
+/// circuit, a detector event equals the raw flip of its single named
+/// measurement, shot by shot.
+#[test]
+fn scrambled_ids_dual_output_xors_the_named_raw_channels() {
+    use pecos_random::PecosRng;
+
+    // q1's measurement gets the LOW id, so its id rank disagrees with both
+    // circuit order and qubit order.
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1]);
+    for (qubit, id) in [(0usize, 7usize), (1, 3)] {
+        dag.try_add_gate_auto_wire(mz_with_id(qubit, id))
+            .expect("gate is valid");
+    }
+    let target = dag
+        .find_measurement(MeasId::from_raw(3))
+        .expect("the id was just supplied");
+    dag.detector(&[target]).expect("refs are from this circuit");
+
+    let map = InfluenceBuilder::new(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+    let raw_idx = map
+        .meas_index_of(MeasId::from_raw(3))
+        .expect("the id is in the map");
+    let other_idx = map
+        .meas_index_of(MeasId::from_raw(7))
+        .expect("the id is in the map");
+    let sampler = DemSamplerBuilder::new(&map)
+        .with_uniform_noise(0.3)
+        .raw_measurements()
+        .with_circuit_annotations(&dag)
+        .expect("annotations resolve against the influence map")
+        .build()
+        .expect("sampler builds");
+
+    let mut rng = PecosRng::seed_from_u64(11);
+    let (mut saw_flip, mut saw_clear, mut saw_disagreement) = (false, false, false);
+    for _ in 0..500 {
+        let shot = sampler
+            .sample_dual(&mut rng)
+            .expect("detectors are configured");
+        assert_eq!(
+            shot.detector_events[0], shot.raw_measurements[raw_idx],
+            "the detector must XOR exactly its named raw channel"
+        );
+        saw_flip |= shot.raw_measurements[raw_idx];
+        saw_clear |= !shot.raw_measurements[raw_idx];
+        saw_disagreement |= shot.raw_measurements[raw_idx] != shot.raw_measurements[other_idx];
+    }
+    assert!(
+        saw_flip && saw_clear && saw_disagreement,
+        "the witness is vacuous unless the named channel varies and disagrees \
+         with the other channel at least once"
+    );
+}
+
+/// A detector can reference exactly one measurement of a batched gate --
+/// previously inexpressible, because a node id covered the whole batch. The
+/// annotation Pauli must touch only that measurement's qubit.
+#[test]
+fn a_detector_on_one_measurement_of_a_batched_gate_touches_only_its_qubit() {
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1]);
+    let node = dag
+        .try_add_gate_auto_wire(Gate::mz(&[0, 1]))
+        .expect("gate is valid");
+    let refs = dag.meas_refs(node).expect("MZ holds measurements");
+    assert_eq!(refs.len(), 2);
+    dag.detector(&[refs[1]])
+        .expect("refs are from this circuit");
+
+    let ann = &dag.annotations()[0];
+    let AnnotationKind::Detector {
+        measurement_ids, ..
+    } = &ann.kind
+    else {
+        panic!("expected detector annotation");
+    };
+    assert_eq!(measurement_ids.as_slice(), &[refs[1].meas_id]);
+    assert_eq!(
+        ann.pauli,
+        pecos_core::PauliString::zs(&[1usize]),
+        "Z on qubit 1 only -- not sprayed over the whole batch"
+    );
+}
+
+/// A reference to a removed measurement is its own loud failure at the
+/// consumer, distinct from an unknown id. Construction validation cannot see
+/// it: the annotation arrives pre-built, as it would from a conversion.
+#[test]
+fn a_reference_to_a_removed_measurement_is_a_removed_error() {
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1]);
+    let ms = dag.mz(&[0]);
+    dag.mz(&[1]);
+    dag.remove_gate(ms[0].node);
+    dag.add_annotation(pecos_quantum::PauliAnnotation {
+        pauli: pecos_core::PauliString::zs(&[0usize]),
+        kind: AnnotationKind::Observable {
+            measurement_ids: vec![ms[0].meas_id],
+        },
+        label: None,
+    });
+
+    let err = InfluenceBuilder::new(&dag)
+        .with_circuit_annotations()
+        .map(|_| ())
+        .expect_err("the measurement was removed");
+    assert!(matches!(
+        err,
+        pecos_qec::fault_tolerance::influence_builder::AnnotationIngestError::ObservableRefUnresolved {
+            source: pecos_quantum::MeasResolveError::Removed(_),
+            ..
+        }
+    ));
+}
+
+/// Tick -> Dag -> Tick round-trip preserves scrambled annotation ids verbatim.
+#[test]
+fn scrambled_annotation_ids_survive_tick_dag_round_trip() {
+    let mut tc = TickCircuit::new();
+    tc.tick().pz(&[0, 1]);
+    for (qubit, id) in [(0usize, 9usize), (1, 5)] {
+        tc.tick()
+            .try_add_gate(mz_with_id(qubit, id))
+            .expect("gate is valid");
+    }
+    let refs: Vec<_> = (0..2)
+        .map(|tick| {
+            tc.meas_ref(tick + 1, 0, QubitId::from(tick))
+                .expect("the measurement is there")
+        })
+        .collect();
+    tc.detector(&refs).expect("refs are from this circuit");
+    tc.observable(&[refs[1]])
+        .expect("refs are from this circuit");
+
+    let dag = DagCircuit::try_from(&tc).expect("valid circuit");
+    let back = TickCircuit::from(&dag);
+
+    let expect_ids = |kind: &AnnotationKind, want: &[usize]| {
+        let ids = match kind {
+            AnnotationKind::Detector {
+                measurement_ids, ..
+            }
+            | AnnotationKind::Observable { measurement_ids } => measurement_ids,
+            AnnotationKind::TrackedPauli => panic!("unexpected tracked Pauli"),
+        };
+        let want: Vec<MeasId> = want.iter().map(|&id| MeasId::from_raw(id)).collect();
+        assert_eq!(ids, &want);
+    };
+    for circuit_annotations in [dag.annotations(), back.annotations()] {
+        assert_eq!(circuit_annotations.len(), 2);
+        expect_ids(&circuit_annotations[0].kind, &[9, 5]);
+        expect_ids(&circuit_annotations[1].kind, &[5]);
+    }
+}
+
+/// A sparse id must not cause an id-sized allocation anywhere in the pipeline.
+/// If any consumer indexes a dense structure by raw id value, this either
+/// fails or takes far too long to pass.
+#[test]
+fn a_huge_sparse_id_causes_no_id_sized_allocation() {
+    let huge = 1usize << 44;
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1, 2]);
+    dag.cx(&[(0, 2)]);
+    dag.cx(&[(1, 2)]);
+    dag.try_add_gate_auto_wire(mz_with_id(2, huge))
+        .expect("gate is valid");
+    let mref = dag
+        .find_measurement(MeasId::from_raw(huge))
+        .expect("the id was just supplied");
+    dag.detector(&[mref]).expect("refs are from this circuit");
+
+    let map = InfluenceBuilder::new(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+    assert_eq!(
+        map.meas_index_of(MeasId::from_raw(huge)),
+        Some(0),
+        "one measurement exists and the huge id ranks first"
+    );
+}

--- a/crates/pecos-qec/tests/meas_id_pivot_tests.rs
+++ b/crates/pecos-qec/tests/meas_id_pivot_tests.rs
@@ -65,7 +65,7 @@ fn parity_check_with_ids(ids: [usize; 3]) -> DagCircuit {
 #[test]
 fn scrambled_ids_build_the_same_influence_relations_as_positional_ids() {
     let positional = parity_check_with_ids([0, 1, 2]);
-    let scrambled = parity_check_with_ids([9, 1, 5]);
+    let scrambled = parity_check_with_ids([9, 4, 7]);
 
     let map_pos = InfluenceBuilder::new(&positional)
         .with_circuit_annotations()
@@ -144,7 +144,7 @@ fn location_index_by_key(
 #[test]
 fn scrambled_ids_influence_the_same_named_measurements() {
     let positional = parity_check_with_ids([0, 1, 2]);
-    let scrambled = parity_check_with_ids([9, 1, 5]);
+    let scrambled = parity_check_with_ids([9, 4, 7]);
 
     let build = |dag: &DagCircuit| {
         InfluenceBuilder::new(dag)
@@ -159,7 +159,7 @@ fn scrambled_ids_influence_the_same_named_measurements() {
     // scr-index -> pos-index for the same physical measurement: ids[i] of one
     // circuit names the same physical measurement as ids[i] of the other.
     let mut scr_to_pos = [usize::MAX; 3];
-    for (pos_id, scr_id) in [(0usize, 9usize), (1, 1), (2, 5)] {
+    for (pos_id, scr_id) in [(0usize, 9usize), (1, 4), (2, 7)] {
         let pi = map_pos
             .meas_index_of(MeasId::from_raw(pos_id))
             .expect("id is in the positional map");
@@ -200,10 +200,11 @@ fn scrambled_ids_influence_the_same_named_measurements() {
 }
 
 /// Under scrambled ids, `sample_dual` detector events must XOR exactly the
-/// raw channels that `meas_index_of` names -- the sampler witness for the
-/// one-order-per-map invariant. FLIP space: with a noiseless deterministic
-/// circuit, a detector event equals the raw flip of its single named
-/// measurement, shot by shot.
+/// raw channels that `meas_index_of` names. Both sides of the assertion
+/// resolve through the same `meas_index_of`, so this pins the sampler's
+/// internal consistency; the one-order-per-map invariant itself is killed by
+/// `scrambled_ids_influence_the_same_named_measurements`, whose id-to-ordinal
+/// map is checked against the independent influence data.
 #[test]
 fn scrambled_ids_dual_output_xors_the_named_raw_channels() {
     use pecos_random::PecosRng;
@@ -259,6 +260,57 @@ fn scrambled_ids_dual_output_xors_the_named_raw_channels() {
         "the witness is vacuous unless the named channel varies and disagrees \
          with the other channel at least once"
     );
+}
+
+/// A `gate_mut` edit can leave two measurements holding one id. The sampler's
+/// annotation resolution refuses the whole map instead of silently binding to
+/// the first holder.
+#[test]
+fn sampler_annotations_refuse_a_map_with_duplicate_ids() {
+    use pecos_qec::fault_tolerance::propagator::DagFaultAnalyzer;
+
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0, 1]);
+    let a = dag.mz(&[0]);
+    let b = dag.mz(&[1]);
+    dag.gate_mut(b[0].node).expect("gate exists").meas_ids[0] = a[0].meas_id;
+
+    let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+    let err = DemSamplerBuilder::new(&map)
+        .with_uniform_noise(0.01)
+        .raw_measurements()
+        .with_circuit_annotations(&dag)
+        .map(|_| ())
+        .expect_err("two measurements hold one id");
+    assert!(matches!(
+        err,
+        pecos_qec::fault_tolerance::dem_builder::DetectorValidationError::InvalidMetadata { .. }
+    ));
+}
+
+/// `measurement_order` is a legacy escape hatch for id-less circuits; on a
+/// stamped-id circuit its qubit-occurrence heuristic silently mis-binds, so
+/// the combination is refused outright.
+#[test]
+fn measurement_order_is_refused_on_a_stamped_id_circuit() {
+    let dag = parity_check_with_ids([9, 4, 7]);
+    let map = InfluenceBuilder::new(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+
+    let err = DemSamplerBuilder::new(&map)
+        .with_uniform_noise(0.01)
+        .raw_measurements()
+        .with_measurement_order(vec![0, 1, 2])
+        .build()
+        .map(|_| ())
+        .expect_err("stamped ids already define the mapping");
+    assert!(matches!(
+        err,
+        pecos_qec::fault_tolerance::dem_builder::DetectorValidationError::InvalidMetadata { .. }
+    ));
 }
 
 /// A detector can reference exactly one measurement of a batched gate --

--- a/crates/pecos-qec/tests/meas_id_pivot_tests.rs
+++ b/crates/pecos-qec/tests/meas_id_pivot_tests.rs
@@ -110,7 +110,7 @@ fn location_key(
 ) -> LocationKey {
     (
         loc.node,
-        loc.qubits.iter().map(|q| q.index()).collect(),
+        loc.qubits.iter().map(pecos_core::QubitId::index).collect(),
         loc.before,
         loc.gate_type,
     )
@@ -158,7 +158,7 @@ fn scrambled_ids_influence_the_same_named_measurements() {
 
     // scr-index -> pos-index for the same physical measurement: ids[i] of one
     // circuit names the same physical measurement as ids[i] of the other.
-    let mut scr_to_pos = vec![usize::MAX; 3];
+    let mut scr_to_pos = [usize::MAX; 3];
     for (pos_id, scr_id) in [(0usize, 9usize), (1, 1), (2, 5)] {
         let pi = map_pos
             .meas_index_of(MeasId::from_raw(pos_id))

--- a/crates/pecos-qec/tests/targeted_tests.rs
+++ b/crates/pecos-qec/tests/targeted_tests.rs
@@ -128,7 +128,8 @@ fn custom_p1_weights_affect_decoder() {
     dag.h(&[0]);
     dag.cx(&[(0, 1)]);
     let ms = dag.mz(&[0, 1]);
-    dag.observable(&[ms[0], ms[1]]);
+    dag.observable(&[ms[0], ms[1]])
+        .expect("refs are from this circuit");
 
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()
@@ -277,7 +278,8 @@ fn detector_derives_pauli_from_measurements() {
     dag.pz(&[0, 1]);
     dag.cx(&[(0, 1)]);
     let ms = dag.mz(&[0, 1]);
-    dag.detector(&[ms[0], ms[1]]);
+    dag.detector(&[ms[0], ms[1]])
+        .expect("refs are from this circuit");
 
     let ann = &dag.annotations()[0];
     // Pauli should be Z on both measured qubits
@@ -312,7 +314,8 @@ fn probability_sums_to_one() {
     dag.h(&[0]);
     dag.cx(&[(0, 1)]);
     let ms = dag.mz(&[0, 1]);
-    dag.observable(&[ms[0], ms[1]]);
+    dag.observable(&[ms[0], ms[1]])
+        .expect("refs are from this circuit");
 
     let map = InfluenceBuilder::new(&dag)
         .with_circuit_annotations()

--- a/crates/pecos-qec/tests/unified_sampler_tests.rs
+++ b/crates/pecos-qec/tests/unified_sampler_tests.rs
@@ -432,7 +432,7 @@ fn circuit_annotation_dual_output() {
     let mut dag = DagCircuit::new();
 
     // 3 rounds for meaningful round-to-round detectors
-    let mut meas_nodes = Vec::new();
+    let mut meas_refs = Vec::new();
     for _ in 0..3 {
         dag.pz(&[3, 4]);
         dag.cx(&[(0, 3)]);
@@ -440,14 +440,14 @@ fn circuit_annotation_dual_output() {
         dag.cx(&[(1, 4)]);
         dag.cx(&[(2, 4)]);
         let ms = dag.mz(&[3, 4]);
-        meas_nodes.push((ms[0].node, ms[1].node));
+        meas_refs.push((ms[0], ms[1]));
     }
 
     // Annotate round-to-round detectors (rounds 1-2 and 2-3)
-    dag.detector(&[meas_nodes[0].0, meas_nodes[1].0]); // q3 r1↔r2
-    dag.detector(&[meas_nodes[0].1, meas_nodes[1].1]); // q4 r1↔r2
-    dag.detector(&[meas_nodes[1].0, meas_nodes[2].0]); // q3 r2↔r3
-    dag.detector(&[meas_nodes[1].1, meas_nodes[2].1]); // q4 r2↔r3
+    dag.detector(&[meas_refs[0].0, meas_refs[1].0]).unwrap(); // q3 r1↔r2
+    dag.detector(&[meas_refs[0].1, meas_refs[1].1]).unwrap(); // q4 r1↔r2
+    dag.detector(&[meas_refs[1].0, meas_refs[2].0]).unwrap(); // q3 r2↔r3
+    dag.detector(&[meas_refs[1].1, meas_refs[2].1]).unwrap(); // q4 r2↔r3
 
     // Build MEASUREMENT-LEVEL influence map (DagFaultAnalyzer, not InfluenceBuilder)
     // DagFaultAnalyzer creates one "detector" per raw measurement, so

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -451,6 +451,58 @@ impl fmt::Display for MeasResolveError {
 
 impl std::error::Error for MeasResolveError {}
 
+/// Why a measurement reference was rejected at annotation construction.
+///
+/// Validation is an O(1) lookup at the referenced node, so it catches stale
+/// references (the gate was removed or replaced) and references whose
+/// (node, qubit, id) triple this circuit does not hold. A reference minted by a
+/// *different* circuit that agrees structurally at that node cannot be detected
+/// here -- ids are circuit-local numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnnotationRefError {
+    /// No gate lives at the referenced node.
+    NoSuchNode { node: usize },
+    /// The gate at the referenced node does not consume measurement records.
+    NotAMeasurement { node: usize },
+    /// The gate does not hold this (qubit, id) pair.
+    RefMismatch {
+        node: usize,
+        qubit: usize,
+        meas_id: MeasId,
+    },
+}
+
+impl fmt::Display for AnnotationRefError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoSuchNode { node } => {
+                write!(
+                    f,
+                    "measurement reference names node {node}, which holds no gate"
+                )
+            }
+            Self::NotAMeasurement { node } => write!(
+                f,
+                "measurement reference names node {node}, whose gate consumes no \
+                 measurement record"
+            ),
+            Self::RefMismatch {
+                node,
+                qubit,
+                meas_id,
+            } => write!(
+                f,
+                "measurement reference (node {node}, qubit {qubit}, MeasId({})) does not \
+                 match the measurement stored there -- the reference is stale or from \
+                 another circuit",
+                meas_id.index()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AnnotationRefError {}
+
 /// The role of a Pauli annotation in the circuit.
 ///
 /// All three kinds track the same thing -- whether a Pauli string flips due to
@@ -458,15 +510,20 @@ impl std::error::Error for MeasResolveError {}
 #[derive(Debug, Clone)]
 pub enum AnnotationKind {
     /// Stabilizer check: the Pauli should be deterministic (flip = error detected).
-    /// Stores measurement node indices for classical readout via XOR, plus
+    /// Stores the identities of the measurements whose XOR is the readout, plus
     /// optional coordinates for visualization/matching.
+    ///
+    /// Identities, not positions: a [`MeasId`] travels on the gate itself, so it
+    /// survives conversion between circuit representations and reordering.
+    /// Duplicate ids are kept, not deduplicated -- XOR readout cancels them,
+    /// matching the stim convention.
     Detector {
-        measurement_nodes: Vec<usize>,
+        measurement_ids: Vec<MeasId>,
         coords: Vec<f64>,
     },
     /// Logical observable: the Pauli's flip determines a logical outcome.
-    /// Stores measurement node indices for classical readout via XOR.
-    Observable { measurement_nodes: Vec<usize> },
+    /// Stores the identities of the measurements whose XOR is the readout.
+    Observable { measurement_ids: Vec<MeasId> },
     /// Tracked Pauli: no measurement readout.
     /// Position is determined by a `TrackedPauliMeta` node in the DAG.
     TrackedPauli,
@@ -2015,115 +2072,138 @@ impl DagCircuit {
     /// Annotate a detector: a set of measurements whose XOR should be
     /// deterministic in the noiseless case.
     ///
-    /// The Pauli string is automatically Z on the measured qubits.
+    /// The Pauli string is Z on each referenced measurement's own qubit --
+    /// referencing one measurement of a batched gate touches only that qubit.
     ///
-    /// Returns the annotation index.
-    pub fn detector(&mut self, measurements: &[impl Into<usize> + Copy]) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|&m| m.into()).collect();
-        let pauli = self.pauli_from_measurement_nodes(&meas_nodes);
-        let idx = self.annotations.len();
-        self.annotations.push(PauliAnnotation {
+    /// Returns the annotation index, or [`AnnotationRefError`] if any
+    /// reference does not name a measurement this circuit holds.
+    pub fn detector(&mut self, measurements: &[MeasRef]) -> Result<usize, AnnotationRefError> {
+        let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
+        Ok(self.push_annotation(PauliAnnotation {
             pauli,
             kind: AnnotationKind::Detector {
-                measurement_nodes: meas_nodes,
+                measurement_ids,
                 coords: Vec::new(),
             },
             label: None,
-        });
-        idx
+        }))
     }
 
     /// Annotate a labeled detector.
     pub fn detector_labeled(
         &mut self,
         label: &str,
-        measurements: &[impl Into<usize> + Copy],
-    ) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|&m| m.into()).collect();
-        let pauli = self.pauli_from_measurement_nodes(&meas_nodes);
-        let idx = self.annotations.len();
-        self.annotations.push(PauliAnnotation {
-            pauli,
-            kind: AnnotationKind::Detector {
-                measurement_nodes: meas_nodes,
-                coords: Vec::new(),
-            },
-            label: Some(label.to_string()),
-        });
-        idx
+        measurements: &[MeasRef],
+    ) -> Result<usize, AnnotationRefError> {
+        let idx = self.detector(measurements)?;
+        self.annotations[idx].label = Some(label.to_string());
+        Ok(idx)
     }
 
     /// Annotate a detector with coordinates.
     pub fn detector_with_coords(
         &mut self,
-        measurements: &[impl Into<usize> + Copy],
+        measurements: &[MeasRef],
         coords: &[f64],
-    ) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|&m| m.into()).collect();
-        let pauli = self.pauli_from_measurement_nodes(&meas_nodes);
-        let idx = self.annotations.len();
-        self.annotations.push(PauliAnnotation {
-            pauli,
-            kind: AnnotationKind::Detector {
-                measurement_nodes: meas_nodes,
-                coords: coords.to_vec(),
-            },
-            label: None,
-        });
-        idx
+    ) -> Result<usize, AnnotationRefError> {
+        let idx = self.detector(measurements)?;
+        let AnnotationKind::Detector { coords: c, .. } = &mut self.annotations[idx].kind else {
+            unreachable!("detector() pushes a Detector annotation");
+        };
+        *c = coords.to_vec();
+        Ok(idx)
     }
 
     /// Annotate a logical observable: a set of measurements whose XOR
     /// defines whether a logical operator flipped.
     ///
-    /// The Pauli string is automatically Z on the measured qubits.
+    /// The Pauli string is Z on each referenced measurement's own qubit.
     ///
-    /// Returns the annotation index.
-    pub fn observable(&mut self, measurements: &[impl Into<usize> + Copy]) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|&m| m.into()).collect();
-        let pauli = self.pauli_from_measurement_nodes(&meas_nodes);
-        let idx = self.annotations.len();
-        self.annotations.push(PauliAnnotation {
+    /// Returns the annotation index, or [`AnnotationRefError`] if any
+    /// reference does not name a measurement this circuit holds.
+    pub fn observable(&mut self, measurements: &[MeasRef]) -> Result<usize, AnnotationRefError> {
+        let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
+        Ok(self.push_annotation(PauliAnnotation {
             pauli,
-            kind: AnnotationKind::Observable {
-                measurement_nodes: meas_nodes,
-            },
+            kind: AnnotationKind::Observable { measurement_ids },
             label: None,
-        });
-        idx
+        }))
     }
 
     /// Annotate a labeled observable.
     pub fn observable_labeled(
         &mut self,
         label: &str,
-        measurements: &[impl Into<usize> + Copy],
-    ) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|&m| m.into()).collect();
-        let pauli = self.pauli_from_measurement_nodes(&meas_nodes);
+        measurements: &[MeasRef],
+    ) -> Result<usize, AnnotationRefError> {
+        let idx = self.observable(measurements)?;
+        self.annotations[idx].label = Some(label.to_string());
+        Ok(idx)
+    }
+
+    /// The measurement references held by the gate at `node`, in qubit order.
+    ///
+    /// This is how callers that added a batched measurement via `add_gate`
+    /// (which returns only the node) recover the per-measurement references
+    /// that [`Self::detector`] and [`Self::observable`] take.
+    ///
+    /// Returns `None` when the node holds no gate or the gate consumes no
+    /// measurement records.
+    #[must_use]
+    pub fn meas_refs(&self, node: usize) -> Option<Vec<MeasRef>> {
+        let gate = self.gate(node)?;
+        if !gate.gate_type.consumes_measurement_record() {
+            return None;
+        }
+        Some(
+            gate.qubits
+                .iter()
+                .zip(gate.meas_ids.iter())
+                .map(|(&qubit, &meas_id)| MeasRef {
+                    node,
+                    qubit,
+                    meas_id,
+                })
+                .collect(),
+        )
+    }
+
+    fn push_annotation(&mut self, annotation: PauliAnnotation) -> usize {
         let idx = self.annotations.len();
-        self.annotations.push(PauliAnnotation {
-            pauli,
-            kind: AnnotationKind::Observable {
-                measurement_nodes: meas_nodes,
-            },
-            label: Some(label.to_string()),
-        });
+        self.annotations.push(annotation);
         idx
     }
 
-    /// Derive a `PauliString` from measurement nodes.
-    /// Z-basis measurements → Z on the measured qubit.
-    fn pauli_from_measurement_nodes(&self, nodes: &[usize]) -> pecos_core::PauliString {
-        let qubits: Vec<usize> = nodes
-            .iter()
-            .filter_map(|&node| {
-                let gate = self.gate(node)?;
-                Some(gate.qubits.iter().map(pecos_core::QubitId::index))
-            })
-            .flatten()
-            .collect();
-        pecos_core::PauliString::zs(&qubits)
+    /// Validate each reference against the gate it names and derive the ids
+    /// and Z-Pauli. Validation is an O(1) lookup per reference: the gate must
+    /// exist, consume measurement records, and hold the (qubit, id) pair.
+    fn validated_ids_and_pauli(
+        &self,
+        measurements: &[MeasRef],
+    ) -> Result<(Vec<MeasId>, pecos_core::PauliString), AnnotationRefError> {
+        for m in measurements {
+            let Some(gate) = self.gate(m.node) else {
+                return Err(AnnotationRefError::NoSuchNode { node: m.node });
+            };
+            if !gate.gate_type.consumes_measurement_record() {
+                return Err(AnnotationRefError::NotAMeasurement { node: m.node });
+            }
+            let held = gate
+                .qubits
+                .iter()
+                .position(|&q| q == m.qubit)
+                .is_some_and(|pos| gate.meas_ids.get(pos) == Some(&m.meas_id));
+            if !held {
+                return Err(AnnotationRefError::RefMismatch {
+                    node: m.node,
+                    qubit: m.qubit.index(),
+                    meas_id: m.meas_id,
+                });
+            }
+        }
+        let ids = measurements.iter().map(|m| m.meas_id).collect();
+        let qubits: Vec<usize> = measurements.iter().map(|m| m.qubit.index()).collect();
+        Ok((ids, pecos_core::PauliString::zs(&qubits)))
     }
 
     /// Place a tracked-Pauli meta-gate at this point in the circuit.

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -2075,8 +2075,12 @@ impl DagCircuit {
     /// The Pauli string is Z on each referenced measurement's own qubit --
     /// referencing one measurement of a batched gate touches only that qubit.
     ///
-    /// Returns the annotation index, or [`AnnotationRefError`] if any
-    /// reference does not name a measurement this circuit holds.
+    /// Returns the annotation index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationRefError`] if any reference does not name a
+    /// measurement this circuit holds.
     pub fn detector(&mut self, measurements: &[MeasRef]) -> Result<usize, AnnotationRefError> {
         let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
         Ok(self.push_annotation(PauliAnnotation {
@@ -2090,6 +2094,10 @@ impl DagCircuit {
     }
 
     /// Annotate a labeled detector.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::detector`].
     pub fn detector_labeled(
         &mut self,
         label: &str,
@@ -2101,6 +2109,10 @@ impl DagCircuit {
     }
 
     /// Annotate a detector with coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::detector`].
     pub fn detector_with_coords(
         &mut self,
         measurements: &[MeasRef],
@@ -2119,8 +2131,12 @@ impl DagCircuit {
     ///
     /// The Pauli string is Z on each referenced measurement's own qubit.
     ///
-    /// Returns the annotation index, or [`AnnotationRefError`] if any
-    /// reference does not name a measurement this circuit holds.
+    /// Returns the annotation index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationRefError`] if any reference does not name a
+    /// measurement this circuit holds.
     pub fn observable(&mut self, measurements: &[MeasRef]) -> Result<usize, AnnotationRefError> {
         let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
         Ok(self.push_annotation(PauliAnnotation {
@@ -2131,6 +2147,10 @@ impl DagCircuit {
     }
 
     /// Annotate a labeled observable.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::observable`].
     pub fn observable_labeled(
         &mut self,
         label: &str,

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -453,7 +453,8 @@ impl std::error::Error for MeasResolveError {}
 
 /// Why a measurement reference was rejected at annotation construction.
 ///
-/// Validation is an O(1) lookup at the referenced node, so it catches stale
+/// Validation is a direct lookup at the referenced node (linear only in the
+/// gate's own batch width), so it catches stale
 /// references (the gate was removed or replaced) and references whose
 /// (node, qubit, id) triple this circuit does not hold. A reference minted by a
 /// *different* circuit that agrees structurally at that node cannot be detected
@@ -2195,7 +2196,8 @@ impl DagCircuit {
     }
 
     /// Validate each reference against the gate it names and derive the ids
-    /// and Z-Pauli. Validation is an O(1) lookup per reference: the gate must
+    /// and Z-Pauli. Validation is a direct lookup per reference -- linear only
+    /// in the named gate's batch width, never in the circuit: the gate must
     /// exist, consume measurement records, and hold the (qubit, id) pair.
     fn validated_ids_and_pauli(
         &self,

--- a/crates/pecos-quantum/src/lib.rs
+++ b/crates/pecos-quantum/src/lib.rs
@@ -82,12 +82,13 @@ pub mod hugr_convert;
 
 pub use circuit::{Circuit, CircuitMut, GateHandle, GateView};
 pub use dag_circuit::{
-    AnnotationKind, Attribute, DagCircuit, DagTraversalIndex, MeasRef, MeasResolveError,
-    PauliAnnotation, TraversalWorkBuffers,
+    AnnotationKind, AnnotationRefError, Attribute, DagCircuit, DagTraversalIndex, MeasRef,
+    MeasResolveError, PauliAnnotation, TraversalWorkBuffers,
 };
 pub use tick_circuit::{
     CustomGateError, GateSignatureMismatchError, PHYSICAL_DURATION_META_KEY, QubitConflictError,
-    Tick, TickCircuit, TickGateError, TickHandle, TickMeasRef, TickMeasureHandle, TickPrepHandle,
+    Tick, TickAnnotationRefError, TickCircuit, TickGateError, TickHandle, TickMeasRef,
+    TickMeasureHandle, TickPrepHandle,
 };
 
 // Re-export commonly used types from dependencies

--- a/crates/pecos-quantum/src/pass.rs
+++ b/crates/pecos-quantum/src/pass.rs
@@ -3236,8 +3236,8 @@ mod tests {
     fn split_batched_tick_commands_preserves_payloads_attrs_and_counters() {
         let mut tc = TickCircuit::new();
         let initial_refs = tc.tick().mz(&[0, 1]);
-        assert_eq!(initial_refs[0].record_idx, 0);
-        assert_eq!(initial_refs[1].record_idx, 1);
+        assert_eq!(initial_refs[0].meas_id.index(), 0);
+        assert_eq!(initial_refs[1].meas_id.index(), 1);
         tc.get_tick_mut(0).unwrap().set_gate_attr(
             0,
             "role",
@@ -3298,7 +3298,7 @@ mod tests {
         }
 
         let later_refs = tc.tick().mz(&[6]);
-        assert_eq!(later_refs[0].record_idx, 2);
+        assert_eq!(later_refs[0].meas_id.index(), 2);
         assert_eq!(later_refs[0].meas_id, MeasId::from_raw(2));
         assert_eq!(tc.next_tick_index(), 3);
         assert_eq!(tc.num_measurements(), 3);

--- a/crates/pecos-quantum/src/pass.rs
+++ b/crates/pecos-quantum/src/pass.rs
@@ -3232,6 +3232,48 @@ mod tests {
         );
     }
 
+    /// Splitting batched commands must not disturb annotations: they
+    /// reference measurements by identity, and the ids ride on the gates.
+    #[test]
+    fn split_batched_tick_commands_preserves_annotation_ids() {
+        use crate::AnnotationKind;
+
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        let mut gate = pecos_core::Gate::mz(&[0, 1]);
+        gate.meas_ids = smallvec::smallvec![MeasId::from_raw(9), MeasId::from_raw(4)];
+        tc.tick().try_add_gate(gate).expect("gate is valid");
+        let r0 = tc
+            .meas_ref(1, 0, QubitId::from(0))
+            .expect("measurement exists");
+        let r1 = tc
+            .meas_ref(1, 0, QubitId::from(1))
+            .expect("measurement exists");
+        tc.detector(&[r0, r1]).expect("refs are from this circuit");
+
+        split_batched_tick_commands(&mut tc);
+
+        let anns = tc.annotations();
+        assert_eq!(anns.len(), 1);
+        let AnnotationKind::Detector {
+            measurement_ids, ..
+        } = &anns[0].kind
+        else {
+            panic!("expected detector annotation");
+        };
+        assert_eq!(
+            measurement_ids,
+            &[MeasId::from_raw(9), MeasId::from_raw(4)],
+            "split must not renumber or reorder annotation ids"
+        );
+        // The split gates still hold the ids, so the refs remain resolvable.
+        let dag = crate::DagCircuit::try_from(&tc).expect("valid circuit");
+        dag.find_measurement(MeasId::from_raw(9))
+            .expect("id 9 still resolves");
+        dag.find_measurement(MeasId::from_raw(4))
+            .expect("id 4 still resolves");
+    }
+
     #[test]
     fn split_batched_tick_commands_preserves_payloads_attrs_and_counters() {
         let mut tc = TickCircuit::new();

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1241,7 +1241,8 @@ pub struct TickMeasRef {
 
 /// Why a measurement reference was rejected at annotation construction.
 ///
-/// Validation is an O(1) lookup at the referenced batch, so it catches stale
+/// Validation is a direct lookup at the referenced batch (linear only in the
+/// batch's own width), so it catches stale
 /// references and references whose (tick, batch, qubit, id) tuple this circuit
 /// does not hold. A reference minted by a *different* circuit that agrees
 /// structurally cannot be detected -- ids are circuit-local numbers.

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -1230,11 +1230,45 @@ pub struct TickMeasRef {
     pub gate_idx: usize,
     /// Qubit that was measured.
     pub qubit: QubitId,
-    /// Measurement record index (cumulative count of MZ qubits in circuit order).
-    pub record_idx: usize,
     /// Stable measurement result identity (SSA value).
+    ///
+    /// This is the only number that names the measurement. A record ordinal is
+    /// not stored: allocation order and storage order diverge under `tick_at`
+    /// out-of-order filling and compatible-batch merging, so any boundary that
+    /// needs an ordinal computes its own from the ids it can see.
     pub meas_id: MeasId,
 }
+
+/// Why a measurement reference was rejected at annotation construction.
+///
+/// Validation is an O(1) lookup at the referenced batch, so it catches stale
+/// references and references whose (tick, batch, qubit, id) tuple this circuit
+/// does not hold. A reference minted by a *different* circuit that agrees
+/// structurally cannot be detected -- ids are circuit-local numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TickAnnotationRefError {
+    pub tick: usize,
+    pub gate_idx: usize,
+    pub qubit: usize,
+    pub meas_id: MeasId,
+}
+
+impl std::fmt::Display for TickAnnotationRefError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "measurement reference (tick {}, batch {}, qubit {}, MeasId({})) does not \
+             name a measurement this circuit holds -- the reference is stale or from \
+             another circuit",
+            self.tick,
+            self.gate_idx,
+            self.qubit,
+            self.meas_id.index()
+        )
+    }
+}
+
+impl std::error::Error for TickAnnotationRefError {}
 
 #[derive(Debug, Clone, Default)]
 pub struct TickCircuit {
@@ -1476,9 +1510,9 @@ impl TickCircuit {
     /// gate-batch index and qubit.
     ///
     /// Callers that hold only `(tick, gate_idx, qubit)` -- notably the Python
-    /// bindings, whose measurement handles are plain tuples -- need the record
-    /// index and [`MeasId`] that `mz()` assigned. Fabricating a `TickMeasRef`
-    /// with placeholder values instead silently collapses every reference onto
+    /// bindings, whose measurement handles are plain tuples -- need the
+    /// [`MeasId`] that `mz()` assigned. Fabricating a `TickMeasRef` with
+    /// placeholder values instead silently collapses every reference onto
     /// record 0, which corrupts detector and observable annotations built from
     /// them (issue #382).
     ///
@@ -1491,17 +1525,6 @@ impl TickCircuit {
     /// was not measured by it.
     #[must_use]
     pub fn meas_ref(&self, tick: usize, gate_idx: usize, qubit: QubitId) -> Option<TickMeasRef> {
-        // The `MeasId` stored alongside each measured qubit is what `mz` /
-        // `mz_free` assigned at call time, so reading it back recovers the
-        // record index directly. Reconstructing the ordinal by walking stored
-        // ticks and batches instead is wrong: a later measurement can be
-        // appended to an earlier compatible batch, and `tick_at` allows filling
-        // ticks out of order, so storage order is not allocation order.
-        //
-        // Limitation: `mz_with_ids` lets callers supply external stable ids
-        // (Guppy result ids) that are not positional, and for those the record
-        // index and the id genuinely differ. `TickCircuit` does not store the
-        // positional ordinal separately, so that case cannot be resolved here.
         let batch = self.get_tick(tick)?.iter_gate_batches().nth(gate_idx)?;
         let gate = batch.as_gate();
         if !matches!(gate.gate_type, GateType::MZ | GateType::MeasureFree) {
@@ -1513,7 +1536,6 @@ impl TickCircuit {
             tick,
             gate_idx,
             qubit,
-            record_idx: meas_id.index(),
             meas_id,
         })
     }
@@ -2259,58 +2281,89 @@ impl TickCircuit {
     // ==================== Annotations ====================
 
     /// Annotate a detector: measurements whose XOR should be deterministic.
-    pub fn detector(&mut self, measurements: &[TickMeasRef]) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|m| m.record_idx).collect();
-        let pauli = pecos_core::PauliString::zs(
-            &measurements
-                .iter()
-                .map(|m| m.qubit.index())
-                .collect::<Vec<_>>(),
-        );
+    ///
+    /// Returns the annotation index, or [`TickAnnotationRefError`] if any
+    /// reference does not name a measurement this circuit holds.
+    pub fn detector(
+        &mut self,
+        measurements: &[TickMeasRef],
+    ) -> Result<usize, TickAnnotationRefError> {
+        let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
         let idx = self.annotations.len();
         self.annotations.push(PauliAnnotation {
             pauli,
             kind: AnnotationKind::Detector {
-                measurement_nodes: meas_nodes,
+                measurement_ids,
                 coords: Vec::new(),
             },
             label: None,
         });
-        idx
+        Ok(idx)
     }
 
     /// Annotate a labeled detector.
-    pub fn detector_labeled(&mut self, label: &str, measurements: &[TickMeasRef]) -> usize {
-        let idx = self.detector(measurements);
+    pub fn detector_labeled(
+        &mut self,
+        label: &str,
+        measurements: &[TickMeasRef],
+    ) -> Result<usize, TickAnnotationRefError> {
+        let idx = self.detector(measurements)?;
         self.annotations[idx].label = Some(label.to_string());
-        idx
+        Ok(idx)
     }
 
     /// Annotate a logical observable.
-    pub fn observable(&mut self, measurements: &[TickMeasRef]) -> usize {
-        let meas_nodes: Vec<usize> = measurements.iter().map(|m| m.record_idx).collect();
-        let pauli = pecos_core::PauliString::zs(
-            &measurements
-                .iter()
-                .map(|m| m.qubit.index())
-                .collect::<Vec<_>>(),
-        );
+    ///
+    /// Returns the annotation index, or [`TickAnnotationRefError`] if any
+    /// reference does not name a measurement this circuit holds.
+    pub fn observable(
+        &mut self,
+        measurements: &[TickMeasRef],
+    ) -> Result<usize, TickAnnotationRefError> {
+        let (measurement_ids, pauli) = self.validated_ids_and_pauli(measurements)?;
         let idx = self.annotations.len();
         self.annotations.push(PauliAnnotation {
             pauli,
-            kind: AnnotationKind::Observable {
-                measurement_nodes: meas_nodes,
-            },
+            kind: AnnotationKind::Observable { measurement_ids },
             label: None,
         });
-        idx
+        Ok(idx)
     }
 
     /// Annotate a labeled observable.
-    pub fn observable_labeled(&mut self, label: &str, measurements: &[TickMeasRef]) -> usize {
-        let idx = self.observable(measurements);
+    pub fn observable_labeled(
+        &mut self,
+        label: &str,
+        measurements: &[TickMeasRef],
+    ) -> Result<usize, TickAnnotationRefError> {
+        let idx = self.observable(measurements)?;
         self.annotations[idx].label = Some(label.to_string());
-        idx
+        Ok(idx)
+    }
+
+    /// Validate each reference against the batch it names and derive the ids
+    /// and Z-Pauli. Validation re-runs the [`Self::meas_ref`] lookup: the
+    /// reference must round-trip to the same id.
+    fn validated_ids_and_pauli(
+        &self,
+        measurements: &[TickMeasRef],
+    ) -> Result<(Vec<MeasId>, pecos_core::PauliString), TickAnnotationRefError> {
+        for m in measurements {
+            let held = self
+                .meas_ref(m.tick, m.gate_idx, m.qubit)
+                .is_some_and(|found| found.meas_id == m.meas_id);
+            if !held {
+                return Err(TickAnnotationRefError {
+                    tick: m.tick,
+                    gate_idx: m.gate_idx,
+                    qubit: m.qubit.index(),
+                    meas_id: m.meas_id,
+                });
+            }
+        }
+        let ids = measurements.iter().map(|m| m.meas_id).collect();
+        let qubits: Vec<usize> = measurements.iter().map(|m| m.qubit.index()).collect();
+        Ok((ids, pecos_core::PauliString::zs(&qubits)))
     }
 
     /// Place a tracked-Pauli annotation.
@@ -3117,7 +3170,6 @@ impl<'a> TickHandle<'a> {
                 tick: tick_idx,
                 gate_idx: 0, // placeholder, updated below
                 qubit: q.into(),
-                record_idx,
                 meas_id: mr,
             });
         }
@@ -3168,7 +3220,6 @@ impl<'a> TickHandle<'a> {
                 tick: tick_idx,
                 gate_idx: 0,
                 qubit: q.into(),
-                record_idx,
                 meas_id: mr,
             });
         }
@@ -3300,7 +3351,6 @@ impl From<&DagCircuit> for TickCircuit {
     /// ```
     fn from(dag: &DagCircuit) -> Self {
         let mut tc = TickCircuit::new();
-        let mut dag_node_to_record_indices: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
         let mut next_meas_record = 0usize;
 
         for layer in dag.layers() {
@@ -3316,24 +3366,14 @@ impl From<&DagCircuit> for TickCircuit {
                     // already held.
                     if gate.gate_type.consumes_measurement_record() {
                         if gate.meas_ids.is_empty() {
-                            let mut records = Vec::with_capacity(gate.qubits.len());
                             for _ in &gate.qubits {
-                                let record_idx = next_meas_record;
+                                gate.meas_ids.push(MeasId::from_raw(next_meas_record));
                                 next_meas_record += 1;
-                                gate.meas_ids.push(MeasId::from_raw(record_idx));
-                                records.push(record_idx);
                             }
-                            dag_node_to_record_indices.insert(node_id, records);
-                        } else {
-                            let records: Vec<usize> = gate
-                                .meas_ids
-                                .iter()
-                                .map(|meas_id| meas_id.index())
-                                .collect();
-                            if let Some(next) = records.iter().max().map(|record| record + 1) {
-                                next_meas_record = next_meas_record.max(next);
-                            }
-                            dag_node_to_record_indices.insert(node_id, records);
+                        } else if let Some(next) =
+                            gate.meas_ids.iter().map(|id| id.index() + 1).max()
+                        {
+                            next_meas_record = next_meas_record.max(next);
                         }
                     }
 
@@ -3383,60 +3423,12 @@ impl From<&DagCircuit> for TickCircuit {
             }
         }
 
-        // Transfer annotations, remapping DAG measurement nodes to TickCircuit
-        // measurement record indices. Tracked Paulis have no measurement
-        // readout and keep their Pauli role unchanged.
-        tc.annotations = dag
-            .annotations()
-            .iter()
-            .map(|ann| {
-                let kind = match &ann.kind {
-                    AnnotationKind::Detector {
-                        measurement_nodes,
-                        coords,
-                    } => AnnotationKind::Detector {
-                        measurement_nodes: remap_dag_measurement_nodes(
-                            &dag_node_to_record_indices,
-                            measurement_nodes,
-                        ),
-                        coords: coords.clone(),
-                    },
-                    AnnotationKind::Observable { measurement_nodes } => {
-                        AnnotationKind::Observable {
-                            measurement_nodes: remap_dag_measurement_nodes(
-                                &dag_node_to_record_indices,
-                                measurement_nodes,
-                            ),
-                        }
-                    }
-                    AnnotationKind::TrackedPauli => AnnotationKind::TrackedPauli,
-                };
-                PauliAnnotation {
-                    pauli: ann.pauli.clone(),
-                    kind,
-                    label: ann.label.clone(),
-                }
-            })
-            .collect();
+        // Annotations copy verbatim: they reference measurements by identity,
+        // and identities travel on the gates themselves.
+        tc.annotations = dag.annotations().to_vec();
 
         tc
     }
-}
-
-fn remap_dag_measurement_nodes(
-    dag_node_to_record_indices: &BTreeMap<usize, Vec<usize>>,
-    measurement_nodes: &[usize],
-) -> Vec<usize> {
-    measurement_nodes
-        .iter()
-        .flat_map(|node| {
-            dag_node_to_record_indices
-                .get(node)
-                .unwrap_or_else(|| panic!("annotation references non-measurement DAG node {node}"))
-                .iter()
-                .copied()
-        })
-        .collect()
 }
 
 impl From<DagCircuit> for TickCircuit {
@@ -3504,10 +3496,6 @@ impl TryFrom<&TickCircuit> for DagCircuit {
         // Track the last node for each qubit to connect wires
         let mut last_node: BTreeMap<QubitId, usize> = BTreeMap::new();
 
-        // Map measurement_record_index -> dag node for annotation transfer
-        let mut meas_record_to_node: BTreeMap<usize, usize> = BTreeMap::new();
-        let mut meas_record_idx = 0usize;
-
         for (tick_idx, tick) in tc.iter_ticks() {
             for batch in tick.iter_gate_batches() {
                 // DagCircuit stores individual gate applications. Use the
@@ -3532,22 +3520,6 @@ impl TryFrom<&TickCircuit> for DagCircuit {
                                 reason,
                             })?;
                     split_nodes.push(node);
-
-                    // Every measurement consumes a record, `MeasureFree`
-                    // included -- `TickHandle::mz_free` advances
-                    // `next_meas_record` exactly like `mz`. Counting only `MZ`
-                    // here left later records unmappable, so annotations
-                    // referencing them silently resolved to nothing.
-                    //
-                    // `MeasureLeaked` is a measurement too but is excluded
-                    // here, matching every other site that decides which gates
-                    // consume a record.
-                    if split_gate.gate_type.consumes_measurement_record() {
-                        for _q in &split_gate.qubits {
-                            meas_record_to_node.insert(meas_record_idx, node);
-                            meas_record_idx += 1;
-                        }
-                    }
 
                     // Connect wires from previous gates on the same qubits
                     for qubit in &split_gate.qubits {
@@ -3578,43 +3550,12 @@ impl TryFrom<&TickCircuit> for DagCircuit {
             dag.set_attr(key.clone(), value.clone());
         }
 
-        // Transfer annotations, remapping measurement record indices to DAG node indices
+        // Annotations copy verbatim: they reference measurements by identity,
+        // and identities travel on the gates themselves. Tracked-Pauli meta
+        // gates already crossed with the gate stream, so no meta gate is
+        // re-inserted here.
         for ann in &tc.annotations {
-            let remapped_kind = match &ann.kind {
-                AnnotationKind::Detector {
-                    measurement_nodes,
-                    coords,
-                } => {
-                    let dag_nodes: Vec<usize> = measurement_nodes
-                        .iter()
-                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
-                        .collect();
-                    AnnotationKind::Detector {
-                        measurement_nodes: dag_nodes,
-                        coords: coords.clone(),
-                    }
-                }
-                AnnotationKind::Observable { measurement_nodes } => {
-                    let dag_nodes: Vec<usize> = measurement_nodes
-                        .iter()
-                        .filter_map(|&rec| meas_record_to_node.get(&rec).copied())
-                        .collect();
-                    AnnotationKind::Observable {
-                        measurement_nodes: dag_nodes,
-                    }
-                }
-                AnnotationKind::TrackedPauli => AnnotationKind::TrackedPauli,
-            };
-            let remapped_annotation = PauliAnnotation {
-                pauli: ann.pauli.clone(),
-                kind: remapped_kind,
-                label: ann.label.clone(),
-            };
-            if matches!(remapped_annotation.kind, AnnotationKind::TrackedPauli) {
-                dag.add_annotation_without_meta_gate(remapped_annotation);
-            } else {
-                dag.add_annotation(remapped_annotation);
-            }
+            dag.add_annotation_without_meta_gate(ann.clone());
         }
 
         Ok(dag)
@@ -4588,8 +4529,10 @@ mod tests {
     fn test_batched_measurement_annotation_records_round_trip() {
         let mut tc1 = TickCircuit::new();
         let ms = tc1.tick().mz(&[0, 1]);
-        tc1.detector_labeled("det01", &ms);
-        tc1.observable_labeled("obs1", &[ms[1]]);
+        tc1.detector_labeled("det01", &ms)
+            .expect("refs are from this circuit");
+        tc1.observable_labeled("obs1", &[ms[1]])
+            .expect("refs are from this circuit");
 
         let dag = DagCircuit::try_from(&tc1).expect("valid circuit");
         let tc2 = TickCircuit::from(&dag);
@@ -4598,13 +4541,16 @@ mod tests {
         assert_eq!(tc2.annotations().len(), 2);
         match &tc2.annotations()[0].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
-            } => assert_eq!(measurement_nodes.as_slice(), &[0, 1]),
+                measurement_ids, ..
+            } => assert_eq!(
+                measurement_ids.as_slice(),
+                &[MeasId::from_raw(0), MeasId::from_raw(1)]
+            ),
             other => panic!("expected detector annotation, got {other:?}"),
         }
         match &tc2.annotations()[1].kind {
-            AnnotationKind::Observable { measurement_nodes } => {
-                assert_eq!(measurement_nodes.as_slice(), &[1]);
+            AnnotationKind::Observable { measurement_ids } => {
+                assert_eq!(measurement_ids.as_slice(), &[MeasId::from_raw(1)]);
             }
             other => panic!("expected observable annotation, got {other:?}"),
         }
@@ -4620,15 +4566,20 @@ mod tests {
     fn test_dag_batched_measurement_node_annotation_expands_to_tick_records() {
         let mut dag = DagCircuit::new();
         let node = dag.add_gate(Gate::mz(&[0, 1]));
-        dag.detector_labeled("batched-detector", &[node]);
+        let refs = dag.meas_refs(node).expect("MZ holds measurements");
+        dag.detector_labeled("batched-detector", &refs)
+            .expect("refs are from this circuit");
 
         let tc = TickCircuit::from(&dag);
         assert_eq!(tc.num_measurements(), 2);
         assert_eq!(tc.annotations().len(), 1);
         match &tc.annotations()[0].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
-            } => assert_eq!(measurement_nodes.as_slice(), &[0, 1]),
+                measurement_ids, ..
+            } => assert_eq!(
+                measurement_ids.as_slice(),
+                &[MeasId::from_raw(0), MeasId::from_raw(1)]
+            ),
             other => panic!("expected detector annotation, got {other:?}"),
         }
 
@@ -4647,7 +4598,9 @@ mod tests {
         let mut gate = Gate::mz(&[0]);
         gate.meas_ids.push(MeasId::from_raw(5));
         let node = dag.add_gate(gate);
-        dag.observable_labeled("obs5", &[node]);
+        let refs = dag.meas_refs(node).expect("MZ holds measurements");
+        dag.observable_labeled("obs5", &refs)
+            .expect("refs are from this circuit");
 
         let mut tc = TickCircuit::from(&dag);
         assert_eq!(tc.num_measurements(), 6);
@@ -4657,26 +4610,33 @@ mod tests {
             &[MeasId::from_raw(5)]
         );
         match &tc.annotations()[0].kind {
-            AnnotationKind::Observable { measurement_nodes } => {
-                assert_eq!(measurement_nodes.as_slice(), &[5]);
+            AnnotationKind::Observable { measurement_ids } => {
+                assert_eq!(measurement_ids.as_slice(), &[MeasId::from_raw(5)]);
             }
             other => panic!("expected observable annotation, got {other:?}"),
         }
 
         let next = tc.tick().mz(&[1]);
-        assert_eq!(next[0].record_idx, 6);
+        assert_eq!(next[0].meas_id.index(), 6);
         assert_eq!(next[0].meas_id, MeasId::from_raw(6));
         assert_eq!(tc.num_measurements(), 7);
     }
 
     #[test]
-    #[should_panic(expected = "annotation references non-measurement DAG node")]
-    fn test_dag_to_tick_rejects_annotation_referencing_non_measurement_node() {
+    fn dag_detector_rejects_reference_to_non_measurement_node() {
+        use crate::dag_circuit::{AnnotationRefError, MeasRef};
+
         let mut dag = DagCircuit::new();
         let h = dag.add_gate(Gate::h(&[0]));
-        dag.detector_labeled("not-a-measurement", &[h]);
-
-        let _ = TickCircuit::from(&dag);
+        let forged = MeasRef {
+            node: h,
+            qubit: QubitId::from(0),
+            meas_id: MeasId::from_raw(0),
+        };
+        let err = dag
+            .detector_labeled("not-a-measurement", &[forged])
+            .expect_err("H consumes no measurement record");
+        assert!(matches!(err, AnnotationRefError::NotAMeasurement { .. }));
     }
 
     #[test]
@@ -4686,8 +4646,10 @@ mod tests {
         let mut tc1 = TickCircuit::new();
         tc1.tick().pz(&[0, 1, 2]);
         let ms = tc1.tick().mz(&[0, 1]);
-        tc1.detector_labeled("detector", &[ms[0]]);
-        tc1.observable_labeled("observable", &[ms[1]]);
+        tc1.detector_labeled("detector", &[ms[0]])
+            .expect("refs are from this circuit");
+        tc1.observable_labeled("observable", &[ms[1]])
+            .expect("refs are from this circuit");
         tc1.tracked_pauli_labeled("tracked", X(0) & Z(2));
 
         let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
@@ -4696,15 +4658,15 @@ mod tests {
         assert_eq!(tc2.annotations()[0].label.as_deref(), Some("detector"));
         match &tc2.annotations()[0].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
-            } => assert_eq!(measurement_nodes.as_slice(), &[0]),
+                measurement_ids, ..
+            } => assert_eq!(measurement_ids.as_slice(), &[MeasId::from_raw(0)]),
             other => panic!("expected detector annotation, got {other:?}"),
         }
 
         assert_eq!(tc2.annotations()[1].label.as_deref(), Some("observable"));
         match &tc2.annotations()[1].kind {
-            AnnotationKind::Observable { measurement_nodes } => {
-                assert_eq!(measurement_nodes.as_slice(), &[1]);
+            AnnotationKind::Observable { measurement_ids } => {
+                assert_eq!(measurement_ids.as_slice(), &[MeasId::from_raw(1)]);
             }
             other => panic!("expected observable annotation, got {other:?}"),
         }
@@ -4768,9 +4730,11 @@ mod tests {
 
             let ms = tc1.tick().mz(&[base, base + 1]);
             if case_idx % 2 == 0 {
-                tc1.detector_labeled("det", &ms);
+                tc1.detector_labeled("det", &ms)
+                    .expect("refs are from this circuit");
             } else {
-                tc1.observable_labeled("obs", &ms);
+                tc1.observable_labeled("obs", &ms)
+                    .expect("refs are from this circuit");
             }
 
             let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
@@ -4829,8 +4793,10 @@ mod tests {
                 Y(base + 3)
             };
 
-            tc1.detector_labeled(&format!("det-{case_idx}"), &detector_records);
-            tc1.observable_labeled(&format!("obs-{case_idx}"), &observable_records);
+            tc1.detector_labeled(&format!("det-{case_idx}"), &detector_records)
+                .expect("refs are from this circuit");
+            tc1.observable_labeled(&format!("obs-{case_idx}"), &observable_records)
+                .expect("refs are from this circuit");
             tc1.tracked_pauli_labeled(&format!("track-{case_idx}"), tracked.clone());
 
             let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
@@ -4845,12 +4811,12 @@ mod tests {
             let det = annotation_by_label(&tc2, &format!("det-{case_idx}"));
             match &det.kind {
                 AnnotationKind::Detector {
-                    measurement_nodes, ..
+                    measurement_ids, ..
                 } => assert_eq!(
-                    measurement_nodes,
+                    measurement_ids,
                     &detector_records
                         .iter()
-                        .map(|m| m.record_idx)
+                        .map(|m| m.meas_id)
                         .collect::<Vec<_>>(),
                     "case {case_idx}"
                 ),
@@ -4859,11 +4825,11 @@ mod tests {
 
             let obs = annotation_by_label(&tc2, &format!("obs-{case_idx}"));
             match &obs.kind {
-                AnnotationKind::Observable { measurement_nodes } => assert_eq!(
-                    measurement_nodes,
+                AnnotationKind::Observable { measurement_ids } => assert_eq!(
+                    measurement_ids,
                     &observable_records
                         .iter()
-                        .map(|m| m.record_idx)
+                        .map(|m| m.meas_id)
                         .collect::<Vec<_>>(),
                     "case {case_idx}"
                 ),
@@ -4941,8 +4907,10 @@ mod tests {
         tc1.tick().idle(3u64, &[60]);
         tc1.tick().pz(&[70, 71]);
         let ms = tc1.tick().mz(&[70, 71]);
-        tc1.detector_labeled("det-all-gates", &[ms[0]]);
-        tc1.observable_labeled("obs-all-gates", &[ms[1]]);
+        tc1.detector_labeled("det-all-gates", &[ms[0]])
+            .expect("refs are from this circuit");
+        tc1.observable_labeled("obs-all-gates", &[ms[1]])
+            .expect("refs are from this circuit");
         tc1.tracked_pauli_labeled("tracked-all-gates", X(70) & Z(71));
 
         let tc2 = TickCircuit::from(&DagCircuit::try_from(&tc1).expect("valid circuit"));
@@ -5139,8 +5107,10 @@ mod tests {
             tc1.detector_labeled(
                 &format!("det-{case_idx}"),
                 &[measurements[0], measurements[2]],
-            );
-            tc1.observable_labeled(&format!("obs-{case_idx}"), &[measurements[1]]);
+            )
+            .expect("refs are from this circuit");
+            tc1.observable_labeled(&format!("obs-{case_idx}"), &[measurements[1]])
+                .expect("refs are from this circuit");
             let tracked = if state & (1 << 32) == 0 {
                 X(base) & Z(base + 3)
             } else {
@@ -5788,8 +5758,10 @@ mod tests {
     fn test_reset_clears_annotations_and_measurement_counter() {
         let mut tc = TickCircuit::new();
         let first_measurement = tc.tick().mz(&[0]);
-        tc.detector(&first_measurement);
-        tc.observable(&first_measurement);
+        tc.detector(&first_measurement)
+            .expect("refs are from this circuit");
+        tc.observable(&first_measurement)
+            .expect("refs are from this circuit");
         tc.tracked_pauli(pecos_core::pauli::Z(0));
 
         assert_eq!(tc.num_measurements(), 1);
@@ -5802,7 +5774,7 @@ mod tests {
         assert!(tc.annotations().is_empty());
 
         let reused_measurement = tc.tick().mz(&[1]);
-        assert_eq!(reused_measurement[0].record_idx, 0);
+        assert_eq!(reused_measurement[0].meas_id.index(), 0);
     }
 
     #[test]
@@ -6311,8 +6283,10 @@ mod tests {
         assert_eq!(ms.len(), 1);
         assert_eq!(ms[0].qubit, QubitId::from(2));
 
-        tc.detector_labeled("Z_check", &ms);
-        tc.observable_labeled("logical_Z", &ms);
+        tc.detector_labeled("Z_check", &ms)
+            .expect("refs are from this circuit");
+        tc.observable_labeled("logical_Z", &ms)
+            .expect("refs are from this circuit");
         tc.tracked_pauli_labeled("logical_X", X(0) & X(1));
 
         assert_eq!(tc.annotations().len(), 3);
@@ -6330,8 +6304,10 @@ mod tests {
         tc.tick().cx(&[(0, 2)]);
         tc.tick().cx(&[(1, 2)]);
         let ms = tc.tick().mz(&[2]);
-        tc.detector_labeled("det0", &ms);
-        tc.observable_labeled("obs0", &ms);
+        tc.detector_labeled("det0", &ms)
+            .expect("refs are from this circuit");
+        tc.observable_labeled("obs0", &ms)
+            .expect("refs are from this circuit");
         tc.tracked_pauli_labeled("op0", Z(0) & Z(1));
 
         let dag = DagCircuit::try_from(&tc).expect("valid circuit");
@@ -6365,8 +6341,10 @@ mod tests {
         dag.pz(&[0, 1]);
         dag.cx(&[(0, 1)]);
         let ms = dag.mz(&[0, 1]);
-        dag.detector_labeled("d0", &[ms[0]]);
-        dag.observable_labeled("o0", &[ms[0], ms[1]]);
+        dag.detector_labeled("d0", &[ms[0]])
+            .expect("refs are from this circuit");
+        dag.observable_labeled("o0", &[ms[0], ms[1]])
+            .expect("refs are from this circuit");
         dag.tracked_pauli_labeled("p0", X(0) & X(1));
 
         let tc = TickCircuit::from(&dag);
@@ -6387,9 +6365,11 @@ mod tests {
         tc1.tick().cx(&[(0, 2)]);
         tc1.tick().cx(&[(1, 2)]);
         let ms = tc1.tick().mz(&[2]);
-        tc1.detector_labeled("syndr", &ms);
+        tc1.detector_labeled("syndr", &ms)
+            .expect("refs are from this circuit");
         let ms_data = tc1.tick().mz(&[0, 1]);
-        tc1.observable_labeled("log_Z", &ms_data);
+        tc1.observable_labeled("log_Z", &ms_data)
+            .expect("refs are from this circuit");
         tc1.tracked_pauli_labeled("log_X", X(0) & X(1));
 
         // TickCircuit -> DagCircuit -> TickCircuit
@@ -6787,20 +6767,20 @@ mod tests {
         let mut tc = TickCircuit::new();
         let m0 = tc.tick().mz(&[0]);
         let m1 = tc.tick().mz(&[1]);
-        assert_eq!(m0[0].record_idx, 0);
-        assert_eq!(m1[0].record_idx, 1);
+        assert_eq!(m0[0].meas_id.index(), 0);
+        assert_eq!(m1[0].meas_id.index(), 1);
     }
 
     #[test]
     fn test_meas_record_idx_multi_qubit() {
         let mut tc = TickCircuit::new();
         let ms = tc.tick().mz(&[0, 1, 2]);
-        assert_eq!(ms[0].record_idx, 0);
-        assert_eq!(ms[1].record_idx, 1);
-        assert_eq!(ms[2].record_idx, 2);
+        assert_eq!(ms[0].meas_id.index(), 0);
+        assert_eq!(ms[1].meas_id.index(), 1);
+        assert_eq!(ms[2].meas_id.index(), 2);
         // Next measurement continues the count
         let m2 = tc.tick().mz(&[3]);
-        assert_eq!(m2[0].record_idx, 3);
+        assert_eq!(m2[0].meas_id.index(), 3);
     }
 
     #[test]
@@ -6812,24 +6792,32 @@ mod tests {
         let ms = tc.tick().mz(&[0, 1]);
 
         // Detector on qubit 0's measurement
-        tc.detector(&[ms[0]]);
+        tc.detector(&[ms[0]]).expect("refs are from this circuit");
         // Detector on qubit 1's measurement
-        tc.detector(&[ms[1]]);
+        tc.detector(&[ms[1]]).expect("refs are from this circuit");
 
         let anns = tc.annotations();
         match &anns[0].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
+                measurement_ids, ..
             } => {
-                assert_eq!(measurement_nodes, &[0], "D0 should reference record 0 (q0)");
+                assert_eq!(
+                    measurement_ids,
+                    &[MeasId::from_raw(0)],
+                    "D0 should reference measurement 0 (q0)"
+                );
             }
             _ => panic!("Expected detector"),
         }
         match &anns[1].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
+                measurement_ids, ..
             } => {
-                assert_eq!(measurement_nodes, &[1], "D1 should reference record 1 (q1)");
+                assert_eq!(
+                    measurement_ids,
+                    &[MeasId::from_raw(1)],
+                    "D1 should reference measurement 1 (q1)"
+                );
             }
             _ => panic!("Expected detector"),
         }
@@ -6845,17 +6833,18 @@ mod tests {
         let ms = tc.tick().mz(&[0, 1]);
 
         // Detector comparing both measurements (XOR of records 0 and 1)
-        tc.detector(&[ms[0], ms[1]]);
+        tc.detector(&[ms[0], ms[1]])
+            .expect("refs are from this circuit");
 
         let anns = tc.annotations();
         match &anns[0].kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
+                measurement_ids, ..
             } => {
-                assert_eq!(measurement_nodes.len(), 2);
+                assert_eq!(measurement_ids.len(), 2);
                 assert_ne!(
-                    measurement_nodes[0], measurement_nodes[1],
-                    "Two qubits from same MZ must have different record indices"
+                    measurement_ids[0], measurement_ids[1],
+                    "Two qubits from same MZ must have different identities"
                 );
             }
             _ => panic!("Expected detector"),
@@ -6878,20 +6867,47 @@ mod tests {
                 .meas_ref(expected.tick, expected.gate_idx, expected.qubit)
                 .expect("mz() refs must resolve");
             assert_eq!(
-                recovered.record_idx, expected.record_idx,
+                recovered.meas_id.index(),
+                expected.meas_id.index(),
                 "record index for qubit {:?}",
                 expected.qubit
             );
             assert_eq!(recovered.meas_id, expected.meas_id);
         }
 
-        let records: Vec<usize> = first.iter().map(|r| r.record_idx).collect();
+        let records: Vec<usize> = first.iter().map(|r| r.meas_id.index()).collect();
         assert_eq!(
             records,
             vec![0, 1, 2],
             "a batched mz must hand out distinct record indices"
         );
-        assert_eq!(second[0].record_idx, 3);
+        assert_eq!(second[0].meas_id.index(), 3);
+    }
+
+    /// A forged or stale reference is rejected at annotation construction --
+    /// the validation is the round-trip through `meas_ref`.
+    #[test]
+    fn detector_rejects_a_forged_measurement_ref() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0]);
+        let refs = circuit.tick().mz(&[0]);
+
+        let forged = TickMeasRef {
+            meas_id: MeasId::from_raw(7),
+            ..refs[0]
+        };
+        let err = circuit
+            .detector(&[forged])
+            .expect_err("id 7 is not what the batch holds");
+        assert_eq!(err.meas_id, MeasId::from_raw(7));
+
+        let stale = TickMeasRef {
+            tick: 99,
+            ..refs[0]
+        };
+        circuit
+            .observable(&[stale])
+            .expect_err("tick 99 does not exist");
     }
 
     #[test]
@@ -6929,9 +6945,9 @@ mod tests {
         let third = circuit.tick_at(1).mz(&[2]);
         assert_eq!(
             (
-                first[0].record_idx,
-                freed[0].record_idx,
-                third[0].record_idx
+                first[0].meas_id.index(),
+                freed[0].meas_id.index(),
+                third[0].meas_id.index()
             ),
             (0, 1, 2),
             "records are allocated in call order"
@@ -6942,7 +6958,8 @@ mod tests {
                 .meas_ref(expected.tick, expected.gate_idx, expected.qubit)
                 .expect("every ref mz() handed out must resolve");
             assert_eq!(
-                recovered.record_idx, expected.record_idx,
+                recovered.meas_id.index(),
+                expected.meas_id.index(),
                 "qubit {:?} must recover the record it was allocated",
                 expected.qubit
             );
@@ -6959,17 +6976,18 @@ mod tests {
         let freed = circuit.tick().mz_free(&[0, 1]);
         let kept = circuit.tick().mz(&[2]);
 
-        assert_eq!(freed[0].record_idx, 0);
-        assert_eq!(freed[1].record_idx, 1);
+        assert_eq!(freed[0].meas_id.index(), 0);
+        assert_eq!(freed[1].meas_id.index(), 1);
         assert_eq!(
-            kept[0].record_idx, 2,
+            kept[0].meas_id.index(),
+            2,
             "MZ after two MeasureFree is record 2"
         );
 
         let recovered = circuit
             .meas_ref(kept[0].tick, kept[0].gate_idx, kept[0].qubit)
             .expect("ref must resolve");
-        assert_eq!(recovered.record_idx, 2);
+        assert_eq!(recovered.meas_id.index(), 2);
     }
 
     /// A measurement record that `mz()` handed out must still resolve after the
@@ -6983,30 +7001,29 @@ mod tests {
         let _freed = circuit.tick().mz_free(&[0, 1]);
         let kept = circuit.tick().mz(&[2, 3]);
         assert_eq!(
-            kept[0].record_idx, 2,
+            kept[0].meas_id.index(),
+            2,
             "MZ after two MeasureFree is record 2"
         );
-        circuit.observable(&kept);
+        circuit
+            .observable(&kept)
+            .expect("refs are from this circuit");
 
         let dag = crate::DagCircuit::try_from(&circuit).expect("valid circuit");
-        let nodes: Vec<Vec<usize>> = dag
+        let ids: Vec<Vec<MeasId>> = dag
             .annotations()
             .iter()
             .filter_map(|ann| match &ann.kind {
-                AnnotationKind::Observable { measurement_nodes } => Some(measurement_nodes.clone()),
+                AnnotationKind::Observable { measurement_ids } => Some(measurement_ids.clone()),
                 _ => None,
             })
             .collect();
 
-        assert_eq!(nodes.len(), 1);
+        assert_eq!(ids.len(), 1);
         assert_eq!(
-            nodes[0].len(),
-            2,
-            "both records must resolve; an empty annotation silently drops the observable"
-        );
-        assert_ne!(
-            nodes[0][0], nodes[0][1],
-            "records must map to distinct nodes"
+            ids[0],
+            vec![MeasId::from_raw(2), MeasId::from_raw(3)],
+            "both identities must survive the conversion unchanged"
         );
     }
 }

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -2282,8 +2282,12 @@ impl TickCircuit {
 
     /// Annotate a detector: measurements whose XOR should be deterministic.
     ///
-    /// Returns the annotation index, or [`TickAnnotationRefError`] if any
-    /// reference does not name a measurement this circuit holds.
+    /// Returns the annotation index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TickAnnotationRefError`] if any reference does not name a
+    /// measurement this circuit holds.
     pub fn detector(
         &mut self,
         measurements: &[TickMeasRef],
@@ -2302,6 +2306,10 @@ impl TickCircuit {
     }
 
     /// Annotate a labeled detector.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::detector`].
     pub fn detector_labeled(
         &mut self,
         label: &str,
@@ -2314,8 +2322,12 @@ impl TickCircuit {
 
     /// Annotate a logical observable.
     ///
-    /// Returns the annotation index, or [`TickAnnotationRefError`] if any
-    /// reference does not name a measurement this circuit holds.
+    /// Returns the annotation index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TickAnnotationRefError`] if any reference does not name a
+    /// measurement this circuit holds.
     pub fn observable(
         &mut self,
         measurements: &[TickMeasRef],
@@ -2331,6 +2343,10 @@ impl TickCircuit {
     }
 
     /// Annotate a labeled observable.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::observable`].
     pub fn observable_labeled(
         &mut self,
         label: &str,

--- a/crates/pecos/tests/neo_surface_ler_test.rs
+++ b/crates/pecos/tests/neo_surface_ler_test.rs
@@ -39,9 +39,9 @@ struct MemoryExperiment {
     tick: TickCircuit,
     /// Detector definitions as relative measurement records (Stim style:
     /// record -k is the k-th most recent measurement).
-    detectors: Vec<Vec<i32>>,
-    /// The logical-Z observable as relative measurement records.
-    observable: Vec<i32>,
+    detectors: Vec<Vec<usize>>,
+    /// The logical-Z observable as stable measurement ids.
+    observable: Vec<usize>,
     num_measurements: usize,
     /// Classical registers in declaration order: (name, width).
     registers: Vec<(String, usize)>,
@@ -149,22 +149,22 @@ fn build_surface_memory(distance: usize, rounds: usize) -> MemoryExperiment {
     // first-round Z checks are deterministic for |0...0> initialization,
     // consecutive rounds compare like checks, and the final round compares
     // each Z check against the data measurements in its support.
-    let mut detectors: Vec<Vec<i32>> = Vec::new();
+    let mut detectors: Vec<Vec<usize>> = Vec::new();
     for &meas_ref in &z_round[0] {
-        detectors.push(relative_records(num_measurements, &[meas_ref]));
+        detectors.push(ref_meas_ids(&[meas_ref]));
     }
     for round in 1..rounds {
         for (&current, &previous) in x_round[round].iter().zip(&x_round[round - 1]) {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
         for (&current, &previous) in z_round[round].iter().zip(&z_round[round - 1]) {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
     }
     for check in code.z_stabilizers() {
         let mut refs = vec![z_round[rounds - 1][check.index]];
         refs.extend(check.qubits().into_iter().map(|q| final_data[q]));
-        detectors.push(relative_records(num_measurements, &refs));
+        detectors.push(ref_meas_ids(&refs));
     }
 
     let logical_refs: Vec<TickMeasRef> = code
@@ -173,16 +173,16 @@ fn build_surface_memory(distance: usize, rounds: usize) -> MemoryExperiment {
         .iter()
         .map(|&q| final_data[q])
         .collect();
-    let observable = relative_records(num_measurements, &logical_refs);
+    let observable = ref_meas_ids(&logical_refs);
 
     tick.set_meta(
         "num_measurements",
         Attribute::String(num_measurements.to_string()),
     );
-    tick.set_meta("detectors", Attribute::String(records_json(&detectors)));
+    tick.set_meta("detectors", Attribute::String(meas_ids_json(&detectors)));
     tick.set_meta(
         "observables",
-        Attribute::String(records_json(std::slice::from_ref(&observable))),
+        Attribute::String(meas_ids_json(std::slice::from_ref(&observable))),
     );
 
     let mut qasm = String::new();
@@ -205,22 +205,21 @@ fn build_surface_memory(distance: usize, rounds: usize) -> MemoryExperiment {
     }
 }
 
-fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
-    let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
-    refs.iter()
-        .map(|m| {
-            i32::try_from(m.meas_id.index()).expect("record index fits in i32") - num_measurements
-        })
-        .collect()
+fn ref_meas_ids(refs: &[TickMeasRef]) -> Vec<usize> {
+    refs.iter().map(|m| m.meas_id.index()).collect()
 }
 
-fn records_json(records: &[Vec<i32>]) -> String {
-    let entries: Vec<String> = records
+fn meas_ids_json(annotations: &[Vec<usize>]) -> String {
+    let entries: Vec<String> = annotations
         .iter()
         .enumerate()
-        .map(|(id, rs)| {
-            let values = rs.iter().map(i32::to_string).collect::<Vec<_>>().join(",");
-            format!(r#"{{"id":{id},"records":[{values}]}}"#)
+        .map(|(id, ids)| {
+            let values = ids
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(r#"{{"id":{id},"meas_ids":[{values}]}}"#)
         })
         .collect();
     format!("[{}]", entries.join(","))
@@ -252,12 +251,10 @@ fn shot_record_bits(
 }
 
 /// XOR a relative-record definition over a shot's measurement bits.
-fn xor_records(bits: &[u8], records: &[i32], num_measurements: usize) -> u8 {
-    records.iter().fold(0u8, |acc, &rec| {
-        let idx = i64::try_from(num_measurements).unwrap() + i64::from(rec);
-        let idx = usize::try_from(idx).expect("record index in range");
-        acc ^ bits[idx]
-    })
+fn xor_meas_bits(bits: &[u8], meas_ids: &[usize]) -> u8 {
+    // Ids in this test are minted positionally by `mz()`, so they coincide
+    // with the record order of the shot bits the engines produce.
+    meas_ids.iter().fold(0u8, |acc, &id| acc ^ bits[id])
 }
 
 /// Convert a `ShotVec` into per-shot detector syndromes and observable masks.
@@ -272,13 +269,9 @@ fn shots_to_syndromes(
         let syndrome: Vec<u8> = experiment
             .detectors
             .iter()
-            .map(|records| xor_records(&bits, records, experiment.num_measurements))
+            .map(|meas_ids| xor_meas_bits(&bits, meas_ids))
             .collect();
-        let mask = u64::from(xor_records(
-            &bits,
-            &experiment.observable,
-            experiment.num_measurements,
-        ));
+        let mask = u64::from(xor_meas_bits(&bits, &experiment.observable));
         syndromes.push(syndrome);
         masks.push(mask);
     }

--- a/crates/pecos/tests/neo_surface_ler_test.rs
+++ b/crates/pecos/tests/neo_surface_ler_test.rs
@@ -42,7 +42,6 @@ struct MemoryExperiment {
     detectors: Vec<Vec<usize>>,
     /// The logical-Z observable as stable measurement ids.
     observable: Vec<usize>,
-    num_measurements: usize,
     /// Classical registers in declaration order: (name, width).
     registers: Vec<(String, usize)>,
     /// Global measurement record index -> (register index, bit index).
@@ -199,7 +198,6 @@ fn build_surface_memory(distance: usize, rounds: usize) -> MemoryExperiment {
         tick,
         detectors,
         observable,
-        num_measurements,
         registers,
         record_map,
     }

--- a/crates/pecos/tests/neo_surface_ler_test.rs
+++ b/crates/pecos/tests/neo_surface_ler_test.rs
@@ -208,7 +208,9 @@ fn build_surface_memory(distance: usize, rounds: usize) -> MemoryExperiment {
 fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
     let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
     refs.iter()
-        .map(|m| i32::try_from(m.record_idx).expect("record index fits in i32") - num_measurements)
+        .map(|m| {
+            i32::try_from(m.meas_id.index()).expect("record index fits in i32") - num_measurements
+        })
         .collect()
 }
 

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -4,7 +4,8 @@ Status: implemented. Revised after three adversarial design reviews (core
 claim upheld, plan corrected twice). Step 3 of #387. Depends on #391 (merged as
 `cdfddba1b`), which made every `DagCircuit` measurement carry a unique `MeasId`.
 Steps 1-3 below are merged (#397, #401, #403); step 4 -- the pivot -- is built,
-with three deviations from the plan recorded in "As built" at the end.
+with the deviations from the plan, and the closures from the pivot's
+adversarial review round, recorded in "As built" at the end.
 
 ## The defect
 
@@ -318,3 +319,23 @@ interchanged; within one map there is exactly one.
 The de-aliased matrix lives in `crates/pecos-qec/tests/meas_id_pivot_tests.rs`
 plus the eeg byte-equivalence test and the Python `mz_with_ids` tier; every
 guard is mutation-tested.
+
+Closed by the adversarial round (two independent reviews):
+
+- **Duplicate ids are refused at every id-resolving consumer.** `TickCircuit`
+  permits duplicate supplied ids (and `try_add_gate` does not advance the mint
+  counter, so supplied/minted collisions are constructible); `gate_mut` can
+  duplicate ids on a `DagCircuit`. eeg's expansion and the sampler's
+  annotation ingestion now refuse such circuits loudly, mirroring the guard
+  the DEM JSON path already had. The influence builder was already safe via
+  `find_measurement`'s `Inconsistent`.
+- **`measurement_order` cannot be combined with stamped ids.** The
+  qubit-occurrence heuristic behind a supplied order silently mis-binds on
+  non-positional ids; ids already define the mapping. Both the DEM builder and
+  the sampler reject the combination; the escape hatch remains for id-less
+  legacy circuits only.
+- **The record-arithmetic callers got the real migration** the plan asked for:
+  the three files now emit `meas_ids` JSON and read out in id space; the
+  `record_idx - num_measurements` arithmetic is gone, not renamed.
+- Validation cost is stated honestly: linear in the named gate's batch width,
+  never in the circuit.

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -173,6 +173,19 @@ Scope cut, stated explicitly: the DEM builder's id plumbing stays untyped --
 (`builder.rs:3413`), JSON `meas_ids: Vec<usize>`. Conflation can persist there
 and the tests must cover it.
 
+**Result tags, when that seam is typed (follow-on, not this series):** tags
+remain supported as names layered over identity, never as a second key space.
+The durable shape is `tag -> Vec<MeasId>` in emission order -- equivalently
+`(tag, occurrence) -> MeasId` -- because a tag emitted inside a loop or a
+repeat-until-success gadget names one measurement *per emission*, so the tag
+alone is not unique; the id always is. Flattening this is the `_selene_harness`
+defect in #72, where internal RUS measurements shifted record positions under
+the `measurement_N` tags. The tag table is boundary-owned, built where tags
+enter (Guppy/Selene `result(...)`, detector/observable JSON), and is never
+consulted inside the analysis -- the same rule as ordinals. Numeric Guppy
+result ids already follow this design degenerately: `mz_with_ids` makes the
+external id *be* the `MeasId`, a one-element association per emission.
+
 ## Test strategy
 
 The reason conflation bugs have been invisible: in virtually every existing test

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -329,11 +329,17 @@ Closed by the adversarial round (two independent reviews):
   annotation ingestion now refuse such circuits loudly, mirroring the guard
   the DEM JSON path already had. The influence builder was already safe via
   `find_measurement`'s `Inconsistent`.
-- **`measurement_order` cannot be combined with stamped ids.** The
-  qubit-occurrence heuristic behind a supplied order silently mis-binds on
-  non-positional ids; ids already define the mapping. Both the DEM builder and
-  the sampler reject the combination; the escape hatch remains for id-less
-  legacy circuits only.
+- **`measurement_order` ordinal mixing, fixed at its actual defect.** The
+  stamped branch of the DEM builder's mapping resolved an id to an
+  influence-map index and then re-composed it through the tick-to-influence
+  occurrence mapping -- wrong whenever the two orders differ. The composition
+  is gone: stamped resolution is used directly, and only the legacy positional
+  branch routes through the occurrence mapping. A first attempt rejected the
+  order/ids combination outright; the test suite falsified that (the surface
+  pipeline supplies `measurement_order` on minted-id circuits routinely, where
+  per-qubit chronology holds and the combination is benign). The narrow
+  rejection that survives: a supplied order with *non-positional* stamped ids,
+  where the caller's record order is genuinely unrecoverable.
 - **The record-arithmetic callers got the real migration** the plan asked for:
   the three files now emit `meas_ids` JSON and read out in id space; the
   `record_idx - num_measurements` arithmetic is gone, not renamed.

--- a/design/measurement-id-annotations.md
+++ b/design/measurement-id-annotations.md
@@ -1,9 +1,10 @@
 # Annotations should reference measurements by identity
 
-Status: in progress. Revised after three adversarial design reviews (core
+Status: implemented. Revised after three adversarial design reviews (core
 claim upheld, plan corrected twice). Step 3 of #387. Depends on #391 (merged as
 `cdfddba1b`), which made every `DagCircuit` measurement carry a unique `MeasId`.
-Steps 1 and 2 below are merged (#397, #401); the pivot itself is not started.
+Steps 1-3 below are merged (#397, #401, #403); step 4 -- the pivot -- is built,
+with three deviations from the plan recorded in "As built" at the end.
 
 ## The defect
 
@@ -265,3 +266,42 @@ make the DEM comparisons that validate this change impossible to interpret.
 identity-over-ordering direction. Originally written in an external notes vault
 and cited from there by an earlier draft of this document; now ported into this
 directory so the citation chain is complete.
+
+## As built
+
+The pivot landed as designed -- `measurement_ids: Vec<MeasId>` on both
+variants, `&[MeasRef]`/`&[TickMeasRef]` fallible annotation constructors, both
+conversions copying annotations verbatim, consumers on the step-3 resolvers,
+the record-index maps (`meas_record_to_node`, `dag_node_to_record_indices`,
+`node_to_meas_idx`) deleted -- with three deviations:
+
+**1. Construction validation is an O(1) lookup, not a `find_measurement`
+scan.** A reference carries its node (or tick/batch), so validation checks the
+gate it names directly: exists, consumes a record, holds the (qubit, id) pair.
+The O(gates) scan per reference would have made surface-code builders
+quadratic. The honesty limit is unchanged: a foreign reference that agrees
+structurally cannot be detected.
+
+**2. Python keeps tuple handles instead of opaque reference objects.** The
+seam the opaque-object plan closed was integer *id* forgery -- and the tuples
+never contain an id. A dag handle is `(node, qubit)`, a tick handle is
+`(tick, gate_idx, qubit)`; both are resolved against the circuit at
+annotation construction, and the recovered id comes from the gate itself.
+Plain ints are rejected with a `TypeError`. Forging a tuple is node-space
+forgery, caught by resolution unless the forger names a real measurement --
+the same limit the Rust `MeasRef` has.
+
+**3. One order per influence map.** The de-aliased tests exposed that
+`InfluenceBuilder` maps carried two internal orderings: `detectors` (and the
+propagation data, and the sampler's raw channels) in symbolic-replay order,
+`measurements`/`meas_ids` re-sorted by id rank. `meas_index_of` therefore did
+not index the raw stream -- invisible while ids were positional, wrong the
+moment they were not. `InfluenceBuilder` now emits `measurements`/`meas_ids`
+in replay order, aligned with everything else in the map;
+`DagFaultAnalyzer` maps were already internally consistent (id-rank
+throughout). The rule stands: orderings differ *between* maps and are never
+interchanged; within one map there is exactly one.
+
+The de-aliased matrix lives in `crates/pecos-qec/tests/meas_id_pivot_tests.rs`
+plus the eeg byte-equivalence test and the Python `mz_with_ids` tier; every
+guard is mutation-tested.

--- a/examples/surface/d3_fault_catalog_lookup.rs
+++ b/examples/surface/d3_fault_catalog_lookup.rs
@@ -228,7 +228,7 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
     let final_data_measurements = circuit.tick().mz(&data_qubits);
     let num_measurements = circuit.num_measurements();
 
-    let mut detectors: Vec<Vec<i32>> = Vec::new();
+    let mut detectors: Vec<Vec<usize>> = Vec::new();
 
     // Initial Z-basis boundary detectors: data starts in |0...0>, so the first
     // Z-check round is deterministic. Without these, an initial data X fault can
@@ -238,7 +238,7 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
         .iter()
         .take(code.num_z_stabilizers())
     {
-        detectors.push(relative_records(num_measurements, &[meas_ref]));
+        detectors.push(ref_meas_ids(&[meas_ref]));
     }
 
     // Repeated syndrome detectors: current stabilizer measurement XOR previous
@@ -249,14 +249,14 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
             .zip(x_round_measurements[round - 1].iter())
             .take(code.num_x_stabilizers())
         {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
         for (&current, &previous) in z_round_measurements[round]
             .iter()
             .zip(z_round_measurements[round - 1].iter())
             .take(code.num_z_stabilizers())
         {
-            detectors.push(relative_records(num_measurements, &[current, previous]));
+            detectors.push(ref_meas_ids(&[current, previous]));
         }
     }
 
@@ -271,7 +271,7 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
                 .into_iter()
                 .map(|q| final_data_measurements[q]),
         );
-        detectors.push(relative_records(num_measurements, &refs));
+        detectors.push(ref_meas_ids(&refs));
     }
 
     let logical_z_refs: Vec<TickMeasRef> = code
@@ -280,14 +280,17 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
         .iter()
         .map(|&q| final_data_measurements[q])
         .collect();
-    let observables = vec![relative_records(num_measurements, &logical_z_refs)];
+    let observables = vec![ref_meas_ids(&logical_z_refs)];
 
     circuit.set_meta(
         "num_measurements",
         Attribute::String(num_measurements.to_string()),
     );
-    circuit.set_meta("detectors", Attribute::String(records_json(&detectors)));
-    circuit.set_meta("observables", Attribute::String(records_json(&observables)));
+    circuit.set_meta("detectors", Attribute::String(meas_ids_json(&detectors)));
+    circuit.set_meta(
+        "observables",
+        Attribute::String(meas_ids_json(&observables)),
+    );
 
     Ok(MemoryCircuit {
         circuit,
@@ -296,22 +299,20 @@ fn build_d3_z_memory_circuit(rounds: usize) -> Result<MemoryCircuit, String> {
     })
 }
 
-fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
-    let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
-    refs.iter()
-        .map(|m| {
-            i32::try_from(m.meas_id.index()).expect("measurement record index fits in i32")
-                - num_measurements
-        })
-        .collect()
+fn ref_meas_ids(refs: &[TickMeasRef]) -> Vec<usize> {
+    refs.iter().map(|m| m.meas_id.index()).collect()
 }
 
-fn records_json(records: &[Vec<i32>]) -> String {
-    let entries: Vec<String> = records
+fn meas_ids_json(annotations: &[Vec<usize>]) -> String {
+    let entries: Vec<String> = annotations
         .iter()
-        .map(|rs| {
-            let values = rs.iter().map(i32::to_string).collect::<Vec<_>>().join(",");
-            format!(r#"{{"records":[{values}]}}"#)
+        .map(|ids| {
+            let values = ids
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(r#"{{"meas_ids":[{values}]}}"#)
         })
         .collect();
     format!("[{}]", entries.join(","))

--- a/examples/surface/d3_fault_catalog_lookup.rs
+++ b/examples/surface/d3_fault_catalog_lookup.rs
@@ -300,7 +300,7 @@ fn relative_records(num_measurements: usize, refs: &[TickMeasRef]) -> Vec<i32> {
     let num_measurements = i32::try_from(num_measurements).expect("measurement count fits in i32");
     refs.iter()
         .map(|m| {
-            i32::try_from(m.record_idx).expect("measurement record index fits in i32")
+            i32::try_from(m.meas_id.index()).expect("measurement record index fits in i32")
                 - num_measurements
         })
         .collect()

--- a/exp/pecos-eeg/src/builder.rs
+++ b/exp/pecos-eeg/src/builder.rs
@@ -188,37 +188,22 @@ fn build_detectors(
 ) -> Result<(Vec<Detector>, Vec<Observable>), EegBuildError> {
     let mut detectors = Vec::new();
     let mut observables = Vec::new();
-    let num_meas = expanded.measurement_qubit.len();
 
     for annotation in tc.annotations() {
         match &annotation.kind {
             AnnotationKind::Detector {
-                measurement_nodes, ..
+                measurement_ids, ..
             } => {
-                // measurement_nodes are gate indices in the ORIGINAL circuit.
-                // We need to map these to measurement record indices, then
-                // to auxiliary qubits in the expanded circuit.
-                //
-                // The gate indices correspond to MZ gates. Each MZ gate can
-                // measure multiple qubits. We need to find which measurement
-                // record each gate index maps to.
-                //
-                // Strategy: the k-th measurement record corresponds to the
-                // k-th qubit measured across all MZ gates in order. Each
-                // measurement_node is a gate index — we find which measurement
-                // records that gate produced.
-                let bitmask =
-                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas)?;
+                let bitmask = measurement_ids_to_aux_bitmask(measurement_ids, expanded)?;
                 detectors.push(Detector {
                     id: detectors.len(),
                     stabilizer: bitmask,
                 });
             }
             AnnotationKind::Observable {
-                measurement_nodes, ..
+                measurement_ids, ..
             } => {
-                let bitmask =
-                    measurement_nodes_to_aux_bitmask(measurement_nodes, tc, expanded, num_meas)?;
+                let bitmask = measurement_ids_to_aux_bitmask(measurement_ids, expanded)?;
                 observables.push(Observable {
                     id: observables.len(),
                     pauli: bitmask,
@@ -231,32 +216,66 @@ fn build_detectors(
     Ok((detectors, observables))
 }
 
-/// Map measurement record indices to a Z bitmask on auxiliary qubits.
+/// Map measurement ids to a Z bitmask on auxiliary qubits.
 ///
-/// Each measurement_node is a measurement record index (counting all
-/// MZ qubits in circuit order). Maps directly to an auxiliary qubit
-/// in the expanded circuit via `expanded.measurement_qubit[record]`.
-fn measurement_nodes_to_aux_bitmask(
-    measurement_nodes: &[usize],
-    _tc: &TickCircuit,
+/// Each id resolves through the expansion's own id-rank map, so external
+/// (non-positional) ids land on the right auxiliary qubit. An unknown id is
+/// an error, never a skip.
+fn measurement_ids_to_aux_bitmask(
+    measurement_ids: &[pecos_core::MeasId],
     expanded: &expand::ExpandedCircuit,
-    num_meas: usize,
 ) -> Result<Bm, EegBuildError> {
     let mut bitmask = Bm::default();
-
-    let _ = num_meas;
-    for &record_idx in measurement_nodes {
-        // Single resolver: an out-of-range record is an error, never a skip.
-        let aux_qubit = expanded.aux_qubit_for_record(record_idx)?;
+    for &meas_id in measurement_ids {
+        let aux_qubit = expanded.aux_qubit_for_id(meas_id)?;
         bitmask.z_bits.xor_bit(aux_qubit);
     }
-
     Ok(bitmask)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Scrambled (non-positional) annotation ids must produce a byte-identical
+    /// DEM to positional ids on the same physical circuit: eeg orders its
+    /// auxiliaries by expansion rank, which is invariant under id relabeling.
+    #[test]
+    fn scrambled_annotation_ids_build_a_byte_identical_dem() {
+        let build = |ids: [usize; 3]| {
+            let mut dag = pecos_quantum::DagCircuit::new();
+            dag.pz(&[0, 1, 2]);
+            dag.cx(&[(0, 2)]);
+            dag.cx(&[(1, 2)]);
+            for (qubit, id) in [(2usize, ids[0]), (0, ids[1]), (1, ids[2])] {
+                let mut gate = pecos_core::Gate::mz(&[qubit]);
+                gate.meas_ids = smallvec::smallvec![pecos_core::MeasId::from_raw(id)];
+                dag.try_add_gate_auto_wire(gate).expect("gate is valid");
+            }
+            let refs: Vec<_> = ids
+                .iter()
+                .map(|&id| {
+                    dag.find_measurement(pecos_core::MeasId::from_raw(id))
+                        .expect("the id was just supplied")
+                })
+                .collect();
+            dag.detector(&refs).expect("refs are from this circuit");
+            dag.observable(&[refs[1]])
+                .expect("refs are from this circuit");
+            let tc = TickCircuit::from(&dag);
+            EegDemBuilder::from_tick_circuit(&tc)
+                .noise(NoiseModel::depolarizing(0.01))
+                .build_dem_string()
+                .expect("the circuit is MZ-only and every id resolves")
+        };
+        let positional = build([0, 1, 2]);
+        let scrambled = build([9, 1, 5]);
+        assert!(
+            positional.contains("error("),
+            "the comparison is vacuous without error mechanisms:\n{positional}"
+        );
+        assert_eq!(positional, scrambled);
+    }
 
     /// A `MeasureFree` used to pass through the expansion unchanged, silently
     /// deleting its measurement record. It now lowers to `MZ`.
@@ -305,31 +324,34 @@ mod tests {
         assert!(matches!(err, EegBuildError::UnsupportedMeasurement { .. }));
     }
 
-    /// An annotation referencing a record the expansion never produced used to
-    /// be skipped, thinning the observable. It is now an error naming both
-    /// sides of the mismatch.
+    /// An annotation referencing an id the expansion never recorded used to
+    /// be skipped, thinning the observable. It is now an error naming the id.
+    ///
+    /// Construction validation cannot catch this reference: it arrives
+    /// pre-built on a converted circuit, which is exactly how a stale
+    /// reference reaches eeg in practice.
     #[test]
-    fn an_out_of_range_record_annotation_is_an_error() {
-        let mut tc = TickCircuit::new();
-        tc.tick().pz(&[0]);
-        let refs = tc.tick().mz(&[0]);
-        tc.detector(&refs);
-        // Forge a measurement ref onto record 7 of a 1-record circuit.
-        // TickMeasRef fields are public, so a caller can construct exactly this.
-        let forged = pecos_quantum::TickMeasRef {
-            record_idx: 7,
-            ..refs[0]
-        };
-        tc.observable(&[forged]);
+    fn an_unknown_id_annotation_is_an_error() {
+        let mut dag = pecos_quantum::DagCircuit::new();
+        dag.pz(&[0]);
+        dag.mz(&[0]);
+        dag.add_annotation(pecos_quantum::PauliAnnotation {
+            pauli: pecos_core::PauliString::zs(&[0usize]),
+            kind: pecos_quantum::AnnotationKind::Observable {
+                measurement_ids: vec![pecos_core::MeasId::from_raw(7)],
+            },
+            label: None,
+        });
+        let tc = TickCircuit::from(&dag);
 
         let err = EegDemBuilder::from_tick_circuit(&tc)
             .noise(NoiseModel::coherent_only(0.01))
             .build()
-            .expect_err("record 7 does not exist");
+            .expect_err("id 7 was never recorded by the expansion");
         assert_eq!(
             err,
-            EegBuildError::UnresolvableAnnotationRecord {
-                record_idx: 7,
+            EegBuildError::UnresolvableAnnotationId {
+                meas_id: pecos_core::MeasId::from_raw(7),
                 num_measurements: 1,
             }
         );
@@ -455,7 +477,8 @@ mod tests {
         let m2 = tc.tick().mz(&[2]);
 
         // Detector: compare m1 and m2
-        tc.detector(&[m1[0], m2[0]]);
+        tc.detector(&[m1[0], m2[0]])
+            .expect("refs are from this circuit");
 
         // Final readout
         tc.tick().mz(&[0, 1]);

--- a/exp/pecos-eeg/src/builder.rs
+++ b/exp/pecos-eeg/src/builder.rs
@@ -237,6 +237,51 @@ fn measurement_ids_to_aux_bitmask(
 mod tests {
     use super::*;
 
+    /// Two measurements carrying the same supplied id would make id
+    /// resolution last-wins -- a silently wrong DEM. `TickCircuit` permits the
+    /// duplicate; the expansion must refuse it.
+    #[test]
+    fn duplicate_supplied_ids_are_refused() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        for qubit in [0usize, 1] {
+            let mut gate = pecos_core::Gate::mz(&[qubit]);
+            gate.meas_ids = smallvec::smallvec![pecos_core::MeasId::from_raw(5)];
+            tc.tick().try_add_gate(gate).expect("gate is valid");
+        }
+
+        let err = EegDemBuilder::from_tick_circuit(&tc)
+            .noise(NoiseModel::depolarizing(0.01))
+            .build()
+            .expect_err("two measurements hold id 5");
+        assert_eq!(
+            err,
+            EegBuildError::DuplicateMeasId {
+                meas_id: pecos_core::MeasId::from_raw(5),
+            }
+        );
+    }
+
+    /// A supplied id colliding with a later minted one is the same ambiguity
+    /// arriving through two different doors; the expansion refuses it too.
+    #[test]
+    fn a_supplied_id_colliding_with_a_minted_id_is_refused() {
+        let mut tc = TickCircuit::new();
+        tc.tick().pz(&[0, 1]);
+        let mut gate = pecos_core::Gate::mz(&[0usize]);
+        gate.meas_ids = smallvec::smallvec![pecos_core::MeasId::from_raw(0)];
+        tc.tick().try_add_gate(gate).expect("gate is valid");
+        // `try_add_gate` does not advance the mint counter, so this mints 0.
+        let minted = tc.tick().mz(&[1]);
+        assert_eq!(minted[0].meas_id, pecos_core::MeasId::from_raw(0));
+
+        let err = EegDemBuilder::from_tick_circuit(&tc)
+            .noise(NoiseModel::depolarizing(0.01))
+            .build()
+            .expect_err("supplied and minted ids collide on 0");
+        assert!(matches!(err, EegBuildError::DuplicateMeasId { .. }));
+    }
+
     /// Scrambled (non-positional) annotation ids must produce a byte-identical
     /// DEM to positional ids on the same physical circuit: eeg orders its
     /// auxiliaries by expansion rank, which is invariant under id relabeling.
@@ -269,7 +314,7 @@ mod tests {
                 .expect("the circuit is MZ-only and every id resolves")
         };
         let positional = build([0, 1, 2]);
-        let scrambled = build([9, 1, 5]);
+        let scrambled = build([9, 4, 7]);
         assert!(
             positional.contains("error("),
             "the comparison is vacuous without error mechanisms:\n{positional}"

--- a/exp/pecos-eeg/src/dem_simulator.rs
+++ b/exp/pecos-eeg/src/dem_simulator.rs
@@ -234,7 +234,8 @@ fn build_tick_circuit(
             det_refs.push(resolve_record_offset_ref(rec, meta, &all_meas_refs)?);
         }
         if !det_refs.is_empty() {
-            tc.detector(&det_refs);
+            tc.detector(&det_refs)
+                .expect("refs were just resolved from this circuit");
         }
     }
 
@@ -245,7 +246,8 @@ fn build_tick_circuit(
             obs_refs.push(resolve_record_offset_ref(rec, meta, &all_meas_refs)?);
         }
         if !obs_refs.is_empty() {
-            tc.observable(&obs_refs);
+            tc.observable(&obs_refs)
+                .expect("refs were just resolved from this circuit");
         }
     }
 

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -31,6 +31,13 @@ pub enum EegBuildError {
         /// How many measurement records the expansion produced.
         num_measurements: usize,
     },
+    /// Two measurements carry the same id, so id resolution would be
+    /// ambiguous. `TickCircuit` does not enforce uniqueness; this expansion
+    /// must, because it resolves annotations by id.
+    DuplicateMeasId {
+        /// The id held by more than one measurement.
+        meas_id: pecos_core::MeasId,
+    },
     /// An annotation references a measurement id the expansion never recorded.
     UnresolvableAnnotationId {
         /// The unknown id.
@@ -55,6 +62,12 @@ impl std::fmt::Display for EegBuildError {
                 f,
                 "annotation references measurement record {record_idx}, but the expansion \
                  produced only {num_measurements}"
+            ),
+            Self::DuplicateMeasId { meas_id } => write!(
+                f,
+                "two measurements carry MeasId({}); annotation resolution by id \
+                 requires each measurement to hold a unique id",
+                meas_id.index()
             ),
             Self::UnresolvableAnnotationId {
                 meas_id,
@@ -183,8 +196,12 @@ pub fn expand_circuit(gates: &[Gate]) -> Result<ExpandedCircuit, EegBuildError> 
                 // For each qubit in this MZ gate, create CX to auxiliary
                 for (position, q) in gate.qubits.iter().enumerate() {
                     let q_idx = q.index();
-                    if let Some(&id) = gate.meas_ids.get(position) {
-                        meas_id_rank.insert(id, measurement_qubit.len());
+                    if let Some(&id) = gate.meas_ids.get(position)
+                        && meas_id_rank.insert(id, measurement_qubit.len()).is_some()
+                    {
+                        // Last-wins would silently rebind every annotation
+                        // naming this id to the later measurement.
+                        return Err(EegBuildError::DuplicateMeasId { meas_id: id });
                     }
                     let aux = next_aux;
                     next_aux += 1;

--- a/exp/pecos-eeg/src/expand.rs
+++ b/exp/pecos-eeg/src/expand.rs
@@ -31,6 +31,13 @@ pub enum EegBuildError {
         /// How many measurement records the expansion produced.
         num_measurements: usize,
     },
+    /// An annotation references a measurement id the expansion never recorded.
+    UnresolvableAnnotationId {
+        /// The unknown id.
+        meas_id: pecos_core::MeasId,
+        /// How many measurement records the expansion produced.
+        num_measurements: usize,
+    },
 }
 
 impl std::fmt::Display for EegBuildError {
@@ -48,6 +55,15 @@ impl std::fmt::Display for EegBuildError {
                 f,
                 "annotation references measurement record {record_idx}, but the expansion \
                  produced only {num_measurements}"
+            ),
+            Self::UnresolvableAnnotationId {
+                meas_id,
+                num_measurements,
+            } => write!(
+                f,
+                "annotation references MeasId({}), which the expansion never recorded \
+                 ({num_measurements} measurement records exist)",
+                meas_id.index()
             ),
         }
     }
@@ -360,6 +376,26 @@ impl ExpandedCircuit {
                 num_measurements: self.measurement_qubit.len(),
             },
         )
+    }
+
+    /// The auxiliary qubit whose final Z-measurement carries the measurement
+    /// named by `meas_id`.
+    ///
+    /// Resolution goes through `meas_id_rank`, so it is correct for external
+    /// (non-positional) ids -- an id's numeric value is never used as an index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EegBuildError::UnresolvableAnnotationId`] when the expansion
+    /// never recorded the id.
+    pub fn aux_qubit_for_id(&self, meas_id: pecos_core::MeasId) -> Result<usize, EegBuildError> {
+        let rank = self.meas_id_rank.get(&meas_id).copied().ok_or(
+            EegBuildError::UnresolvableAnnotationId {
+                meas_id,
+                num_measurements: self.measurement_qubit.len(),
+            },
+        )?;
+        self.aux_qubit_for_record(rank)
     }
 }
 

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -1636,13 +1636,13 @@ fn build_rust_tick_circuit_from_gates(
         && let Ok(s) = det_json.extract::<String>()
     {
         // Create structured annotations from JSON
-        create_annotations_from_json(&mut tc, &s, &all_meas_refs, true);
+        create_annotations_from_json(&mut tc, &s, &all_meas_refs, true)?;
         tc.set_meta("detectors", Attribute::String(s));
     }
     if let Ok(obs_json) = py_tc.call_method1("get_meta", ("observables",))
         && let Ok(s) = obs_json.extract::<String>()
     {
-        create_annotations_from_json(&mut tc, &s, &all_meas_refs, false);
+        create_annotations_from_json(&mut tc, &s, &all_meas_refs, false)?;
         tc.set_meta("observables", Attribute::String(s));
     }
     copy_tracked_pauli_annotations_from_python(py_tc, &mut tc)?;
@@ -1745,32 +1745,44 @@ fn channel_expr_from_python_gate(gate: &Bound<'_, PyAny>) -> PyResult<ChannelExp
 }
 
 /// Create detector or observable annotations from JSON metadata.
+/// Malformed JSON and unresolvable record offsets are errors: a dropped or
+/// thinned annotation silently weakens the DEM.
 fn create_annotations_from_json(
     tc: &mut pecos_quantum::TickCircuit,
     json_str: &str,
     all_meas_refs: &[pecos_quantum::TickMeasRef],
     is_detector: bool,
-) {
+) -> PyResult<()> {
+    let kind = if is_detector {
+        "detector"
+    } else {
+        "observable"
+    };
     let num_meas = all_meas_refs.len();
-    if let Ok(defs) = serde_json::from_str::<Vec<RecDef>>(json_str) {
-        for def in &defs {
-            let refs: Vec<pecos_quantum::TickMeasRef> = def
-                .records
-                .iter()
-                .filter_map(|&rec| {
-                    let abs_idx = measurement_record_index(rec, num_meas)?;
-                    all_meas_refs.get(abs_idx).copied()
-                })
-                .collect();
-            if !refs.is_empty() {
-                if is_detector {
-                    tc.detector(&refs).expect("refs are from this circuit");
-                } else {
-                    tc.observable(&refs).expect("refs are from this circuit");
-                }
-            }
+    let defs: Vec<RecDef> = serde_json::from_str(json_str).map_err(|err| {
+        pyo3::exceptions::PyValueError::new_err(format!("malformed {kind} JSON metadata: {err}"))
+    })?;
+    for (def_idx, def) in defs.iter().enumerate() {
+        let mut refs: Vec<pecos_quantum::TickMeasRef> = Vec::with_capacity(def.records.len());
+        for &rec in &def.records {
+            let mref = measurement_record_index(rec, num_meas)
+                .and_then(|abs_idx| all_meas_refs.get(abs_idx).copied())
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "{kind} {def_idx} references record offset {rec}, which does \
+                         not resolve among the circuit's {num_meas} measurement(s)"
+                    ))
+                })?;
+            refs.push(mref);
         }
+        let result = if is_detector {
+            tc.detector(&refs)
+        } else {
+            tc.observable(&refs)
+        };
+        result.map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
     }
+    Ok(())
 }
 
 /// Build a pecos_core::Gate from a Python gate object.

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -34,7 +34,13 @@ use pyo3::prelude::*;
 
 #[derive(serde::Deserialize)]
 struct RecDef {
+    /// DEM-style negative record offsets. Alternative to `meas_ids`.
+    #[serde(default)]
     records: Vec<i32>,
+    /// Stable measurement ids. Alternative to `records`; the traced-QIS
+    /// pipeline emits only this field.
+    #[serde(default)]
+    meas_ids: Vec<usize>,
 }
 
 fn measurement_record_index(record: i32, num_measurements: usize) -> Option<usize> {
@@ -1762,8 +1768,18 @@ fn create_annotations_from_json(
     let defs: Vec<RecDef> = serde_json::from_str(json_str).map_err(|err| {
         pyo3::exceptions::PyValueError::new_err(format!("malformed {kind} JSON metadata: {err}"))
     })?;
+    let ref_by_id: std::collections::BTreeMap<usize, pecos_quantum::TickMeasRef> = all_meas_refs
+        .iter()
+        .map(|r| (r.meas_id.index(), *r))
+        .collect();
     for (def_idx, def) in defs.iter().enumerate() {
-        let mut refs: Vec<pecos_quantum::TickMeasRef> = Vec::with_capacity(def.records.len());
+        if def.records.is_empty() && def.meas_ids.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "{kind} {def_idx} carries neither records nor meas_ids"
+            )));
+        }
+        let mut refs: Vec<pecos_quantum::TickMeasRef> =
+            Vec::with_capacity(def.records.len() + def.meas_ids.len());
         for &rec in &def.records {
             let mref = measurement_record_index(rec, num_meas)
                 .and_then(|abs_idx| all_meas_refs.get(abs_idx).copied())
@@ -1773,6 +1789,15 @@ fn create_annotations_from_json(
                          not resolve among the circuit's {num_meas} measurement(s)"
                     ))
                 })?;
+            refs.push(mref);
+        }
+        for &meas_id in &def.meas_ids {
+            let mref = ref_by_id.get(&meas_id).copied().ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "{kind} {def_idx} references MeasId({meas_id}), which no \
+                     measurement in the circuit holds"
+                ))
+            })?;
             refs.push(mref);
         }
         let result = if is_detector {

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -1764,9 +1764,9 @@ fn create_annotations_from_json(
                 .collect();
             if !refs.is_empty() {
                 if is_detector {
-                    tc.detector(&refs);
+                    tc.detector(&refs).expect("refs are from this circuit");
                 } else {
-                    tc.observable(&refs);
+                    tc.observable(&refs).expect("refs are from this circuit");
                 }
             }
         }

--- a/python/pecos-rslib/src/dag_circuit_bindings.rs
+++ b/python/pecos-rslib/src/dag_circuit_bindings.rs
@@ -990,23 +990,38 @@ pyo3::create_exception!(
     pyo3::exceptions::PyException
 );
 
-/// Extract node indices from a list of either `int` or `(int, int)` tuples.
-/// This allows `detector()` / `observable()` to accept both raw node indices
-/// and measurement refs from `mz()`.
-fn extract_measurement_nodes(list: &Bound<'_, pyo3::types::PyList>) -> PyResult<Vec<usize>> {
+/// Resolve `(node, qubit)` measurement refs from `mz()` against the circuit.
+///
+/// Plain ints are rejected: a bare int is ambiguous between a node index and
+/// a measurement id, and silently reinterpreting it is how annotations end up
+/// referencing the wrong measurement. The tuple is resolved against the gate
+/// it names, so a stale or foreign ref raises instead of resolving to nonsense.
+fn extract_dag_meas_refs(
+    circuit: &DagCircuit,
+    list: &Bound<'_, pyo3::types::PyList>,
+) -> PyResult<Vec<pecos_quantum::MeasRef>> {
     list.iter()
         .map(|item| {
-            // Try (node, qubit) tuple first
-            if let Ok((node, _qubit)) = item.extract::<(usize, usize)>() {
-                Ok(node)
-            } else {
-                // Fall back to plain int
-                item.extract::<usize>().map_err(|_| {
-                    pyo3::exceptions::PyTypeError::new_err(
-                        "measurements must be a list of ints or (node, qubit) tuples from mz()",
-                    )
+            let (node, qubit): (usize, usize) = item.extract().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(
+                    "measurements must be (node, qubit) tuples from mz(); plain ints are \
+                     not accepted because a bare index does not identify a measurement",
+                )
+            })?;
+            let refs = circuit.meas_refs(node).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "measurement ref (node={node}, qubit={qubit}) does not name a \
+                     measurement gate in this circuit; pass refs returned by mz()"
+                ))
+            })?;
+            refs.into_iter()
+                .find(|r| r.qubit.index() == qubit)
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "measurement gate at node {node} does not measure qubit {qubit}; \
+                         pass refs returned by mz()"
+                    ))
                 })
-            }
         })
         .collect()
 }
@@ -1457,12 +1472,13 @@ impl PyDagCircuit {
         measurements: &Bound<'_, pyo3::types::PyList>,
         label: Option<String>,
     ) -> PyResult<usize> {
-        let nodes = extract_measurement_nodes(measurements)?;
-        Ok(if let Some(l) = label {
-            self.inner.detector_labeled(&l, &nodes)
+        let refs = extract_dag_meas_refs(&self.inner, measurements)?;
+        let result = if let Some(l) = label {
+            self.inner.detector_labeled(&l, &refs)
         } else {
-            self.inner.detector(&nodes)
-        })
+            self.inner.detector(&refs)
+        };
+        result.map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))
     }
 
     /// Annotate a logical observable: measurements whose XOR gives a logical outcome.
@@ -1480,12 +1496,13 @@ impl PyDagCircuit {
         measurements: &Bound<'_, pyo3::types::PyList>,
         label: Option<String>,
     ) -> PyResult<usize> {
-        let nodes = extract_measurement_nodes(measurements)?;
-        Ok(if let Some(l) = label {
-            self.inner.observable_labeled(&l, &nodes)
+        let refs = extract_dag_meas_refs(&self.inner, measurements)?;
+        let result = if let Some(l) = label {
+            self.inner.observable_labeled(&l, &refs)
         } else {
-            self.inner.observable(&nodes)
-        })
+            self.inner.observable(&refs)
+        };
+        result.map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))
     }
 
     /// Place a tracked-Pauli annotation at this point in the circuit.
@@ -1534,6 +1551,16 @@ impl PyDagCircuit {
                 pecos_quantum::AnnotationKind::TrackedPauli => "tracked_pauli",
             };
             dict.set_item("kind", kind_str)?;
+            match &ann.kind {
+                pecos_quantum::AnnotationKind::Detector {
+                    measurement_ids, ..
+                }
+                | pecos_quantum::AnnotationKind::Observable { measurement_ids } => {
+                    let ids: Vec<usize> = measurement_ids.iter().map(|id| id.index()).collect();
+                    dict.set_item("measurement_ids", ids)?;
+                }
+                pecos_quantum::AnnotationKind::TrackedPauli => {}
+            }
             dict.set_item("label", &ann.label)?;
             list.append(dict)?;
         }
@@ -2981,12 +3008,12 @@ impl PyTickCircuit {
         label: Option<String>,
     ) -> PyResult<usize> {
         let refs = extract_tick_meas_refs(&self.inner, measurements)?;
-        let idx = if let Some(l) = label {
+        let result = if let Some(l) = label {
             self.inner.detector_labeled(&l, &refs)
         } else {
             self.inner.detector(&refs)
         };
-        Ok(idx)
+        result.map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))
     }
 
     /// Annotate a logical observable.
@@ -2997,12 +3024,12 @@ impl PyTickCircuit {
         label: Option<String>,
     ) -> PyResult<usize> {
         let refs = extract_tick_meas_refs(&self.inner, measurements)?;
-        let idx = if let Some(l) = label {
+        let result = if let Some(l) = label {
             self.inner.observable_labeled(&l, &refs)
         } else {
             self.inner.observable(&refs)
         };
-        Ok(idx)
+        result.map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))
     }
 
     /// Place a tracked-Pauli annotation.
@@ -3034,6 +3061,16 @@ impl PyTickCircuit {
                 pecos_quantum::AnnotationKind::TrackedPauli => "tracked_pauli",
             };
             dict.set_item("kind", kind_str)?;
+            match &ann.kind {
+                pecos_quantum::AnnotationKind::Detector {
+                    measurement_ids, ..
+                }
+                | pecos_quantum::AnnotationKind::Observable { measurement_ids } => {
+                    let ids: Vec<usize> = measurement_ids.iter().map(|id| id.index()).collect();
+                    dict.set_item("measurement_ids", ids)?;
+                }
+                pecos_quantum::AnnotationKind::TrackedPauli => {}
+            }
             dict.set_item("label", &ann.label)?;
             list.append(dict)?;
         }
@@ -3054,10 +3091,9 @@ fn extract_tick_meas_refs(
                 )
             })?;
             let qubit = pecos_core::QubitId::from(qubit);
-            // Resolve against the circuit rather than fabricating the record
-            // index. `TickCircuit::detector`/`observable` read `record_idx`
-            // immediately, so a placeholder collapsed every reference onto
-            // record 0 and silently corrupted the annotation (issue #382).
+            // Resolve against the circuit rather than fabricating the id.
+            // A placeholder id collapsed every reference onto measurement 0
+            // and silently corrupted the annotation (issue #382).
             circuit.meas_ref(tick, gate_idx, qubit).ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(format!(
                     "measurement ref (tick={tick}, gate_idx={gate_idx}, qubit={}) does not \

--- a/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
+++ b/python/quantum-pecos/tests/qec/test_annotation_measurement_refs.py
@@ -75,3 +75,62 @@ def test_measurement_ref_from_another_circuit_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="does not identify a measurement"):
         tc.observable([(99, 0, 0)])
+
+
+def test_dag_detector_rejects_plain_int_measurement_refs() -> None:
+    """A bare int is ambiguous between a node index and a measurement id.
+
+    Silently reinterpreting it is how annotations end up referencing the wrong
+    measurement, so the binding refuses it outright.
+    """
+    from pecos.quantum import DagCircuit
+
+    dag = DagCircuit()
+    dag.pz([0])
+    ms = dag.mz([0])
+
+    with pytest.raises(TypeError, match="plain ints are"):
+        dag.detector([0])
+    # The tuple refs from mz() still work.
+    dag.detector(ms)
+
+
+def test_dag_detector_rejects_a_forged_tuple_ref() -> None:
+    """A (node, qubit) tuple that names no measurement raises, never guesses."""
+    from pecos.quantum import DagCircuit
+
+    dag = DagCircuit()
+    dag.pz([0])
+    h_node = dag.gate_count()
+    dag.h([0])
+    dag.mz([0])
+
+    with pytest.raises(ValueError, match="does not name a measurement gate"):
+        dag.detector([(h_node, 0)])
+
+
+def test_scrambled_mz_with_ids_annotations_survive_to_the_dag() -> None:
+    """Non-positional ids (the Guppy pattern) name measurements exactly.
+
+    De-aliased: ids 9 and 5 are neither positional nor contiguous, so any
+    consumer that treats the id as an index gives a wrong answer here.
+    """
+    from pecos.quantum import TickCircuit
+
+    tc = TickCircuit()
+    tc.tick().pz([0, 1])
+    refs = tc.tick().mz_with_ids([0, 1], [9, 5])
+    assert len(refs) == 2
+    tc.detector(refs, label="d")
+    tc.observable([refs[1]], label="o")
+
+    anns = tc.annotations()
+    by_label = {a["label"]: a for a in anns}
+    assert by_label["d"]["measurement_ids"] == [9, 5]
+    assert by_label["o"]["measurement_ids"] == [5]
+
+    dag = tc.to_dag_circuit()
+    dag_anns = dag.annotations()
+    dag_by_label = {a["label"]: a for a in dag_anns}
+    assert dag_by_label["d"]["measurement_ids"] == [9, 5]
+    assert dag_by_label["o"]["measurement_ids"] == [5]

--- a/python/quantum-pecos/tests/qec/test_meas_sampling_backend.py
+++ b/python/quantum-pecos/tests/qec/test_meas_sampling_backend.py
@@ -179,3 +179,21 @@ class TestMethodDispatch:
     def test_no_noise_errors(self, d3_tc):
         with pytest.raises(Exception, match="noise"):
             sim_neo(d3_tc).quantum(meas_sampling()).shots(10).seed(42).run()
+
+
+class TestMalformedAnnotationMetadata:
+    """Detector/observable JSON that cannot be honored raises, never thins.
+
+    A malformed or out-of-range entry used to be silently dropped, producing a
+    weaker DEM with no signal to the caller.
+    """
+
+    def test_malformed_detectors_json_raises(self, d3_tc, depol):
+        d3_tc.set_meta("detectors", "not json at all")
+        with pytest.raises(ValueError, match="malformed detector JSON"):
+            sim_neo(d3_tc).quantum(meas_sampling()).noise(depol).shots(1).seed(1).run()
+
+    def test_out_of_range_detector_record_raises(self, d3_tc, depol):
+        d3_tc.set_meta("detectors", '[{"records": [-100000]}]')
+        with pytest.raises(ValueError, match="does not resolve"):
+            sim_neo(d3_tc).quantum(meas_sampling()).noise(depol).shots(1).seed(1).run()


### PR DESCRIPTION
Step 4 of #387, per `design/measurement-id-annotations.md`: detector and observable annotations now reference measurements by identity instead of by position.

## The change

- `AnnotationKind::{Detector, Observable}` store `measurement_ids: Vec<MeasId>`. The old `measurement_nodes: Vec<usize>` meant record indices in a `TickCircuit` and node ids in a `DagCircuit` -- one type, two meanings, translated (buggily) on every conversion.
- `DagCircuit::detector`/`observable` (and the tick equivalents) take `&[MeasRef]` / `&[TickMeasRef]` and return `Result`. Each reference is validated O(1) against the gate it names -- stale and forged references are rejected at construction (`AnnotationRefError`, `TickAnnotationRefError`). The annotation Pauli is Z on each referenced measurement's own qubit, fixing the batched-gate Z-spray corruption.
- Both circuit conversions copy annotations **verbatim**. The translation maps (`meas_record_to_node`, `dag_node_to_record_indices`, `node_to_meas_idx`) and their `filter_map` silent drops are deleted; `TickMeasRef.record_idx` -- a documented lie for external ids -- is gone.
- Consumers resolve ids through the step-3 helpers (#403): `find_measurement` in the influence builder (one Z term per measurement on its own qubit), `meas_index_of` in the DEM sampler/builder, `aux_qubit_for_id` (via `meas_id_rank`) in eeg. Every unresolvable reference is a typed error naming the id and the annotation.
- Python boundary: plain-int measurement refs are rejected (`TypeError`); `(node, qubit)` / `(tick, gate_idx, qubit)` tuples are resolved against the circuit, never trusted; `annotations()` exposes `measurement_ids`. `DagCircuit::meas_refs(node)` recovers per-measurement refs from a batched `add_gate` node -- a detector on one measurement of a batched gate is now expressible.

## A defect the de-aliased tests exposed

`InfluenceBuilder`-built influence maps carried **two internal orderings**: detectors, propagation data, and the sampler's raw channels in symbolic-replay order, but `measurements`/`meas_ids` re-sorted by id rank -- so `meas_index_of` did not index the raw stream. Invisible while ids were positional (the orders coincide), wrong the moment they were not. `InfluenceBuilder` now emits one order per map (replay order throughout); `DagFaultAnalyzer` maps were already internally consistent. Recorded in the design doc's "As built" section along with two other deviations (O(1) construction validation instead of a per-ref scan; tuple handles instead of opaque Python objects, since the tuples never contain a forgeable id).

## Tests

`crates/pecos-qec/tests/meas_id_pivot_tests.rs`: every tier with non-positional, non-contiguous ids (9, 1, 5) -- influence-relation and per-measurement-influence equivalence between positional and scrambled ids (locations matched by physical key, indices through each map's own ordinal), a sampler dual-output witness with self-verifying non-vacuity asserts, batched-gate single-measurement detector, removed/unknown/record-less reference errors, tick<->dag round-trip of scrambled ids, and a 2^44 sparse id proving no id-sized allocation. Plus eeg byte-identical DEM under scrambled ids, tick/dag forged-ref rejection, and the Python `mz_with_ids` tier. Eight mutations run against the guards (skip validation, restore the id-rank re-sort, resolve by raw id value, spray the Pauli, drop the verbatim copy, skip unresolved ids, index eeg by id value, drop annotations in conversion) -- all killed.

## Verification

Cold `cargo clippy --locked --workspace --all-targets -- -D warnings` on a fresh target dir, `cargo fmt --check`, the CI-shaped `cargo test` exclusion set, both extensions rebuilt via maturin, the full Python lane with `CARGO_TARGET_DIR` unset, `pre-commit run --all-files`, and the #391 end-to-end DEM ordering harness (50k shots) at this commit -- all green.
