### PR TITLE
Seed the simulator RNG in test_multiple_shots to make it deterministic

### DIFF
--- a/exp/pecos-neo/src/lib.rs
+++ b/exp/pecos-neo/src/lib.rs
@@ -333,7 +333,9 @@ mod tests {
     fn test_prelude_usage() {
         let commands = CommandBuilder::new().pz(&[0]).h(&[0]).mz(&[0]).build();
 
-        let mut state = SparseStab::new(1);
+        // Measurement outcomes draw from the simulator's RNG, so the simulator
+        // must be seeded for determinism; the runner seed does not govern them.
+        let mut state = SparseStab::with_seed(1, 42);
         let mut runner = CircuitRunner::<SparseStab>::new().with_seed(42);
         let outcomes = runner.apply_circuit(&mut state, &commands).unwrap();
 
@@ -400,7 +402,9 @@ mod tests {
     fn test_multiple_shots() {
         let commands = CommandBuilder::new().pz(&[0]).h(&[0]).mz(&[0]).build();
 
-        let mut state = SparseStab::new(1);
+        // Measurement outcomes draw from the simulator's RNG, so the simulator
+        // must be seeded for determinism; the runner seed does not govern them.
+        let mut state = SparseStab::with_seed(1, 42);
         let mut runner = CircuitRunner::<SparseStab>::new().with_seed(42);
 
         let mut count_0 = 0;

--- a/exp/pecos-neo/src/lib.rs
+++ b/exp/pecos-neo/src/lib.rs
@@ -83,9 +83,11 @@
 //!     .mz(&[1])
 //!     .build();
 //!
-//! // Run without noise
-//! let mut state = SparseStab::new(2);
-//! let mut runner = CircuitRunner::<SparseStab>::new().with_seed(42);
+//! // Run without noise. Measurement randomness comes from the simulator's
+//! // RNG, so seed the simulator for reproducible outcomes; the runner seed
+//! // only governs noise sampling.
+//! let mut state = SparseStab::with_seed(2, 42);
+//! let mut runner = CircuitRunner::<SparseStab>::new();
 //! let outcomes = runner.apply_circuit(&mut state, &commands).unwrap();
 //!
 //! // Outcomes are correlated (Bell state)

--- a/exp/pecos-neo/src/runner.rs
+++ b/exp/pecos-neo/src/runner.rs
@@ -802,6 +802,10 @@ impl<S: CliffordGateable> CircuitRunner<S> {
     }
 
     /// Set the RNG seed for noise operations.
+    ///
+    /// This does not affect measurement randomness, which comes from the
+    /// simulator's own RNG (e.g. `SparseStab::with_seed`); use
+    /// `set_full_seed` on a program for whole-run determinism.
     #[must_use]
     pub fn with_seed(mut self, seed: u64) -> Self {
         self.rng = PecosRng::seed_from_u64(seed);


### PR DESCRIPTION
`test_multiple_shots` intermittently fails its statistical 50/50 assertion (observed "got 70/30" on PR #453's unrelated CI run, ~8e-5 per-run odds on a fair coin at n=100). The test fixes the runner seed, but measurement outcomes draw from the simulator's own RNG, which `SparseStab::new` seeds from entropy — so the outcomes were never deterministic.

Fix: construct the simulator with `SparseStab::with_seed(1, 42)`. The test is now fully deterministic (verified identical results across repeated runs); the assertion itself is unchanged.

Note for the RNG backlog (issue #332): `CircuitRunner::with_seed` not governing measurement randomness is the underlying wart; this change makes the test honest without preempting the canonical RNG plumbing work.