### PR TITLE
Migrate the first files off runtime NumPy and document the pattern (#458 step 2)

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -154,14 +154,23 @@ object. Constructors and casts take PECOS dtypes, for example `zeros(size, dtype
 `Array` has no `flatten()` method. For a known two-dimensional array, preserve row-major order explicitly:
 
 ```python
+from pecos import asarray, dtypes
+
+values = [[1, 0], [0, 1]]
 flat = [value for row in asarray(values, dtype=dtypes.uint8) for value in row]
+assert flat == [1, 0, 0, 1]
 ```
 
 Elementwise comparison returns a boolean `Array`, and `array_sum()` accepts it directly -- counting
 mismatches needs no cast:
 
 ```python
+from pecos import array, dtypes, sum as array_sum
+
+predicted = array([1, 0, 1], dtype=dtypes.uint8)
+expected = array([1, 1, 1], dtype=dtypes.uint8)
 logical_errors = int(array_sum(predicted != expected))
+assert logical_errors == 1
 ```
 
 ## Dependency and Security Checks

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -133,6 +133,37 @@ just check-all
 
 Note: For the Rust side of the project, you can use `cargo` to run tests, benchmarks, formatting, etc.
 
+## Native Numeric Migration Pattern
+
+Runtime code imports numeric primitives from the public `pecos` surface. NumPy remains in tests as an oracle.
+
+```python
+from pecos import Array, array, asarray, dtypes, sum as array_sum, zeros
+```
+
+Map the dtype used by the migrated code as follows:
+
+| NumPy dtype | PECOS dtype |
+|-------------|-------------|
+| `np.uint8`  | `dtypes.uint8` |
+
+Use `Array` in annotations and enter the native layer with `asarray()` when an external API returns an array-like
+object. Constructors and casts take PECOS dtypes, for example `zeros(size, dtype=dtypes.uint8)` and
+`array(values, dtype=dtypes.uint8)`.
+
+`Array` has no `flatten()` method. For a known two-dimensional array, preserve row-major order explicitly:
+
+```python
+flat = [value for row in asarray(values, dtype=dtypes.uint8) for value in row]
+```
+
+Elementwise comparison returns a boolean `Array`, and `array_sum()` accepts it directly -- counting
+mismatches needs no cast:
+
+```python
+logical_errors = int(array_sum(predicted != expected))
+```
+
 ## Dependency and Security Checks
 
 Use the Justfile recipes below so local checks match CI:

--- a/examples/surface/graphlike_dem_projection_benchmark.py
+++ b/examples/surface/graphlike_dem_projection_benchmark.py
@@ -14,15 +14,19 @@ import json
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
 from dem_decomposition_diagnostics import (
     compare_raw_dems,
     dem_stats,
     terminal_graphlike_projection,
     true_observable_flips,
 )
+from pecos import array, asarray, dtypes
+from pecos import sum as array_sum
+
+if TYPE_CHECKING:
+    from pecos import Array
 
 # SZZ/SZZdg surface diagnostics model Z-frame gates as virtual and p1-free.
 SZZ_Z_FRAME_P1_GATE_RATES = {"Z": 0.0, "SZ": 0.0, "SZdg": 0.0}
@@ -69,8 +73,8 @@ def timed(label: str, callback: Any) -> tuple[Any, float]:
 
 def decode_with_correlated_pymatching(
     dem_text: str,
-    detection_events: np.ndarray,
-    observable_flips: np.ndarray,
+    detection_events: Array,
+    observable_flips: Array,
 ) -> tuple[int, float, float]:
     from pecos.decoders import PyMatchingDecoder
 
@@ -79,15 +83,15 @@ def decode_with_correlated_pymatching(
         lambda: PyMatchingDecoder.from_dem_with_correlations(dem_text, enable_correlations=True),
     )
 
-    expected = true_observable_flips(observable_flips)
+    expected = asarray(true_observable_flips(observable_flips), dtype=dtypes.uint8)
 
     def decode() -> list[list[int]]:
-        flat = detection_events.astype(np.uint8).flatten().tolist()
+        flat = [value for row in asarray(detection_events, dtype=dtypes.uint8) for value in row]
         return decoder.decode_batch(flat, len(detection_events))
 
     predictions, decode_s = timed("decode batch", decode)
-    predicted = np.array([prediction[0] if prediction else 0 for prediction in predictions], dtype=np.uint8)
-    logical_errors = int(np.sum(predicted != expected))
+    predicted = array([prediction[0] if prediction else 0 for prediction in predictions], dtype=dtypes.uint8)
+    logical_errors = int(array_sum(predicted != expected))
     return logical_errors, decoder_build_s, decode_s
 
 

--- a/python/quantum-pecos/tests/qec/test_graphlike_dem_projection_benchmark.py
+++ b/python/quantum-pecos/tests/qec/test_graphlike_dem_projection_benchmark.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The PECOS Developers
+# Licensed under the Apache License, Version 2.0
+
+"""NumPy-oracle tests for the graphlike DEM projection benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import numpy as np
+import pecos.decoders
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "Justfile").is_file() and (candidate / "examples").is_dir():
+            return candidate
+    msg = f"Could not locate repo root above {current}"
+    raise RuntimeError(msg)
+
+
+def _load_benchmark_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    surface_examples = _repo_root() / "examples" / "surface"
+    monkeypatch.syspath_prepend(str(surface_examples))
+    module_path = surface_examples / "graphlike_dem_projection_benchmark.py"
+    module_name = "_graphlike_dem_projection_benchmark_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load benchmark module from {module_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+class _FakeDecoder:
+    predictions: ClassVar[list[list[int]]] = []
+    seen_flat: ClassVar[list[int] | None] = None
+    expected_shots: ClassVar[int] = 0
+
+    @classmethod
+    def from_dem_with_correlations(cls, dem_text: str, *, enable_correlations: bool) -> _FakeDecoder:
+        assert dem_text == "fixed-seed-dem"
+        assert enable_correlations is True
+        return cls()
+
+    def decode_batch(self, flat: list[int], num_shots: int) -> list[list[int]]:
+        type(self).seen_flat = flat
+        assert num_shots == type(self).expected_shots
+        return type(self).predictions
+
+
+def test_logical_error_count_matches_fixed_seed_numpy_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    benchmark = _load_benchmark_module(monkeypatch)
+    seed = 20260810
+    shots = 17
+    rng = np.random.default_rng(seed)
+    detection_events = rng.integers(0, 2, size=(shots, 6), dtype=np.uint8).astype(bool)
+    observable_flips = rng.integers(0, 2, size=(shots, 1), dtype=np.uint8).astype(bool)
+    prediction_bits = rng.integers(0, 2, size=shots, dtype=np.uint8)
+    predictions = [[] if index % 4 == 0 else [int(bit)] for index, bit in enumerate(prediction_bits)]
+
+    _FakeDecoder.predictions = predictions
+    _FakeDecoder.seen_flat = None
+    _FakeDecoder.expected_shots = shots
+    monkeypatch.setattr(pecos.decoders, "PyMatchingDecoder", _FakeDecoder)
+
+    logical_errors, _, _ = benchmark.decode_with_correlated_pymatching(
+        "fixed-seed-dem",
+        detection_events,
+        observable_flips,
+    )
+
+    predicted = np.array([prediction[0] if prediction else 0 for prediction in predictions], dtype=np.uint8)
+    expected = observable_flips[:, 0].astype(np.uint8)
+    expected_flat = detection_events.astype(np.uint8).flatten().tolist()
+    assert logical_errors == int(np.sum(predicted != expected)) == 12
+    assert _FakeDecoder.seen_flat == expected_flat
+    assert _FakeDecoder.seen_flat is not None
+    assert all(type(value) is int for value in _FakeDecoder.seen_flat)

--- a/ruff.toml
+++ b/ruff.toml
@@ -121,14 +121,12 @@ ignore = [
 # (decode.py's TID251 lives in its existing entry further down, to avoid a duplicate key.)
 "python/quantum-pecos/src/pecos/qec/reliable_observables.py" = ["TID251"]
 "examples/surface/dem_decomposition_diagnostics.py" = ["TID251"]
-"examples/surface/graphlike_dem_projection_benchmark.py" = ["TID251"]
 "examples/surface/native_dem_threshold_sweep.py" = ["TID251"]
 "examples/measurement_throughput_benchmark.ipynb" = ["TID251"]
 "examples/surface_code_experiments.ipynb" = ["TID251"]
 "examples/surface_code_noisy_decoding.ipynb" = ["TID251"]
 "examples/surface_code_threshold.ipynb" = ["TID251"]
 "examples/surface_code_thresholds.ipynb" = ["TID251"]
-"scripts/compare_meas_sampling_pipeline.py" = ["TID251"]
 
 # Standalone offline oracle-fixture generators inside Rust crate test dirs -
 # scripts run via uv, not an importable package

--- a/scripts/compare_meas_sampling_pipeline.py
+++ b/scripts/compare_meas_sampling_pipeline.py
@@ -17,9 +17,9 @@ import argparse
 import json
 import time
 
-import numpy as np
 import pymatching
 import stim
+from pecos import dtypes, zeros
 from pecos.qec.surface import SurfacePatch
 from pecos.qec.surface.circuit_builder import tick_circuit_to_stim
 from pecos.qec.surface.decode import _build_surface_tick_circuit_for_native_model
@@ -77,7 +77,7 @@ def extract_and_decode(result, tc, matching, shots):
     t0 = time.perf_counter()
 
     errors = 0
-    syndrome = np.zeros(num_dets, dtype=np.uint8)
+    syndrome = zeros(num_dets, dtype=dtypes.uint8)
 
     for shot_idx in range(shots):
         row = result[shot_idx]
@@ -124,7 +124,7 @@ def run_native_sampler(tc, noise_args, matching, shots, seed):
 
     t0 = time.perf_counter()
     errors = 0
-    syndrome = np.zeros(num_dets, dtype=np.uint8)
+    syndrome = zeros(num_dets, dtype=dtypes.uint8)
 
     for i in range(shots):
         syn = batch.get_syndrome(i)


### PR DESCRIPTION
## Summary

#458 step 2: the proof-of-path for migrating PECOS off runtime NumPy, plus the template the
remaining ~200 sites will follow.

| file | sites | now |
|---|---:|---|
| `scripts/compare_meas_sampling_pipeline.py` | 2 | native |
| `examples/surface/graphlike_dem_projection_benchmark.py` | 5 | native |

Both files' entries are **deleted** from the `ruff.toml` NumPy allowlist, so the #460 ban now
enforces them with no exemption -- that is the proof they are actually clean, and it is how the
ratchet shrinks as later steps land.

## Why not `reliable_observables.py`

The issue originally proposed that file (6 sites) as step 2. It is the wrong target: a
quarantined prototype that imports `stim` at module load -- a larger instance of the same rule
violation -- referenced only by its own test, and whose docstring already states a production
version must be rewritten natively (pecos-eeg + pecos-num). Migrating its NumPy would have left
the `stim` import in place and polished code slated for replacement. It is now tracked for a
native rewrite instead; #458's plan is updated.

## The template

Documented in `docs/development/DEVELOPMENT.md`: the import line, the dtype mapping
(`np.zeros/array/asarray + np.uint8` -> `zeros/array/asarray + dtypes.uint8`, `np.ndarray`
annotation -> `Array`), and the two conversions that are not one-for-one -- flattening a 2-D
array without `flatten()`, and counting mismatches (elementwise `!=` yields a boolean `Array`
and `array_sum()` accepts it directly, no cast).

## Equivalence, not just green tests

The logical-error count is captured pre-migration and asserted post-migration on a fixed seed:
**33 before, 33 after** on the full case (d=3, 3 rounds, X basis, p=0.03, 200 shots, seed
20260810), with a durable oracle test pinning **12 before / 12 after** on its own seed. NumPy is
used in that test as the oracle, which is its sanctioned role.

## Gaps found (the point of a proof-of-path)

`Array` has no `fill`, `flatten`, `reshape`, or `ravel` -- filed as #470, blocking the larger
later steps but not this one. The `fill(0)` case was left reported rather than rewritten as
slice assignment, so the requirement is recorded rather than hidden.

## Verification

qec 1489 passed; both scripts execute end to end; `ruff check` clean with the allowlist entries
removed; pre-commit two passes exit 0; Rust untouched.
