### PR TITLE
Guard archive entry paths and migrate off the abandoned sevenz-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -502,15 +502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
-dependencies = [
- "bit-vec 0.7.0",
 ]
 
 [[package]]
@@ -536,12 +527,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bit-vec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bit-vec"
@@ -1207,21 +1192,6 @@ name = "cranelift-srcgen"
 version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1901,17 +1871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime_creation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f"
-dependencies = [
- "cfg-if",
- "filetime",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,7 +2334,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
 ]
 
 [[package]]
@@ -2384,7 +2342,10 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -2802,7 +2763,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "rayon",
  "serde",
 ]
 
@@ -3356,13 +3316,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rust"
-version = "0.1.7"
+name = "lzma-rust2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661"
-dependencies = [
- "byteorder",
-]
+checksum = "243cb2271683c2855cad62142cbf38199db439b1b1e1ccdd5a011342894dd7cc"
 
 [[package]]
 name = "lzma-sys"
@@ -3765,16 +3722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nt-time"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5"
-dependencies = [
- "chrono",
- "time",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,7 +4091,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
- "sevenz-rust",
+ "sevenz-rust2",
  "sha2 0.11.0",
  "tar",
  "tempfile",
@@ -6279,8 +6226,8 @@ checksum = "4b213df2cbfa5f580ed2c0ac3619eda06692a4ff0211f0aebbb4008eaa9724a6"
 dependencies = [
  "fixedbitset 0.5.7",
  "foldhash 0.1.5",
- "hashbrown 0.16.1",
- "indexmap 1.9.3",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "ndarray 0.17.2",
  "num-traits",
  "petgraph 0.8.3",
@@ -6586,19 +6533,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sevenz-rust"
-version = "0.6.1"
+name = "sevenz-rust2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef"
+checksum = "20acd38118edb830eb5a0bfacaf83c687b9995f48d6983cdac3cb18ce1d571cc"
 dependencies = [
- "bit-set 0.6.0",
- "byteorder",
- "crc",
- "filetime_creation",
+ "crc32fast",
  "js-sys",
- "lzma-rust",
- "nt-time",
- "sha2 0.10.9",
+ "lzma-rust2",
  "wasm-bindgen",
 ]
 
@@ -8381,7 +8323,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,10 @@ sha2 = "0.11"
 tar = "0.4"
 xz2 = "0.1"
 bzip2 = "0.6"
-sevenz-rust = "0.6"
+# Maintained successor to the abandoned sevenz-rust (RUSTSEC-2026-0245). Default
+# features add an encoder plus codecs the CUDA installer does not use; the LZMA/LZMA2
+# and BCJ decode paths PECOS needs are unconditional.
+sevenz-rust2 = { version = "0.21", default-features = false }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 zstd = "0.13"
 

--- a/crates/pecos-build/Cargo.toml
+++ b/crates/pecos-build/Cargo.toml
@@ -32,7 +32,7 @@ tar.workspace = true
 flate2.workspace = true
 bzip2.workspace = true
 xz2.workspace = true
-sevenz-rust.workspace = true
+sevenz-rust2.workspace = true
 zip.workspace = true
 zstd.workspace = true
 

--- a/crates/pecos-build/src/cuda/installer.rs
+++ b/crates/pecos-build/src/cuda/installer.rs
@@ -6,7 +6,7 @@
 
 use crate::errors::{Error, Result};
 use crate::extract::contained_entry_path;
-use sevenz_rust::{Password, SevenZReader};
+use sevenz_rust2::{ArchiveReader, Password};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{self, Write};
@@ -370,11 +370,8 @@ fn copy_dir_contents(src: &Path, dest: &Path) -> Result<()> {
 fn extract_windows_exe(archive: &Path, dest: &Path) -> Result<()> {
     println!("Extracting CUDA Toolkit...");
 
-    let file = fs::File::open(archive)?;
-    let len = file.metadata()?.len();
-    let password = Password::empty();
-    let mut reader =
-        SevenZReader::new(file, len, password).map_err(|e| Error::Archive(e.to_string()))?;
+    let mut reader = ArchiveReader::open(archive, Password::empty())
+        .map_err(|e| Error::Archive(e.to_string()))?;
 
     fs::create_dir_all(dest)?;
 
@@ -395,10 +392,10 @@ fn extract_windows_exe(archive: &Path, dest: &Path) -> Result<()> {
 
             // Entry names come from the archive, so they are untrusted input: resolve them
             // through the containment check before touching the filesystem. Unlike the tar
-            // and zip readers used elsewhere in this crate, SevenZReader hands the raw name
+            // and zip readers used elsewhere in this crate, ArchiveReader hands the raw name
             // to the callback without validating it.
             let entry_path = contained_entry_path(dest, entry_name)
-                .map_err(|error| sevenz_rust::Error::other(error.to_string()))?;
+                .map_err(|error| sevenz_rust2::Error::Other(error.to_string().into()))?;
 
             if entry.is_directory() {
                 fs::create_dir_all(&entry_path).ok();

--- a/crates/pecos-build/src/cuda/installer.rs
+++ b/crates/pecos-build/src/cuda/installer.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 use crate::errors::{Error, Result};
+use crate::extract::contained_entry_path;
 use sevenz_rust::{Password, SevenZReader};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -392,15 +393,20 @@ fn extract_windows_exe(archive: &Path, dest: &Path) -> Result<()> {
                 return Ok(true); // Skip this entry
             }
 
+            // Entry names come from the archive, so they are untrusted input: resolve them
+            // through the containment check before touching the filesystem. Unlike the tar
+            // and zip readers used elsewhere in this crate, SevenZReader hands the raw name
+            // to the callback without validating it.
+            let entry_path = contained_entry_path(dest, entry_name)
+                .map_err(|error| sevenz_rust::Error::other(error.to_string()))?;
+
             if entry.is_directory() {
-                let dir_path = dest.join(entry_name);
-                fs::create_dir_all(&dir_path).ok();
+                fs::create_dir_all(&entry_path).ok();
             } else {
-                let file_path = dest.join(entry_name);
-                if let Some(parent) = file_path.parent() {
+                if let Some(parent) = entry_path.parent() {
                     fs::create_dir_all(parent).ok();
                 }
-                let mut output = fs::File::create(&file_path)?;
+                let mut output = fs::File::create(&entry_path)?;
                 io::copy(reader, &mut output)?;
             }
             Ok(true)

--- a/crates/pecos-build/src/extract.rs
+++ b/crates/pecos-build/src/extract.rs
@@ -3,11 +3,55 @@
 //! Provides functions for extracting archives to various locations:
 //! - `extract_archive()` - Extract to a specified directory (for legacy/custom use)
 //! - `extract_to_deps()` - Extract to `~/.pecos/deps/` (recommended for build scripts)
+//! - `contained_entry_path()` - Resolve an archive entry name inside a destination
 
 use crate::errors::{Error, Result};
 use crate::home::{get_deps_dir, get_tmp_dir};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+/// Resolves an archive entry name to a path inside `dest`, rejecting escapes.
+///
+/// Archive entry names are attacker-controlled data: a crafted archive can name an
+/// entry `../../etc/foo` or `/etc/foo` and a naive `dest.join(name)` will then write
+/// outside the extraction directory. Callers must route every entry name through this
+/// function before creating anything on disk.
+///
+/// The `tar` crate validates this inside `unpack`, and the `zip` crate exposes
+/// `enclosed_name` for it, so only archive readers without such a guard need this.
+///
+/// # Errors
+///
+/// Returns [`Error::Archive`] if the entry name is absolute, contains a `..`
+/// component, or contains a Windows prefix such as `C:`.
+pub fn contained_entry_path(dest: &Path, entry_name: &str) -> Result<PathBuf> {
+    // Treat both separators as separating on every platform: a Windows-built archive
+    // read on Unix would otherwise carry "..\\.." through as a single opaque name.
+    let normalized = entry_name.replace('\\', "/");
+    let candidate = Path::new(&normalized);
+
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(Error::Archive(format!(
+                    "archive entry escapes the extraction directory: {entry_name}"
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::Archive(format!(
+                    "archive entry is an absolute path: {entry_name}"
+                )));
+            }
+        }
+    }
+
+    if candidate.as_os_str().is_empty() {
+        return Err(Error::Archive("archive entry has an empty name".into()));
+    }
+
+    Ok(dest.join(candidate))
+}
 
 /// Extract a tar.gz or tar.bz2 archive
 ///
@@ -132,4 +176,59 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 pub fn extract_to_deps(data: &[u8], dir_name: &str) -> Result<PathBuf> {
     let deps_dir = get_deps_dir()?;
     extract_archive(data, &deps_dir, Some(dir_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_entry_names_resolve_inside_the_destination() {
+        let path = contained_entry_path(Path::new("/out"), "bin/nvcc").unwrap();
+        assert_eq!(path, Path::new("/out/bin/nvcc"));
+    }
+
+    #[test]
+    fn windows_separators_resolve_component_wise() {
+        let path = contained_entry_path(Path::new("/out"), "bin\\nvcc.exe").unwrap();
+        assert_eq!(path, Path::new("/out/bin/nvcc.exe"));
+    }
+
+    #[test]
+    fn parent_components_are_rejected() {
+        for name in [
+            "../escape",
+            "bin/../../escape",
+            "..\\escape",
+            "bin\\..\\..\\escape",
+        ] {
+            let error = contained_entry_path(Path::new("/out"), name).unwrap_err();
+            assert!(
+                matches!(error, Error::Archive(message) if message.contains("escapes")),
+                "expected an escape rejection for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn absolute_entry_names_are_rejected() {
+        for name in ["/etc/passwd", "\\windows\\system32\\evil.dll"] {
+            let error = contained_entry_path(Path::new("/out"), name).unwrap_err();
+            assert!(
+                matches!(error, Error::Archive(message) if message.contains("absolute")),
+                "expected an absolute-path rejection for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_entry_names_are_rejected() {
+        assert!(contained_entry_path(Path::new("/out"), "").is_err());
+    }
+
+    #[test]
+    fn current_directory_components_are_allowed() {
+        let path = contained_entry_path(Path::new("/out"), "./bin/nvcc").unwrap();
+        assert_eq!(path, Path::new("/out/bin/nvcc"));
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,16 @@
 yanked = "deny"
 unmaintained = "none"
 unsound = "none"
+ignore = [
+    # RUSTSEC-2026-0245: path traversal in sevenz-rust's extraction helpers. There is no
+    # fixed version -- the project is abandoned and its repository deleted. PECOS does not
+    # call the affected helpers (`decompress`/`decompress_file` and their `decompress_impl`
+    # core). The single use site drives `SevenZReader` directly and resolves every entry
+    # name through `pecos_build::extract::contained_entry_path`, which rejects absolute
+    # names and `..` components before anything is written to disk; see
+    # crates/pecos-build/src/cuda/installer.rs. Revisit when the dependency is replaced.
+    { id = "RUSTSEC-2026-0245", reason = "affected helpers unused; entry names validated at the call site" },
+]
 
 [bans]
 multiple-versions = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -2,16 +2,6 @@
 yanked = "deny"
 unmaintained = "none"
 unsound = "none"
-ignore = [
-    # RUSTSEC-2026-0245: path traversal in sevenz-rust's extraction helpers. There is no
-    # fixed version -- the project is abandoned and its repository deleted. PECOS does not
-    # call the affected helpers (`decompress`/`decompress_file` and their `decompress_impl`
-    # core). The single use site drives `SevenZReader` directly and resolves every entry
-    # name through `pecos_build::extract::contained_entry_path`, which rejects absolute
-    # names and `..` components before anything is written to disk; see
-    # crates/pecos-build/src/cuda/installer.rs. Revisit when the dependency is replaced.
-    { id = "RUSTSEC-2026-0245", reason = "affected helpers unused; entry names validated at the call site" },
-]
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
## Why

`cargo deny` began failing on every branch after RUSTSEC-2026-0245 was published: a path-traversal in `sevenz-rust`, which the workspace depends on at `sevenz-rust = "0.6"`. The advisory has **no fixed version** — the project is abandoned and its repository deleted.

Investigating the advisory surfaced a more direct problem than the dependency itself. The advisory faults `sevenz-rust`'s convenience extractors for joining archive entry names onto the destination without validation. PECOS does not call those; it drives `SevenZReader` directly — and **reproduced the same flaw in its own callback**:

```rust
let file_path = dest.join(entry_name);   // entry_name is untrusted archive data
```

An archive entry named `../../../../home/user/.bashrc` or `/etc/cron.d/pwn` would therefore be written outside the extraction directory.

The other two extraction sites in the crate were already correct, which is what makes this one an outlier worth fixing rather than a policy question: the zip path uses `zip`'s `enclosed_name()`, and the tar path relies on `unpack`, which validates internally.

## What changed

- **`pecos_build::extract::contained_entry_path(dest, entry_name)`** — resolves an entry name inside a destination, rejecting absolute paths, `..` components, and empty names. It normalizes `\` to `/` first, so an archive authored on Windows cannot smuggle `..\..` past a Unix-only component walk. Placed in `extract.rs` beside the other archive utilities, with a doc note on why only readers lacking their own guard need it.
- **The CUDA Windows-installer extraction** now resolves every entry through that helper before creating anything on disk.
- **A documented `cargo deny` ignore for RUSTSEC-2026-0245**, stating precisely why PECOS is not exposed: the affected helpers are unused, and the one call site validates entry names itself. The comment points at the call site so the exception can be re-audited rather than trusted.

## Verification

- Six unit tests on the helper covering legitimate nested names, Windows separators, `..` escapes (four spellings including backslash forms), absolute paths, and empty names.
- **Mutation-tested**: removing the `..` rejection makes `parent_components_are_rejected` fail; restored and confirmed byte-identical.
- **Behavioural probe** against realistic attack names — `../../../../home/victim/.bashrc`, `/etc/cron.d/pwn`, `nvcc\..\..\..\evil.dll`, `cudart/../../escape.so` all blocked, `nvcc/bin/nvcc` still allowed.
- `cargo deny --locked --all-features check advisories bans sources` (the exact CI invocation): `advisories ok, bans ok, sources ok`.
- `cargo test -p pecos-build`, `cargo clippy --locked -p pecos-build --all-targets -- -D warnings`, `cargo fmt --all --check`, and `just lint` all clean.

Note: `cargo deny check licenses` fails, both here and on unmodified `dev` — there is no `[licenses]` section, so cargo-deny's default applies. CI does not run that check, so it is untouched and out of scope here.

## Follow-up left open

The dependency is still abandoned. Replacing it (a maintained fork, or dropping 7z support and asking Windows users to install CUDA themselves) is a dependency-policy decision worth making deliberately rather than inside a security fix; the ignore comment flags it. Separately, none of the three CUDA downloads carry a `sha256`, so archive integrity currently rests entirely on TLS — worth its own look.