### PR TITLE
Patch pymdown-extensions in exp/zlup and stop that lockfile drifting

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1174,6 +1174,7 @@ build-native: (build "native")
 [group('setup')]
 lock:
     uvx uv@{{uv-pin}} lock --project .
+    uvx uv@{{uv-pin}} lock --project exp/zlup
     uvx uv@{{uv-pin}} lock --project exp/zluppy
 
 # Regenerate all lockfiles from scratch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,9 +13,9 @@ The version is a literal in many coordinated places. Bump them all:
   `python/selene-plugins/*` packages)
 - Exact-version internal pins: the root's `quantum-pecos[cuda12/13]==...`
   entries and quantum-pecos's `pecos-rslib==...` / `pecos-rslib-llvm==...`
-- Regenerate both lockfiles: `just lock` (runs the pinned uv from
-  `.github/uv.toml` at the root and in `exp/zluppy/`; verify the diffs
-  are version-lines-only)
+- Regenerate all three lockfiles: `just lock` (runs the pinned uv from
+  `.github/uv.toml` at the root and in `exp/zlup/` and `exp/zluppy/`; verify
+  the diffs are version-lines-only)
 
 Verify: `git grep <old-version>` returns nothing outside this file's
 historical note; `uv lock --check` passes;

--- a/exp/zlup/uv.lock
+++ b/exp/zlup/uv.lock
@@ -431,15 +431,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`exp/zlup/uv.lock` pinned `pymdown-extensions` at 11.0, which carries PYSEC-2026-3654 / GHSA-gm37-52c6-37mw (CVSS 7.5, exponential-backtracking ReDoS in the caret, tilde, betterem and magiclink inline processors). It is the only unfiltered fixable finding in the OSV scan of `dev`; the root `uv.lock` was already on the patched 11.0.1.

The root cause is the `lock` recipe: it re-resolved the root and `exp/zluppy` lockfiles but not `exp/zlup`, so the third tracked lockfile only moved during a full `updatelocks`. This adds `exp/zlup` to `lock` and updates the release checklist, which described two lockfiles rather than three.

Verified: `uvx uv@0.11.16 lock --project exp/zlup --upgrade-package pymdown-extensions` produces a three-line diff (version plus the sdist and wheel hashes); a following `just lock` leaves the root and `exp/zluppy` lockfiles untouched; `just lint check` passes.