### PR TITLE
Collapse the interim indexing loops in dem_decomposition_diagnostics

### DIFF
--- a/examples/surface/dem_decomposition_diagnostics.py
+++ b/examples/surface/dem_decomposition_diagnostics.py
@@ -367,9 +367,7 @@ def dense_effect_arrays(effects: dict[str, float]) -> tuple[list[str], Array, Ar
     for index, key in enumerate(keys):
         detectors = [int(detector) for detector in DET_RE.findall(key)]
         if detectors:
-            # Collapse to one indexed assignment when Array fancy assignment lands in #482.
-            for detector in detectors:
-                detection_events[index, detector] = 1
+            detection_events[index, detectors] = 1
         observable_flips[index] = 1 if "0" in OBS_RE.findall(key) else 0
 
     return keys, probabilities, detection_events, observable_flips
@@ -508,15 +506,8 @@ def two_fault_pair_analysis(
     for name, predicted in predictions.items():
         wrong = predicted != pair_observable_flips
         disagree = predicted != reference
-        # Collapse these selections to boolean-mask indexing when #482 covers Array reads.
-        wrong_weights = asarray(
-            [weight for weight, selected in zip(weights, wrong, strict=True) if selected],
-            dtype=dtypes.float64,
-        )
-        disagree_weights = asarray(
-            [weight for weight, selected in zip(weights, disagree, strict=True) if selected],
-            dtype=dtypes.float64,
-        )
+        wrong_weights = weights[wrong]
+        disagree_weights = weights[disagree]
         wrong_mass = float(array_sum(wrong_weights))
         disagree_mass = float(array_sum(disagree_weights))
         summaries.append(


### PR DESCRIPTION
## Summary

#486 added indexed assignment and boolean-mask reads to `Array`. The #458 step 3a migration had
two sites marked as interim, waiting on exactly that. They are now collapsed, and the workarounds
are gone rather than wrapped:

```python
# was: a loop, commented "collapse when #482 lands"
for detector in detectors:
    detection_events[index, detector] = 1
# now:
detection_events[index, detectors] = 1

# was: list comprehensions rebuilding a filtered array
wrong_weights = asarray([w for w, sel in zip(weights, wrong, strict=True) if sel], dtype=dtypes.float64)
# now:
wrong_weights = weights[wrong]
```

Net **3 insertions, 12 deletions**, and zero `#482` references remain in the file.

## Why this is behaviour-preserving, not hopefully-equivalent

Step 3a pinned this module with an exact-equality oracle: eight statistics including
`probability_sum` to full precision, over both the native and stim DEM paths, captured from the
pre-migration file. That oracle passes unchanged after the collapse, so the interim loops and the
real indexing produce identical results -- asserted, not assumed.

## Verification

Oracle test 5 passed; both importing scripts (`graphlike_dem_projection_benchmark.py`,
`szz_circuit_quality_report.py`) run; qec **1494** passed; `ruff check` clean; pre-commit two
passes exit 0.

Follow-up context: `Array` still refuses advanced indices separated by a slice, multiple advanced
indices, and multi-dimensional masks -- one root cause, tracked in #488, whose implementation is
in progress. Neither site here needs those forms.
