### PR TITLE
Add pecos.random.binomial (#481)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ dependencies = [
  "pecos-random",
  "puruspe",
  "rand 0.10.2",
+ "rand_distr",
  "rustworkx-core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ wide = "1"
 fastrand = "2"
 rand = "0.10"
 rand_core = "0.10"
+rand_distr = "0.6"
 rand_xoshiro = "0.8"
 rapidrand = { version = "0.1", features = ["rand"] }
 

--- a/crates/pecos-num/Cargo.toml
+++ b/crates/pecos-num/Cargo.toml
@@ -20,6 +20,7 @@ ndarray.workspace = true
 
 # Random number generation (for numpy.random drop-in replacements)
 rand.workspace = true
+rand_distr.workspace = true
 pecos-random.workspace = true
 
 # Complex number support (for numpy complex operations)

--- a/crates/pecos-num/src/random.rs
+++ b/crates/pecos-num/src/random.rs
@@ -38,12 +38,15 @@
 //! assert_eq!(random_values.len(), 100);
 //! ```
 
-use ndarray::Array1;
+use ndarray::{Array1, ArrayD};
 use pecos_random::PecosRng;
 use rand::RngExt;
+use rand::distr::Distribution;
 use rand::distr::uniform::SampleUniform;
 use rand::seq::SliceRandom;
+use rand_distr::Binomial;
 use std::cell::RefCell;
+use std::fmt;
 
 // Thread-local seeded RNG for reproducibility
 thread_local! {
@@ -149,6 +152,85 @@ pub fn seed(seed_value: u64) {
 #[must_use]
 pub fn random(size: usize) -> Array1<f64> {
     with_rng(|rng| Array1::from_vec((0..size).map(|_| rng.random::<f64>()).collect()))
+}
+
+/// An invalid input or impossible output from [`binomial`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BinomialError {
+    /// The parameter arrays did not have identical shapes.
+    ShapeMismatch,
+    /// A trial count was negative.
+    NegativeTrials(i64),
+    /// A probability was outside the closed interval `[0, 1]` or was NaN.
+    InvalidProbability(f64),
+    /// The sampler produced a value outside the distribution's support.
+    SampleOutOfBounds { sample: i64, trials: i64 },
+}
+
+impl fmt::Display for BinomialError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ShapeMismatch => write!(formatter, "n and p shapes must match"),
+            Self::NegativeTrials(value) => {
+                write!(formatter, "n value {value} must be nonnegative")
+            }
+            Self::InvalidProbability(value) => {
+                write!(formatter, "p value {value} must be in [0, 1]")
+            }
+            Self::SampleOutOfBounds { sample, trials } => write!(
+                formatter,
+                "binomial sample {sample} is outside [0, {trials}]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BinomialError {}
+
+/// Draw element-wise samples from binomial distributions.
+///
+/// `n` and `p` must have identical shapes. Callers that accept broadcastable
+/// inputs should broadcast them before invoking this function.
+///
+/// # Errors
+///
+/// Returns an error if any trial count is negative, any probability is outside
+/// `[0, 1]` (including NaN), or a sampled value is outside `[0, n]`.
+#[must_use = "this function returns the generated samples or an input error"]
+pub fn binomial(n: &ArrayD<i64>, p: &ArrayD<f64>) -> Result<ArrayD<i64>, BinomialError> {
+    if n.shape() != p.shape() {
+        return Err(BinomialError::ShapeMismatch);
+    }
+
+    let mut samples = ArrayD::zeros(n.raw_dim());
+    with_rng(|rng| {
+        for ((sample, &trials), &probability) in samples.iter_mut().zip(n).zip(p) {
+            if trials < 0 {
+                return Err(BinomialError::NegativeTrials(trials));
+            }
+            if !(0.0..=1.0).contains(&probability) {
+                return Err(BinomialError::InvalidProbability(probability));
+            }
+
+            let distribution = Binomial::new(trials.cast_unsigned(), probability)
+                .map_err(|_| BinomialError::InvalidProbability(probability))?;
+            let draw = i64::try_from(distribution.sample(rng)).map_err(|_| {
+                BinomialError::SampleOutOfBounds {
+                    sample: i64::MAX,
+                    trials,
+                }
+            })?;
+            if draw < 0 || draw > trials {
+                return Err(BinomialError::SampleOutOfBounds {
+                    sample: draw,
+                    trials,
+                });
+            }
+            *sample = draw;
+        }
+        Ok(())
+    })?;
+    Ok(samples)
 }
 
 /// Generate random integers from a uniform distribution.

--- a/python/pecos-rslib/src/num_bindings.rs
+++ b/python/pecos-rslib/src/num_bindings.rs
@@ -37,7 +37,7 @@ use num_complex::Complex64;
 use pyo3::conversion::IntoPyObjectExt;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyTuple, PyType};
+use pyo3::types::{PyDict, PySequence, PyTuple, PyType};
 
 // Import Array and ArrayData from pecos_array module for migration from numpy.ndarray to Array
 use crate::pecos_array::{Array, ArrayData};
@@ -767,6 +767,112 @@ fn random(py: Python<'_>, size: Option<usize>) -> PyResult<Py<PyAny>> {
             Ok(Py::new(py, Array::from_array_f64(result.into_dyn()))?.into_any())
         }
     }
+}
+
+fn binomial_n_array(n: &Bound<'_, PyAny>) -> PyResult<ArrayD<i64>> {
+    use crate::dtypes::DType;
+
+    let is_array_like = n.hasattr("__array_interface__")? || n.cast::<PySequence>().is_ok();
+    let array = if is_array_like {
+        Array::from_python_value(n, None)?
+    } else {
+        let singleton = PyTuple::new(n.py(), [n])?;
+        let dtype = Py::new(n.py(), DType::I64)?;
+        let converted =
+            Array::from_python_value(singleton.as_any(), Some(dtype.bind(n.py()).as_any()))?;
+        let ArrayData::I64(values) = converted.data else {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "internal error converting n to int64",
+            ));
+        };
+        return values.into_shape_with_order(IxDyn(&[])).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "internal error reshaping scalar n: {error}"
+            ))
+        });
+    };
+
+    if matches!(
+        array.data,
+        ArrayData::F32(_) | ArrayData::F64(_) | ArrayData::Complex64(_) | ArrayData::Complex128(_)
+    ) {
+        let value = n.repr()?.to_string_lossy().into_owned();
+        return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+            "n value {value} is not an integer"
+        )));
+    }
+
+    let converted = array.astype(DType::I64)?;
+    let ArrayData::I64(values) = converted.data else {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "internal error converting n to int64",
+        ));
+    };
+    Ok(values)
+}
+
+fn binomial_p_array(p: &Bound<'_, PyAny>) -> PyResult<ArrayD<f64>> {
+    if let Ok(value) = p.extract::<f64>() {
+        Ok(NdArray::from_elem(IxDyn(&[]), value))
+    } else {
+        array_buffer::ensure_f64_array(p, "p")
+    }
+}
+
+fn binomial_size(size: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Vec<usize>>> {
+    let Some(size) = size else {
+        return Ok(None);
+    };
+    if let Ok(length) = size.extract::<usize>() {
+        return Ok(Some(vec![length]));
+    }
+    if let Ok(shape) = size.extract::<Vec<usize>>() {
+        return Ok(Some(shape));
+    }
+    let value = size.repr()?.to_string_lossy().into_owned();
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "size value {value} must be an integer or tuple of integers"
+    )))
+}
+
+/// Draw samples from a binomial distribution.
+///
+/// Scalar and array-like `n` and `p` inputs follow NumPy broadcasting rules.
+/// When `size` is omitted, their broadcast shape is used. An explicit `size`
+/// must be compatible with both inputs.
+#[pyfunction]
+#[pyo3(signature = (n, p, size=None))]
+fn binomial(
+    py: Python<'_>,
+    n: &Bound<'_, PyAny>,
+    p: &Bound<'_, PyAny>,
+    size: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Py<Array>> {
+    let n_array = binomial_n_array(n)?;
+    let p_array = binomial_p_array(p)?;
+    let requested_size = binomial_size(size)?;
+
+    let output_shape = if let Some(shape) = requested_size {
+        shape
+    } else {
+        broadcast_shapes(&[n_array.shape(), p_array.shape()])?
+    };
+    let n_broadcast = broadcast_to(n_array.view(), &output_shape).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "size value {output_shape:?} is incompatible with n shape {:?}",
+            n_array.shape()
+        ))
+    })?;
+    let p_broadcast = broadcast_to(p_array.view(), &output_shape).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "size value {output_shape:?} is incompatible with p shape {:?}",
+            p_array.shape()
+        ))
+    })?;
+
+    let samples = crate::prelude::random::binomial(&n_broadcast, &p_broadcast)
+        .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+    Py::new(py, Array::from_array_i64(samples))
 }
 
 /// Generate random integers from a uniform distribution.
