### PR TITLE
Pauli propagation collapses instead of resetting at non-destructive measurements

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -519,7 +519,9 @@ fn propagate_forward(
             GateType::PZ | GateType::QAlloc if !loc.qubits.is_empty() => {
                 prop.clear_qubit(loc.qubits[0]);
             }
-            // MZ: X component flips the measurement, then qubit state collapses
+            // The X component flips the measurement and then survives the
+            // collapse -- a non-destructive measurement absorbs only the Z
+            // component. Only a discarded qubit (`MeasureFree`) clears fully.
             GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked
                 if !loc.qubits.is_empty() =>
             {
@@ -529,7 +531,12 @@ fn propagate_forward(
                 {
                     affected.insert(meas_idx);
                 }
-                prop.clear_qubit(q);
+                super::propagator::cross_measurement(
+                    prop,
+                    q,
+                    loc.gate_type,
+                    super::propagator::Direction::Forward,
+                );
             }
             _ => {}
         }
@@ -2327,10 +2334,13 @@ mod tests {
         );
     }
 
+    /// Collapse projects; it does not reset. After the first measurement the
+    /// faulty and ideal states still differ by X, so the second measurement is
+    /// flipped too -- verified directly on `StateVec` (X; MZ -> 1; MZ -> 1)
+    /// and matching Stim's `M`-versus-`MR` distinction. Clearing here was the
+    /// defect: it predicted the second measurement unflipped.
     #[test]
