### PR TITLE
Bump Python packages to 0.10.0.dev0

### DIFF
--- a/exp/zluppy/uv.lock
+++ b/exp/zluppy/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "../../python/pecos-rslib" }
 
 [package.metadata]
@@ -554,7 +554,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "../../python/pecos-rslib-llvm" }
 
 [package.metadata]
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "../../python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-workspace"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 # Meta-package; runtime deps live in the member packages. Test/example/dev
 # tooling is declared in [dependency-groups] below.
@@ -10,8 +10,8 @@ dependencies = []
 # Keep these in sync with the cuda dependency groups below. The extras support
 # `uv sync --extra cuda13`; the groups support `uv run --group cuda13 ...`.
 # Pick the extra matching your CUDA major -- do not install both.
-cuda13 = ["quantum-pecos[cuda13]==0.9.0.dev3"]
-cuda12 = ["quantum-pecos[cuda12]==0.9.0.dev3"]
+cuda13 = ["quantum-pecos[cuda13]==0.10.0.dev0"]
+cuda12 = ["quantum-pecos[cuda12]==0.10.0.dev0"]
 
 [tool.uv.workspace]
 members = [
@@ -70,10 +70,10 @@ numpy-compat = [ # NumPy/SciPy compatibility tests - verify compatibility with s
   "scipy>=1.1.0",
 ]
 cuda13 = [ # CUDA 13 Python packages for GPU-accelerated simulations (requires CUDA toolkit)
-  "quantum-pecos[cuda13]==0.9.0.dev3",
+  "quantum-pecos[cuda13]==0.10.0.dev0",
 ]
 cuda12 = [ # CUDA 12 Python packages for GPU-accelerated simulations
-  "quantum-pecos[cuda12]==0.9.0.dev3",
+  "quantum-pecos[cuda12]==0.10.0.dev0",
 ]
 
 [tool.uv]

--- a/python/pecos-rslib-cuda/pyproject.toml
+++ b/python/pecos-rslib-cuda/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 description = "CUDA/cuQuantum Python bindings for PECOS quantum simulators (Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-exp/pyproject.toml
+++ b/python/pecos-rslib-exp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 description = "Python bindings for experimental PECOS simulators (StabMps, Mast)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib-llvm/pyproject.toml
+++ b/python/pecos-rslib-llvm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 description = "LLVM IR generation Python bindings for PECOS (llvmlite-compatible API, Rust implementation)."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/pecos-rslib/pyproject.toml
+++ b/python/pecos-rslib/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-rslib"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 description = "Rust libary extensions for Python PECOS."
 authors = [
     {name = "The PECOS Developers"},

--- a/python/quantum-pecos/pyproject.toml
+++ b/python/quantum-pecos/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quantum-pecos"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 authors = [
     {name = "The PECOS Developers"},
 ]
@@ -28,8 +28,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE"}
 keywords = ["quantum", "QEC", "simulation", "PECOS"]
 dependencies = [
-    "pecos-rslib==0.9.0.dev3",
-    "pecos-rslib-llvm==0.9.0.dev3",
+    "pecos-rslib==0.10.0.dev0",
+    "pecos-rslib-llvm==0.10.0.dev0",
     "phir>=0.3.3",
     "networkx>=2.1.0",
     # Pin to the 0.21.x line (tket.bool era). guppylang 0.22+ emits the

--- a/python/selene-plugins/pecos-selene-mast/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-mast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-mast"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS Mast simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-mps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StabMps simulator plugin for the Selene quantum emulator"
 license = "Apache-2.0"

--- a/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stab-vec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StabVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-stabilizer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS Stabilizer simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/python/selene-plugins/pecos-selene-statevec/pyproject.toml
+++ b/python/selene-plugins/pecos-selene-statevec/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 requires-python = ">=3.10"
 description = "PECOS StateVec simulator plugin for the Selene quantum emulator"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3081,7 +3081,7 @@ wheels = [
 
 [[package]]
 name = "pecos-rslib"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/pecos-rslib" }
 
 [package.dev-dependencies]
@@ -3112,7 +3112,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-cuda"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/pecos-rslib-cuda" }
 
 [package.dev-dependencies]
@@ -3128,12 +3128,12 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-rslib-exp"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/pecos-rslib-exp" }
 
 [[package]]
 name = "pecos-rslib-llvm"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/pecos-rslib-llvm" }
 
 [package.dev-dependencies]
@@ -3149,7 +3149,7 @@ test = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "pecos-selene-mast"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-mast" }
 dependencies = [
     { name = "selene-core" },
@@ -3173,7 +3173,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-mps"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stab-mps" }
 dependencies = [
     { name = "selene-core" },
@@ -3197,7 +3197,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stab-vec"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stab-vec" }
 dependencies = [
     { name = "selene-core" },
@@ -3221,7 +3221,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-stabilizer"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-stabilizer" }
 dependencies = [
     { name = "selene-core" },
@@ -3245,7 +3245,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-selene-statevec"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/selene-plugins/pecos-selene-statevec" }
 dependencies = [
     { name = "selene-core" },
@@ -3269,7 +3269,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "pecos-workspace"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -4211,7 +4211,7 @@ wheels = [
 
 [[package]]
 name = "quantum-pecos"
-version = "0.9.0.dev3"
+version = "0.10.0.dev0"
 source = { editable = "python/quantum-pecos" }
 dependencies = [
     { name = "guppylang" },


### PR DESCRIPTION
Version-only change: every workspace manifest moves from 0.9.0.dev3 to 0.10.0.dev0, along with both sets of exact internal pins (the root's `quantum-pecos[cuda12/13]==` entries and quantum-pecos's `pecos-rslib==` / `pecos-rslib-llvm==`), and the lockfiles are re-resolved.

A minor bump rather than another dev increment, per the versioning convention in `RELEASING.md`: the work since the `py-0.9.0.dev3` tag changes user-visible default behavior rather than only adding to it. `remove_identity` was removed from the typed surface and split into unitary-identity removal plus `strip_idles` (#445); the idle-noise vocabulary was realigned across DEM, engines and neo so the requested Pauli channel is the one emitted (#420); DEM batch sampling was consolidated onto `SampleBatch`, changing call sites in the shipped examples (#452). No 0.9.0 final was ever tagged, so nothing is skipped by moving the minor number.

Verified: 12 manifests updated with no `0.9.0.dev3` left anywhere in the tree; `just lock` produces a 14-line diff in which every changed line is a `version = ` line, with no dependency or marker churn; `uv lock --check` passes for the root, `exp/zlup` and `exp/zluppy`; after `just python-ci-sync-test`, `quantum-pecos`, `pecos-rslib` and `pecos-rslib-llvm` all report 0.10.0.dev0 and `pecos.__version__` is 0.10.0.dev0; `just lint check` passes.

The "last exercised" note at the top of `RELEASING.md` is deliberately left alone; it should move once this version has actually been through the publish sequence.