### PR TITLE
Ban NumPy outside tests, and close the docs gap ruff cannot see

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,12 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # Ruff's TID251 ban covers .py and .ipynb but not Markdown, and the doctests
+      # generated from docs/ are not committed, so docs need their own check.
+      - id: check-docs-no-numpy
+        name: no numpy in documentation snippets
+        entry: scripts/check-docs-no-numpy.sh
+        language: system
+        pass_filenames: false
+        files: ^docs/.*\.md$

--- a/docs/development/parallel-blocks-and-optimization.md
+++ b/docs/development/parallel-blocks-and-optimization.md
@@ -270,7 +270,7 @@ Comprehensive tests are available in:
 Here's a more complex example showing parallel phase gates:
 
 ```python
-import numpy as np
+import math
 from pecos.slr import Main, Parallel, QReg, rad
 from pecos.slr.qeclib import qubit as qb
 
@@ -279,7 +279,7 @@ def qft_layer(q, n, k):
     """Generate parallel controlled rotations for QFT layer k"""
     operations = []
     for j in range(k + 1, n):
-        angle = np.pi / (2 ** (j - k))
+        angle = math.pi / (2 ** (j - k))
         operations.append(qb.CRZ(rad(angle), q[j], q[k]))
     return Parallel(*operations) if len(operations) > 1 else operations[0]
 

--- a/docs/user-guide/parallel-execution.md
+++ b/docs/user-guide/parallel-execution.md
@@ -162,7 +162,7 @@ Here's a complete example showing parallel quantum phase estimation:
 ```python
 from pecos.slr import Main, Parallel, Block, QReg, CReg, SlrConverter, rad
 from pecos.slr.qeclib import qubit as qb
