### PR TITLE
Record the 0.10.0.dev0 release run in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 The final PyPI push is deliberately **manual**: artifact building and testing
 are automated, but a human runs the upload and confirms each package. This
-sequence was last exercised for `0.9.0.dev1`.
+sequence was last exercised for `0.10.0.dev0`.
 
 ## 1. Version bump (its own PR)
 
@@ -51,14 +51,23 @@ ref.
 ## 4. Download the bundle and dry-run
 
 ```
-gh run download <tag-run-id> -n pecos-distribution -D pecos-distribution
-./scripts/publish-wheels.sh --dry-run -f pecos-distribution
+gh run download <tag-run-id> -n pecos-distribution -D pecos-distribution-<version>
+./scripts/publish-wheels.sh --dry-run -f pecos-distribution-<version>
 ```
 
 (`-f` accepts the extracted directory `gh` produces, or the original zip.)
 
+Download into a version-suffixed directory. A previous release's bundle left in
+a plain `pecos-distribution/` would mix two versions in one directory, and the
+preflight -- complete set, consistent version, only expected files -- is the
+only thing standing between that and a stray upload.
+
 The dry run must show a real `twine check ... PASSED` per file (twine must be
-installed, e.g. `uv tool install twine`).
+installed, e.g. `uv tool install twine`). The script prints only a
+`Distribution checks passed` summary and swallows `twine check` output unless it
+fails, so confirm the per-file result directly:
+`uvx twine check pecos-distribution-<version>/*/*.whl pecos-distribution-<version>/*/*.tar.gz`
+and check the `PASSED` count equals the file count.
 
 ## 5. Publish (the manual step)
 


### PR DESCRIPTION
The header note said the publish sequence was last exercised for 0.9.0.dev1; it has now been walked end to end for 0.10.0.dev0, so the note moves.

Two additions to step 4, both from friction hit during that run:

- Download the bundle into a version-suffixed directory. The previous release's bundle was still sitting in a plain `pecos-distribution/`, and downloading on top of it would have mixed two versions in one directory, leaving the preflight as the only guard against a stray upload.
- The checklist requires a real `twine check ... PASSED` per file, but `publish-wheels.sh` prints only a `Distribution checks passed` summary and discards `twine check` output unless it fails. The step now gives the command to confirm the per-file result directly and says to compare the `PASSED` count against the file count.