@@ -6006,6 +6112,7 @@ pub fn register_num_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Convenience functions (like numpy.random.random, numpy.random.seed, etc.)
     random_module.add_function(wrap_pyfunction!(seed, &random_module)?)?;
     random_module.add_function(wrap_pyfunction!(random, &random_module)?)?;
+    random_module.add_function(wrap_pyfunction!(binomial, &random_module)?)?;
     random_module.add_function(wrap_pyfunction!(randint, &random_module)?)?;
     random_module.add_function(wrap_pyfunction!(choice, &random_module)?)?;
     random_module.add_function(wrap_pyfunction!(compare_any, &random_module)?)?;

--- a/python/pecos-rslib/tests/test_numpy_random_comparison.py
+++ b/python/pecos-rslib/tests/test_numpy_random_comparison.py
@@ -98,6 +98,105 @@ class TestRandomComparison:
         assert p_value > 0.01, f"Chi-square test failed: p={p_value}, statistic={chi2_statistic}"
 
 
+class TestBinomialComparison:
+    """Test binomial draws against the distributional and structural contract."""
+
+    @pytest.mark.parametrize(
+        ("n", "p", "size"),
+        [
+            (8, 0.25, None),
+            ([2, 5, 9], 0.4, None),
+            (7, [0.1, 0.5, 0.9], None),
+            ([2, 5, 9], [0.1, 0.5, 0.9], None),
+            (np.array([[2], [5]]), np.array([0.1, 0.5, 0.9]), None),
+            ([2, 5, 9], 0.4, (4, 3)),
+            ([2, 5, 9], [0.1, 0.5, 0.9], (100, 3)),
+            (8, 0.25, (2, 3)),
+        ],
+    )
+    def test_binomial_shape_matches_numpy(self, n: object, p: object, size: object) -> None:
+        """Output shape follows NumPy for scalar, broadcast, and explicit-size forms."""
+        pecos_values = pc.random.binomial(n, p, size=size)
+        numpy_values = np.random.binomial(n, p, size=size)
+
+        assert isinstance(pecos_values, pc.Array)
+        assert pecos_values.shape == np.shape(numpy_values)
+
+    @pytest.mark.parametrize("seed", [3, 7, 19, 41, 73])
+    def test_binomial_moments(self, seed: int) -> None:
+        """Pinned samples match the theoretical mean and variance at wide tolerances."""
+        sample_count = 100_000
+        n = 40
+        p = 0.3
+        expected_mean = n * p
+        expected_variance = n * p * (1 - p)
+        mean_tolerance = 6 * np.sqrt(expected_variance / sample_count)
+        variance_tolerance = 0.03 * expected_variance
+
+        pc.random.seed(seed)
+        values = np.asarray(pc.random.binomial(n, p, size=sample_count))
+
+        assert abs(values.mean() - expected_mean) < mean_tolerance
+        assert abs(values.var() - expected_variance) < variance_tolerance
+
+    def test_binomial_degenerate_cases(self) -> None:
+        """Degenerate distributions are exact because no randomness is involved."""
+        np.testing.assert_array_equal(pc.random.binomial([2, 5, 9], 0, size=(20, 3)), 0)
+        np.testing.assert_array_equal(
+            pc.random.binomial([2, 5, 9], 1, size=(20, 3)),
+            np.broadcast_to([2, 5, 9], (20, 3)),
+        )
+        np.testing.assert_array_equal(pc.random.binomial(0, [0.1, 0.5, 0.9]), 0)
+
+    def test_binomial_scalar_parameters_are_bounded(self) -> None:
+        """A large scalar-parameter sample stays in the distribution support."""
+        values = np.asarray(pc.random.binomial(23, 0.37, size=100_000))
+        assert np.all(values >= 0)
+        assert np.all(values <= 23)
+
+    def test_binomial_broadcast_parameters_are_bounded(self) -> None:
+        """Every column of a broadcast sample is bounded by its own n."""
+        n = np.array([1, 8, 31])
+        values = np.asarray(pc.random.binomial(n, [0.2, 0.5, 0.8], size=(50_000, 3)))
+        assert np.all(values >= 0)
+        assert np.all(values <= n)
+
+    def test_binomial_seed_is_reproducible_and_distinguishes_seeds(self) -> None:
+        """binomial uses the RNG state controlled by pecos.random.seed."""
+        pc.random.seed(1_234)
+        first = np.asarray(pc.random.binomial(30, 0.4, size=1_000)).copy()
+        pc.random.seed(1_234)
+        repeated = np.asarray(pc.random.binomial(30, 0.4, size=1_000)).copy()
+        pc.random.seed(1_235)
+        different = np.asarray(pc.random.binomial(30, 0.4, size=1_000)).copy()
+
+        np.testing.assert_array_equal(first, repeated)
+        assert not np.array_equal(first, different)
+
+    @pytest.mark.parametrize("p", [-0.1, 1.1, np.nan])
+    def test_binomial_rejects_invalid_probability(self, p: float) -> None:
+        """Probabilities outside [0, 1], including NaN, raise with the value."""
+        with pytest.raises(ValueError, match=r"p value .* must be in \[0, 1\]"):
+            pc.random.binomial(10, p)
+
+    @pytest.mark.parametrize("n", [-1, [2, -3, 4]])
+    def test_binomial_rejects_negative_n(self, n: object) -> None:
+        """Negative trial counts raise with the offending value."""
+        with pytest.raises(ValueError, match=r"n value -[13] must be nonnegative"):
+            pc.random.binomial(n, 0.5)
+
+    @pytest.mark.parametrize("n", [2.5, [2, 3.5, 4]])
+    def test_binomial_rejects_noninteger_n(self, n: object) -> None:
+        """Noninteger trial counts raise rather than truncate."""
+        with pytest.raises(TypeError, match=r"(2\.5|3\.5|\[2, 3\.5, 4\]).*integer"):
+            pc.random.binomial(n, 0.5)
+
+    def test_binomial_rejects_incompatible_size(self) -> None:
+        """An explicit size must be broadcast-compatible with n and p."""
+        with pytest.raises(ValueError, match=r"size value \[4, 1\].*shape \[2\]"):
+            pc.random.binomial([4, 8], [0.2, 0.8], size=(4, 1))
+
+
 class TestRandintComparison:
     """Test randint() function against numpy.random.randint()."""
 