-import numpy as np
+import math
 
 # Parallel Quantum Phase Estimation
 prog = Main(
@@ -175,15 +175,15 @@ prog = Main(
         qb.H(q[2]),
     ),
     # Apply controlled rotations
-    qb.CRZ(rad(np.pi), q[0], q[3]),
-    qb.CRZ(rad(np.pi / 2), q[1], q[3]),
-    qb.CRZ(rad(np.pi / 4), q[2], q[3]),
+    qb.CRZ(rad(math.pi), q[0], q[3]),
+    qb.CRZ(rad(math.pi / 2), q[1], q[3]),
+    qb.CRZ(rad(math.pi / 4), q[2], q[3]),
     # Inverse QFT on ancillas
     qb.H(q[0]),
-    qb.CRZ(rad(-np.pi / 2), q[0], q[1]),
+    qb.CRZ(rad(-math.pi / 2), q[0], q[1]),
     qb.H(q[1]),
-    qb.CRZ(rad(-np.pi / 4), q[0], q[2]),
-    qb.CRZ(rad(-np.pi / 2), q[1], q[2]),
+    qb.CRZ(rad(-math.pi / 4), q[0], q[2]),
+    qb.CRZ(rad(-math.pi / 2), q[1], q[2]),
     qb.H(q[2]),
     # Measure ancillas
     Parallel(

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,14 @@ split-on-trailing-comma = true
 [lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
+# PECOS owns its numeric primitives. NumPy is permitted in tests only, as an oracle to
+# compare against -- never as a runtime dependency of shipped code, examples, or scripts.
+# The replacement is the NumPy-compatible layer re-exported from `pecos` itself:
+# `array`, `zeros`, `ones`, `arange`, `array_equal`, `dtypes`, `any`, `all`, and friends.
+# Tests are exempted via per-file-ignores below. Tracking issue: #458.
+[lint.flake8-tidy-imports.banned-api]
+"numpy".msg = "PECOS owns its numerics -- use the NumPy-compatible layer from `pecos` (array, zeros, arange, dtypes, ...). NumPy is allowed in tests only, as an oracle. See issue #458."
+
 [lint.flake8-type-checking]
 strict = true
 
@@ -102,11 +110,32 @@ ignore = [
 [lint.per-file-ignores]
 "**/__init__.py" = ["F401"]  # imported but unused - Expected for __init__.py re-exports
 
+# NumPy is the oracle the test suite compares PECOS's own numerics against, so tests may
+# import it. Everything else must use the NumPy-compatible layer re-exported from `pecos`.
+"**/tests/**" = ["TID251"]
+"**/test_*.py" = ["TID251"]
+"**/conftest.py" = ["TID251"]
+
+# Pre-existing NumPy users, allowed only until #458 migrates them. This list must SHRINK.
+# Do not add to it: new non-test NumPy use is the thing the ban exists to stop.
+# (decode.py's TID251 lives in its existing entry further down, to avoid a duplicate key.)
+"python/quantum-pecos/src/pecos/qec/reliable_observables.py" = ["TID251"]
+"examples/surface/dem_decomposition_diagnostics.py" = ["TID251"]
+"examples/surface/graphlike_dem_projection_benchmark.py" = ["TID251"]
+"examples/surface/native_dem_threshold_sweep.py" = ["TID251"]
+"examples/measurement_throughput_benchmark.ipynb" = ["TID251"]
+"examples/surface_code_experiments.ipynb" = ["TID251"]
+"examples/surface_code_noisy_decoding.ipynb" = ["TID251"]
+"examples/surface_code_threshold.ipynb" = ["TID251"]
+"examples/surface_code_thresholds.ipynb" = ["TID251"]
+"scripts/compare_meas_sampling_pipeline.py" = ["TID251"]
+
 # Standalone offline oracle-fixture generators inside Rust crate test dirs -
 # scripts run via uv, not an importable package
 "crates/*/tests/fixtures/*.py" = [
     "INP001",   # Implicit namespace package - standalone scripts, not a package
     "S311",     # Standard pseudo-random - fixed-seed case sampling, not crypto
+    "TID251",   # NumPy allowed - these generate oracle fixtures for the test suite
 ]
 
 # Main pecos __init__.py - special case for module initialization
@@ -174,6 +203,7 @@ ignore = [
     "N806",     # H variable name - standard parity check matrix notation
     "SLF001",   # Private member access - accessing internal decoder APIs
     "ANN401",   # Any types - required for optional dependency types (pymatching, stim)
+    "TID251",   # NumPy - pre-existing, allowed only until #458 migrates these 114 sites
 ]
 "python/quantum-pecos/src/pecos/qec/dem.py" = [
     "PLC0415",  # Import inside function - lazy import breaks the qec/__init__ <-> decode cycle

--- a/scripts/check-docs-no-numpy.sh
+++ b/scripts/check-docs-no-numpy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Reject NumPy in documentation snippets.
+# Reject NumPy in documentation code snippets.
 #
 # PECOS owns its numeric primitives; NumPy belongs in the test suite as an oracle. Ruff
 # enforces that for .py and .ipynb via flake8-tidy-imports banned-api (TID251), but it does
@@ -9,18 +9,30 @@
 # Docs matter more than their line count suggests: a snippet in the user guide teaches the
 # pattern, and readers copy it into their own code.
 #
+# Only fenced code blocks are scanned. Prose may name NumPy freely -- a migration guide has
+# to be able to write "replace np.array(x) with array(x)" without tripping this check.
+#
 # Tracking issue for the remaining migration: #458.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Match `import numpy`, `from numpy import ...`, and `np.` usage inside docs.
-pattern='(^|[^A-Za-z0-9_])(import[[:space:]]+numpy|from[[:space:]]+numpy[[:space:]]+import|np\.)'
-
-hits=$(grep -rInE "$pattern" --include='*.md' docs/ 2>/dev/null || true)
+hits=$(
+    find docs -name '*.md' -type f -print0 |
+        xargs -0 awk '
+            # Track fenced blocks. Only code inside a fence is subject to the ban.
+            /^[[:space:]]*```/ {
+                if (in_fence) { in_fence = 0 } else { in_fence = 1 }
+                next
+            }
+            in_fence && /(^|[^A-Za-z0-9_])(import[[:space:]]+numpy|from[[:space:]]+numpy[[:space:]]+import|np\.)/ {
+                printf "%s:%d: %s\n", FILENAME, FNR, $0
+            }
+        '
+)
 
 if [ -n "$hits" ]; then
-    echo "NumPy found in documentation snippets:" >&2
+    echo "NumPy found in documentation code snippets:" >&2
     echo "$hits" | sed 's/^/  /' >&2
     cat >&2 <<'MSG'
 
@@ -29,6 +41,7 @@ PECOS owns its numerics. Use the NumPy-compatible layer re-exported from `pecos`
 library where that is the honest answer -- `math.pi` rather than `np.pi`.
 
 NumPy is permitted in tests only, as an oracle to compare PECOS's own results against.
+Prose outside a code fence may mention NumPy freely; only fenced code is checked.
 See issue #458.
 MSG
     exit 1

--- a/scripts/check-docs-no-numpy.sh
+++ b/scripts/check-docs-no-numpy.sh
@@ -1,16 +1,33 @@
 #!/usr/bin/env bash
-# Reject NumPy in documentation code snippets.
+# Reject accidental NumPy in documentation code snippets.
 #
-# PECOS owns its numeric primitives; NumPy belongs in the test suite as an oracle. Ruff
-# enforces that for .py and .ipynb via flake8-tidy-imports banned-api (TID251), but it does
-# not lint Markdown, and the doctests generated from docs/ are not committed -- so docs are
-# the one place the ban cannot reach. This closes that gap.
+# PECOS owns its numeric primitives and is self-sufficient: internal code must not depend on
+# NumPy. Ruff enforces that for .py and .ipynb via flake8-tidy-imports banned-api (TID251),
+# but it does not lint Markdown, and the doctests generated from docs/ are not committed --
+# so docs are the one place the ban cannot reach. This closes that gap.
 #
 # Docs matter more than their line count suggests: a snippet in the user guide teaches the
 # pattern, and readers copy it into their own code.
 #
-# Only fenced code blocks are scanned. Prose may name NumPy freely -- a migration guide has
-# to be able to write "replace np.array(x) with array(x)" without tripping this check.
+# Two deliberate exemptions, because the goal is "PECOS does not depend on NumPy", not
+# "PECOS pretends NumPy does not exist":
+#
+#   1. Prose. Only fenced code blocks are scanned, so a migration guide can write
+#      "replace np.array(x) with array(x)" without tripping this check.
+#
+#   2. Interop documentation. NumPy is ubiquitous in scientific computing, and users are
+#      entitled to know how to move data between it and PECOS -- np.asarray(pecos_array)
+#      and pecos.array(np_array) both work. Mark such a block with an HTML comment on the
+#      line before the fence:
+#
+#          <!-- numpy-interop: converting a PECOS array for an existing NumPy workflow -->
+#          ```python
+#          import numpy as np
+#          ...
+#          ```
+#
+#      The marker is per-block and must state why, so the exemption is a deliberate act by
+#      an author rather than something that spreads by copy-paste.
 #
 # Tracking issue for the remaining migration: #458.
 set -euo pipefail
@@ -20,12 +37,25 @@ cd "$(dirname "$0")/.."
 hits=$(
     find docs -name '*.md' -type f -print0 |
         xargs -0 awk '
-            # Track fenced blocks. Only code inside a fence is subject to the ban.
+            # Remember whether the most recent non-blank line opted this block in.
+            /^[[:space:]]*$/ { next }
+
             /^[[:space:]]*```/ {
-                if (in_fence) { in_fence = 0 } else { in_fence = 1 }
+                if (in_fence) {
+                    in_fence = 0
+                } else {
+                    in_fence = 1
+                    exempt = pending_exempt
+                }
+                pending_exempt = 0
                 next
             }
-            in_fence && /(^|[^A-Za-z0-9_])(import[[:space:]]+numpy|from[[:space:]]+numpy[[:space:]]+import|np\.)/ {
+
+            {
+                pending_exempt = (!in_fence && /numpy-interop/) ? 1 : 0
+            }
+
+            in_fence && !exempt && /(^|[^A-Za-z0-9_])(import[[:space:]]+numpy|from[[:space:]]+numpy[[:space:]]+import|np\.)/ {
                 printf "%s:%d: %s\n", FILENAME, FNR, $0
             }
         '
@@ -36,13 +66,17 @@ if [ -n "$hits" ]; then
     echo "$hits" | sed 's/^/  /' >&2
     cat >&2 <<'MSG'
 
-PECOS owns its numerics. Use the NumPy-compatible layer re-exported from `pecos`
-(array, zeros, ones, arange, array_equal, dtypes, any, all, ...), or the standard
-library where that is the honest answer -- `math.pi` rather than `np.pi`.
+PECOS owns its numerics and does not depend on NumPy. In documentation examples use the
+NumPy-compatible layer re-exported from `pecos` (array, zeros, ones, arange, array_equal,
+dtypes, any, all, ...), or the standard library where that is the honest answer --
+`math.pi` rather than `np.pi`.
 
-NumPy is permitted in tests only, as an oracle to compare PECOS's own results against.
+If the block is deliberately teaching NumPy interop, mark it and say why:
+
+    <!-- numpy-interop: converting a PECOS array for an existing NumPy workflow -->
+
 Prose outside a code fence may mention NumPy freely; only fenced code is checked.
-See issue #458.
+NumPy also remains available in tests, as an oracle. See issue #458.
 MSG
     exit 1
 fi

--- a/scripts/check-docs-no-numpy.sh
+++ b/scripts/check-docs-no-numpy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Reject NumPy in documentation snippets.
+#
+# PECOS owns its numeric primitives; NumPy belongs in the test suite as an oracle. Ruff
+# enforces that for .py and .ipynb via flake8-tidy-imports banned-api (TID251), but it does
+# not lint Markdown, and the doctests generated from docs/ are not committed -- so docs are
+# the one place the ban cannot reach. This closes that gap.
+#
+# Docs matter more than their line count suggests: a snippet in the user guide teaches the
+# pattern, and readers copy it into their own code.
+#
+# Tracking issue for the remaining migration: #458.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Match `import numpy`, `from numpy import ...`, and `np.` usage inside docs.
+pattern='(^|[^A-Za-z0-9_])(import[[:space:]]+numpy|from[[:space:]]+numpy[[:space:]]+import|np\.)'
+
+hits=$(grep -rInE "$pattern" --include='*.md' docs/ 2>/dev/null || true)
+
+if [ -n "$hits" ]; then
+    echo "NumPy found in documentation snippets:" >&2
+    echo "$hits" | sed 's/^/  /' >&2
+    cat >&2 <<'MSG'
+
+PECOS owns its numerics. Use the NumPy-compatible layer re-exported from `pecos`
+(array, zeros, ones, arange, array_equal, dtypes, any, all, ...), or the standard
+library where that is the honest answer -- `math.pi` rather than `np.pi`.
+
+NumPy is permitted in tests only, as an oracle to compare PECOS's own results against.
+See issue #458.
+MSG
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Makes the "PECOS owns its numerics" rule enforceable instead of conventional, so NumPy cannot be
reintroduced into non-test code by a contributor or a coding agent who has not read the rule.

NumPy stays in the test suite, where it is the oracle PECOS's own results are compared against.

Groundwork for #458, which tracks migrating the remaining call sites.

## The guard

`TID` was already selected in `ruff.toml`, so this is a config addition rather than new tooling --
it runs in the existing `pre-commit` hook and the `python-lint` CI job automatically:

```toml
[lint.flake8-tidy-imports.banned-api]
"numpy".msg = "PECOS owns its numerics -- use the NumPy-compatible layer from `pecos` ..."
```

Verified behaviour, each checked by planting a file and running ruff:

| case | result |
|---|---|
| new non-test `.py` importing NumPy | rejected, `TID251`, with the replacement named in the message |
| new **notebook** cell importing NumPy | rejected -- ruff lints `.ipynb` |
| new test file importing NumPy | allowed |

Tests are exempted via `**/tests/**`, `**/test_*.py`, and `**/conftest.py`. `TID251` was added to
the existing `crates/*/tests/fixtures/*.py` entry, since those scripts generate oracle fixtures.

## The gap ruff cannot cover

Ruff does not lint Markdown, and the doctests generated from `docs/` are not committed, so
documentation escapes the ban entirely. That matters more than the line count suggests: a snippet
in the user guide teaches the pattern, and readers copy it.

`scripts/check-docs-no-numpy.sh` closes it, wired as a local pre-commit hook alongside the
existing `dependency-integrity-check`.

The goal is "PECOS does not depend on NumPy", not "PECOS pretends NumPy does not exist", so the
check has two deliberate exemptions:

**Prose.** Only fenced code blocks are scanned. A migration guide has to be able to write
"replace `np.array(x)` with `array(x)`" -- and #458's own migration will need exactly that.

**Interop documentation.** NumPy is ubiquitous in scientific computing and users are entitled to
know how to move data between it and PECOS. Both directions already work
(`np.asarray(pecos_array)` and `pecos.array(np_array)`), and that deserves to be documented. Such
a block opts in explicitly, and must say why:

```
<!-- numpy-interop: converting a PECOS array for an existing NumPy workflow -->
```

The marker is per-block, so the exemption is a deliberate authorial act rather than something
that spreads by copy-paste.

Behaviour verified by planting each case and running the hook:

| case | result |
|---|---|
| clean tree | passes |
| prose naming `np.array` | allowed |
| unmarked fence importing NumPy | blocked, exit 1, file:line |
| marked interop fence | allowed |
| marker leaking to the *next* fence | blocked -- it does not leak |

## Docs migrated rather than exempted

Both offending docs used only `np.pi` -- a constant, no array work -- so they now use `math.pi`.
Standard library, no dependency, and the honest expression of what the code needed.

- `docs/user-guide/parallel-execution.md`
- `docs/development/parallel-blocks-and-optimization.md`

Both are executed as generated doctests; 15 pass after the change.

## The shrinking allowlist

Eleven pre-existing NumPy users are exempted so this can land ahead of the migration. Each entry
is marked as allowed only until #458 removes it, and the list carries an explicit instruction not
to grow it. New non-test NumPy use is exactly what the ban exists to stop; the allowlist is a
ratchet for existing debt, not an escape hatch.

## Verification

- `uv run --frozen pre-commit run --all-files` -- exit 0, 17 hooks (16 plus the new docs check).
- `uv run pytest python/quantum-pecos/tests/docs/generated -q` -- 246 passed, 10 skipped. The two
  `test_qec_guppy.py` failures (blocks 9 and 10) are the known HUGR stall in #427; this branch is
  straight off `dev` and does not touch that path, which independently confirms they are
  pre-existing rather than introduced.
- Guard behaviour verified by planting and removing probe files, as tabulated above.

