### PR TITLE
Migrate dem_decomposition_diagnostics off runtime NumPy (#458 step 3a)

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -146,6 +146,7 @@ Map the dtype used by the migrated code as follows:
 | NumPy dtype | PECOS dtype |
 |-------------|-------------|
 | `np.uint8`  | `dtypes.uint8` |
+| `np.float64` or `float` | `dtypes.float64` |
 
 Use `Array` in annotations and enter the native layer with `asarray()` when an external API returns an array-like
 object. Constructors and casts take PECOS dtypes, for example `zeros(size, dtype=dtypes.uint8)` and
@@ -170,6 +171,15 @@ assert flat == [1, 0, 0, 1]
   rejected, even though NumPy treats any single negative dimension as inferred.
 - `fill()` does not coerce values by truthiness or parse numeric strings. Convert values
   explicitly instead of relying on behavior such as a non-empty string becoming `True`.
+
+Three more migration boundaries currently need local workarounds:
+
+- Advanced indexed assignment and boolean-mask reads are not available yet (#482). Use scalar
+  assignment or explicit selection locally, and collapse the workaround when indexed access lands.
+- Elementwise `Array ^ Array` is not available yet (#458). For arrays already known to contain only
+  binary values, elementwise inequality has the same result; do not use that substitution for general integers.
+- Spell NumPy's `dtype=float` as `dtype=dtypes.float64`, especially with `asarray()`, to preserve
+  NumPy's 64-bit width explicitly.
 
 Elementwise comparison returns a boolean `Array`, and `array_sum()` accepts it directly -- counting
 mismatches needs no cast:

--- a/examples/surface/dem_decomposition_diagnostics.py
+++ b/examples/surface/dem_decomposition_diagnostics.py
@@ -21,9 +21,13 @@ import re
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
+from pecos import array, asarray, dtypes, zeros
+from pecos import sum as array_sum
+
+if TYPE_CHECKING:
+    from pecos import Array
 
 ERROR_RE = re.compile(r"error\(([^)]+)\)\s*(.*)")
 DET_RE = re.compile(r"\bD(\d+)\b")
@@ -343,32 +347,35 @@ def strip_logical_observable_lines(dem_text: str) -> str:
     return "\n".join(line for line in dem_text.splitlines() if not line.startswith("logical_observable"))
 
 
-def true_observable_flips(observable_flips: np.ndarray) -> np.ndarray:
+def true_observable_flips(observable_flips: Array) -> Array:
+    observable_flips = asarray(observable_flips)
     if observable_flips.ndim == 1:
-        return observable_flips.astype(np.uint8)
+        return observable_flips.astype(dtypes.uint8)
     if observable_flips.shape[1] == 0:
-        return np.zeros(observable_flips.shape[0], dtype=np.uint8)
-    return observable_flips[:, 0].astype(np.uint8)
+        return zeros(observable_flips.shape[0], dtype=dtypes.uint8)
+    return observable_flips[:, 0].astype(dtypes.uint8)
 
 
-def dense_effect_arrays(effects: dict[str, float]) -> tuple[list[str], np.ndarray, np.ndarray, np.ndarray]:
+def dense_effect_arrays(effects: dict[str, float]) -> tuple[list[str], Array, Array, Array]:
     """Convert effect keys into dense detector rows and observable flips."""
     keys = list(effects)
-    probabilities = np.array([effects[key] for key in keys], dtype=float)
+    probabilities = array([effects[key] for key in keys], dtype=dtypes.float64)
     max_detector = max((int(detector) for key in keys for detector in DET_RE.findall(key)), default=-1)
-    detection_events = np.zeros((len(keys), max_detector + 1), dtype=np.uint8)
-    observable_flips = np.zeros(len(keys), dtype=np.uint8)
+    detection_events = zeros((len(keys), max_detector + 1), dtype=dtypes.uint8)
+    observable_flips = zeros(len(keys), dtype=dtypes.uint8)
 
     for index, key in enumerate(keys):
         detectors = [int(detector) for detector in DET_RE.findall(key)]
         if detectors:
-            detection_events[index, detectors] = 1
+            # Collapse to one indexed assignment when Array fancy assignment lands in #482.
+            for detector in detectors:
+                detection_events[index, detector] = 1
         observable_flips[index] = 1 if "0" in OBS_RE.findall(key) else 0
 
     return keys, probabilities, detection_events, observable_flips
 
 
-def tesseract_predictions(dem_text: str, detection_events: np.ndarray, *, beam: int) -> np.ndarray:
+def tesseract_predictions(dem_text: str, detection_events: Array, *, beam: int) -> Array:
     from pecos.decoders import TesseractDecoder
 
     decoder = TesseractDecoder.from_dem(
@@ -377,10 +384,10 @@ def tesseract_predictions(dem_text: str, detection_events: np.ndarray, *, beam: 
         det_beam=beam,
     )
     results = decoder.decode_batch([row.tolist() for row in detection_events])
-    return np.array([int(result.observable_flips[0]) for result in results], dtype=np.uint8)
+    return array([int(result.observable_flips[0]) for result in results], dtype=dtypes.uint8)
 
 
-def pymatching_predictions(dem_text: str, detection_events: np.ndarray, *, correlated: bool) -> np.ndarray:
+def pymatching_predictions(dem_text: str, detection_events: Array, *, correlated: bool) -> Array:
     from pecos.decoders import PyMatchingDecoder
 
     if correlated:
@@ -388,34 +395,34 @@ def pymatching_predictions(dem_text: str, detection_events: np.ndarray, *, corre
     else:
         decoder = PyMatchingDecoder.from_dem(dem_text)
     predictions = decoder.decode_batch(
-        detection_events.astype(np.uint8).flatten().tolist(),
+        detection_events.astype(dtypes.uint8).flatten().tolist(),
         len(detection_events),
     )
-    return np.array([prediction[0] if prediction else 0 for prediction in predictions], dtype=np.uint8)
+    return array([prediction[0] if prediction else 0 for prediction in predictions], dtype=dtypes.uint8)
 
 
 def decode_with_tesseract(
     dem_text: str,
-    detection_events: np.ndarray,
-    observable_flips: np.ndarray,
+    detection_events: Array,
+    observable_flips: Array,
     *,
     beam: int,
 ) -> int:
     expected = true_observable_flips(observable_flips)
     predicted = tesseract_predictions(dem_text, detection_events, beam=beam)
-    return int(np.sum(predicted != expected))
+    return int(array_sum(predicted != expected))
 
 
 def decode_with_pymatching(
     dem_text: str,
-    detection_events: np.ndarray,
-    observable_flips: np.ndarray,
+    detection_events: Array,
+    observable_flips: Array,
     *,
     correlated: bool,
 ) -> int:
     expected = true_observable_flips(observable_flips)
     predicted = pymatching_predictions(dem_text, detection_events, correlated=correlated)
-    return int(np.sum(predicted != expected))
+    return int(array_sum(predicted != expected))
 
 
 def _timed_decode(label: str, callback: Any, shots: int) -> DecodeSummary:
@@ -444,22 +451,23 @@ def two_fault_pair_analysis(
     if len(keys) > max_effects:
         return None
 
-    pair_rows: list[np.ndarray] = []
+    pair_rows: list[Array] = []
     pair_observables: list[int] = []
     pair_weights: list[float] = []
     for left in range(len(keys)):
         for right in range(left + 1, len(keys)):
-            pair_rows.append(detection_events[left] ^ detection_events[right])
+            # Collapse this binary XOR workaround when Array XOR support lands under #458.
+            pair_rows.append(asarray(detection_events[left] != detection_events[right], dtype=dtypes.uint8))
             pair_observables.append(int(observable_flips[left] ^ observable_flips[right]))
             pair_weights.append(float(probabilities[left] * probabilities[right]))
 
     if not pair_rows:
         return []
 
-    pair_detection_events = np.asarray(pair_rows, dtype=np.uint8)
-    pair_observable_flips = np.asarray(pair_observables, dtype=np.uint8)
-    weights = np.asarray(pair_weights, dtype=float)
-    total_weight = float(np.sum(weights))
+    pair_detection_events = asarray(pair_rows, dtype=dtypes.uint8)
+    pair_observable_flips = asarray(pair_observables, dtype=dtypes.uint8)
+    weights = asarray(pair_weights, dtype=dtypes.float64)
+    total_weight = float(array_sum(weights))
 
     predictions = {
         "native_raw_tesseract_b5": tesseract_predictions(native_raw, pair_detection_events, beam=5),
@@ -500,8 +508,17 @@ def two_fault_pair_analysis(
     for name, predicted in predictions.items():
         wrong = predicted != pair_observable_flips
         disagree = predicted != reference
-        wrong_mass = float(np.sum(weights[wrong]))
-        disagree_mass = float(np.sum(weights[disagree]))
+        # Collapse these selections to boolean-mask indexing when #482 covers Array reads.
+        wrong_weights = asarray(
+            [weight for weight, selected in zip(weights, wrong, strict=True) if selected],
+            dtype=dtypes.float64,
+        )
+        disagree_weights = asarray(
+            [weight for weight, selected in zip(weights, disagree, strict=True) if selected],
+            dtype=dtypes.float64,
+        )
+        wrong_mass = float(array_sum(wrong_weights))
+        disagree_mass = float(array_sum(disagree_weights))
         summaries.append(
             PairAnalysisSummary(
                 decoder=name,
@@ -510,8 +527,8 @@ def two_fault_pair_analysis(
                 wrong_probability_fraction=wrong_mass / total_weight if total_weight else 0.0,
                 disagree_tesseract_probability_mass=disagree_mass,
                 disagree_tesseract_probability_fraction=disagree_mass / total_weight if total_weight else 0.0,
-                wrong_count=int(np.sum(wrong)),
-                disagree_tesseract_count=int(np.sum(disagree)),
+                wrong_count=int(array_sum(wrong)),
+                disagree_tesseract_count=int(array_sum(disagree)),
             ),
         )
     return summaries

--- a/python/quantum-pecos/tests/qec/test_dem_decomposition_diagnostics.py
+++ b/python/quantum-pecos/tests/qec/test_dem_decomposition_diagnostics.py
@@ -1,0 +1,345 @@
+# Copyright 2026 The PECOS Developers
+# Licensed under the Apache License, Version 2.0
+
+"""NumPy-oracle tests for the DEM decomposition diagnostics example."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import numpy as np
+import pecos.decoders
+from pecos import asarray, dtypes
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "Justfile").is_file() and (candidate / "examples").is_dir():
+            return candidate
+    msg = f"Could not locate repo root above {current}"
+    raise RuntimeError(msg)
+
+
+def _load_diagnostics_module() -> ModuleType:
+    module_path = _repo_root() / "examples" / "surface" / "dem_decomposition_diagnostics.py"
+    module_name = "_dem_decomposition_diagnostics_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load diagnostics module from {module_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _fixed_seed_dems() -> tuple[str, str]:
+    rng = np.random.default_rng(20260811)
+    probabilities = rng.uniform(0.001, 0.2, size=6)
+    native_dem = "\n".join(
+        [
+            "detector(0, 0) D0",
+            f"error({probabilities[0]:.17g}) D0 D2 ^ D4 L0",
+            f"error({probabilities[1]:.17g}) D1 L0",
+            f"error({probabilities[2]:.17g}) D3",
+            f"error({probabilities[3]:.17g}) D3",
+            "logical_observable L0",
+        ],
+    )
+    stim_dem = "\n".join(
+        [
+            "detector(0, 0) D0",
+            f"error({probabilities[4]:.17g}) D0 D2 D4 L0",
+            f"error({probabilities[5]:.17g}) D5",
+            "logical_observable L0",
+        ],
+    )
+    return native_dem, stim_dem
+
+
+def test_dem_stats_and_compare_raw_dems_match_captured_fixed_seed_values() -> None:
+    diagnostics = _load_diagnostics_module()
+    native_dem, stim_dem = _fixed_seed_dems()
+    comparison_native_dem = "\n".join(native_dem.splitlines()[1:3])
+    comparison_stim_dem = "\n".join(stim_dem.splitlines()[1:3])
+
+    assert asdict(diagnostics.dem_stats(native_dem)) == {
+        "error_lines": 4,
+        "probability_sum": 0.34778671791333904,
+        "separator_lines": 1,
+        "hyperedge_lines": 1,
+        "logical_lines": 2,
+        "max_component_detectors": 2,
+        "max_line_detectors": 3,
+        "pure_logical_components": 0,
+    }
+    assert asdict(diagnostics.dem_stats(stim_dem)) == {
+        "error_lines": 2,
+        "probability_sum": 0.21691480573842542,
+        "separator_lines": 0,
+        "hyperedge_lines": 1,
+        "logical_lines": 1,
+        "max_component_detectors": 3,
+        "max_line_detectors": 3,
+        "pure_logical_components": 0,
+    }
+    assert asdict(diagnostics.compare_raw_dems(comparison_native_dem, comparison_stim_dem)) == {
+        "native_errors": 2,
+        "stim_errors": 2,
+        "only_native": 1,
+        "only_stim": 1,
+        "common": 1,
+        "max_abs_probability_diff": 0.04490873066068533,
+        "max_rel_probability_diff": 0.44347431107696206,
+        "l1_probability_diff": 0.21975757274400112,
+    }
+
+
+def test_dense_effect_arrays_matches_fixed_seed_numpy_oracle() -> None:
+    diagnostics = _load_diagnostics_module()
+    rng = np.random.default_rng(20260811)
+    effects = {
+        "D0 D3 L0": float(rng.uniform(0.001, 0.2)),
+        "D1": float(rng.uniform(0.001, 0.2)),
+        "D2 D4": float(rng.uniform(0.001, 0.2)),
+    }
+
+    expected_probabilities = np.array(list(effects.values()), dtype=float)
+    expected_detection_events = np.zeros((3, 5), dtype=np.uint8)
+    expected_detection_events[0, [0, 3]] = 1
+    expected_detection_events[1, [1]] = 1
+    expected_detection_events[2, [2, 4]] = 1
+    expected_observable_flips = np.array([1, 0, 0], dtype=np.uint8)
+
+    keys, probabilities, detection_events, observable_flips = diagnostics.dense_effect_arrays(effects)
+
+    assert keys == list(effects)
+    assert probabilities.dtype == dtypes.float64
+    assert detection_events.dtype == dtypes.uint8
+    assert observable_flips.dtype == dtypes.uint8
+    assert probabilities.tolist() == expected_probabilities.tolist()
+    assert detection_events.tolist() == expected_detection_events.tolist()
+    assert observable_flips.tolist() == expected_observable_flips.tolist()
+
+
+def test_true_observable_flips_matches_numpy_oracle() -> None:
+    diagnostics = _load_diagnostics_module()
+    rng = np.random.default_rng(20260811)
+    numpy_cases = [
+        rng.integers(0, 2, size=9, dtype=np.uint8),
+        np.zeros((9, 0), dtype=np.uint8),
+        rng.integers(0, 2, size=(9, 3), dtype=np.uint8),
+    ]
+
+    for numpy_case in numpy_cases:
+        if numpy_case.ndim == 1:
+            expected = numpy_case.astype(np.uint8)
+        elif numpy_case.shape[1] == 0:
+            expected = np.zeros(numpy_case.shape[0], dtype=np.uint8)
+        else:
+            expected = numpy_case[:, 0].astype(np.uint8)
+        actual = diagnostics.true_observable_flips(numpy_case)
+        assert actual.dtype == dtypes.uint8
+        assert actual.tolist() == expected.tolist()
+
+
+@dataclass(frozen=True)
+class _FakeTesseractResult:
+    observable_flips: list[int]
+
+
+class _FakeTesseractDecoder:
+    prediction_bits: ClassVar[list[int]] = []
+    seen_rows: ClassVar[list[list[int]] | None] = None
+
+    @classmethod
+    def from_dem(cls, dem_text: str, *, preset: str, det_beam: int) -> _FakeTesseractDecoder:
+        assert dem_text == "fixed-seed-dem"
+        assert preset == "fast"
+        assert det_beam == 7
+        return cls()
+
+    def decode_batch(self, rows: list[list[int]]) -> list[_FakeTesseractResult]:
+        type(self).seen_rows = rows
+        return [_FakeTesseractResult([bit]) for bit in type(self).prediction_bits]
+
+
+class _FakePyMatchingDecoder:
+    predictions: ClassVar[list[list[int]]] = []
+    seen_flat: ClassVar[list[int] | None] = None
+    expected_shots: ClassVar[int] = 0
+
+    @classmethod
+    def from_dem(cls, dem_text: str) -> _FakePyMatchingDecoder:
+        assert dem_text == "fixed-seed-dem"
+        return cls()
+
+    @classmethod
+    def from_dem_with_correlations(
+        cls,
+        dem_text: str,
+        *,
+        enable_correlations: bool,
+    ) -> _FakePyMatchingDecoder:
+        assert dem_text == "fixed-seed-dem"
+        assert enable_correlations is True
+        return cls()
+
+    def decode_batch(self, flat: list[int], num_shots: int) -> list[list[int]]:
+        type(self).seen_flat = flat
+        assert num_shots == type(self).expected_shots
+        return type(self).predictions
+
+
+def test_decoder_predictions_and_reductions_match_fixed_seed_numpy_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diagnostics = _load_diagnostics_module()
+    rng = np.random.default_rng(20260811)
+    shots = 19
+    numpy_events = rng.integers(0, 2, size=(shots, 6), dtype=np.uint8)
+    numpy_observables = rng.integers(0, 2, size=(shots, 1), dtype=np.uint8)
+    tesseract_bits = rng.integers(0, 2, size=shots, dtype=np.uint8)
+    pymatching_bits = rng.integers(0, 2, size=shots, dtype=np.uint8)
+    pymatching_predictions = [[] if index % 5 == 0 else [int(bit)] for index, bit in enumerate(pymatching_bits)]
+    normalized_pymatching_bits = np.array(
+        [prediction[0] if prediction else 0 for prediction in pymatching_predictions],
+        dtype=np.uint8,
+    )
+
+    _FakeTesseractDecoder.prediction_bits = tesseract_bits.tolist()
+    _FakeTesseractDecoder.seen_rows = None
+    _FakePyMatchingDecoder.predictions = pymatching_predictions
+    _FakePyMatchingDecoder.seen_flat = None
+    _FakePyMatchingDecoder.expected_shots = shots
+    monkeypatch.setattr(pecos.decoders, "TesseractDecoder", _FakeTesseractDecoder)
+    monkeypatch.setattr(pecos.decoders, "PyMatchingDecoder", _FakePyMatchingDecoder)
+
+    events = asarray(numpy_events, dtype=dtypes.uint8)
+    observables = asarray(numpy_observables, dtype=dtypes.uint8)
+    expected = numpy_observables[:, 0].astype(np.uint8)
+
+    tesseract_errors = diagnostics.decode_with_tesseract(
+        "fixed-seed-dem",
+        events,
+        observables,
+        beam=7,
+    )
+    pymatching_errors = diagnostics.decode_with_pymatching(
+        "fixed-seed-dem",
+        events,
+        observables,
+        correlated=True,
+    )
+
+    assert tesseract_errors == int(np.sum(tesseract_bits != expected)) == 9
+    assert pymatching_errors == int(np.sum(normalized_pymatching_bits != expected)) == 13
+    assert _FakeTesseractDecoder.seen_rows == numpy_events.tolist()
+    assert _FakePyMatchingDecoder.seen_flat == numpy_events.astype(np.uint8).flatten().tolist()
+    assert _FakePyMatchingDecoder.seen_flat is not None
+    assert all(type(value) is int for value in _FakePyMatchingDecoder.seen_flat)
+
+
+def test_two_fault_pair_analysis_matches_numpy_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    diagnostics = _load_diagnostics_module()
+    probabilities = np.array([0.03125, 0.0625, 0.125, 0.25], dtype=float)
+    native_raw = "\n".join(
+        [
+            f"error({probabilities[0]:.17g}) D0 L0",
+            f"error({probabilities[1]:.17g}) D1",
+            f"error({probabilities[2]:.17g}) D0 D2",
+            f"error({probabilities[3]:.17g}) D2 L0",
+        ],
+    )
+    variant_offsets = {
+        ("native", False): 0,
+        ("native", True): 1,
+        ("stim", False): 1,
+        ("stim", True): 0,
+        ("terminal", False): 0,
+        ("terminal", True): 1,
+    }
+
+    def predictions(events: object, offset: int) -> object:
+        numpy_events = np.asarray(events.tolist(), dtype=np.uint8)
+        bits = (np.sum(numpy_events, axis=1) + offset) % 2
+        return asarray(bits.astype(np.uint8), dtype=dtypes.uint8)
+
+    def fake_tesseract(dem_text: str, detection_events: object, *, beam: int) -> object:
+        assert dem_text == native_raw
+        assert beam == 5
+        return predictions(detection_events, 0)
+
+    def fake_pymatching(dem_text: str, detection_events: object, *, correlated: bool) -> object:
+        return predictions(detection_events, variant_offsets[(dem_text, correlated)])
+
+    monkeypatch.setattr(diagnostics, "tesseract_predictions", fake_tesseract)
+    monkeypatch.setattr(diagnostics, "pymatching_predictions", fake_pymatching)
+
+    actual = diagnostics.two_fault_pair_analysis(
+        native_raw=native_raw,
+        native_decomposed="native",
+        stim_decomposed="stim",
+        terminal_decomposed="terminal",
+        max_effects=4,
+    )
+
+    event_rows = np.array([[1, 0, 0], [0, 1, 0], [1, 0, 1], [0, 0, 1]], dtype=np.uint8)
+    observable_flips = np.array([1, 0, 0, 1], dtype=np.uint8)
+    pair_rows = []
+    pair_observables = []
+    pair_weights = []
+    for left in range(4):
+        for right in range(left + 1, 4):
+            pair_rows.append(event_rows[left] ^ event_rows[right])
+            pair_observables.append(observable_flips[left] ^ observable_flips[right])
+            pair_weights.append(probabilities[left] * probabilities[right])
+    pair_rows_array = np.asarray(pair_rows, dtype=np.uint8)
+    pair_observables_array = np.asarray(pair_observables, dtype=np.uint8)
+    pair_weights_array = np.asarray(pair_weights, dtype=float)
+    reference = (np.sum(pair_rows_array, axis=1) % 2).astype(np.uint8)
+    expected_predictions = {
+        "native_raw_tesseract_b5": reference,
+        "native_decomp_pymatching": reference,
+        "native_decomp_pymatching_correlated": 1 - reference,
+        "stim_decomp_pymatching": 1 - reference,
+        "stim_decomp_pymatching_correlated": reference,
+        "terminal_decomp_pymatching": reference,
+        "terminal_decomp_pymatching_correlated": 1 - reference,
+    }
+    total_weight = float(np.sum(pair_weights_array))
+    expected = []
+    for name, predicted in expected_predictions.items():
+        wrong = predicted != pair_observables_array
+        disagree = predicted != reference
+        wrong_mass = float(np.sum(pair_weights_array[wrong]))
+        disagree_mass = float(np.sum(pair_weights_array[disagree]))
+        expected.append(
+            {
+                "decoder": name,
+                "pair_probability_mass": total_weight,
+                "wrong_probability_mass": wrong_mass,
+                "wrong_probability_fraction": wrong_mass / total_weight,
+                "disagree_tesseract_probability_mass": disagree_mass,
+                "disagree_tesseract_probability_fraction": disagree_mass / total_weight,
+                "wrong_count": int(np.sum(wrong)),
+                "disagree_tesseract_count": int(np.sum(disagree)),
+            },
+        )
+
+    assert actual is not None
+    assert [asdict(summary) for summary in actual] == expected

--- a/ruff.toml
+++ b/ruff.toml
@@ -120,7 +120,6 @@ ignore = [
 # Do not add to it: new non-test NumPy use is the thing the ban exists to stop.
 # (decode.py's TID251 lives in its existing entry further down, to avoid a duplicate key.)
 "python/quantum-pecos/src/pecos/qec/reliable_observables.py" = ["TID251"]
-"examples/surface/dem_decomposition_diagnostics.py" = ["TID251"]
 "examples/surface/native_dem_threshold_sweep.py" = ["TID251"]
 "examples/measurement_throughput_benchmark.ipynb" = ["TID251"]
 "examples/surface_code_experiments.ipynb" = ["TID251"]


### PR DESCRIPTION
## Summary

#458 step 3a: `examples/surface/dem_decomposition_diagnostics.py` off runtime NumPy -- 28 sites,
now zero. Its allowlist entry in `ruff.toml` is deleted, so the #460 ban enforces the file with
no exemption.

This file matters beyond its own count: it is imported by
`graphlike_dem_projection_benchmark.py` (migrated in step 2) and `szz_circuit_quality_report.py`,
both otherwise NumPy-free. It was the last **transitive** runtime NumPy import for all three, so
that cluster is now genuinely clean rather than clean-on-paper.

`native_dem_threshold_sweep.py` is deliberately untouched (still 25 sites): its bootstrap needs
`rng.binomial(n, p, size=...)`, which the native layer lacks -- #481.

## Equivalence

Deterministic code, so the bar is exact equality, captured before the change and asserted after.
Seed `20260811`, base file vs migrated file compared directly: **`exact_equal = true`** across
`error_lines`, `probability_sum` (to full precision), `separator_lines`, `hyperedge_lines`,
`logical_lines`, `max_component_detectors`, `max_line_detectors`, and
`pure_logical_components`, for both the native and stim DEM paths. Pinned in
`python/quantum-pecos/tests/qec/test_dem_decomposition_diagnostics.py` against `dem_stats` and
`compare_raw_dems` -- the two functions the other scripts import.

## Layer gaps this surfaced (the point of migrating real code)

| gap | issue | handling here |
|---|---|---|
| indexed ("fancy") assignment `a[i, [j, k]] = 1` | #482 | explicit loop at the one site, commented with the issue number |
| boolean-mask reads | #482 | explicit selection, same treatment |
| `Array ^ Array` | noted in #458 | binary inequality locally |
| **`dtype=float` yields float32, silently** | **#483** | spelled `dtypes.float64` explicitly |
| `random.binomial` | #481 | out of scope -- that file is fenced off |

#483 is the one worth reading: `asarray([1.0 + 2**-30], dtype=float)` returns `[1.0]` -- silent
precision loss on a spelling every Python programmer expects to mean float64. Scoped by
execution to `float` alone; `int`, `bool`, and `complex` map correctly.

The first implementation attempt STOPPED rather than substitute blindly, having found that
`np.zeros` -> `zeros` would make a reachable path throw. The interim loop was authorized
deliberately and is marked, not silently introduced.

## Verification

qec **1494** passed; rslib **1539**; docs **271** passed, 0 failed; both importing scripts run;
`ruff check` clean with the allowlist entry removed; pre-commit two passes exit 0; Rust untouched.