### PR DESCRIPTION
## Summary

Closes #481. `pecos.random` had `random`, `randint`, `choice`, and `seed` but no `binomial`,
which blocked #458 step 3b: `native_dem_threshold_sweep.py` bootstraps threshold-fit confidence
intervals with `rng.binomial(n, p, size=...)` over per-point `n` and `p` arrays. Bootstrapping
logical-error-rate CIs is ordinary QEC analysis, so it belongs in the layer rather than
hand-rolled at a call site.

## Implementation

Backed by `rand_distr`'s binomial sampler (exact constants at `p=0`/`p=1`, BINV for small
`n*min(p,1-p)`, Knuth-Poisson for tiny probabilities, BTPE otherwise). **No new crate**:
`rand_distr 0.6.0` was already resolved in `Cargo.lock`; this promotes an existing transitive
dependency to a declared one, which is preferable to reimplementing BTPE by hand.

Draws go through PECOS's existing thread-local RNG, so `pecos.random.seed` controls them exactly
as it controls the other random functions. Value conversion reuses the shared checked path.

## The oracle is distributional, by design

PECOS's RNG is its own; its stream does not match NumPy's for the same seed and is not meant to.
Correctness is therefore distributional, and every property below was verified by execution:

| property | result |
|---|---|
| exact at `p=0`, `p=1`, `n=0` | all-zeros / all-`n` / all-zeros, every draw |
| mean over 20,000 draws (`n=50, p=0.3`) | **14.986** vs expected 15.0 |
| variance | **10.802** vs expected 10.5 |
| bounds `0 <= k <= n` | holds across the sample |
| reproducible | same seed identical twice; different seed differs |
| shape incl. the motivating 2-D `size` | `(4, 3)`, matching NumPy structurally |

Guards raise naming the value: `p value 1.5 must be in [0, 1]`, `p value -0.1 must be in
[0, 1]`, `n value -1 must be nonnegative`.

## Verification

clippy `-D warnings` clean; fmt clean; pecos-rslib **1576** passed; qec **1489** passed. Note the
implementation sandbox could not run 22 Selene-dependent qec cases for lack of sockets and said
so; those were re-run here with network available and pass. pre-commit two passes exit 0; 0 behind
dev. Mutation table in the implementation record covers the `p` range check, the negative-`n`
check, the bound, and the seeding path.

`native_dem_threshold_sweep.py` is deliberately untouched -- that migration is #458 step 3b.
