### PR TITLE
Cap selene-sim and guppylang in plugin extras until the 0.3 ABI migration

### DIFF
--- a/python/selene-plugins/pecos-selene-mast/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-mast/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0",
-    "selene-sim>=0.2",
-    "guppylang>=0.14",
+    "selene-sim>=0.2,<0.3",
+    "guppylang>=0.14,<1.0",
 ]
 
 [project.urls]

--- a/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0",
-    "selene-sim>=0.2",
-    "guppylang>=0.14",
+    "selene-sim>=0.2,<0.3",
+    "guppylang>=0.14,<1.0",
 ]
 
 [project.urls]

--- a/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0",
-    "selene-sim>=0.2",
-    "guppylang>=0.14",
+    "selene-sim>=0.2,<0.3",
+    "guppylang>=0.14,<1.0",
 ]
 
 [project.urls]

--- a/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0",
-    "selene-sim>=0.2",
-    "guppylang>=0.14",
+    "selene-sim>=0.2,<0.3",
+    "guppylang>=0.14,<1.0",
 ]
 
 [project.urls]

--- a/python/selene-plugins/pecos-selene-statevec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-statevec/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=9.0",
-    "selene-sim>=0.2",
-    "guppylang>=0.14",
+    "selene-sim>=0.2,<0.3",
+    "guppylang>=0.14,<1.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -3164,10 +3164,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14,<1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "selene-core", specifier = ">=0.2" },
-    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2" },
+    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2,<0.3" },
 ]
 provides-extras = ["test"]
 
@@ -3188,10 +3188,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14,<1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "selene-core", specifier = ">=0.2" },
-    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2" },
+    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2,<0.3" },
 ]
 provides-extras = ["test"]
 
@@ -3212,10 +3212,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14,<1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "selene-core", specifier = ">=0.2" },
-    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2" },
+    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2,<0.3" },
 ]
 provides-extras = ["test"]
 
@@ -3236,10 +3236,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14,<1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "selene-core", specifier = ">=0.2" },
-    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2" },
+    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2,<0.3" },
 ]
 provides-extras = ["test"]
 
@@ -3260,10 +3260,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "guppylang", marker = "extra == 'test'", specifier = ">=0.14,<1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "selene-core", specifier = ">=0.2" },
-    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2" },
+    { name = "selene-sim", marker = "extra == 'test'", specifier = ">=0.2,<0.3" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
Unblocks every branch's Selene-plugin compat job, red since 2026-08-03 on all platforms.

The plugin extras floated `selene-sim>=0.2` and `guppylang>=0.14`. When guppylang 1.0 released it pulled the Python host to `selene-sim`/`selene-core` 0.3.0, whose loader requires the new plugin-descriptor ABI (`selene_simulator_plugin_descriptor_v1`) -- while the Rust plugin SDK stays git-pinned at selene-core 0.2.2 with the old symbol. Every plugin then fails to load on every OS (green on dev 2026-08-02 with selene-sim 0.2.18 / guppylang-internals 0.36.1; red the next day with 0.3.0 / 1.0.1; no PECOS code changed in between).

This caps `selene-sim<0.3` and `guppylang<1.0` so the two sides of the ABI agree again. The real selene-0.3 migration -- bumping the Rust SDK rev and adopting the v1 descriptor -- is filed separately as the proper fix; the caps come off there.