-    fn test_propagate_x_absorbed_by_mz() {
-        // Circuit: MZ(0) MZ(0) — X on q0 should flip first MZ only
-        // (MZ collapses qubit, absorbing the error)
+    fn test_propagate_x_persists_through_nondestructive_mz() {
         let mut tc = TickCircuit::new();
         tc.tick().mz(&[QubitId(0)]);
         tc.tick().mz(&[QubitId(0)]);
@@ -2339,8 +2349,53 @@ mod tests {
         let affected = propagate_single(PauliType::X, 0, 0, &gates, &meas_pos);
         assert_eq!(
             affected,
+            BTreeSet::from([0, 1]),
+            "X before a non-destructive MZ flips it AND every later measurement \
+             on the qubit until a reset or free"
+        );
+    }
+
+    /// The Z component is what collapse absorbs: it commutes with the
+    /// measurement, and both branches land on the same eigenstate up to phase.
+    #[test]
+    fn test_propagate_z_component_absorbed_by_mz() {
+        // Z -> (via H) X flips the first MZ; the surviving component after the
+        // collapse is X only, so an H after the measurement rotates it to Z,
+        // which cannot flip the final MZ. If the Z component survived the
+        // collapse, the recombined Y would flip it.
+        let mut tc = TickCircuit::new();
+        tc.tick().h(&[QubitId(0)]);
+        tc.tick().mz(&[QubitId(0)]);
+        tc.tick().h(&[QubitId(0)]);
+        tc.tick().mz(&[QubitId(0)]);
+
+        let (gates, meas_pos) = flatten_tick_circuit(&tc);
+        let affected = propagate_single(PauliType::Y, 0, 0, &gates, &meas_pos);
+        assert_eq!(
+            affected,
             BTreeSet::from([0]),
-            "X should flip first MZ only, not second"
+            "the Y's X part flips MZ 0 (Y -> H -> Y anticommutes with Z); only \
+             X survives the collapse, and H turns it into Z, invisible to MZ 1"
+        );
+    }
+
+    /// `MeasureFree` discards the qubit, so it genuinely clears: an error
+    /// before it cannot reach anything after.
+    #[test]
+    fn test_propagate_x_cleared_by_measure_free() {
+        let mut tc = TickCircuit::new();
+        tc.tick()
+            .try_add_gate(pecos_core::Gate::mz_free(&[0usize]))
+            .expect("gate is valid");
+        tc.tick().pz(&[QubitId(0)]);
+        tc.tick().mz(&[QubitId(0)]);
+
+        let (gates, meas_pos) = flatten_tick_circuit(&tc);
+        let affected = propagate_single(PauliType::X, 0, 0, &gates, &meas_pos);
+        assert_eq!(
+            affected,
+            BTreeSet::from([0]),
+            "X flips the MeasureFree it precedes and nothing after the discard"
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/fault_sampler.rs
@@ -207,7 +207,9 @@ pub(crate) enum PauliType {
 /// - All single-qubit Cliffords: Clifford conjugation via direct Pauli-basis updates
 /// - All two-qubit Cliffords: Clifford conjugation via direct Pauli-basis updates
 /// - `PZ`, `QAlloc`: absorbs all Pauli components on the reset qubit
-/// - `MZ`: records `X`-component flip, then absorbs all components (state collapse)
+/// - `MZ`, `MeasureLeaked`: records `X`-component flip, then absorbs the Z
+///   component only -- collapse projects, it does not reset, so the X keeps
+///   propagating. `MeasureFree` absorbs everything: the qubit is discarded.
 ///
 /// **No-op** (pass through without noise or transformation):
 /// - `I`, `Idle`, `QFree`, `MeasCrosstalkGlobalPayload`,

--- a/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/influence_builder.rs
@@ -691,33 +691,34 @@ impl<'a> InfluenceBuilder<'a> {
         };
 
         for (det_idx, detector) in detectors.iter().enumerate() {
-            // Build combined Pauli from all measurements in the detector
-            let mut combined_prop = PauliProp::new();
-
+            // One walk per member measurement, each seeded at its own node.
+            // A combined seed XORed at the circuit end cancels same-qubit
+            // members to identity before the walk starts, erasing every
+            // influence between the measurements. The recorder toggles, so
+            // influences shared by several members cancel exactly as the
+            // detector's XOR readout does.
             for &meas_idx in &detector.measurement_indices {
-                // Find the node and qubit for this measurement
                 if let Some(node) = info
                     .node_to_meas_idx
                     .iter()
                     .position(|&opt| opt == Some(meas_idx))
                     && let Some(gate) = propagator.gate(node)
                 {
+                    let mut seed = PauliProp::new();
                     for qubit in &gate.qubits {
                         // Z-basis measurement means we propagate Z
-                        combined_prop.track_z(&[qubit.index()]);
+                        seed.track_z(&[qubit.index()]);
                     }
+                    Self::propagate_observable(
+                        propagator,
+                        &seed,
+                        det_idx,
+                        true, // is_detector
+                        &mut work,
+                        Some(propagator.topo_position(node)),
+                    );
                 }
             }
-
-            // Propagate the combined observable backward
-            Self::propagate_observable(
-                propagator,
-                &combined_prop,
-                det_idx,
-                true, // is_detector
-                &mut work,
-                None, // detectors: walk from circuit end
-            );
         }
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_frame.rs
@@ -500,11 +500,17 @@ fn propagate_tracked_pauli_forward(
                         }
                     }
                 }
-                // Every measurement collapses the qubit, including one that
-                // consumes no record. Clearing used to sit inside the record
-                // lookup above, so a `MeasureLeaked` let the Pauli propagate on.
+                // Collapse, not reset: a non-destructive measurement absorbs
+                // only the Z component -- the X component keeps flipping later
+                // measurements on the same qubit. Only a discarded qubit
+                // (`MeasureFree`) clears fully.
                 for qubit in &gate.qubits {
-                    clear_qubit(&mut prop, qubit.index());
+                    crate::fault_tolerance::propagator::cross_measurement(
+                        &mut prop,
+                        qubit.index(),
+                        gate.gate_type,
+                        Direction::Forward,
+                    );
                 }
             }
             GateType::PZ | GateType::QAlloc => {
@@ -568,14 +574,8 @@ mod tests {
     use pecos_quantum::Gate;
 
     /// A `MeasureLeaked` must affect a propagating Pauli exactly as an `MZ`
-    /// does. Clearing used to sit inside the record lookup, so once
-    /// `MeasureLeaked` stopped consuming a record it also stopped touching the
-    /// Pauli, and an X propagated straight through it to flip a later
-    /// measurement that an `MZ` in the same position would have shielded.
-    ///
-    /// This pins the two against each other rather than against an absolute,
-    /// because whether a non-destructive measurement should clear at all is a
-    /// separate question -- see the collapse-semantics issue.
+    /// does: both are non-destructive Z-collapses, executed identically by the
+    /// simulators.
     #[test]
     fn measure_leaked_affects_a_propagating_pauli_like_an_mz() {
         fn later_measurement_flipped(leading: GateType) -> bool {
@@ -619,7 +619,13 @@ mod tests {
         assert_eq!(
             later_measurement_flipped(GateType::MeasureLeaked),
             later_measurement_flipped(GateType::MZ),
-            "a leaked measurement must not let a Pauli through that an MZ stops"
+            "the two non-destructive measurements must treat a Pauli identically"
+        );
+        // And the absolute: collapse projects, it does not reset, so the X
+        // survives the first measurement and flips the later one.
+        assert!(
+            later_measurement_flipped(GateType::MZ),
+            "an X before a non-destructive MZ keeps flipping later measurements"
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/pauli_prop_checker.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_prop_checker.rs
@@ -53,7 +53,7 @@ use super::{
 use pecos_core::QubitId;
 use pecos_core::gate_type::GateType;
 use pecos_quantum::TickCircuit;
-use pecos_simulators::{CliffordGateable, PauliProp};
+use pecos_simulators::PauliProp;
 use std::collections::HashSet;
 
 /// Detects which qubits in a circuit are "input qubits" (used but never prepared).
@@ -268,6 +268,31 @@ fn init_pauli_prop_with_fault(fault: &PauliFault) -> PauliProp {
     prop
 }
 
+/// Apply a gate to an end-read flip ledger.
+///
+/// The checker classifies faults by reading `contains_x` on measurement
+/// qubits *after* full propagation, so a measurement's outcome flip must stay
+/// readable on the wire until a reset clears it -- including for
+/// `MeasureFree`, whose collapse-accurate crossing would discard the flip
+/// together with the qubit. The Z component is still absorbed at every
+/// measurement: left in the ledger it could rotate into X through later
+/// Cliffords and read back as a phantom flip.
+fn apply_gate_flip_ledger(prop: &mut PauliProp, gate: &pecos_core::Gate) {
+    match gate.gate_type {
+        GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked => {
+            for q in &gate.qubits {
+                let qubit = q.index();
+                if prop.contains_z(qubit) {
+                    prop.track_z(&[qubit]);
+                }
+            }
+        }
+        _ => {
+            apply_gate(prop, gate, Direction::Forward);
+        }
+    }
+}
+
 /// Propagates a Pauli fault through a circuit using `PauliProp`.
 ///
 /// Returns the propagated `PauliProp` state after the circuit.
@@ -297,7 +322,7 @@ pub fn propagate_fault(circuit: &TickCircuit, fault: &PauliFault) -> PauliProp {
 
         // Apply all gates in this tick
         for gate in tick.iter_gate_batches() {
-            apply_gate(&mut prop, gate.as_gate(), Direction::Forward);
+            apply_gate_flip_ledger(&mut prop, gate.as_gate());
         }
     }
 
@@ -336,7 +361,7 @@ pub fn propagate_faults(circuit: &TickCircuit, faults: &FaultConfiguration) -> P
     for (tick_idx, tick) in circuit.iter_ticks() {
         if tick_idx >= min_tick {
             for gate in tick.iter_gate_batches() {
-                apply_gate(&mut prop, gate.as_gate(), Direction::Forward);
+                apply_gate_flip_ledger(&mut prop, gate.as_gate());
             }
         }
     }
@@ -1039,22 +1064,11 @@ pub fn extract_measurement_rounds(circuit: &TickCircuit) -> Vec<MeasurementRound
 ///
 /// This simulates what the syndrome would be if we stopped propagation at `until_tick`.
 fn propagate_until_tick(circuit: &TickCircuit, fault: &PauliFault, until_tick: usize) -> PauliProp {
-    let mut prop = PauliProp::new();
-
-    // Initialize with fault
-    for (qubit, pauli_byte) in fault.location.qubits.iter().zip(fault.paulis.iter()) {
-        let qubit_idx = qubit.0;
-        match pauli_byte {
-            1 => prop.track_x(&[qubit_idx]), // X
-            2 => prop.track_z(&[qubit_idx]), // Z
-            3 => {
-                // Y = iXZ
-                prop.track_x(&[qubit_idx]);
-                prop.track_z(&[qubit_idx]);
-            }
-            _ => {} // I
-        }
-    }
+    // The canonical fault encoding (1=X, 2=Y, 3=Z) and the same skip rule as
+    // `propagate_fault`: this walker had drifted into its own encoding (Y and
+    // Z swapped) and its own fault-tick handling, giving the checker several
+    // opinions about one fault.
+    let mut prop = init_pauli_prop_with_fault(fault);
 
     // Propagate through ticks up to and including until_tick
     let fault_tick = fault.location.tick;
@@ -1064,74 +1078,21 @@ fn propagate_until_tick(circuit: &TickCircuit, fault: &PauliFault, until_tick: u
             break;
         }
 
-        // Skip propagation before the fault occurs
-        if tick_idx < fault_tick || (tick_idx == fault_tick && fault.location.before) {
-            continue;
+        if fault.location.before {
+            // Fault is before gates at fault_tick, so propagate from fault_tick onward
+            if tick_idx < fault_tick {
+                continue;
+            }
+        } else {
+            // Fault is after gates at fault_tick, so propagate from fault_tick+1 onward
+            if tick_idx <= fault_tick {
+                continue;
+            }
         }
 
         // Propagate through all gates in this tick
         for gate in tick.iter_gate_batches() {
-            let qubits: Vec<QubitId> = gate.qubits.iter().copied().collect();
-            match gate.gate_type {
-                GateType::CX if qubits.len() >= 2 => {
-                    prop.cx(&[(qubits[0], qubits[1])]);
-                }
-                GateType::CZ if qubits.len() >= 2 => {
-                    prop.cz(&[(qubits[0], qubits[1])]);
-                }
-                GateType::CY if qubits.len() >= 2 => {
-                    prop.cy(&[(qubits[0], qubits[1])]);
-                }
-                GateType::H => {
-                    prop.h(&qubits);
-                }
-                GateType::F => {
-                    prop.f(&qubits);
-                }
-                GateType::Fdg => {
-                    prop.fdg(&qubits);
-                }
-                GateType::SX => {
-                    prop.sx(&qubits);
-                }
-                GateType::SXdg => {
-                    prop.sxdg(&qubits);
-                }
-                GateType::SY => {
-                    prop.sy(&qubits);
-                }
-                GateType::SYdg => {
-                    prop.sydg(&qubits);
-                }
-                GateType::SZ => {
-                    prop.sz(&qubits);
-                }
-                GateType::SZdg => {
-                    prop.szdg(&qubits);
-                }
-                GateType::SWAP if qubits.len() >= 2 => {
-                    prop.swap(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SXX if qubits.len() >= 2 => {
-                    prop.sxx(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SXXdg if qubits.len() >= 2 => {
-                    prop.sxxdg(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SYY if qubits.len() >= 2 => {
-                    prop.syy(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SYYdg if qubits.len() >= 2 => {
-                    prop.syydg(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SZZ if qubits.len() >= 2 => {
-                    prop.szz(&[(qubits[0], qubits[1])]);
-                }
-                GateType::SZZdg if qubits.len() >= 2 => {
-                    prop.szzdg(&[(qubits[0], qubits[1])]);
-                }
-                _ => {}
-            }
+            apply_gate_flip_ledger(&mut prop, gate.as_gate());
         }
     }
 
@@ -2125,7 +2086,7 @@ impl<'a> PauliPropChecker<'a> {
                     // Propagate through circuit
                     for (_tick_idx, tick) in self.circuit.iter_ticks() {
                         for gate in tick.iter_gate_batches() {
-                            apply_gate(&mut prop, gate.as_gate(), Direction::Forward);
+                            apply_gate_flip_ledger(&mut prop, gate.as_gate());
                         }
                     }
 
@@ -2547,6 +2508,7 @@ fn pauli_product(choices: &[u8], count: usize) -> Vec<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pecos_simulators::CliffordGateable;
 
     #[test]
     fn test_init_pauli_prop_with_fault() {
@@ -2592,6 +2554,61 @@ mod tests {
         // Z should now be on both qubits
         assert!(prop.contains_z(0));
         assert!(prop.contains_z(1));
+    }
+
+    /// The flip ledger keeps an `mz_free` outcome flip readable at the
+    /// end-read: the collapse-accurate crossing would discard it with the
+    /// qubit, silently zeroing the syndrome the same measurement recorded.
+    #[test]
+    fn a_measure_free_readout_flip_stays_readable_at_the_end_read() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0]);
+        circuit.tick().mz_free(&[0]);
+
+        let loc = SpacetimeLocation {
+            tick: 1,
+            qubits: vec![QubitId(0)],
+            before: true,
+            gate_type: GateType::MeasureFree,
+            gate_index: 0,
+        };
+        let fault = PauliFault::new(loc, vec![1]); // X before the readout
+        let prop = propagate_fault(&circuit, &fault);
+
+        assert_eq!(
+            classify_fault(&prop, &[0], &[], &[]),
+            FaultClass::DetectableError,
+            "the X flips the mz_free outcome; the ledger must still show it"
+        );
+    }
+
+    /// The per-round walker shares the ledger crossing: a Y that crossed an
+    /// earlier measurement arrives at the later round as the rotated X
+    /// survivor only. The old identity dispatch carried the whole Y through.
+    #[test]
+    fn until_tick_crosses_measurements_with_the_ledger_rule() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0]);
+        circuit.tick().mz(&[0]);
+        circuit.tick().h(&[0]);
+        circuit.tick().mz(&[0]);
+
+        let loc = SpacetimeLocation {
+            tick: 1,
+            qubits: vec![QubitId(0)],
+            before: true,
+            gate_type: GateType::MZ,
+            gate_index: 0,
+        };
+        // Y before the first measurement: the Z part is absorbed there, the X
+        // part survives and the H rotates it into Z by the later round.
+        let fault = PauliFault::new(loc, vec![2]);
+        let per_round = propagate_until_tick(&circuit, &fault, 2);
+        assert!(
+            !per_round.contains_x(0),
+            "an intact Y here means the crossing was identity"
+        );
+        assert!(per_round.contains_z(0));
     }
 
     #[test]

--- a/crates/pecos-qec/src/fault_tolerance/pauli_prop_checker.rs
+++ b/crates/pecos-qec/src/fault_tolerance/pauli_prop_checker.rs
@@ -287,6 +287,14 @@ fn apply_gate_flip_ledger(prop: &mut PauliProp, gate: &pecos_core::Gate) {
                 }
             }
         }
+        // The shared dispatcher keeps preps transparent and expects walkers
+        // to clear at their own call sites; without this arm a stale ledger
+        // entry would survive a re-preparation and read as a phantom flip.
+        GateType::PZ | GateType::QAlloc => {
+            for q in &gate.qubits {
+                prop.clear_qubit(q.index());
+            }
+        }
         _ => {
             apply_gate(prop, gate, Direction::Forward);
         }
@@ -2579,6 +2587,31 @@ mod tests {
             classify_fault(&prop, &[0], &[], &[]),
             FaultClass::DetectableError,
             "the X flips the mz_free outcome; the ledger must still show it"
+        );
+    }
+
+    /// A re-preparation ends the ledger entry: the flip recorded before the
+    /// reset must not read back afterward, and must not spread onward.
+    #[test]
+    fn a_reset_clears_the_ledger_entry() {
+        let mut circuit = TickCircuit::new();
+        circuit.tick().pz(&[0]);
+        circuit.tick().mz(&[0]);
+        circuit.tick().pz(&[0]);
+        circuit.tick().mz(&[0]);
+
+        let loc = SpacetimeLocation {
+            tick: 1,
+            qubits: vec![QubitId(0)],
+            before: true,
+            gate_type: GateType::MZ,
+            gate_index: 0,
+        };
+        let fault = PauliFault::new(loc, vec![1]);
+        let prop = propagate_fault(&circuit, &fault);
+        assert!(
+            !prop.contains_x(0) && !prop.contains_z(0),
+            "the re-preparation must clear the recorded flip from the ledger"
         );
     }
 

--- a/crates/pecos-qec/src/fault_tolerance/propagator.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator.rs
@@ -106,10 +106,11 @@ pub use dag::{
     DemOutputKind, DemOutputMetadata, FaultCombo, FaultComponent, FaultEffect, FaultLocations,
     GateFaultLocation, InfluencesSoA, InfluencesSoAStats, SoARecorderBuilder,
 };
+pub(crate) use pauli::cross_measurement;
 pub use pauli::{
-    Direction, apply_gate, cross_measurement, init_pauli_prop_with_fault,
-    propagate_backward_from_tick, propagate_fault_backward, propagate_observable_backward,
-    propagate_through_circuit, propagate_tick_range,
+    Direction, apply_gate, init_pauli_prop_with_fault, propagate_backward_from_tick,
+    propagate_fault_backward, propagate_observable_backward, propagate_through_circuit,
+    propagate_tick_range,
 };
 pub use tick::TickFaultAnalyzer;
 pub use types::{

--- a/crates/pecos-qec/src/fault_tolerance/propagator.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator.rs
@@ -107,9 +107,9 @@ pub use dag::{
     GateFaultLocation, InfluencesSoA, InfluencesSoAStats, SoARecorderBuilder,
 };
 pub use pauli::{
-    Direction, apply_gate, init_pauli_prop_with_fault, propagate_backward_from_tick,
-    propagate_fault_backward, propagate_observable_backward, propagate_through_circuit,
-    propagate_tick_range,
+    Direction, apply_gate, cross_measurement, init_pauli_prop_with_fault,
+    propagate_backward_from_tick, propagate_fault_backward, propagate_observable_backward,
+    propagate_through_circuit, propagate_tick_range,
 };
 pub use tick::TickFaultAnalyzer;
 pub use types::{

--- a/crates/pecos-qec/src/fault_tolerance/propagator/pauli.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/pauli.rs
@@ -68,8 +68,10 @@ fn consecutive_pairs(
 /// daggers), we swap the gate with its adjoint for backward propagation.
 ///
 /// Special handling:
-/// - **Prep gates**: No transformation in either direction (transparent to propagation)
-/// - **Measure gates**: No transformation in either direction (for propagation purposes)
+/// - **Prep gates**: No transformation in either direction (transparent to propagation;
+///   walkers that model resets clear at their own call sites)
+/// - **Measure gates**: collapse via [`cross_measurement`] -- the component that
+///   commutes with the measurement in the direction of travel is absorbed
 #[inline]
 pub fn apply_gate(prop: &mut PauliProp, gate: &pecos_core::Gate, direction: Direction) {
     if apply_named_gate(prop, gate.gate_type, &gate.qubits, direction) {
@@ -160,16 +162,18 @@ impl PauliComponents for pecos_simulators::BitmaskPauliProp {
 /// measures. A non-destructive Z-collapse (`MZ`, `MeasureLeaked` -- executed
 /// as a plain `MZ` with no reset):
 ///
-/// - Forward: the X component survives -- the faulty and ideal states still
-///   differ by X after collapse, so later measurements keep flipping -- while
-///   the Z component is absorbed (both branches collapse to the same
-///   eigenstate up to phase). This matches the physical simulators and Stim's
-///   `M`-versus-`MR` distinction.
-/// - Backward: the mirror. A Z-type observable passes through (errors before
-///   the measurement flip both it and later measurements); an X-type
-///   observable gains no deterministic dependence on anything before the
-///   collapse, so it is dropped rather than manufacturing a phantom
-///   influence.
+/// - Forward: `(x, z) -> (x, 0)`. The X component survives -- the faulty and
+///   ideal runs still differ by X after collapse, so later measurements keep
+///   flipping (Stim's `M`-versus-`MR` distinction) -- while the Z component
+///   is absorbed. This is Stim's frame algebra with the measurement gauge
+///   fixed to identity instead of randomized; the two choices differ only on
+///   individually non-deterministic measurements, where any detector is
+///   invalid input, and the difference cancels in every deterministic
+///   detector XOR.
+/// - Backward: the symplectic adjoint, `(x, z) -> (0, z)`, so the two
+///   directions agree by construction. A Z-type observable passes through; an
+///   X-type observable is dropped -- relative to the gauge, nothing before
+///   the collapse deterministically flips it.
 ///
 /// `MeasureFree` discards the qubit: nothing crosses in either direction.
 pub fn cross_measurement<P: PauliComponents>(

--- a/crates/pecos-qec/src/fault_tolerance/propagator/pauli.rs
+++ b/crates/pecos-qec/src/fault_tolerance/propagator/pauli.rs
@@ -107,6 +107,95 @@ pub fn apply_gate(prop: &mut PauliProp, gate: &pecos_core::Gate, direction: Dire
     }
 }
 
+/// The component operations `cross_measurement` needs, implemented by both
+/// Pauli-propagation representations so the collapse rule has exactly one
+/// implementation.
+pub trait PauliComponents {
+    fn contains_x(&self, qubit: usize) -> bool;
+    fn contains_z(&self, qubit: usize) -> bool;
+    fn toggle_x(&mut self, qubit: usize);
+    fn toggle_z(&mut self, qubit: usize);
+    fn clear_qubit(&mut self, qubit: usize);
+}
+
+impl PauliComponents for PauliProp {
+    fn contains_x(&self, qubit: usize) -> bool {
+        Self::contains_x(self, qubit)
+    }
+    fn contains_z(&self, qubit: usize) -> bool {
+        Self::contains_z(self, qubit)
+    }
+    fn toggle_x(&mut self, qubit: usize) {
+        self.track_x(&[qubit]);
+    }
+    fn toggle_z(&mut self, qubit: usize) {
+        self.track_z(&[qubit]);
+    }
+    fn clear_qubit(&mut self, qubit: usize) {
+        Self::clear_qubit(self, qubit);
+    }
+}
+
+impl PauliComponents for pecos_simulators::BitmaskPauliProp {
+    fn contains_x(&self, qubit: usize) -> bool {
+        Self::contains_x(self, qubit)
+    }
+    fn contains_z(&self, qubit: usize) -> bool {
+        Self::contains_z(self, qubit)
+    }
+    fn toggle_x(&mut self, qubit: usize) {
+        self.track_x(&[qubit]);
+    }
+    fn toggle_z(&mut self, qubit: usize) {
+        self.track_z(&[qubit]);
+    }
+    fn clear_qubit(&mut self, qubit: usize) {
+        Self::clear_qubit(self, qubit);
+    }
+}
+
+/// Cross a measurement site with a propagating Pauli.
+///
+/// Clearing follows whether the gate *discards* the qubit, not whether it
+/// measures. A non-destructive Z-collapse (`MZ`, `MeasureLeaked` -- executed
+/// as a plain `MZ` with no reset):
+///
+/// - Forward: the X component survives -- the faulty and ideal states still
+///   differ by X after collapse, so later measurements keep flipping -- while
+///   the Z component is absorbed (both branches collapse to the same
+///   eigenstate up to phase). This matches the physical simulators and Stim's
+///   `M`-versus-`MR` distinction.
+/// - Backward: the mirror. A Z-type observable passes through (errors before
+///   the measurement flip both it and later measurements); an X-type
+///   observable gains no deterministic dependence on anything before the
+///   collapse, so it is dropped rather than manufacturing a phantom
+///   influence.
+///
+/// `MeasureFree` discards the qubit: nothing crosses in either direction.
+pub fn cross_measurement<P: PauliComponents>(
+    prop: &mut P,
+    qubit: usize,
+    gate_type: GateType,
+    direction: Direction,
+) {
+    match gate_type {
+        GateType::MZ | GateType::MeasureLeaked => match direction {
+            Direction::Forward => {
+                if prop.contains_z(qubit) {
+                    prop.toggle_z(qubit);
+                }
+            }
+            Direction::Backward => {
+                if prop.contains_x(qubit) {
+                    prop.toggle_x(qubit);
+                }
+            }
+        },
+        GateType::MeasureFree => prop.clear_qubit(qubit),
+        _ => debug_assert!(false, "cross_measurement called on {gate_type:?}"),
+    }
+}
+
 #[inline]
 fn apply_named_gate(
     prop: &mut PauliProp,
@@ -115,6 +204,11 @@ fn apply_named_gate(
     direction: Direction,
 ) -> bool {
     match gate_type {
+        GateType::MZ | GateType::MeasureFree | GateType::MeasureLeaked => {
+            for qid in qubits {
+                cross_measurement(prop, qid.index(), gate_type, direction);
+            }
+        }
         // Self-adjoint single-qubit gates - same in both directions
         GateType::I => {
             prop.identity(qubits);
@@ -580,5 +674,61 @@ mod batched_pair_tests {
                  comparison would be vacuous for this gate"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod collapse_tests {
+    use super::{Direction, cross_measurement};
+    use pecos_quantum::GateType;
+    use pecos_simulators::PauliProp;
+
+    /// Forward across a non-destructive measurement: X survives, Z is
+    /// absorbed. This is the StateVec-verified behavior (X; MZ -> 1; MZ -> 1)
+    /// and Stim's `M`.
+    #[test]
+    fn forward_nondestructive_keeps_x_drops_z() {
+        for gate_type in [GateType::MZ, GateType::MeasureLeaked] {
+            let mut prop = PauliProp::new();
+            prop.track_y(&[0]);
+            cross_measurement(&mut prop, 0, gate_type, Direction::Forward);
+            assert!(prop.contains_x(0), "{gate_type:?}: X must survive");
+            assert!(!prop.contains_z(0), "{gate_type:?}: Z must be absorbed");
+        }
+    }
+
+    /// Backward is the mirror: Z passes (errors before the measurement flip
+    /// both it and later measurements), X is dropped (an X-type observable
+    /// gains no deterministic dependence on anything before the collapse).
+    #[test]
+    fn backward_nondestructive_keeps_z_drops_x() {
+        for gate_type in [GateType::MZ, GateType::MeasureLeaked] {
+            let mut prop = PauliProp::new();
+            prop.track_y(&[0]);
+            cross_measurement(&mut prop, 0, gate_type, Direction::Backward);
+            assert!(!prop.contains_x(0), "{gate_type:?}: X must be dropped");
+            assert!(prop.contains_z(0), "{gate_type:?}: Z must pass");
+        }
+    }
+
+    /// A discarded qubit carries nothing across, in either direction.
+    #[test]
+    fn measure_free_clears_both_directions() {
+        for direction in [Direction::Forward, Direction::Backward] {
+            let mut prop = PauliProp::new();
+            prop.track_y(&[0]);
+            cross_measurement(&mut prop, 0, GateType::MeasureFree, direction);
+            assert!(!prop.contains_x(0) && !prop.contains_z(0));
+        }
+    }
+
+    /// Untouched qubits are untouched.
+    #[test]
+    fn collapse_is_local_to_the_measured_qubit() {
+        let mut prop = PauliProp::new();
+        prop.track_y(&[0]);
+        prop.track_y(&[1]);
+        cross_measurement(&mut prop, 0, GateType::MZ, Direction::Forward);
+        assert!(prop.contains_x(1) && prop.contains_z(1));
     }
 }

--- a/crates/pecos-qec/tests/collapse_semantics_tests.rs
+++ b/crates/pecos-qec/tests/collapse_semantics_tests.rs
@@ -1,0 +1,164 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Collapse-semantics discriminators at the influence-map level.
+//!
+//! Collapse projects; it does not reset. The physical simulators keep the
+//! post-measurement eigenstate, so an X error before a non-destructive `MZ`
+//! flips it AND every later measurement on the qubit until a reset or free.
+//! These tests pin that end to end, where a repeated measurement actually
+//! exists -- the surface-code circuits re-prepare every ancilla, so they
+//! cannot distinguish collapse from reset.
+
+use pecos_qec::fault_tolerance::propagator::DagFaultAnalyzer;
+use pecos_quantum::{DagCircuit, GateType};
+
+/// Influence indices of a fault at (`node`, `before`) for the given fault
+/// Pauli, resolved by physical location rather than index.
+fn detector_hits(
+    map: &pecos_qec::fault_tolerance::propagator::DagFaultInfluenceMap,
+    node: usize,
+    before: bool,
+    pauli: pecos_qec::fault_tolerance::propagator::types::Pauli,
+) -> Vec<u32> {
+    let loc_idx = map
+        .locations
+        .iter()
+        .position(|loc| loc.node == node && loc.before == before)
+        .expect("the fault location exists");
+    let mut hits = map.get_detector_indices(loc_idx, pauli.as_u8()).to_vec();
+    hits.sort_unstable();
+    hits
+}
+
+/// X before the first of two measurements flips BOTH; between them, only the
+/// second. The old clearing predicted the first case flips one measurement.
+#[test]
+fn an_x_before_a_repeated_mz_flips_both_measurements() {
+    use pecos_qec::fault_tolerance::propagator::types::Pauli;
+
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0]);
+    let m1 = dag.mz(&[0]);
+    let m2 = dag.mz(&[0]);
+    let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+
+    let i1 = u32::try_from(
+        map.meas_index_of(m1[0].meas_id)
+            .expect("measurement 1 is in the map"),
+    )
+    .expect("fits");
+    let i2 = u32::try_from(
+        map.meas_index_of(m2[0].meas_id)
+            .expect("measurement 2 is in the map"),
+    )
+    .expect("fits");
+
+    // X after the prep (before both measurements): flips both.
+    assert_eq!(
+        detector_hits(&map, 0, false, Pauli::X),
+        {
+            let mut want = vec![i1, i2];
+            want.sort_unstable();
+            want
+        },
+        "collapse projects; it does not reset -- the X keeps flipping"
+    );
+    // X between the measurements (before the second): flips the second only.
+    assert_eq!(detector_hits(&map, m2[0].node, true, Pauli::X), vec![i2]);
+    // Z anywhere: flips nothing.
+    assert_eq!(detector_hits(&map, 0, false, Pauli::Z), Vec::<u32>::new());
+}
+
+/// The backward mirror kills a phantom: with an H between two measurements,
+/// the second measurement's observable arrives at the first collapse as an
+/// X-type operator, which gains no deterministic dependence on anything
+/// earlier. Passing it through (the old identity behavior) manufactured a
+/// "Z fault before the first measurement flips the second" influence that no
+/// simulator reproduces.
+#[test]
+fn a_z_before_a_collapse_does_not_haunt_a_later_rotated_measurement() {
+    use pecos_qec::fault_tolerance::propagator::types::Pauli;
+
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0]);
+    let m1 = dag.mz(&[0]);
+    dag.h(&[0]);
+    let m2 = dag.mz(&[0]);
+    let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+
+    let i1 = u32::try_from(
+        map.meas_index_of(m1[0].meas_id)
+            .expect("measurement 1 is in the map"),
+    )
+    .expect("fits");
+    let i2 = u32::try_from(
+        map.meas_index_of(m2[0].meas_id)
+            .expect("measurement 2 is in the map"),
+    )
+    .expect("fits");
+
+    // A fault after the prep can flip the first measurement (X component)
+    // but must NOT influence the rotated second measurement at all: its
+    // observable does not deterministically depend on anything before the
+    // collapse.
+    assert_eq!(
+        detector_hits(&map, 0, false, Pauli::X),
+        vec![i1],
+        "X flips the first measurement only"
+    );
+    assert_eq!(
+        detector_hits(&map, 0, false, Pauli::Z),
+        Vec::<u32>::new(),
+        "the old identity-crossing manufactured a phantom influence here"
+    );
+    let _ = i2;
+}
+
+/// `MeasureFree` genuinely discards: nothing before it reaches anything
+/// after, even on the same qubit id.
+#[test]
+fn a_measure_free_stops_propagation_where_a_plain_mz_does_not() {
+    use pecos_core::Gate;
+    use pecos_qec::fault_tolerance::propagator::types::Pauli;
+
+    let build = |leading: GateType| {
+        let mut dag = DagCircuit::new();
+        dag.pz(&[0]);
+        let leading_gate = match leading {
+            GateType::MeasureFree => Gate::mz_free(&[0usize]),
+            _ => Gate::mz(&[0usize]),
+        };
+        dag.try_add_gate_auto_wire(leading_gate)
+            .expect("gate is valid");
+        let m2 = dag.mz(&[0]);
+        let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+        let i2 = u32::try_from(
+            map.meas_index_of(m2[0].meas_id)
+                .expect("measurement 2 is in the map"),
+        )
+        .expect("fits");
+        let hits = detector_hits(&map, 0, false, Pauli::X);
+        (hits, i2)
+    };
+
+    let (mz_hits, mz_i2) = build(GateType::MZ);
+    assert!(
+        mz_hits.contains(&mz_i2),
+        "through a plain MZ the X reaches the second measurement"
+    );
+    let (free_hits, free_i2) = build(GateType::MeasureFree);
+    assert!(
+        !free_hits.contains(&free_i2),
+        "through a MeasureFree it does not -- the qubit was discarded"
+    );
+}

--- a/crates/pecos-qec/tests/collapse_semantics_tests.rs
+++ b/crates/pecos-qec/tests/collapse_semantics_tests.rs
@@ -124,6 +124,92 @@ fn a_z_before_a_collapse_does_not_haunt_a_later_rotated_measurement() {
     let _ = i2;
 }
 
+/// A detector over two same-qubit measurements must keep the influences that
+/// lie BETWEEN its members. Seeding the combined observable at the circuit
+/// end cancels the two Z seeds before the walk starts, deleting the exact
+/// mechanism the detector exists to catch (Stim: `error(p) D0`).
+#[test]
+fn a_detector_over_repeated_measurements_keeps_between_faults() {
+    use pecos_qec::fault_tolerance::InfluenceBuilder;
+    use pecos_qec::fault_tolerance::propagator::types::Pauli;
+
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0]);
+    dag.h(&[0]);
+    let m0 = dag.mz(&[0]);
+    dag.z(&[0]);
+    let m1 = dag.mz(&[0]);
+    dag.detector(&[m0[0], m1[0]])
+        .expect("refs are from this circuit");
+    let map = InfluenceBuilder::new(&dag)
+        .with_circuit_annotations()
+        .expect("annotations resolve")
+        .build()
+        .expect("circuit is replayable");
+
+    let z_gate_loc = map
+        .locations
+        .iter()
+        .position(|loc| loc.gate_type == GateType::Z && !loc.before)
+        .expect("the Z gate has an after location");
+    assert_eq!(
+        map.get_detector_indices(z_gate_loc, Pauli::X.as_u8()),
+        &[0],
+        "an X between the two measurements flips exactly the second, so it \
+         flips their XOR"
+    );
+    // Faults before the first measurement flip both members and cancel.
+    let prep_loc = map
+        .locations
+        .iter()
+        .position(|loc| loc.node == 0 && !loc.before)
+        .expect("the prep has an after location");
+    for pauli in [Pauli::X, Pauli::Y, Pauli::Z] {
+        assert_eq!(
+            map.get_detector_indices(prep_loc, pauli.as_u8()),
+            Vec::<u32>::new(),
+            "{pauli:?} before both members flips both, cancelling in the XOR"
+        );
+    }
+}
+
+/// An SX between two measurements delivers the backward observable to the
+/// first collapse as a Y, exercising the keep-Z branch at integration level:
+/// the Z part passes (faults before the first measurement reach the second,
+/// relative to the measurement gauge), the X part is dropped.
+#[test]
+fn an_sx_rotated_repeated_measurement_keeps_the_z_component() {
+    use pecos_qec::fault_tolerance::propagator::types::Pauli;
+
+    let mut dag = DagCircuit::new();
+    dag.pz(&[0]);
+    let m1 = dag.mz(&[0]);
+    dag.sx(&[0]);
+    let m2 = dag.mz(&[0]);
+    let map = DagFaultAnalyzer::new(&dag).build_influence_map();
+
+    let i1 = u32::try_from(
+        map.meas_index_of(m1[0].meas_id)
+            .expect("measurement 1 is in the map"),
+    )
+    .expect("fits");
+    let i2 = u32::try_from(
+        map.meas_index_of(m2[0].meas_id)
+            .expect("measurement 2 is in the map"),
+    )
+    .expect("fits");
+
+    // X after the prep: flips m1 directly; the passed Z component of m2's
+    // backward observable anticommutes with it too, so it reaches m2.
+    let mut hits = detector_hits(&map, 0, false, Pauli::X);
+    hits.sort_unstable();
+    let mut want = vec![i1, i2];
+    want.sort_unstable();
+    assert_eq!(hits, want);
+    // Z after the prep: commutes with everything that survives to cross.
+    assert_eq!(detector_hits(&map, 0, false, Pauli::Z), Vec::<u32>::new());
+}
+
 /// `MeasureFree` genuinely discards: nothing before it reaches anything
 /// after, even on the same qubit id.
 #[test]

--- a/crates/pecos-qec/tests/fault_enumeration_example.rs
+++ b/crates/pecos-qec/tests/fault_enumeration_example.rs
@@ -86,7 +86,8 @@ fn build_repetition_code(num_rounds: usize) -> DagCircuit {
 
     // Pauli operator: track logical X = X_0 X_1 X_2. Placed BEFORE the
     // transversal Z readout: after it, every data qubit has collapsed and an
-    // X-type operator is gauge -- no fault can deterministically flip it.
+    // X-type operator is destroyed as an observable -- no fault can
+    // deterministically flip it.
     dag.tracked_pauli_labeled("logical_X", X(0) & X(1) & X(2));
 
     // Final data qubit measurements
@@ -611,7 +612,8 @@ fn build_422_code(num_rounds: usize) -> DagCircuit {
 
     // Tracked Paulis: logical X operators. Placed BEFORE the transversal Z
     // readout: after it, every data qubit has collapsed and an X-type
-    // operator is gauge -- no fault can deterministically flip it.
+    // operator is destroyed as an observable -- no fault can
+    // deterministically flip it.
     // Logical X_1 = X_0 X_2
     dag.tracked_pauli_labeled("logical_X1", X(0) & X(2));
     // Logical X_2 = X_0 X_1

--- a/crates/pecos-qec/tests/fault_enumeration_example.rs
+++ b/crates/pecos-qec/tests/fault_enumeration_example.rs
@@ -84,6 +84,11 @@ fn build_repetition_code(num_rounds: usize) -> DagCircuit {
         prev_meas_12 = Some(ms_12[0]);
     }
 
+    // Pauli operator: track logical X = X_0 X_1 X_2. Placed BEFORE the
+    // transversal Z readout: after it, every data qubit has collapsed and an
+    // X-type operator is gauge -- no fault can deterministically flip it.
+    dag.tracked_pauli_labeled("logical_X", X(0) & X(1) & X(2));
+
     // Final data qubit measurements
     let ms_data = dag.mz(&data);
 
@@ -104,9 +109,6 @@ fn build_repetition_code(num_rounds: usize) -> DagCircuit {
     // Observable: logical Z readout = Z_0 (any single data qubit works for rep code)
     dag.observable_labeled("logical_Z", &[ms_data[0]])
         .expect("refs are from this circuit");
-
-    // Pauli operator: track logical X = X_0 X_1 X_2
-    dag.tracked_pauli_labeled("logical_X", X(0) & X(1) & X(2));
 
     dag
 }
@@ -307,9 +309,10 @@ fn repetition_code_labels() {
     assert_eq!(map.num_dem_outputs(), 1, "1 observable");
     assert_eq!(map.num_tracked_paulis(), 1, "1 tracked Pauli");
 
-    // Labels accessible via internal index
-    assert_eq!(map.dem_output_label(0), Some("logical_Z"));
-    assert_eq!(map.dem_output_label(1), Some("logical_X"));
+    // Labels accessible via internal index -- annotation order: the tracked
+    // Pauli is placed before the readout, so it precedes the observable.
+    assert_eq!(map.dem_output_label(0), Some("logical_X"));
+    assert_eq!(map.dem_output_label(1), Some("logical_Z"));
     assert_eq!(map.dem_output_label(99), None);
 
     // Use labels during fault introspection
@@ -606,6 +609,14 @@ fn build_422_code(num_rounds: usize) -> DagCircuit {
         prev_meas_z = Some(ms_z[0]);
     }
 
+    // Tracked Paulis: logical X operators. Placed BEFORE the transversal Z
+    // readout: after it, every data qubit has collapsed and an X-type
+    // operator is gauge -- no fault can deterministically flip it.
+    // Logical X_1 = X_0 X_2
+    dag.tracked_pauli_labeled("logical_X1", X(0) & X(2));
+    // Logical X_2 = X_0 X_1
+    dag.tracked_pauli_labeled("logical_X2", X(0) & X(1));
+
     // Final data qubit measurements
     let ms_data = dag.mz(&data);
 
@@ -632,12 +643,6 @@ fn build_422_code(num_rounds: usize) -> DagCircuit {
     // Logical Z_2 = Z_0 Z_2
     dag.observable_labeled("logical_Z2", &[ms_data[0], ms_data[2]])
         .expect("refs are from this circuit");
-
-    // Tracked Paulis: logical X operators
-    // Logical X_1 = X_0 X_2
-    dag.tracked_pauli_labeled("logical_X1", X(0) & X(2));
-    // Logical X_2 = X_0 X_1
-    dag.tracked_pauli_labeled("logical_X2", X(0) & X(1));
 
     dag
 }

--- a/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
+++ b/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
@@ -923,7 +923,7 @@ class TestRepeatedMeasurementCollapse:
         kwargs = {
             "p1": 0.01,
             "p2": 0.0,
-            "p_meas": 0.0,
+            "p_meas": 0.02,
             "p_prep": 0.0,
             "decompose_errors": False,
         }
@@ -933,15 +933,16 @@ class TestRepeatedMeasurementCollapse:
         pecos_errors = parse_dem_string(pecos_dem)
         stim_errors = parse_dem_string(stim_dem)
 
-        # The X/Y components of the depolarizing fault flip both measurements:
-        # one joint D0 D1 mechanism, no D0-only mechanism. Clearing at the
-        # first measurement predicted the opposite split.
+        # Both PECOS and the Stim reference model p_meas as a PHYSICAL X
+        # before the measurement (X_ERROR then M), so on a repeated
+        # measurement it joins the propagating joint mechanism rather than
+        # flipping one record classically. The last measurement's p_meas has
+        # nothing after it, so it stays alone -- guarding against over-joining.
         assert ((0, 1), ()) in pecos_errors, f"missing joint mechanism:\n{pecos_dem}"
-        assert (
-            (0,),
-            (),
-        ) not in pecos_errors, (
-            f"a D0-only mechanism means the error was absorbed at the first measurement:\n{pecos_dem}"
+        assert ((1,), ()) in pecos_errors, f"missing final p_meas mechanism:\n{pecos_dem}"
+        assert ((0,), ()) not in pecos_errors, (
+            f"a D0-only mechanism means an error was absorbed at the first "
+            f"measurement:\n{pecos_dem}"
         )
         assert set(pecos_errors) == set(stim_errors), f"mechanism sets differ.\nPECOS:\n{pecos_dem}\nStim:\n{stim_dem}"
         for key, p_pecos in pecos_errors.items():

--- a/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
+++ b/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
@@ -940,10 +940,10 @@ class TestRepeatedMeasurementCollapse:
         # nothing after it, so it stays alone -- guarding against over-joining.
         assert ((0, 1), ()) in pecos_errors, f"missing joint mechanism:\n{pecos_dem}"
         assert ((1,), ()) in pecos_errors, f"missing final p_meas mechanism:\n{pecos_dem}"
-        assert ((0,), ()) not in pecos_errors, (
-            f"a D0-only mechanism means an error was absorbed at the first "
-            f"measurement:\n{pecos_dem}"
-        )
+        assert (
+            (0,),
+            (),
+        ) not in pecos_errors, f"a D0-only mechanism means an error was absorbed at the first measurement:\n{pecos_dem}"
         assert set(pecos_errors) == set(stim_errors), f"mechanism sets differ.\nPECOS:\n{pecos_dem}\nStim:\n{stim_dem}"
         for key, p_pecos in pecos_errors.items():
             # The two DEM strings print at different precisions.

--- a/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
+++ b/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
@@ -888,3 +888,65 @@ class TestDemEquivalenceComprehensive:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestRepeatedMeasurementCollapse:
+    """Collapse projects; it does not reset.
+
+    A propagating X before the first of two measurements on one qubit flips
+    BOTH -- Stim's ``M`` (measure without reset) is the ground truth, and the
+    surface-code fixtures cannot exercise this because every ancilla is
+    re-prepared between rounds.
+    """
+
+    def test_error_persistence_through_repeated_mz_matches_stim(self) -> None:
+        from pecos.qec.surface.circuit_builder import (
+            generate_dem_from_tick_circuit,
+            generate_dem_from_tick_circuit_via_stim,
+        )
+        from pecos.quantum import TickCircuit
+
+        tc = TickCircuit()
+        tc.tick().pz([0])
+        tc.tick().x([0])  # noise carrier between prep and first measurement
+        m1 = tc.tick().mz([0])
+        m2 = tc.tick().mz([0])
+        tc.detector(m1, label="D0")
+        tc.detector(m2, label="D1")
+        tc.set_meta("num_measurements", "2")
+        tc.set_meta(
+            "detectors",
+            '[{"id": 0, "coords": [0, 0, 0], "records": [-2]},'
+            ' {"id": 1, "coords": [0, 0, 1], "records": [-1]}]',
+        )
+        tc.set_meta("observables", "[]")
+
+        kwargs = {
+            "p1": 0.01,
+            "p2": 0.0,
+            "p_meas": 0.0,
+            "p_prep": 0.0,
+            "decompose_errors": False,
+        }
+        pecos_dem = generate_dem_from_tick_circuit(tc, **kwargs)
+        stim_dem = generate_dem_from_tick_circuit_via_stim(tc, **kwargs)
+
+        pecos_errors = parse_dem_string(pecos_dem)
+        stim_errors = parse_dem_string(stim_dem)
+
+        # The X/Y components of the depolarizing fault flip both measurements:
+        # one joint D0 D1 mechanism, no D0-only mechanism. Clearing at the
+        # first measurement predicted the opposite split.
+        assert ((0, 1), ()) in pecos_errors, f"missing joint mechanism:\n{pecos_dem}"
+        assert ((0,), ()) not in pecos_errors, (
+            f"a D0-only mechanism means the error was absorbed at the first "
+            f"measurement:\n{pecos_dem}"
+        )
+        assert set(pecos_errors) == set(stim_errors), (
+            f"mechanism sets differ.\nPECOS:\n{pecos_dem}\nStim:\n{stim_dem}"
+        )
+        for key, p_pecos in pecos_errors.items():
+            # The two DEM strings print at different precisions.
+            assert abs(p_pecos - stim_errors[key]) < 1e-5, (
+                f"probability mismatch at {key}: {p_pecos} vs {stim_errors[key]}"
+            )

--- a/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
+++ b/python/quantum-pecos/tests/qec/test_dem_sampler_vs_stim.py
@@ -916,8 +916,7 @@ class TestRepeatedMeasurementCollapse:
         tc.set_meta("num_measurements", "2")
         tc.set_meta(
             "detectors",
-            '[{"id": 0, "coords": [0, 0, 0], "records": [-2]},'
-            ' {"id": 1, "coords": [0, 0, 1], "records": [-1]}]',
+            '[{"id": 0, "coords": [0, 0, 0], "records": [-2]}, {"id": 1, "coords": [0, 0, 1], "records": [-1]}]',
         )
         tc.set_meta("observables", "[]")
 
@@ -938,15 +937,15 @@ class TestRepeatedMeasurementCollapse:
         # one joint D0 D1 mechanism, no D0-only mechanism. Clearing at the
         # first measurement predicted the opposite split.
         assert ((0, 1), ()) in pecos_errors, f"missing joint mechanism:\n{pecos_dem}"
-        assert ((0,), ()) not in pecos_errors, (
-            f"a D0-only mechanism means the error was absorbed at the first "
-            f"measurement:\n{pecos_dem}"
+        assert (
+            (0,),
+            (),
+        ) not in pecos_errors, (
+            f"a D0-only mechanism means the error was absorbed at the first measurement:\n{pecos_dem}"
         )
-        assert set(pecos_errors) == set(stim_errors), (
-            f"mechanism sets differ.\nPECOS:\n{pecos_dem}\nStim:\n{stim_dem}"
-        )
+        assert set(pecos_errors) == set(stim_errors), f"mechanism sets differ.\nPECOS:\n{pecos_dem}\nStim:\n{stim_dem}"
         for key, p_pecos in pecos_errors.items():
             # The two DEM strings print at different precisions.
-            assert abs(p_pecos - stim_errors[key]) < 1e-5, (
-                f"probability mismatch at {key}: {p_pecos} vs {stim_errors[key]}"
-            )
+            assert (
+                abs(p_pecos - stim_errors[key]) < 1e-5
+            ), f"probability mismatch at {key}: {p_pecos} vs {stim_errors[key]}"


### PR DESCRIPTION
Fixes #394: Pauli propagation cleared the propagating error at every measurement, predicting that an X before a non-destructive `MZ` stops flipping afterward. Collapse projects; it does not reset -- verified directly on `StateVec` (`X; MZ -> 1; MZ -> 1`): `MZ` measures without preparing, and only the MP* family (or an explicit `PZ`) resets the qubit.

## The rule, in one place

`cross_measurement` in `propagator/pauli.rs` is now the single implementation, generic over both Pauli-propagation representations (`PauliProp`, `BitmaskPauliProp`):

- **`MZ` / `MeasureLeaked`** (non-destructive Z-collapse), forward: the X component survives -- the faulty and ideal runs still differ by X after collapse, so later measurements keep flipping -- and the Z component is absorbed. Backward: the symplectic mirror -- a Z-type observable passes (errors before the measurement flip both it and later measurements), an X-type observable is dropped, because it gains no deterministic dependence on anything before the collapse.
- **`MeasureFree`** (discard): nothing crosses, in either direction.
- `PZ`/`QAlloc` clearing is unchanged -- resets legitimately clear.

All four sites the issue names now agree: `pauli_frame.rs` and `fault_sampler.rs` route their forward walks through the shared rule; the backward walkers (`propagator/dag.rs`, `propagator/tick.rs`) inherit it through `apply_gate`, which previously treated measurements as identity.

## The backward fix kills a phantom the issue did not name

Backward identity-crossing let an X-type observable pass through an earlier collapse, manufacturing influences like "a Z fault before the first measurement flips a later rotated measurement" -- a correlation no simulator reproduces. The new backward drop removes it (pinned by `a_z_before_a_collapse_does_not_haunt_a_later_rotated_measurement`).

The same phantom was propping up two fault-enumeration tests: their tracked `logical_X` operators were placed *after* the transversal Z-readout of every data qubit, where an X-type operator is gauge. They are moved before the readout, where the operator is physically meaningful -- the tracked-Pauli API is positional by design.

## Why this stayed latent

Surface-code circuits re-prepare every ancilla and measure data qubits once, so collapse and reset coincide everywhere the existing suites looked. The one test asserting the old behavior (`test_propagate_x_absorbed_by_mz`) was the defect's own regression test; it is rewritten to the verified physics, with new absorbed-Z and `MeasureFree` discriminators beside it.

## Validation

- Cross-validation against Stim (the reference the issue names, whose `M` measures without resetting) on a circuit that actually repeats a measurement (`TestRepeatedMeasurementCollapse`): mechanism sets and probabilities identical -- the joint `D0 D1` mechanism appears and the old `D0`-only split does not.
- Influence-map discriminators: X-before-repeated-MZ flips both measurements, X-between flips one, Z flips nothing, `MeasureFree` stops propagation where `MZ` does not.
- Unit tests on `cross_measurement` for all four direction/type combinations.
- Four mutations (forward clear-all, backward identity, backward over-clear, `MeasureFree`-as-`MZ`), each killed by a named test.
- Cold clippy pedantic `-D warnings` on a fresh target dir, CI-shaped `cargo test`, full Python lane with both extensions rebuilt, the #391 DEM ordering harness, and pre-commit -- all green at the pushed commit.
