### PR TITLE
Map the float dtype alias to float64 (#483)

### DIFF
--- a/python/pecos-rslib/src/dtypes.rs
+++ b/python/pecos-rslib/src/dtypes.rs
@@ -516,7 +516,11 @@ impl DType {
             "paulistring" => Ok(DType::PauliString),
             // Common aliases
             "double" => Ok(DType::F64),
-            "float" => Ok(DType::F32),
+            // Python's builtin `float` is 64-bit, and the `dtypes.float` member is
+            // registered as F64; mapping the *name* to F32 here made
+            // `asarray(x, dtype=float)` and `dtype="float"` silently halve precision
+            // while `dtype=dtypes.float` did not. See #483.
+            "float" => Ok(DType::F64),
             "long" | "int" => Ok(DType::I64),
             _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "Unknown dtype: {s}"

--- a/python/pecos-rslib/tests/test_native_numeric_gaps.py
+++ b/python/pecos-rslib/tests/test_native_numeric_gaps.py
@@ -959,3 +959,41 @@ def test_zero_dimensional_default_axis_reductions_match_numpy(dtype_name: str) -
     else:
         assert num.max(pecos_arr) == complex(np.max(np_arr))
         assert num.min(pecos_arr) == complex(np.min(np_arr))
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        (float, "float64"),
+        ("float", "float64"),
+        ("double", "float64"),
+        (int, "int64"),
+        ("int", "int64"),
+        (bool, "bool"),
+        (complex, "complex128"),
+        ("complex", "complex128"),
+    ],
+)
+def test_dtype_aliases_resolve_to_the_same_width_as_python(alias: object, expected: str) -> None:
+    """Builtin and string dtype aliases must match Python's own widths.
+
+    `from_str("float")` returned F32 while the `dtypes.float` member was F64, so
+    `asarray(x, dtype=float)` silently halved precision -- the module disagreed
+    with itself depending on which spelling reached it (#483).
+    """
+    assert str(pc.asarray([1], dtype=alias).dtype) == expected
+
+
+@pytest.mark.parametrize("alias", [float, "float", "double"])
+def test_float_aliases_preserve_double_precision(alias: object) -> None:
+    """A value needing more than 24 bits of mantissa must survive."""
+    value = 1.0 + 2**-30
+    assert pc.asarray([value], dtype=alias).tolist() == [value]
+    assert np.asarray([value], dtype=float).tolist() == [value]
+
+
+def test_dtype_member_and_builtin_agree_for_every_alias() -> None:
+    """The member spelling and the builtin must never diverge again."""
+    for name, builtin in [("float", float), ("int", int), ("bool", bool), ("complex", complex)]:
+        member = getattr(dtypes, name)
+        assert str(pc.asarray([1], dtype=member).dtype) == str(pc.asarray([1], dtype=builtin).dtype)


### PR DESCRIPTION
## Summary

Closes #483. `asarray(x, dtype=float)` returned a **float32** array, silently halving precision
on the spelling every Python programmer expects to mean float64.

```python
v = 1.0 + 2**-30
asarray([v], dtype=float).tolist()   # was [1.0]                 -- precision gone, no error
                                     # now [1.0000000009313226]  -- matches NumPy
```

## Root cause: the module disagreed with itself

`dtypes.rs:4295` registers the `dtypes.float` member as `F64`, while `from_str` mapped the *name*
`"float"` to `F32` (`dtypes.rs:519`). Builtin `float` and the string `"float"` both resolve
through `from_str`; only the member spelling took the correct path. `"double"` on the line
directly above correctly gave `F64`, which suggests the `F32` line was a C-ism slip rather than a
decision.

One line changed, with a comment naming the issue.

## Scope, established by execution

`float` was the **only** disagreeing alias -- `int` -> int64, `bool` -> bool, and `complex` ->
complex128 all already matched their members. This is one wrong mapping, not a systemic alias
problem, and explicit `dtype="float32"` still narrows as asked.

## Tests

Three regressions pin the class of defect, not just the instance: every builtin/string alias
resolves to Python's width; a value needing more than 24 mantissa bits survives all three float
spellings; and the member spelling must equal the builtin spelling for all four aliases -- the
self-agreement the module lacked. Mutation (restoring `F32`) fails exactly those five cases.

Found while migrating real code in #458 step 3a, where the original NumPy used `dtype=float` for
probability values.

## Verification

clippy `-D warnings` clean; fmt clean; pecos-rslib **1551** passed; qec **1489**; pre-commit two
passes (first pass reformatted the new test; second clean, tests re-run after).
