### PR TITLE
Implement NumPy's advanced-indexing execution model on Array (#488)

### DIFF
--- a/python/pecos-rslib/src/pecos_array.rs
+++ b/python/pecos-rslib/src/pecos_array.rs
@@ -67,11 +67,18 @@ pub enum ArrayData {
     PauliString(ArrayD<PauliString>),
 }
 
-/// Represents an indexing operation: either an integer index or a slice
-#[derive(Debug, Clone, Copy)]
+/// Represents an indexing operation.
+#[derive(Debug, Clone)]
 enum IndexOp {
     Integer(isize),
     Slice(isize, isize, isize),
+    Fancy(Vec<usize>),
+}
+
+struct AssignmentSelection {
+    ranges: Vec<Vec<usize>>,
+    integer_axes: Vec<usize>,
+    shape: Vec<usize>,
 }
 
 impl ArrayData {
@@ -1442,45 +1449,11 @@ impl Array {
         Ok(dict.into())
     }
 
-    /// Implement __setitem__ for slice assignment support
-    /// Supports:
-    /// - 1D slicing: arr[start:stop] = value (unit-step only)
-    /// - Multi-dimensional slicing: arr[0:2, 1:3] = value (unit-step only)
+    /// Implement indexed and slice assignment.
     fn __setitem__(&mut self, index: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        // Check if index is a tuple (multi-dimensional slicing)
         if let Ok(tuple) = index.cast::<PyTuple>() {
-            // Parse the tuple to extract slices
-            // Copy shape to avoid borrow checker issues with mutable methods
             let shape: Vec<usize> = self.data.shape().to_vec();
-            let ndim = shape.len();
-
-            if tuple.len() > ndim {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "Too many indices for array: array is {}-dimensional, but {} were indexed",
-                    ndim,
-                    tuple.len()
-                )));
-            }
-
-            // Parse indexing operations: collect integers and slices
-            let mut index_ops = Vec::new();
-
-            for (axis, item) in tuple.iter().enumerate() {
-                // Check if this dimension is a slice
-                if let Ok(slice) = item.cast::<PySlice>() {
-                    let (start, stop, step) = Self::parse_slice(slice, shape[axis])?;
-                    index_ops.push(IndexOp::Slice(start, stop, step));
-                } else if let Ok(idx) = item.extract::<isize>() {
-                    // Integer index
-                    index_ops.push(IndexOp::Integer(idx));
-                } else {
-                    return Err(pyo3::exceptions::PyTypeError::new_err(
-                        "indices must be integers or slices",
-                    ));
-                }
-            }
-
-            // Apply mixed indexing assignment
+            let index_ops = Self::parse_tuple_index(tuple, &shape)?;
             self.apply_mixed_indexing_assignment(&index_ops, &shape, value)?;
             Ok(())
         } else if let Ok(slice) = index.cast::<PySlice>() {
@@ -1585,6 +1558,15 @@ impl Array {
                 }
             }
             Ok(())
+        } else if index.extract::<PyRef<Array>>().is_ok() || index.cast::<PySequence>().is_ok() {
+            let shape: Vec<usize> = self.data.shape().to_vec();
+            if shape.is_empty() {
+                return Err(pyo3::exceptions::PyIndexError::new_err(
+                    "Cannot index a zero-dimensional array",
+                ));
+            }
+            let index_ops = vec![Self::parse_fancy_index(index, 0, shape[0])?];
+            self.apply_mixed_indexing_assignment(&index_ops, &shape, value)
         } else {
             // Unsupported index type
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1593,46 +1575,13 @@ impl Array {
         }
     }
 
-    /// Implement __getitem__ for slicing support
-    /// Supports:
-    /// - Single integer indexing: arr[i] (not yet implemented)
-    /// - Multi-dimensional indexing: arr[i, j, k] (not yet implemented)
-    /// - Slicing: arr[start:stop:step] (in progress)
-    /// - Multi-dimensional slicing: arr[0:2, 1:5, :] (current focus)
+    /// Implement integer, slice, fancy, and one-dimensional boolean-mask reads.
     fn __getitem__(&self, index: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         let py = index.py();
 
-        // Check if index is a tuple (multi-dimensional indexing/slicing)
         if let Ok(tuple) = index.cast::<PyTuple>() {
-            // Parse the tuple to extract slices/indices
             let shape = self.data.shape();
-            let ndim = shape.len();
-
-            if tuple.len() > ndim {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "Too many indices for array: array is {}-dimensional, but {} were indexed",
-                    ndim,
-                    tuple.len()
-                )));
-            }
-
-            // Parse indexing operations: collect integers and slices
-            let mut index_ops = Vec::new();
-
-            for (axis, item) in tuple.iter().enumerate() {
-                // Check if this dimension is a slice
-                if let Ok(slice) = item.cast::<PySlice>() {
-                    let (start, stop, step) = Self::parse_slice(slice, shape[axis])?;
-                    index_ops.push(IndexOp::Slice(start, stop, step));
-                } else if let Ok(idx) = item.extract::<isize>() {
-                    // Integer index
-                    index_ops.push(IndexOp::Integer(idx));
-                } else {
-                    return Err(pyo3::exceptions::PyTypeError::new_err(
-                        "indices must be integers or slices",
-                    ));
-                }
-            }
+            let index_ops = Self::parse_tuple_index(tuple, shape)?;
 
             // Apply mixed indexing
             let result = self.apply_mixed_indexing(&index_ops)?;
@@ -1684,27 +1633,15 @@ impl Array {
             }
 
             Ok(Py::new(py, result)?.into_any())
-        } else if let Ok(seq) = index.cast::<PySequence>() {
-            // Fancy indexing: arr[[4, 2, 0, 3, 1]]
-            // Check if array is 1D
+        } else if index.extract::<PyRef<Array>>().is_ok() || index.cast::<PySequence>().is_ok() {
             let shape = self.data.shape();
-            if shape.len() != 1 {
-                return Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                    "Fancy indexing currently only works on 1D arrays",
+            if shape.is_empty() {
+                return Err(pyo3::exceptions::PyIndexError::new_err(
+                    "Cannot index a zero-dimensional array",
                 ));
             }
-
-            // Extract indices from the sequence
-            let length = seq.len()?;
-            let mut indices = Vec::with_capacity(length);
-            for i in 0..length {
-                let item = seq.get_item(i)?;
-                let idx: isize = item.extract()?;
-                indices.push(idx);
-            }
-
-            // Perform fancy indexing
-            let result = self.apply_fancy_indexing(&indices)?;
+            let index_ops = vec![Self::parse_fancy_index(index, 0, shape[0])?];
+            let result = self.apply_mixed_indexing(&index_ops)?;
             Ok(Py::new(py, result)?.into_any())
         } else {
             // Unsupported indexing type
@@ -2133,6 +2070,116 @@ impl Array {
 }
 
 impl Array {
+    fn resolve_bool_mask(mask: &[bool], axis: usize, axis_len: usize) -> PyResult<Vec<usize>> {
+        if mask.len() != axis_len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "Boolean mask length {} does not match axis {axis} length {axis_len}",
+                mask.len()
+            )));
+        }
+        Ok(mask
+            .iter()
+            .enumerate()
+            .filter_map(|(position, selected)| selected.then_some(position))
+            .collect())
+    }
+
+    /// Parse a sequence or bool Array used to index one axis.
+    fn parse_fancy_index(
+        index: &Bound<'_, PyAny>,
+        axis: usize,
+        axis_len: usize,
+    ) -> PyResult<IndexOp> {
+        if let Ok(mask) = index.extract::<PyRef<Array>>() {
+            let ArrayData::Bool(values) = &mask.data else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "Array indices must have bool dtype",
+                ));
+            };
+            if values.ndim() != 1 {
+                return Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
+                    "Boolean mask indexing supports only one-dimensional masks; got {} dimensions",
+                    values.ndim()
+                )));
+            }
+            let mask_values = values.iter().copied().collect::<Vec<_>>();
+            return Ok(IndexOp::Fancy(Self::resolve_bool_mask(
+                &mask_values,
+                axis,
+                axis_len,
+            )?));
+        }
+
+        let sequence = index.cast::<PySequence>()?;
+        let length = sequence.len()?;
+        let items = (0..length)
+            .map(|position| sequence.get_item(position))
+            .collect::<PyResult<Vec<_>>>()?;
+        let is_bool_mask = !items.is_empty()
+            && items
+                .iter()
+                .all(pyo3::types::PyAnyMethods::is_instance_of::<PyBool>);
+
+        if is_bool_mask {
+            let mask = items
+                .iter()
+                .map(pyo3::types::PyAnyMethods::extract::<bool>)
+                .collect::<PyResult<Vec<_>>>()?;
+            return Ok(IndexOp::Fancy(Self::resolve_bool_mask(
+                &mask, axis, axis_len,
+            )?));
+        }
+
+        let indices = items
+            .iter()
+            .map(|item| {
+                if item.is_instance_of::<PyBool>() {
+                    item.extract::<bool>().map(isize::from)
+                } else {
+                    item.extract::<isize>()
+                }
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(IndexOp::Fancy(Self::resolve_fancy_indices(
+            &indices, axis, axis_len,
+        )?))
+    }
+
+    /// Parse a tuple index through the same integer-sequence resolver used by reads.
+    fn parse_tuple_index(tuple: &Bound<'_, PyTuple>, shape: &[usize]) -> PyResult<Vec<IndexOp>> {
+        if tuple.len() > shape.len() {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "Too many indices for array: array is {}-dimensional, but {} were indexed",
+                shape.len(),
+                tuple.len()
+            )));
+        }
+
+        let mut index_ops = Vec::with_capacity(tuple.len());
+        let mut fancy_axes = 0;
+        for (axis, item) in tuple.iter().enumerate() {
+            if let Ok(slice) = item.cast::<PySlice>() {
+                let (start, stop, step) = Self::parse_slice(slice, shape[axis])?;
+                index_ops.push(IndexOp::Slice(start, stop, step));
+            } else if let Ok(idx) = item.extract::<isize>() {
+                index_ops.push(IndexOp::Integer(idx));
+            } else if item.extract::<PyRef<Array>>().is_ok() || item.cast::<PySequence>().is_ok() {
+                fancy_axes += 1;
+                if fancy_axes > 1 {
+                    return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                        "Fancy indexing on more than one axis is not supported",
+                    ));
+                }
+                index_ops.push(Self::parse_fancy_index(&item, axis, shape[axis])?);
+            } else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "indices must be integers, slices, or one-dimensional sequences",
+                ));
+            }
+        }
+        Ok(index_ops)
+    }
+
     fn parse_reshape_shape(shape: &Bound<'_, PyTuple>) -> PyResult<Vec<isize>> {
         if shape.is_empty() {
             return Err(pyo3::exceptions::PyTypeError::new_err(
@@ -5199,85 +5246,29 @@ impl Array {
         Ok(())
     }
 
-    /// Apply N-dimensional slice assignment with arbitrary step support
-    /// This is a generalized solution that works for any number of dimensions
-    ///
-    /// Note: ndarray's `slice_mut()` doesn't support non-unit steps for mutation,
-    /// so we must manually iterate through all index combinations.
-    /// This approach generates all valid index combinations across all dimensions,
-    /// then assigns values to those indices.
-    ///
-    /// Fancy indexing: Select elements from a 1D array using a list of integer indices
-    /// Example: arr[[4, 2, 0, 3, 1]] returns elements at indices 4, 2, 0, 3, 1 in that order
-    fn apply_fancy_indexing(&self, indices: &[isize]) -> PyResult<Self> {
-        let shape = self.data.shape();
-        let len = shape[0];
-
-        // Macro to implement fancy indexing for each dtype
-        macro_rules! impl_fancy_indexing {
-            ($arr:expr) => {{
-                // Create result array of the same length as indices
-                let mut result_vec = Vec::with_capacity(indices.len());
-
-                for &idx in indices {
-                    // Resolve negative indices
-                    let resolved_idx = if idx < 0 {
-                        let size = len as isize;
-                        let resolved = size + idx;
-                        if resolved < 0 {
-                            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                                "index {} is out of bounds for array of length {}",
-                                idx, len
-                            )));
-                        }
-                        resolved as usize
-                    } else {
-                        let idx_usize = idx as usize;
-                        if idx_usize >= len {
-                            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                                "index {} is out of bounds for array of length {}",
-                                idx, len
-                            )));
-                        }
-                        idx_usize
-                    };
-
-                    result_vec.push($arr[resolved_idx].clone());
-                }
-
-                // Convert to ndarray
-                let result_arr =
-                    ArrayD::from_shape_vec(vec![indices.len()], result_vec).map_err(|e| {
-                        pyo3::exceptions::PyValueError::new_err(format!(
-                            "Failed to create result array: {}",
-                            e
-                        ))
-                    })?;
-
-                result_arr
-            }};
-        }
-
-        // Apply fancy indexing based on dtype
-        let result_data = match &self.data {
-            ArrayData::Bool(arr) => ArrayData::Bool(impl_fancy_indexing!(arr)),
-            ArrayData::I8(arr) => ArrayData::I8(impl_fancy_indexing!(arr)),
-            ArrayData::I16(arr) => ArrayData::I16(impl_fancy_indexing!(arr)),
-            ArrayData::I32(arr) => ArrayData::I32(impl_fancy_indexing!(arr)),
-            ArrayData::I64(arr) => ArrayData::I64(impl_fancy_indexing!(arr)),
-            ArrayData::U8(arr) => ArrayData::U8(impl_fancy_indexing!(arr)),
-            ArrayData::U16(arr) => ArrayData::U16(impl_fancy_indexing!(arr)),
-            ArrayData::U32(arr) => ArrayData::U32(impl_fancy_indexing!(arr)),
-            ArrayData::U64(arr) => ArrayData::U64(impl_fancy_indexing!(arr)),
-            ArrayData::F32(arr) => ArrayData::F32(impl_fancy_indexing!(arr)),
-            ArrayData::F64(arr) => ArrayData::F64(impl_fancy_indexing!(arr)),
-            ArrayData::Complex64(arr) => ArrayData::Complex64(impl_fancy_indexing!(arr)),
-            ArrayData::Complex128(arr) => ArrayData::Complex128(impl_fancy_indexing!(arr)),
-            ArrayData::Pauli(arr) => ArrayData::Pauli(impl_fancy_indexing!(arr)),
-            ArrayData::PauliString(arr) => ArrayData::PauliString(impl_fancy_indexing!(arr)),
-        };
-
-        Ok(Self { data: result_data })
+    /// Resolve integer-sequence indices once for both reads and writes.
+    fn resolve_fancy_indices(
+        indices: &[isize],
+        axis: usize,
+        axis_len: usize,
+    ) -> PyResult<Vec<usize>> {
+        indices
+            .iter()
+            .map(|&index| {
+                let resolved = if index < 0 {
+                    axis_len.checked_add_signed(index)
+                } else {
+                    usize::try_from(index)
+                        .ok()
+                        .filter(|&value| value < axis_len)
+                };
+                resolved.ok_or_else(|| {
+                    pyo3::exceptions::PyIndexError::new_err(format!(
+                        "index {index} is out of bounds for axis {axis} of length {axis_len}"
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Apply multi-dimensional slicing using iterative `slice_axis()`
@@ -6100,6 +6091,10 @@ impl Array {
                             }
                             current_axis += 1; // Move to next axis in the result
                         }
+                        IndexOp::Fancy(indices) => {
+                            result = result.select(Axis(current_axis), indices);
+                            current_axis += 1;
+                        }
                     }
                 }
 
@@ -6129,272 +6124,142 @@ impl Array {
         }
     }
 
-    /// Apply mixed integer/slice indexing assignment to an array
-    /// This method uses ndarray's `index_axis_mut()` and `slice_axis_mut()` for mutable views
-    /// Similar to `apply_mixed_indexing` but for assignment operations
+    /// Convert an assignment value through the constructor/fill checked-dtype path.
+    fn checked_assignment_value(&self, value: &Bound<'_, PyAny>) -> PyResult<(Self, bool)> {
+        let py = value.py();
+        let dtype = Py::new(py, self.data.dtype())?;
+        if value.hasattr("__array_interface__")? {
+            let converted = Self::from_python_value(value, Some(dtype.bind(py).as_any()))?;
+            let is_scalar = converted.data.shape().is_empty();
+            return Ok((converted, is_scalar));
+        }
+        let is_scalar =
+            value.extract::<PyRef<Array>>().is_err() && value.cast::<PySequence>().is_err();
+        let converted = if is_scalar {
+            let singleton = PyTuple::new(py, [value])?;
+            Self::from_nested_sequence(singleton.as_any(), Some(dtype.bind(py).as_any()))?
+        } else {
+            Self::from_nested_sequence(value, Some(dtype.bind(py).as_any()))?
+        };
+        Ok((converted, is_scalar))
+    }
+
+    /// Resolve each operation into ordered coordinates for mutable assignment.
+    fn assignment_ranges(index_ops: &[IndexOp], shape: &[usize]) -> PyResult<AssignmentSelection> {
+        let mut ranges = Vec::with_capacity(shape.len());
+        let mut integer_axes = Vec::new();
+
+        for (axis, op) in index_ops.iter().enumerate() {
+            match op {
+                IndexOp::Integer(index) => {
+                    let resolved = Self::resolve_fancy_indices(&[*index], axis, shape[axis])?;
+                    integer_axes.push(axis);
+                    ranges.push(resolved);
+                }
+                IndexOp::Slice(start, stop, step) => {
+                    let mut indices = Vec::new();
+                    let mut index = *start;
+                    while (*step > 0 && index < *stop) || (*step < 0 && index > *stop) {
+                        indices.push(index as usize);
+                        index += step;
+                    }
+                    ranges.push(indices);
+                }
+                IndexOp::Fancy(indices) => ranges.push(indices.clone()),
+            }
+        }
+
+        for &axis_len in &shape[index_ops.len()..] {
+            ranges.push((0..axis_len).collect());
+        }
+
+        let selection_shape = ranges
+            .iter()
+            .enumerate()
+            .filter_map(|(axis, indices)| (!integer_axes.contains(&axis)).then_some(indices.len()))
+            .collect();
+        Ok(AssignmentSelection {
+            ranges,
+            integer_axes,
+            shape: selection_shape,
+        })
+    }
+
+    fn apply_converted_assignment<T: Clone>(
+        target: &mut ArrayD<T>,
+        source: &ArrayD<T>,
+        is_scalar: bool,
+        ranges: &[Vec<usize>],
+        integer_axes: &[usize],
+        selection_shape: &[usize],
+    ) -> PyResult<()> {
+        if is_scalar {
+            let scalar = source.first().cloned().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(
+                    "internal error converting assignment value",
+                )
+            })?;
+            Self::assign_to_mixed_indices(target, ranges, scalar);
+        } else {
+            if source.shape() != selection_shape {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Shape mismatch: selection has shape {:?}, but source has shape {:?}",
+                    selection_shape,
+                    source.shape()
+                )));
+            }
+            Self::assign_array_to_mixed_indices(target, ranges, integer_axes, source)?;
+        }
+        Ok(())
+    }
+
+    /// Apply integer, slice, or one-axis fancy assignment to an array.
     fn apply_mixed_indexing_assignment(
         &mut self,
         index_ops: &[IndexOp],
         shape: &[usize],
         value: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
-        // Macro to extract an array from Python for a given variant, avoiding
-        // the unsafe transmute_copy that the old generic function required.
-        macro_rules! extract_array_for_variant {
-            ($value:expr, Bool) => {
-                crate::array_buffer::extract_bool_array($value)
-            };
-            ($value:expr, Float64) => {
-                crate::array_buffer::extract_f64_array($value)
-            };
-            ($value:expr, Float32) => {
-                crate::array_buffer::extract_f32_array($value)
-            };
-            ($value:expr, Int64) => {
-                crate::array_buffer::extract_i64_array($value)
-            };
-            ($value:expr, Int32) => {
-                crate::array_buffer::extract_i32_array($value)
-            };
-            ($value:expr, Int16) => {
-                crate::array_buffer::extract_i16_array($value)
-            };
-            ($value:expr, Int8) => {
-                crate::array_buffer::extract_i8_array($value)
-            };
-            ($value:expr, Uint64) => {
-                crate::array_buffer::extract_u64_array($value)
-            };
-            ($value:expr, Uint32) => {
-                crate::array_buffer::extract_u32_array($value)
-            };
-            ($value:expr, Uint16) => {
-                crate::array_buffer::extract_u16_array($value)
-            };
-            ($value:expr, Uint8) => {
-                crate::array_buffer::extract_u8_array($value)
-            };
-            ($value:expr, Complex128) => {
-                crate::array_buffer::extract_complex64_array($value)
-            };
-            ($value:expr, Complex64) => {
-                crate::array_buffer::extract_complex32_array($value)
+        let (converted, is_scalar) = self.checked_assignment_value(value)?;
+        let selection = Self::assignment_ranges(index_ops, shape)?;
+
+        macro_rules! assign_variant {
+            ($target:expr, $source:expr) => {
+                Self::apply_converted_assignment(
+                    $target,
+                    $source,
+                    is_scalar,
+                    &selection.ranges,
+                    &selection.integer_axes,
+                    &selection.shape,
+                )
             };
         }
 
-        // Macro to generate the mixed indexing assignment logic for each dtype
-        macro_rules! apply_mixed_indexing_assignment_impl {
-            ($arr:expr, $dtype:ty, $variant:ident) => {{
-                // Strategy: Convert integers to single-element slices, then use slice_each_axis_mut
-                // This avoids the borrow checker issues with chaining mutable slices
-
-                use ndarray::SliceInfoElem;
-
-                // Build slice info elements for each axis
-                let mut slice_infos: Vec<SliceInfoElem> = Vec::new();
-                let integer_axes: Vec<usize> = index_ops
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, op)| match op {
-                        IndexOp::Integer(_) => Some(i),
-                        _ => None,
-                    })
-                    .collect();
-
-                for (original_axis, op) in index_ops.iter().enumerate() {
-                    match op {
-                        IndexOp::Integer(idx) => {
-                            // Resolve negative index
-                            let resolved_idx = if *idx < 0 {
-                                let axis_size = shape[original_axis] as isize;
-                                (axis_size + idx) as usize
-                            } else {
-                                *idx as usize
-                            };
-
-                            // Bounds check
-                            if resolved_idx >= shape[original_axis] {
-                                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                                    "Index {} is out of bounds for axis {} with size {}",
-                                    idx, original_axis, shape[original_axis]
-                                )));
-                            }
-
-                            // Use Index to reduce dimensionality directly
-                            slice_infos.push(SliceInfoElem::Index(resolved_idx as isize));
-                        }
-                        IndexOp::Slice(start, stop, step) => {
-                            // Add as a slice (this preserves dimensionality)
-                            slice_infos.push(SliceInfoElem::Slice {
-                                start: *start,
-                                end: Some(*stop),
-                                step: *step,
-                            });
-                        }
-                    }
-                }
-
-                // Try to use ndarray's slice_mut with dynamic SliceInfo
-                // Actually, let's use a different approach: ndarray's slice_each_axis_mut
-                // which works better with dynamic dimensions
-
-                // Use slice_each_axis_mut which returns an iterator
-                // For now, let's use a workaround: manually index into the array
-
-                // Actually, the simplest approach is to use ndarray's select API
-                // But for mutable access, we need to be more careful
-
-                // Let me use a different strategy: process each index operation one at a time
-                // using slice_collapse for integers and slice_axis_mut for slices
-
-                // First, let's check if we have only slices (no integers) - that's simpler
-                if integer_axes.is_empty() {
-                    // All slices - convert to ranges and use the recursive approach
-                    // This avoids the borrow checker issue completely
-                    let mut ranges: Vec<Vec<usize>> = Vec::new();
-
-                    for op in index_ops.iter() {
-                        if let IndexOp::Slice(start, stop, step) = op {
-                            // Generate range of indices
-                            let mut indices = Vec::new();
-                            let mut i = *start;
-                            while (*step > 0 && i < *stop) || (*step < 0 && i > *stop) {
-                                indices.push(i as usize);
-                                i += step;
-                            }
-                            ranges.push(indices);
-                        }
-                    }
-
-                    // Calculate the shape of the result
-                    let result_shape: Vec<usize> = ranges.iter().map(|r| r.len()).collect();
-
-                    // Assign value
-                    if let Ok(scalar_val) = value.extract::<$dtype>() {
-                        // Scalar assignment - iterate over all target indices
-                        Self::assign_to_mixed_indices($arr, &ranges, scalar_val);
-                    } else if let Ok(np_arr) = extract_array_for_variant!(value, $variant) {
-                        // Check shape compatibility
-                        if np_arr.shape() != result_shape.as_slice() {
-                            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                                "Shape mismatch: target has shape {:?}, but source has shape {:?}",
-                                result_shape,
-                                np_arr.shape()
-                            )));
-                        }
-
-                        // Since there are no integer axes, we can use a simpler assignment
-                        let integer_axes_empty: Vec<usize> = Vec::new();
-                        Self::assign_array_to_mixed_indices(
-                            $arr,
-                            &ranges,
-                            &integer_axes_empty,
-                            &np_arr,
-                        )?;
-                    } else {
-                        return Err(pyo3::exceptions::PyTypeError::new_err(
-                            "Value must be a scalar or array matching the slice shape and dtype",
-                        ));
-                    }
-                } else {
-                    // Mixed indexing with integers - need special handling
-                    // Use nested iteration approach
-
-                    // First, convert all operations to slice ranges for iteration
-                    let mut ranges: Vec<Vec<usize>> = Vec::new();
-
-                    for (axis, op) in index_ops.iter().enumerate() {
-                        match op {
-                            IndexOp::Integer(idx) => {
-                                // Resolve negative index
-                                let resolved_idx = if *idx < 0 {
-                                    let axis_size = shape[axis] as isize;
-                                    (axis_size + idx) as usize
-                                } else {
-                                    *idx as usize
-                                };
-
-                                // Single index
-                                ranges.push(vec![resolved_idx]);
-                            }
-                            IndexOp::Slice(start, stop, step) => {
-                                // Generate range of indices
-                                let mut indices = Vec::new();
-                                let mut i = *start;
-                                while (*step > 0 && i < *stop) || (*step < 0 && i > *stop) {
-                                    indices.push(i as usize);
-                                    i += step;
-                                }
-                                ranges.push(indices);
-                            }
-                        }
-                    }
-
-                    // Calculate the shape of the result (only slice dimensions)
-                    let result_shape: Vec<usize> = ranges
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(i, r)| {
-                            if integer_axes.contains(&i) {
-                                None
-                            } else {
-                                Some(r.len())
-                            }
-                        })
-                        .collect();
-
-                    // Now handle the value assignment
-                    if let Ok(scalar_val) = value.extract::<$dtype>() {
-                        // Scalar assignment - iterate over all target indices
-                        // Generate all combinations of indices
-                        Self::assign_to_mixed_indices($arr, &ranges, scalar_val);
-                    } else if let Ok(np_arr) = extract_array_for_variant!(value, $variant) {
-                        // Check shape compatibility
-                        if np_arr.shape() != result_shape.as_slice() {
-                            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                                "Shape mismatch: target has shape {:?}, but source has shape {:?}",
-                                result_shape,
-                                np_arr.shape()
-                            )));
-                        }
-
-                        // Assign array values - need to map result indices to target indices
-                        Self::assign_array_to_mixed_indices($arr, &ranges, &integer_axes, &np_arr)?;
-                    } else {
-                        return Err(pyo3::exceptions::PyTypeError::new_err(
-                            "Value must be a scalar or array matching the slice shape and dtype",
-                        ));
-                    }
-                }
-
-                Ok(())
-            }};
-        }
-
-        // Apply the operation to each dtype variant
-        match &mut self.data {
-            ArrayData::Bool(arr) => apply_mixed_indexing_assignment_impl!(arr, bool, Bool),
-            ArrayData::F64(arr) => apply_mixed_indexing_assignment_impl!(arr, f64, Float64),
-            ArrayData::F32(arr) => apply_mixed_indexing_assignment_impl!(arr, f32, Float32),
-            ArrayData::I64(arr) => apply_mixed_indexing_assignment_impl!(arr, i64, Int64),
-            ArrayData::I32(arr) => apply_mixed_indexing_assignment_impl!(arr, i32, Int32),
-            ArrayData::I16(arr) => apply_mixed_indexing_assignment_impl!(arr, i16, Int16),
-            ArrayData::I8(arr) => apply_mixed_indexing_assignment_impl!(arr, i8, Int8),
-            ArrayData::U64(arr) => apply_mixed_indexing_assignment_impl!(arr, u64, Uint64),
-            ArrayData::U32(arr) => apply_mixed_indexing_assignment_impl!(arr, u32, Uint32),
-            ArrayData::U16(arr) => apply_mixed_indexing_assignment_impl!(arr, u16, Uint16),
-            ArrayData::U8(arr) => apply_mixed_indexing_assignment_impl!(arr, u8, Uint8),
-            ArrayData::Complex128(arr) => {
-                apply_mixed_indexing_assignment_impl!(arr, num_complex::Complex<f64>, Complex128)
+        match (&mut self.data, &converted.data) {
+            (ArrayData::Bool(target), ArrayData::Bool(source)) => assign_variant!(target, source),
+            (ArrayData::I8(target), ArrayData::I8(source)) => assign_variant!(target, source),
+            (ArrayData::I16(target), ArrayData::I16(source)) => assign_variant!(target, source),
+            (ArrayData::I32(target), ArrayData::I32(source)) => assign_variant!(target, source),
+            (ArrayData::I64(target), ArrayData::I64(source)) => assign_variant!(target, source),
+            (ArrayData::U8(target), ArrayData::U8(source)) => assign_variant!(target, source),
+            (ArrayData::U16(target), ArrayData::U16(source)) => assign_variant!(target, source),
+            (ArrayData::U32(target), ArrayData::U32(source)) => assign_variant!(target, source),
+            (ArrayData::U64(target), ArrayData::U64(source)) => assign_variant!(target, source),
+            (ArrayData::F32(target), ArrayData::F32(source)) => assign_variant!(target, source),
+            (ArrayData::F64(target), ArrayData::F64(source)) => assign_variant!(target, source),
+            (ArrayData::Complex64(target), ArrayData::Complex64(source)) => {
+                assign_variant!(target, source)
             }
-            ArrayData::Complex64(arr) => {
-                apply_mixed_indexing_assignment_impl!(arr, num_complex::Complex<f32>, Complex64)
+            (ArrayData::Complex128(target), ArrayData::Complex128(source)) => {
+                assign_variant!(target, source)
             }
-            ArrayData::Pauli(_) => Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                "Mixed integer/slice indexing assignment not yet implemented for Pauli arrays",
-            )),
-            ArrayData::PauliString(_) => Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                "Mixed integer/slice indexing assignment not yet implemented for PauliString arrays",
+            (ArrayData::Pauli(target), ArrayData::Pauli(source)) => assign_variant!(target, source),
+            (ArrayData::PauliString(target), ArrayData::PauliString(source)) => {
+                assign_variant!(target, source)
+            }
+            _ => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "internal error converting assignment value to target dtype",
             )),
         }
     }

--- a/python/pecos-rslib/src/pecos_array.rs
+++ b/python/pecos-rslib/src/pecos_array.rs
@@ -33,12 +33,13 @@
 #![allow(clippy::unnecessary_wraps)] // PyResult is required for Python error handling
 #![allow(clippy::needless_pass_by_value)] // PyO3 requires passing Bound by value
 
-use ndarray::{ArrayD, Axis, Ix2, IxDyn, Slice};
+use ndarray::{ArrayD, Axis, Dimension, Ix2, IxDyn, Slice};
 use num_complex::{Complex32, Complex64};
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyBool, PyFloat, PyInt, PyList, PySequence, PySlice, PySliceIndices, PyTuple, PyType,
+    PyBool, PyEllipsis, PyFloat, PyInt, PyList, PySequence, PySlice, PySliceIndices, PyTuple,
+    PyType,
 };
 
 use crate::dtypes::DType;
@@ -67,17 +68,19 @@ pub enum ArrayData {
     PauliString(ArrayD<PauliString>),
 }
 
-/// Represents an indexing operation.
+/// One parsed component of a complete index tuple.
 #[derive(Debug, Clone)]
 enum IndexOp {
-    Integer(isize),
-    Slice(isize, isize, isize),
-    Fancy(Vec<usize>),
+    Integer(usize),
+    Slice(Vec<usize>),
+    // One broadcast input per consumed source axis. A boolean mask is lowered
+    // to its `nonzero` coordinates, so an N-D mask stores N one-dimensional arrays.
+    Advanced(Vec<ArrayD<usize>>),
 }
 
-struct AssignmentSelection {
-    ranges: Vec<Vec<usize>>,
-    integer_axes: Vec<usize>,
+/// Source coordinates in NumPy result order, shared by reads and writes.
+struct ResolvedSelection {
+    coordinates: ArrayD<Vec<usize>>,
     shape: Vec<usize>,
 }
 
@@ -1463,12 +1466,8 @@ impl Array {
         if let Ok(tuple) = index.cast::<PyTuple>() {
             let shape: Vec<usize> = slf.data.shape().to_vec();
             let index_ops = Self::parse_tuple_index(tuple, &shape)?;
-            slf.apply_mixed_indexing_assignment(
-                &index_ops,
-                &shape,
-                value,
-                value_snapshot.as_ref(),
-            )?;
+            let selection = Self::resolve_selection(&index_ops, &shape)?;
+            slf.apply_resolved_assignment(&selection, value, value_snapshot.as_ref())?;
             Ok(())
         } else if let Ok(slice) = index.cast::<PySlice>() {
             // Single slice: arr[start:stop:step] = value
@@ -1482,13 +1481,9 @@ impl Array {
             let (start, stop, step) = Self::parse_slice(slice, shape[0])?;
 
             if value_snapshot.is_some() {
-                let index_ops = vec![IndexOp::Slice(start, stop, step)];
-                slf.apply_mixed_indexing_assignment(
-                    &index_ops,
-                    &shape,
-                    value,
-                    value_snapshot.as_ref(),
-                )?;
+                let index_ops = vec![IndexOp::Slice(Self::slice_indices(start, stop, step))];
+                let selection = Self::resolve_selection(&index_ops, &shape)?;
+                slf.apply_resolved_assignment(&selection, value, value_snapshot.as_ref())?;
             } else {
                 // Apply 1D slice assignment (now supports arbitrary steps)
                 slf.apply_1d_slice_assignment_with_step(start, stop, step, value)?;
@@ -1582,15 +1577,19 @@ impl Array {
                 }
             }
             Ok(())
-        } else if index.extract::<PyRef<Array>>().is_ok() || index.cast::<PySequence>().is_ok() {
+        } else if index.extract::<PyRef<Array>>().is_ok()
+            || index.cast::<PySequence>().is_ok()
+            || index.hasattr("__array_interface__")?
+        {
             let shape: Vec<usize> = slf.data.shape().to_vec();
             if shape.is_empty() {
                 return Err(pyo3::exceptions::PyIndexError::new_err(
                     "Cannot index a zero-dimensional array",
                 ));
             }
-            let index_ops = vec![Self::parse_fancy_index(index, 0, shape[0])?];
-            slf.apply_mixed_indexing_assignment(&index_ops, &shape, value, value_snapshot.as_ref())
+            let index_ops = vec![Self::parse_advanced_index(index, 0, &shape)?];
+            let selection = Self::resolve_selection(&index_ops, &shape)?;
+            slf.apply_resolved_assignment(&selection, value, value_snapshot.as_ref())
         } else {
             // Unsupported index type
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1599,16 +1598,15 @@ impl Array {
         }
     }
 
-    /// Implement integer, slice, fancy, and one-dimensional boolean-mask reads.
+    /// Implement basic and whole-tuple advanced indexing reads.
     fn __getitem__(&self, index: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         let py = index.py();
 
         if let Ok(tuple) = index.cast::<PyTuple>() {
             let shape = self.data.shape();
             let index_ops = Self::parse_tuple_index(tuple, shape)?;
-
-            // Apply mixed indexing
-            let result = self.apply_mixed_indexing(&index_ops)?;
+            let selection = Self::resolve_selection(&index_ops, shape)?;
+            let result = self.apply_resolved_selection(&selection)?;
 
             // If result is 0-dimensional (scalar), extract the value instead of returning Array
             if result.data.shape().is_empty() {
@@ -1646,10 +1644,10 @@ impl Array {
                 )));
             }
 
-            // Use apply_mixed_indexing with a single integer index
-            // This handles both 1D (returns scalar) and multi-D (returns sub-array) cases
-            let index_ops = vec![IndexOp::Integer(normalized_idx)];
-            let result = self.apply_mixed_indexing(&index_ops)?;
+            // Use the shared resolver for both scalar and sub-array results.
+            let index_ops = vec![IndexOp::Integer(normalized_idx as usize)];
+            let selection = Self::resolve_selection(&index_ops, shape)?;
+            let result = self.apply_resolved_selection(&selection)?;
 
             // If result is 0-dimensional (scalar), extract the value instead of returning Array
             if result.data.shape().is_empty() {
@@ -1657,15 +1655,19 @@ impl Array {
             }
 
             Ok(Py::new(py, result)?.into_any())
-        } else if index.extract::<PyRef<Array>>().is_ok() || index.cast::<PySequence>().is_ok() {
+        } else if index.extract::<PyRef<Array>>().is_ok()
+            || index.cast::<PySequence>().is_ok()
+            || index.hasattr("__array_interface__")?
+        {
             let shape = self.data.shape();
             if shape.is_empty() {
                 return Err(pyo3::exceptions::PyIndexError::new_err(
                     "Cannot index a zero-dimensional array",
                 ));
             }
-            let index_ops = vec![Self::parse_fancy_index(index, 0, shape[0])?];
-            let result = self.apply_mixed_indexing(&index_ops)?;
+            let index_ops = vec![Self::parse_advanced_index(index, 0, shape)?];
+            let selection = Self::resolve_selection(&index_ops, shape)?;
+            let result = self.apply_resolved_selection(&selection)?;
             Ok(Py::new(py, result)?.into_any())
         } else {
             // Unsupported indexing type
@@ -2094,180 +2096,300 @@ impl Array {
 }
 
 impl Array {
-    fn resolve_bool_mask(mask: &[bool], axis: usize, axis_len: usize) -> PyResult<Vec<usize>> {
-        if mask.len() != axis_len {
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "Boolean mask length {} does not match axis {axis} length {axis_len}",
-                mask.len()
-            )));
+    fn slice_indices(start: isize, stop: isize, step: isize) -> Vec<usize> {
+        let mut indices = Vec::new();
+        let mut index = start;
+        while (step > 0 && index < stop) || (step < 0 && index > stop) {
+            indices.push(index as usize);
+            index += step;
         }
-        Ok(mask
-            .iter()
-            .enumerate()
-            .filter_map(|(position, selected)| selected.then_some(position))
-            .collect())
+        indices
     }
 
-    /// Return the dimensionality when every leaf in a non-empty sequence is boolean.
-    fn bool_sequence_ndim(value: &Bound<'_, PyAny>) -> PyResult<Option<usize>> {
-        if value.is_instance_of::<PyBool>() {
-            return Ok(Some(0));
-        }
-        let Ok(sequence) = value.cast::<PySequence>() else {
-            return Ok(None);
+    fn normalize_advanced_index(index: i128, axis: usize, axis_len: usize) -> PyResult<usize> {
+        let axis_len_i128 = axis_len as i128;
+        let resolved = if index < 0 {
+            axis_len_i128.checked_add(index)
+        } else {
+            Some(index)
         };
-        let length = sequence.len()?;
-        if length == 0 {
-            return Ok(None);
-        }
-
-        let mut child_ndim = None;
-        for position in 0..length {
-            let Some(ndim) = Self::bool_sequence_ndim(&sequence.get_item(position)?)? else {
-                return Ok(None);
-            };
-            if child_ndim.is_some_and(|expected| expected != ndim) {
-                return Ok(None);
-            }
-            child_ndim = Some(ndim);
-        }
-        Ok(child_ndim.map(|ndim| ndim + 1))
+        resolved
+            .filter(|&value| value >= 0 && value < axis_len_i128)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| {
+                pyo3::exceptions::PyIndexError::new_err(format!(
+                    "index {index} is out of bounds for axis {axis} of length {axis_len}"
+                ))
+            })
     }
 
-    /// Parse a sequence or bool Array used to index one axis.
-    fn parse_fancy_index(
-        index: &Bound<'_, PyAny>,
+    fn integer_index_array(
+        values: &ArrayData,
         axis: usize,
         axis_len: usize,
-    ) -> PyResult<IndexOp> {
-        if let Ok(mask) = index.extract::<PyRef<Array>>() {
-            let ArrayData::Bool(values) = &mask.data else {
-                return Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Array indices must have bool dtype",
-                ));
-            };
-            if values.ndim() != 1 {
-                return Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
-                    "Boolean mask indexing supports only one-dimensional masks; got {} dimensions",
-                    values.ndim()
-                )));
-            }
-            let mask_values = values.iter().copied().collect::<Vec<_>>();
-            return Ok(IndexOp::Fancy(Self::resolve_bool_mask(
-                &mask_values,
-                axis,
-                axis_len,
-            )?));
+    ) -> PyResult<ArrayD<usize>> {
+        macro_rules! normalize_signed {
+            ($array:expr) => {{
+                let normalized = $array
+                    .iter()
+                    .map(|&index| Self::normalize_advanced_index(i128::from(index), axis, axis_len))
+                    .collect::<PyResult<Vec<_>>>()?;
+                ArrayD::from_shape_vec($array.raw_dim(), normalized).map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "internal error resolving integer index array: {error}"
+                    ))
+                })
+            }};
         }
 
-        let sequence = index.cast::<PySequence>()?;
-        let length = sequence.len()?;
-        let items = (0..length)
-            .map(|position| sequence.get_item(position))
-            .collect::<PyResult<Vec<_>>>()?;
-
-        if let Some(ndim) = Self::bool_sequence_ndim(index)?
-            && ndim > 1
-        {
-            return Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
-                "Boolean mask indexing supports only one-dimensional masks; got {ndim} dimensions"
-            )));
+        match values {
+            ArrayData::I8(array) => normalize_signed!(array),
+            ArrayData::I16(array) => normalize_signed!(array),
+            ArrayData::I32(array) => normalize_signed!(array),
+            ArrayData::I64(array) => normalize_signed!(array),
+            ArrayData::U8(array) => normalize_signed!(array),
+            ArrayData::U16(array) => normalize_signed!(array),
+            ArrayData::U32(array) => normalize_signed!(array),
+            ArrayData::U64(array) => normalize_signed!(array),
+            _ => Err(pyo3::exceptions::PyTypeError::new_err(
+                "advanced indices must have integer or bool dtype",
+            )),
         }
-        let is_bool_mask = !items.is_empty()
-            && items
-                .iter()
-                .all(pyo3::types::PyAnyMethods::is_instance_of::<PyBool>);
-
-        if is_bool_mask {
-            let mask = items
-                .iter()
-                .map(pyo3::types::PyAnyMethods::extract::<bool>)
-                .collect::<PyResult<Vec<_>>>()?;
-            return Ok(IndexOp::Fancy(Self::resolve_bool_mask(
-                &mask, axis, axis_len,
-            )?));
-        }
-
-        let indices = items
-            .iter()
-            .map(|item| {
-                if item.is_instance_of::<PyBool>() {
-                    item.extract::<bool>().map(isize::from)
-                } else {
-                    item.extract::<isize>()
-                }
-            })
-            .collect::<PyResult<Vec<_>>>()?;
-        Ok(IndexOp::Fancy(Self::resolve_fancy_indices(
-            &indices, axis, axis_len,
-        )?))
     }
 
-    /// Parse a tuple index through the same integer-sequence resolver used by reads.
-    fn parse_tuple_index(tuple: &Bound<'_, PyTuple>, shape: &[usize]) -> PyResult<Vec<IndexOp>> {
-        if tuple.len() > shape.len() {
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "Too many indices for array: array is {}-dimensional, but {} were indexed",
-                shape.len(),
-                tuple.len()
-            )));
-        }
-
-        let mut index_ops = Vec::with_capacity(tuple.len());
-        let mut fancy_axes = 0;
-        for (axis, item) in tuple.iter().enumerate() {
-            if let Ok(slice) = item.cast::<PySlice>() {
-                let (start, stop, step) = Self::parse_slice(slice, shape[axis])?;
-                index_ops.push(IndexOp::Slice(start, stop, step));
-            } else if let Ok(idx) = item.extract::<isize>() {
-                index_ops.push(IndexOp::Integer(idx));
-            } else if item.extract::<PyRef<Array>>().is_ok() || item.cast::<PySequence>().is_ok() {
-                fancy_axes += 1;
-                if fancy_axes > 1 {
-                    return Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                        "Fancy indexing on more than one axis is not supported",
-                    ));
-                }
-                index_ops.push(Self::parse_fancy_index(&item, axis, shape[axis])?);
-            } else {
-                return Err(pyo3::exceptions::PyTypeError::new_err(
-                    "indices must be integers, slices, or one-dimensional sequences",
-                ));
-            }
-        }
-
-        if Self::has_separated_advanced_indices(&index_ops) {
+    fn boolean_mask_index(
+        mask: &ArrayD<bool>,
+        axis: usize,
+        source_shape: &[usize],
+    ) -> PyResult<IndexOp> {
+        if mask.ndim() == 0 {
             return Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                "Integer and fancy indices separated by a slice are not supported because NumPy moves the advanced-index result axis",
+                "zero-dimensional boolean indices are not supported",
             ));
         }
-        Ok(index_ops)
+        let end_axis = axis
+            .checked_add(mask.ndim())
+            .ok_or_else(|| pyo3::exceptions::PyIndexError::new_err("too many indices for array"))?;
+        if end_axis > source_shape.len() || mask.shape() != &source_shape[axis..end_axis] {
+            if mask.ndim() == 1 && axis < source_shape.len() {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "Boolean mask length {} does not match axis {axis} length {}",
+                    mask.len(),
+                    source_shape[axis]
+                )));
+            }
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "boolean mask shape {:?} does not match indexed axes {:?}",
+                mask.shape(),
+                source_shape.get(axis..end_axis).unwrap_or(&[])
+            )));
+        }
+
+        let selected_count = mask.iter().filter(|&&selected| selected).count();
+        let mut coordinates = (0..mask.ndim())
+            .map(|_| Vec::with_capacity(selected_count))
+            .collect::<Vec<_>>();
+        for (index, &selected) in mask.indexed_iter() {
+            if selected {
+                for (axis_coordinates, &coordinate) in
+                    coordinates.iter_mut().zip(index.slice().iter())
+                {
+                    axis_coordinates.push(coordinate);
+                }
+            }
+        }
+        let arrays = coordinates
+            .into_iter()
+            .map(|values| {
+                ArrayD::from_shape_vec(IxDyn(&[selected_count]), values).map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "internal error resolving boolean mask: {error}"
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(IndexOp::Advanced(arrays))
     }
 
-    /// NumPy moves the advanced result axes to the front when advanced indices
-    /// are separated by a basic slice. The current axis-order resolver cannot
-    /// represent that layout, so reject it instead of returning transposed data.
-    fn has_separated_advanced_indices(index_ops: &[IndexOp]) -> bool {
-        let Some(fancy_axis) = index_ops
-            .iter()
-            .position(|op| matches!(op, IndexOp::Fancy(_)))
-        else {
-            return false;
-        };
-
-        index_ops.iter().enumerate().any(|(integer_axis, op)| {
-            if !matches!(op, IndexOp::Integer(_)) {
-                return false;
+    fn collect_sequence_indices(
+        value: &Bound<'_, PyAny>,
+        depth: usize,
+        shape: &[usize],
+        all_bool: &mut bool,
+        bool_values: &mut Vec<bool>,
+        integer_values: &mut Vec<i128>,
+    ) -> PyResult<()> {
+        if depth < shape.len() {
+            let sequence = value.cast::<PySequence>().map_err(|_| {
+                pyo3::exceptions::PyValueError::new_err(
+                    "advanced index sequences must have a rectangular shape",
+                )
+            })?;
+            if sequence.len()? != shape[depth] {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "advanced index sequences must have a rectangular shape",
+                ));
             }
-            let (start, end) = if integer_axis < fancy_axis {
-                (integer_axis, fancy_axis)
-            } else {
-                (fancy_axis, integer_axis)
+            for position in 0..shape[depth] {
+                Self::collect_sequence_indices(
+                    &sequence.get_item(position)?,
+                    depth + 1,
+                    shape,
+                    all_bool,
+                    bool_values,
+                    integer_values,
+                )?;
+            }
+            return Ok(());
+        }
+
+        if value.cast::<PySequence>().is_ok() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "advanced index sequences must have a rectangular shape",
+            ));
+        }
+        if value.is_instance_of::<PyBool>() {
+            let bool_value = value.extract::<bool>()?;
+            bool_values.push(bool_value);
+            integer_values.push(i128::from(bool_value));
+            return Ok(());
+        }
+
+        *all_bool = false;
+        let indexed = value.call_method0("__index__").map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err(
+                "advanced indices must contain only integers or only booleans",
+            )
+        })?;
+        let integer = if let Ok(signed) = indexed.extract::<i64>() {
+            i128::from(signed)
+        } else if let Ok(unsigned) = indexed.extract::<u64>() {
+            i128::from(unsigned)
+        } else {
+            return Err(pyo3::exceptions::PyOverflowError::new_err(
+                "advanced index is outside the supported integer range",
+            ));
+        };
+        integer_values.push(integer);
+        Ok(())
+    }
+
+    /// Parse one integer-array or boolean-mask component of an index tuple.
+    fn parse_advanced_index(
+        index: &Bound<'_, PyAny>,
+        axis: usize,
+        source_shape: &[usize],
+    ) -> PyResult<IndexOp> {
+        if let Ok(array) = index.extract::<PyRef<Array>>() {
+            return match &array.data {
+                ArrayData::Bool(mask) => Self::boolean_mask_index(mask, axis, source_shape),
+                data => Ok(IndexOp::Advanced(vec![Self::integer_index_array(
+                    data,
+                    axis,
+                    source_shape[axis],
+                )?])),
             };
-            index_ops[start + 1..end]
-                .iter()
-                .any(|op| matches!(op, IndexOp::Slice(..)))
-        })
+        }
+
+        if index.hasattr("__array_interface__")? {
+            let array = Self::from_python_value(index, None)?;
+            return match &array.data {
+                ArrayData::Bool(mask) => Self::boolean_mask_index(mask, axis, source_shape),
+                data => Ok(IndexOp::Advanced(vec![Self::integer_index_array(
+                    data,
+                    axis,
+                    source_shape[axis],
+                )?])),
+            };
+        }
+
+        let shape = Self::infer_shape(index)?;
+        let mut all_bool = true;
+        let mut bool_values = Vec::new();
+        let mut integer_values = Vec::new();
+        Self::collect_sequence_indices(
+            index,
+            0,
+            &shape,
+            &mut all_bool,
+            &mut bool_values,
+            &mut integer_values,
+        )?;
+        if all_bool && !integer_values.is_empty() {
+            let mask = ArrayD::from_shape_vec(IxDyn(&shape), bool_values).map_err(|error| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid boolean mask shape: {error}"
+                ))
+            })?;
+            return Self::boolean_mask_index(&mask, axis, source_shape);
+        }
+
+        let normalized = integer_values
+            .into_iter()
+            .map(|value| Self::normalize_advanced_index(value, axis, source_shape[axis]))
+            .collect::<PyResult<Vec<_>>>()?;
+        let array = ArrayD::from_shape_vec(IxDyn(&shape), normalized).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid integer index shape: {error}"))
+        })?;
+        Ok(IndexOp::Advanced(vec![array]))
+    }
+
+    /// Parse a tuple index into basic and advanced components against source axes.
+    fn parse_tuple_index(tuple: &Bound<'_, PyTuple>, shape: &[usize]) -> PyResult<Vec<IndexOp>> {
+        let mut index_ops = Vec::with_capacity(tuple.len());
+        let mut source_axis = 0;
+        for item in tuple.iter() {
+            if item.is_instance_of::<PyEllipsis>() {
+                return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                    "Ellipsis indexing is not supported",
+                ));
+            }
+            if item.is_none() {
+                return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                    "newaxis indexing is not supported",
+                ));
+            }
+            if source_axis >= shape.len() {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "Too many indices for array: array is {}-dimensional",
+                    shape.len()
+                )));
+            }
+
+            let operation = if let Ok(slice) = item.cast::<PySlice>() {
+                let (start, stop, step) = Self::parse_slice(slice, shape[source_axis])?;
+                IndexOp::Slice(Self::slice_indices(start, stop, step))
+            } else if let Ok(idx) = item.extract::<isize>() {
+                IndexOp::Integer(Self::normalize_advanced_index(
+                    idx as i128,
+                    source_axis,
+                    shape[source_axis],
+                )?)
+            } else if item.extract::<PyRef<Array>>().is_ok()
+                || item.cast::<PySequence>().is_ok()
+                || item.hasattr("__array_interface__")?
+            {
+                Self::parse_advanced_index(&item, source_axis, shape)?
+            } else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "indices must be integers, slices, integer arrays, or boolean masks",
+                ));
+            };
+
+            source_axis += match &operation {
+                IndexOp::Integer(_) | IndexOp::Slice(_) => 1,
+                IndexOp::Advanced(arrays) => arrays.len(),
+            };
+            if source_axis > shape.len() {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "Too many indices for array: array is {}-dimensional",
+                    shape.len()
+                )));
+            }
+            index_ops.push(operation);
+        }
+
+        Ok(index_ops)
     }
 
     fn parse_reshape_shape(shape: &Bound<'_, PyTuple>) -> PyResult<Vec<isize>> {
@@ -5336,31 +5458,6 @@ impl Array {
         Ok(())
     }
 
-    /// Resolve integer-sequence indices once for both reads and writes.
-    fn resolve_fancy_indices(
-        indices: &[isize],
-        axis: usize,
-        axis_len: usize,
-    ) -> PyResult<Vec<usize>> {
-        indices
-            .iter()
-            .map(|&index| {
-                let resolved = if index < 0 {
-                    axis_len.checked_add_signed(index)
-                } else {
-                    usize::try_from(index)
-                        .ok()
-                        .filter(|&value| value < axis_len)
-                };
-                resolved.ok_or_else(|| {
-                    pyo3::exceptions::PyIndexError::new_err(format!(
-                        "index {index} is out of bounds for axis {axis} of length {axis_len}"
-                    ))
-                })
-            })
-            .collect()
-    }
-
     /// Apply multi-dimensional slicing using iterative `slice_axis()`
     /// This leverages ndarray's built-in slicing capabilities
     /// Supports arbitrary step sizes including negative steps
@@ -6075,142 +6172,236 @@ impl Array {
         }
     }
 
-    /// Apply mixed integer/slice indexing leveraging ndarray's `index_axis` and `slice_axis`
-    /// This method handles cases like arr[0, 1:3] or arr[:, 0]
-    /// where some dimensions are indexed by integers (reducing dimensionality)
-    /// and others are sliced (preserving dimensionality)
-    fn apply_mixed_indexing(&self, index_ops: &[IndexOp]) -> PyResult<Self> {
-        // Check if all are slices (pure slice indexing)
-        let all_slices = index_ops
+    /// Resolve the complete index tuple into result-ordered source coordinates.
+    fn resolve_selection(
+        index_ops: &[IndexOp],
+        source_shape: &[usize],
+    ) -> PyResult<ResolvedSelection> {
+        enum ResolvedAxis {
+            Constant(usize),
+            Basic {
+                output_axis: usize,
+                indices: Vec<usize>,
+            },
+            Advanced(ArrayD<usize>),
+        }
+
+        let has_advanced = index_ops
             .iter()
-            .all(|op| matches!(op, IndexOp::Slice(_, _, _)));
-        if all_slices {
-            // Pure slice indexing - use existing implementation
-            let slices: Vec<(usize, isize, isize, isize)> = index_ops
+            .any(|operation| matches!(operation, IndexOp::Advanced(_)));
+        let advanced_positions = if has_advanced {
+            index_ops
                 .iter()
                 .enumerate()
-                .map(|(axis, op)| {
-                    if let IndexOp::Slice(start, stop, step) = op {
-                        (axis, *start, *stop, *step)
-                    } else {
-                        unreachable!()
-                    }
+                .filter_map(|(position, operation)| {
+                    matches!(operation, IndexOp::Integer(_) | IndexOp::Advanced(_))
+                        .then_some(position)
                 })
-                .collect();
-            return self.apply_multidim_slicing(slices);
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let separated = advanced_positions
+            .windows(2)
+            .any(|positions| positions[1] != positions[0] + 1);
+        let first_advanced = advanced_positions.first().copied();
+
+        let mut advanced_shape = Vec::new();
+        for array in index_ops
+            .iter()
+            .filter_map(|operation| match operation {
+                IndexOp::Advanced(arrays) => Some(arrays),
+                _ => None,
+            })
+            .flatten()
+        {
+            advanced_shape = Self::broadcast_shape(&advanced_shape, array.shape()).map_err(|_| {
+                pyo3::exceptions::PyIndexError::new_err(format!(
+                    "shape mismatch: indexing arrays could not be broadcast together with shapes {:?} and {:?}",
+                    advanced_shape,
+                    array.shape()
+                ))
+            })?;
         }
 
-        // Mixed indexing: combination of integers and slices
-        // Strategy: Apply operations sequentially, but index parameters are ALREADY computed
-        // based on the ORIGINAL array shape. We need to re-normalize them for the CURRENT array.
+        let basic_before_advanced = first_advanced.map_or(0, |position| {
+            index_ops[..position]
+                .iter()
+                .filter(|operation| matches!(operation, IndexOp::Slice(_)))
+                .count()
+        });
+        let advanced_output_start = if separated { 0 } else { basic_before_advanced };
+        let advanced_rank = advanced_shape.len();
 
-        // Macro to generate the mixed indexing logic for each dtype
-        macro_rules! apply_mixed_indexing_impl {
-            ($arr:expr, $variant:ident) => {{
-                // Start with owned array
-                let mut result = $arr.clone();
-                let mut current_axis = 0;
+        let mut basic_lengths = index_ops
+            .iter()
+            .filter_map(|operation| match operation {
+                IndexOp::Slice(indices) => Some(indices.len()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let consumed_axes = index_ops
+            .iter()
+            .map(|operation| match operation {
+                IndexOp::Integer(_) | IndexOp::Slice(_) => 1,
+                IndexOp::Advanced(arrays) => arrays.len(),
+            })
+            .sum::<usize>();
+        if consumed_axes > source_shape.len() {
+            return Err(pyo3::exceptions::PyIndexError::new_err(
+                "too many indices for array",
+            ));
+        }
+        basic_lengths.extend_from_slice(&source_shape[consumed_axes..]);
 
-                for op in index_ops.iter() {
-                    match op {
-                        IndexOp::Integer(idx) => {
-                            // Get the current shape of the result array (which may have been reduced)
-                            let current_shape = result.shape();
+        let mut result_shape = if separated {
+            let mut shape = advanced_shape.clone();
+            shape.extend_from_slice(&basic_lengths);
+            shape
+        } else {
+            let mut shape = basic_lengths[..basic_before_advanced].to_vec();
+            shape.extend_from_slice(&advanced_shape);
+            shape.extend_from_slice(&basic_lengths[basic_before_advanced..]);
+            shape
+        };
+        if !has_advanced {
+            result_shape.clone_from(&basic_lengths);
+        }
 
-                            // current_axis should be within bounds of the current result shape
-                            if current_axis >= current_shape.len() {
-                                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                                    "Too many indices for array with {} dimensions",
-                                    current_shape.len()
-                                )));
-                            }
+        let basic_output_axis = |basic_ordinal: usize| {
+            if !has_advanced {
+                basic_ordinal
+            } else if separated {
+                advanced_rank + basic_ordinal
+            } else if basic_ordinal < basic_before_advanced {
+                basic_ordinal
+            } else {
+                advanced_rank + basic_ordinal
+            }
+        };
 
-                            let axis_size = current_shape[current_axis];
-
-                            // Resolve negative index based on CURRENT axis size
-                            // NOTE: The index was already validated against the ORIGINAL shape,
-                            // but after dimension reduction, we need to re-validate
-                            let resolved_idx = if *idx < 0 {
-                                ((axis_size as isize) + idx) as usize
-                            } else {
-                                *idx as usize
-                            };
-
-                            // Bounds check against CURRENT axis size
-                            if resolved_idx >= axis_size {
-                                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                                    "Index {} is out of bounds for axis {} with size {}",
-                                    idx, current_axis, axis_size
-                                )));
-                            }
-
-                            // Use index_axis to select along this axis and convert to owned
-                            // This reduces dimensionality
-                            result = result.index_axis(Axis(current_axis), resolved_idx).to_owned();
-                            // Don't increment current_axis because we removed a dimension
-                        }
-                        IndexOp::Slice(start, stop, step) => {
-                            // The slice parameters (start, stop, step) were calculated by Python's
-                            // slice.indices() based on the original array shape. These are correct for
-                            // the SIZE of the axis. After dimension reduction from integer indexing,
-                            // the axis SIZE doesn't change (only the axis NUMBER changes).
-                            // So we can use the slice params as-is, just on the current_axis.
-
-                            if *step < 0 {
-                                // ndarray's Slice doesn't match NumPy for negative steps
-                                // We need to manually implement NumPy's behavior:
-                                // 1. Slice forward [stop+1, start+1] with step=1
-                                // 2. Reverse the axis
-                                // 3. Apply step magnitude if > 1
-                                let actual_start = if *stop == -1 { 0 } else { stop + 1 };
-                                let actual_end = start + 1;
-                                let slice_info = Slice::new(actual_start, Some(actual_end), 1);
-                                result = result.slice_axis(Axis(current_axis), slice_info).to_owned();
-                                result.invert_axis(Axis(current_axis));
-
-                                // Now apply step magnitude if it's not -1
-                                let step_magnitude = step.abs();
-                                if step_magnitude > 1 {
-                                    let slice_stepped = Slice::new(0, None, step_magnitude);
-                                    result = result.slice_axis(Axis(current_axis), slice_stepped).to_owned();
-                                }
-                            } else {
-                                // Positive step: use the slice as-is
-                                let slice_info = Slice::new(*start, Some(*stop), *step);
-                                result = result.slice_axis(Axis(current_axis), slice_info).to_owned();
-                            }
-                            current_axis += 1; // Move to next axis in the result
-                        }
-                        IndexOp::Fancy(indices) => {
-                            result = result.select(Axis(current_axis), indices);
-                            current_axis += 1;
-                        }
+        let mut resolved_axes = Vec::with_capacity(source_shape.len());
+        let mut basic_ordinal = 0;
+        for operation in index_ops {
+            match operation {
+                IndexOp::Integer(index) => resolved_axes.push(ResolvedAxis::Constant(*index)),
+                IndexOp::Slice(indices) => {
+                    resolved_axes.push(ResolvedAxis::Basic {
+                        output_axis: basic_output_axis(basic_ordinal),
+                        indices: indices.clone(),
+                    });
+                    basic_ordinal += 1;
+                }
+                IndexOp::Advanced(arrays) => {
+                    for array in arrays {
+                        let broadcast = array
+                            .broadcast(IxDyn(&advanced_shape))
+                            .ok_or_else(|| {
+                                pyo3::exceptions::PyIndexError::new_err(format!(
+                                    "shape mismatch: index shape {:?} cannot broadcast to {:?}",
+                                    array.shape(),
+                                    advanced_shape
+                                ))
+                            })?
+                            .to_owned();
+                        resolved_axes.push(ResolvedAxis::Advanced(broadcast));
                     }
                 }
-
-                Ok(Self {
-                    data: ArrayData::$variant(result),
-                })
-            }};
+            }
+        }
+        for &axis_len in &source_shape[consumed_axes..] {
+            resolved_axes.push(ResolvedAxis::Basic {
+                output_axis: basic_output_axis(basic_ordinal),
+                indices: (0..axis_len).collect(),
+            });
+            basic_ordinal += 1;
         }
 
-        // Apply the operation to each dtype variant
+        let coordinate_options = ArrayD::from_shape_fn(IxDyn(&result_shape), |output_index| {
+            let output = output_index.slice();
+            let advanced_index = output
+                .get(advanced_output_start..advanced_output_start.saturating_add(advanced_rank))?;
+            resolved_axes
+                .iter()
+                .map(|axis| match axis {
+                    ResolvedAxis::Constant(index) => Some(*index),
+                    ResolvedAxis::Basic {
+                        output_axis,
+                        indices,
+                    } => output
+                        .get(*output_axis)
+                        .and_then(|&position| indices.get(position))
+                        .copied(),
+                    ResolvedAxis::Advanced(indices) => indices.get(IxDyn(advanced_index)).copied(),
+                })
+                .collect::<Option<Vec<_>>>()
+        });
+        let coordinates = coordinate_options
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(
+                    "internal error constructing resolved index selection",
+                )
+            })?;
+        let coordinates =
+            ArrayD::from_shape_vec(IxDyn(&result_shape), coordinates).map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "internal error shaping resolved index selection: {error}"
+                ))
+            })?;
+        Ok(ResolvedSelection {
+            coordinates,
+            shape: result_shape,
+        })
+    }
+
+    fn gather_resolved<T: Clone>(
+        source: &ArrayD<T>,
+        selection: &ResolvedSelection,
+    ) -> PyResult<ArrayD<T>> {
+        let values = selection
+            .coordinates
+            .iter()
+            .map(|coordinate| source.get(IxDyn(coordinate)).cloned())
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(
+                    "internal error: resolved index is outside the source array",
+                )
+            })?;
+        ArrayD::from_shape_vec(IxDyn(&selection.shape), values).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "internal error shaping indexed result: {error}"
+            ))
+        })
+    }
+
+    fn apply_resolved_selection(&self, selection: &ResolvedSelection) -> PyResult<Self> {
+        macro_rules! gather_variant {
+            ($source:expr, $variant:ident) => {
+                Ok(Self {
+                    data: ArrayData::$variant(Self::gather_resolved($source, selection)?),
+                })
+            };
+        }
+
         match &self.data {
-            ArrayData::Bool(arr) => apply_mixed_indexing_impl!(arr, Bool),
-            ArrayData::F64(arr) => apply_mixed_indexing_impl!(arr, F64),
-            ArrayData::F32(arr) => apply_mixed_indexing_impl!(arr, F32),
-            ArrayData::I64(arr) => apply_mixed_indexing_impl!(arr, I64),
-            ArrayData::I32(arr) => apply_mixed_indexing_impl!(arr, I32),
-            ArrayData::I16(arr) => apply_mixed_indexing_impl!(arr, I16),
-            ArrayData::I8(arr) => apply_mixed_indexing_impl!(arr, I8),
-            ArrayData::U64(arr) => apply_mixed_indexing_impl!(arr, U64),
-            ArrayData::U32(arr) => apply_mixed_indexing_impl!(arr, U32),
-            ArrayData::U16(arr) => apply_mixed_indexing_impl!(arr, U16),
-            ArrayData::U8(arr) => apply_mixed_indexing_impl!(arr, U8),
-            ArrayData::Complex128(arr) => apply_mixed_indexing_impl!(arr, Complex128),
-            ArrayData::Complex64(arr) => apply_mixed_indexing_impl!(arr, Complex64),
-            ArrayData::Pauli(arr) => apply_mixed_indexing_impl!(arr, Pauli),
-            ArrayData::PauliString(arr) => apply_mixed_indexing_impl!(arr, PauliString),
+            ArrayData::Bool(source) => gather_variant!(source, Bool),
+            ArrayData::I8(source) => gather_variant!(source, I8),
+            ArrayData::I16(source) => gather_variant!(source, I16),
+            ArrayData::I32(source) => gather_variant!(source, I32),
+            ArrayData::I64(source) => gather_variant!(source, I64),
+            ArrayData::U8(source) => gather_variant!(source, U8),
+            ArrayData::U16(source) => gather_variant!(source, U16),
+            ArrayData::U32(source) => gather_variant!(source, U32),
+            ArrayData::U64(source) => gather_variant!(source, U64),
+            ArrayData::F32(source) => gather_variant!(source, F32),
+            ArrayData::F64(source) => gather_variant!(source, F64),
+            ArrayData::Complex64(source) => gather_variant!(source, Complex64),
+            ArrayData::Complex128(source) => gather_variant!(source, Complex128),
+            ArrayData::Pauli(source) => gather_variant!(source, Pauli),
+            ArrayData::PauliString(source) => gather_variant!(source, PauliString),
         }
     }
 
@@ -6252,54 +6443,11 @@ impl Array {
         Ok((converted, is_scalar))
     }
 
-    /// Resolve each operation into ordered coordinates for mutable assignment.
-    fn assignment_ranges(index_ops: &[IndexOp], shape: &[usize]) -> PyResult<AssignmentSelection> {
-        let mut ranges = Vec::with_capacity(shape.len());
-        let mut integer_axes = Vec::new();
-
-        for (axis, op) in index_ops.iter().enumerate() {
-            match op {
-                IndexOp::Integer(index) => {
-                    let resolved = Self::resolve_fancy_indices(&[*index], axis, shape[axis])?;
-                    integer_axes.push(axis);
-                    ranges.push(resolved);
-                }
-                IndexOp::Slice(start, stop, step) => {
-                    let mut indices = Vec::new();
-                    let mut index = *start;
-                    while (*step > 0 && index < *stop) || (*step < 0 && index > *stop) {
-                        indices.push(index as usize);
-                        index += step;
-                    }
-                    ranges.push(indices);
-                }
-                IndexOp::Fancy(indices) => ranges.push(indices.clone()),
-            }
-        }
-
-        for &axis_len in &shape[index_ops.len()..] {
-            ranges.push((0..axis_len).collect());
-        }
-
-        let selection_shape = ranges
-            .iter()
-            .enumerate()
-            .filter_map(|(axis, indices)| (!integer_axes.contains(&axis)).then_some(indices.len()))
-            .collect();
-        Ok(AssignmentSelection {
-            ranges,
-            integer_axes,
-            shape: selection_shape,
-        })
-    }
-
     fn apply_converted_assignment<T: Clone>(
         target: &mut ArrayD<T>,
         source: &ArrayD<T>,
         is_scalar: bool,
-        ranges: &[Vec<usize>],
-        integer_axes: &[usize],
-        selection_shape: &[usize],
+        selection: &ResolvedSelection,
     ) -> PyResult<()> {
         if is_scalar {
             let scalar = source.first().cloned().ok_or_else(|| {
@@ -6307,41 +6455,51 @@ impl Array {
                     "internal error converting assignment value",
                 )
             })?;
-            Self::assign_to_mixed_indices(target, ranges, scalar);
+            for coordinate in &selection.coordinates {
+                let target_value = target.get_mut(IxDyn(coordinate)).ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "internal error: resolved assignment index is outside the target array",
+                    )
+                })?;
+                *target_value = scalar.clone();
+            }
         } else {
-            if source.shape() != selection_shape {
+            if source.shape() != selection.shape {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
                     "Shape mismatch: selection has shape {:?}, but source has shape {:?}",
-                    selection_shape,
+                    selection.shape,
                     source.shape()
                 )));
             }
-            Self::assign_array_to_mixed_indices(target, ranges, integer_axes, source)?;
+            for (output_index, coordinate) in selection.coordinates.indexed_iter() {
+                let source_value = source.get(output_index).cloned().ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "internal error reading converted assignment value",
+                    )
+                })?;
+                let target_value = target.get_mut(IxDyn(coordinate)).ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "internal error: resolved assignment index is outside the target array",
+                    )
+                })?;
+                *target_value = source_value;
+            }
         }
         Ok(())
     }
 
-    /// Apply integer, slice, or one-axis fancy assignment to an array.
-    fn apply_mixed_indexing_assignment(
+    /// Apply assignment through the same whole-index selection used by reads.
+    fn apply_resolved_assignment(
         &mut self,
-        index_ops: &[IndexOp],
-        shape: &[usize],
+        selection: &ResolvedSelection,
         value: &Bound<'_, PyAny>,
         value_snapshot: Option<&Self>,
     ) -> PyResult<()> {
         let (converted, is_scalar) = self.checked_assignment_value(value, value_snapshot)?;
-        let selection = Self::assignment_ranges(index_ops, shape)?;
 
         macro_rules! assign_variant {
             ($target:expr, $source:expr) => {
-                Self::apply_converted_assignment(
-                    $target,
-                    $source,
-                    is_scalar,
-                    &selection.ranges,
-                    &selection.integer_axes,
-                    &selection.shape,
-                )
+                Self::apply_converted_assignment($target, $source, is_scalar, selection)
             };
         }
 
@@ -6371,104 +6529,6 @@ impl Array {
                 "internal error converting assignment value to target dtype",
             )),
         }
-    }
-
-    // Helper method: Assign a scalar value to all indices specified by ranges
-    fn assign_to_mixed_indices<T: Clone>(
-        arr: &mut ndarray::ArrayD<T>,
-        ranges: &[Vec<usize>],
-        value: T,
-    ) {
-        // Recursively iterate through all combinations of indices
-        fn assign_recursive<T: Clone>(
-            arr: &mut ndarray::ArrayD<T>,
-            ranges: &[Vec<usize>],
-            current_indices: &mut Vec<usize>,
-            value: &T,
-        ) {
-            if current_indices.len() == ranges.len() {
-                // We have a complete set of indices - assign the value
-                arr[current_indices.as_slice()] = value.clone();
-            } else {
-                // Recurse through the next dimension
-                let dim = current_indices.len();
-                for &idx in &ranges[dim] {
-                    current_indices.push(idx);
-                    assign_recursive(arr, ranges, current_indices, value);
-                    current_indices.pop();
-                }
-            }
-        }
-
-        let mut current_indices = Vec::new();
-        assign_recursive(arr, ranges, &mut current_indices, &value);
-    }
-
-    // Helper method: Assign array values to indices specified by ranges
-    fn assign_array_to_mixed_indices<T: Clone>(
-        arr: &mut ndarray::ArrayD<T>,
-        ranges: &[Vec<usize>],
-        integer_axes: &[usize],
-        source: &ndarray::ArrayD<T>,
-    ) -> PyResult<()> {
-        use ndarray::IxDyn;
-
-        // Recursively iterate through all combinations of indices
-        fn assign_array_recursive<T: Clone>(
-            arr: &mut ndarray::ArrayD<T>,
-            ranges: &[Vec<usize>],
-            integer_axes: &[usize],
-            source: &ndarray::ArrayD<T>,
-            current_target_indices: &mut Vec<usize>,
-            current_source_indices: &mut Vec<usize>,
-        ) {
-            if current_target_indices.len() == ranges.len() {
-                // We have a complete set of indices - assign the value
-                let target_idx = IxDyn(current_target_indices);
-                let source_idx = IxDyn(current_source_indices);
-                arr[target_idx] = source[source_idx].clone();
-            } else {
-                // Recurse through the next dimension
-                let dim = current_target_indices.len();
-                let is_integer_axis = integer_axes.contains(&dim);
-
-                for (i, &idx) in ranges[dim].iter().enumerate() {
-                    current_target_indices.push(idx);
-
-                    // Only add to source indices if this is NOT an integer axis
-                    // (integer axes reduce dimensionality)
-                    if !is_integer_axis {
-                        current_source_indices.push(i);
-                    }
-
-                    assign_array_recursive(
-                        arr,
-                        ranges,
-                        integer_axes,
-                        source,
-                        current_target_indices,
-                        current_source_indices,
-                    );
-
-                    if !is_integer_axis {
-                        current_source_indices.pop();
-                    }
-                    current_target_indices.pop();
-                }
-            }
-        }
-
-        let mut current_target_indices = Vec::new();
-        let mut current_source_indices = Vec::new();
-        assign_array_recursive(
-            arr,
-            ranges,
-            integer_axes,
-            source,
-            &mut current_target_indices,
-            &mut current_source_indices,
-        );
-        Ok(())
     }
 }
 

--- a/python/pecos-rslib/src/pecos_array.rs
+++ b/python/pecos-rslib/src/pecos_array.rs
@@ -1450,15 +1450,29 @@ impl Array {
     }
 
     /// Implement indexed and slice assignment.
-    fn __setitem__(&mut self, index: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn __setitem__(
+        mut slf: PyRefMut<'_, Self>,
+        index: &Bound<'_, PyAny>,
+        value: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        // PyO3 has already mutably borrowed `self` before entering this method, so
+        // extracting the same Python object as an immutable Array would expose an
+        // internal borrow error. Snapshot it while the mutable borrow is available.
+        let value_snapshot = (slf.as_ptr() == value.as_ptr()).then(|| slf.copy());
+
         if let Ok(tuple) = index.cast::<PyTuple>() {
-            let shape: Vec<usize> = self.data.shape().to_vec();
+            let shape: Vec<usize> = slf.data.shape().to_vec();
             let index_ops = Self::parse_tuple_index(tuple, &shape)?;
-            self.apply_mixed_indexing_assignment(&index_ops, &shape, value)?;
+            slf.apply_mixed_indexing_assignment(
+                &index_ops,
+                &shape,
+                value,
+                value_snapshot.as_ref(),
+            )?;
             Ok(())
         } else if let Ok(slice) = index.cast::<PySlice>() {
             // Single slice: arr[start:stop:step] = value
-            let shape = self.data.shape();
+            let shape: Vec<usize> = slf.data.shape().to_vec();
             if shape.len() != 1 {
                 return Err(pyo3::exceptions::PyNotImplementedError::new_err(
                     "Slice assignment only works on 1D arrays for now",
@@ -1467,12 +1481,22 @@ impl Array {
 
             let (start, stop, step) = Self::parse_slice(slice, shape[0])?;
 
-            // Apply 1D slice assignment (now supports arbitrary steps)
-            self.apply_1d_slice_assignment_with_step(start, stop, step, value)?;
+            if value_snapshot.is_some() {
+                let index_ops = vec![IndexOp::Slice(start, stop, step)];
+                slf.apply_mixed_indexing_assignment(
+                    &index_ops,
+                    &shape,
+                    value,
+                    value_snapshot.as_ref(),
+                )?;
+            } else {
+                // Apply 1D slice assignment (now supports arbitrary steps)
+                slf.apply_1d_slice_assignment_with_step(start, stop, step, value)?;
+            }
             Ok(())
         } else if let Ok(idx) = index.extract::<isize>() {
             // Integer indexing: arr[i] = value
-            let shape = self.data.shape();
+            let shape = slf.data.shape();
 
             // Only 1D arrays support integer indexing with a single integer
             if shape.len() != 1 {
@@ -1495,7 +1519,7 @@ impl Array {
             let idx_usize = normalized_idx as usize;
 
             // Assign the value based on array dtype
-            match &mut self.data {
+            match &mut slf.data {
                 ArrayData::Bool(arr) => {
                     let val: bool = value.extract()?;
                     arr[idx_usize] = val;
@@ -1559,14 +1583,14 @@ impl Array {
             }
             Ok(())
         } else if index.extract::<PyRef<Array>>().is_ok() || index.cast::<PySequence>().is_ok() {
-            let shape: Vec<usize> = self.data.shape().to_vec();
+            let shape: Vec<usize> = slf.data.shape().to_vec();
             if shape.is_empty() {
                 return Err(pyo3::exceptions::PyIndexError::new_err(
                     "Cannot index a zero-dimensional array",
                 ));
             }
             let index_ops = vec![Self::parse_fancy_index(index, 0, shape[0])?];
-            self.apply_mixed_indexing_assignment(&index_ops, &shape, value)
+            slf.apply_mixed_indexing_assignment(&index_ops, &shape, value, value_snapshot.as_ref())
         } else {
             // Unsupported index type
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -2084,6 +2108,32 @@ impl Array {
             .collect())
     }
 
+    /// Return the dimensionality when every leaf in a non-empty sequence is boolean.
+    fn bool_sequence_ndim(value: &Bound<'_, PyAny>) -> PyResult<Option<usize>> {
+        if value.is_instance_of::<PyBool>() {
+            return Ok(Some(0));
+        }
+        let Ok(sequence) = value.cast::<PySequence>() else {
+            return Ok(None);
+        };
+        let length = sequence.len()?;
+        if length == 0 {
+            return Ok(None);
+        }
+
+        let mut child_ndim = None;
+        for position in 0..length {
+            let Some(ndim) = Self::bool_sequence_ndim(&sequence.get_item(position)?)? else {
+                return Ok(None);
+            };
+            if child_ndim.is_some_and(|expected| expected != ndim) {
+                return Ok(None);
+            }
+            child_ndim = Some(ndim);
+        }
+        Ok(child_ndim.map(|ndim| ndim + 1))
+    }
+
     /// Parse a sequence or bool Array used to index one axis.
     fn parse_fancy_index(
         index: &Bound<'_, PyAny>,
@@ -2115,6 +2165,14 @@ impl Array {
         let items = (0..length)
             .map(|position| sequence.get_item(position))
             .collect::<PyResult<Vec<_>>>()?;
+
+        if let Some(ndim) = Self::bool_sequence_ndim(index)?
+            && ndim > 1
+        {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
+                "Boolean mask indexing supports only one-dimensional masks; got {ndim} dimensions"
+            )));
+        }
         let is_bool_mask = !items.is_empty()
             && items
                 .iter()
@@ -2177,7 +2235,39 @@ impl Array {
                 ));
             }
         }
+
+        if Self::has_separated_advanced_indices(&index_ops) {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                "Integer and fancy indices separated by a slice are not supported because NumPy moves the advanced-index result axis",
+            ));
+        }
         Ok(index_ops)
+    }
+
+    /// NumPy moves the advanced result axes to the front when advanced indices
+    /// are separated by a basic slice. The current axis-order resolver cannot
+    /// represent that layout, so reject it instead of returning transposed data.
+    fn has_separated_advanced_indices(index_ops: &[IndexOp]) -> bool {
+        let Some(fancy_axis) = index_ops
+            .iter()
+            .position(|op| matches!(op, IndexOp::Fancy(_)))
+        else {
+            return false;
+        };
+
+        index_ops.iter().enumerate().any(|(integer_axis, op)| {
+            if !matches!(op, IndexOp::Integer(_)) {
+                return false;
+            }
+            let (start, end) = if integer_axis < fancy_axis {
+                (integer_axis, fancy_axis)
+            } else {
+                (fancy_axis, integer_axis)
+            };
+            index_ops[start + 1..end]
+                .iter()
+                .any(|op| matches!(op, IndexOp::Slice(..)))
+        })
     }
 
     fn parse_reshape_shape(shape: &Bound<'_, PyTuple>) -> PyResult<Vec<isize>> {
@@ -6125,16 +6215,34 @@ impl Array {
     }
 
     /// Convert an assignment value through the constructor/fill checked-dtype path.
-    fn checked_assignment_value(&self, value: &Bound<'_, PyAny>) -> PyResult<(Self, bool)> {
+    fn checked_assignment_value(
+        &self,
+        value: &Bound<'_, PyAny>,
+        value_snapshot: Option<&Self>,
+    ) -> PyResult<(Self, bool)> {
+        if let Some(snapshot) = value_snapshot {
+            return Ok((snapshot.copy(), snapshot.data.shape().is_empty()));
+        }
+
         let py = value.py();
         let dtype = Py::new(py, self.data.dtype())?;
-        if value.hasattr("__array_interface__")? {
-            let converted = Self::from_python_value(value, Some(dtype.bind(py).as_any()))?;
+        if let Ok(array) = value.extract::<PyRef<Array>>() {
+            let converted = array.astype(self.data.dtype())?;
             let is_scalar = converted.data.shape().is_empty();
             return Ok((converted, is_scalar));
         }
-        let is_scalar =
-            value.extract::<PyRef<Array>>().is_err() && value.cast::<PySequence>().is_err();
+        if value.hasattr("__array_interface__")? {
+            let converted = if matches!(self.data, ArrayData::Pauli(_) | ArrayData::PauliString(_))
+            {
+                let sequence = value.call_method0("tolist")?;
+                Self::from_nested_sequence(sequence.as_any(), Some(dtype.bind(py).as_any()))?
+            } else {
+                Self::from_python_value(value, Some(dtype.bind(py).as_any()))?
+            };
+            let is_scalar = converted.data.shape().is_empty();
+            return Ok((converted, is_scalar));
+        }
+        let is_scalar = value.cast::<PySequence>().is_err();
         let converted = if is_scalar {
             let singleton = PyTuple::new(py, [value])?;
             Self::from_nested_sequence(singleton.as_any(), Some(dtype.bind(py).as_any()))?
@@ -6219,8 +6327,9 @@ impl Array {
         index_ops: &[IndexOp],
         shape: &[usize],
         value: &Bound<'_, PyAny>,
+        value_snapshot: Option<&Self>,
     ) -> PyResult<()> {
-        let (converted, is_scalar) = self.checked_assignment_value(value)?;
+        let (converted, is_scalar) = self.checked_assignment_value(value, value_snapshot)?;
         let selection = Self::assignment_ranges(index_ops, shape)?;
 
         macro_rules! assign_variant {

--- a/python/pecos-rslib/tests/test_native_numeric_gaps.py
+++ b/python/pecos-rslib/tests/test_native_numeric_gaps.py
@@ -1099,6 +1099,14 @@ def test_multidimensional_boolean_mask_is_explicitly_unsupported() -> None:
         _ = values[mask]
 
 
+def test_nested_list_boolean_mask_is_explicitly_unsupported() -> None:
+    values = Array([[1, 2], [3, 4]], dtype=dtypes.int64)
+    mask = [[True, False], [False, True]]
+
+    with pytest.raises(NotImplementedError, match=r"only one-dimensional masks; got 2 dimensions"):
+        _ = values[mask]
+
+
 def test_boolean_mask_assignment_falls_out_of_indexed_assignment() -> None:
     expected = np.zeros(4, dtype=np.uint8)
     actual = Array([0, 0, 0, 0], dtype=dtypes.uint8)
@@ -1141,6 +1149,76 @@ def test_indexed_assignment_round_trip(index_form: str) -> None:
         index = Array([True, False, True], dtype=dtypes.bool)
     actual[index] = [7, 9]
     assert actual[index].tolist() == [7, 9]
+
+
+def test_separated_advanced_indices_are_explicitly_unsupported() -> None:
+    values = np.arange(18, dtype=np.int64).reshape(2, 3, 3)
+    actual = Array(values)
+    index = (1, slice(0, 2), [0, 2])
+
+    # NumPy moves the advanced-index dimension to the front for this layout.
+    assert values[index].shape == (2, 2)
+    with pytest.raises(NotImplementedError, match="separated by a slice"):
+        _ = actual[index]
+    with pytest.raises(NotImplementedError, match="separated by a slice"):
+        actual[index] = np.arange(4, dtype=np.int64).reshape(2, 2)
+
+    unequal_length_index = (1, slice(0, 3), [0, 2])
+    assert values[unequal_length_index].shape == (2, 3)
+    with pytest.raises(NotImplementedError, match="separated by a slice"):
+        _ = actual[unequal_length_index]
+
+
+def test_contiguous_advanced_indices_continue_to_match_numpy() -> None:
+    expected = np.arange(18, dtype=np.int64).reshape(2, 3, 3)
+    actual = Array(expected)
+    index = (slice(0, 2), 1, [0, 2])
+
+    np.testing.assert_array_equal(np.asarray(actual[index]), expected[index])
+    expected[index] = [[100, 101], [102, 103]]
+    actual[index] = [[100, 101], [102, 103]]
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        ([1, 0, 3, 2], [1, 0, 3, 2]),
+        (slice(None, None, -1), [3, 2, 1, 0]),
+    ],
+)
+def test_direct_self_assignment_snapshots_rhs(index: Any, expected: list[int]) -> None:
+    actual = Array([0, 1, 2, 3], dtype=dtypes.int64)
+
+    actual[index] = actual
+
+    assert actual.tolist() == expected
+
+
+def test_pauli_indexed_assignment_accepts_array_like_rhs() -> None:
+    actual = Array([Pauli.I, Pauli.I, Pauli.I])
+    native_rhs = Array([Pauli.X, Pauli.Z])
+    numpy_rhs = np.array([Pauli.Y, Pauli.X], dtype=object)
+
+    actual[[0, 2]] = native_rhs
+    assert actual.tolist() == [Pauli.X, Pauli.I, Pauli.Z]
+    actual[[1, 2]] = numpy_rhs
+    assert actual.tolist() == [Pauli.X, Pauli.Y, Pauli.X]
+
+
+def test_pauli_string_indexed_assignment_accepts_array_like_rhs() -> None:
+    identity = PauliString.from_dense_str("I")
+    x = PauliString.from_dense_str("X")
+    y = PauliString.from_dense_str("Y")
+    z = PauliString.from_dense_str("Z")
+    actual = Array([identity, identity, identity])
+    native_rhs = Array([x, z])
+    numpy_rhs = np.array([y, x], dtype=object)
+
+    actual[[0, 2]] = native_rhs
+    assert actual.tolist() == [x, identity, z]
+    actual[[1, 2]] = numpy_rhs
+    assert actual.tolist() == [x, y, x]
 
 
 @pytest.mark.parametrize(

--- a/python/pecos-rslib/tests/test_native_numeric_gaps.py
+++ b/python/pecos-rslib/tests/test_native_numeric_gaps.py
@@ -64,10 +64,22 @@ SCALAR_DTYPES = (
 INDEX_ASSIGNMENT_DTYPES = (
     ("bool", dtypes.bool, np.bool_, True, [True, False, True]),
     ("int8", dtypes.int8, np.int8, 7, [2, 3, 4]),
+    ("int16", dtypes.int16, np.int16, 7, [2, 3, 4]),
+    ("int32", dtypes.int32, np.int32, 7, [2, 3, 4]),
     ("int64", dtypes.int64, np.int64, 7, [2, 3, 4]),
     ("uint8", dtypes.uint8, np.uint8, 7, [2, 3, 4]),
+    ("uint16", dtypes.uint16, np.uint16, 7, [2, 3, 4]),
+    ("uint32", dtypes.uint32, np.uint32, 7, [2, 3, 4]),
     ("uint64", dtypes.uint64, np.uint64, 7, [2, 3, 4]),
+    ("float32", dtypes.float32, np.float32, 7.5, [2.5, 3.5, 4.5]),
     ("float64", dtypes.float64, np.float64, 7.5, [2.5, 3.5, 4.5]),
+    (
+        "complex64",
+        dtypes.complex64,
+        np.complex64,
+        7.5 + 1.25j,
+        [2.5 + 1j, 3.5 - 2j, 4.5 + 3j],
+    ),
     (
         "complex128",
         dtypes.complex128,
@@ -159,14 +171,18 @@ def test_array_class_accepts_unsigned_numpy_buffers(
 
 
 @pytest.mark.parametrize("constructor", [num.zeros, num.ones])
-def test_constructor_supported_dtype_message_is_complete(constructor: Callable[..., Array]) -> None:
+def test_constructor_supported_dtype_message_is_complete(
+    constructor: Callable[..., Array],
+) -> None:
     with pytest.raises(ValueError, match="^unsupported dtype: not-a-dtype") as exc_info:
         constructor(1, dtype="not-a-dtype")
     assert str(exc_info.value) == (f"unsupported dtype: not-a-dtype. Supported: {SUPPORTED_DTYPES}")
 
 
 @pytest.mark.parametrize("constructor", [num.array, num.asarray])
-def test_array_typestring_error_lists_unsigned_kind(constructor: Callable[..., Array]) -> None:
+def test_array_typestring_error_lists_unsigned_kind(
+    constructor: Callable[..., Array],
+) -> None:
     with pytest.raises(TypeError) as exc_info:
         constructor(["2026-01-01"], dtype="datetime64[D]")
     assert str(exc_info.value).endswith("Supported typestring kinds: 'b', 'i', 'u', 'f', 'c'")
@@ -223,7 +239,11 @@ def test_unsigned_arithmetic_directly() -> None:
 
 def test_unsigned_comparison_directly() -> None:
     result = num.array([0, 254, 255], dtype=dtypes.uint8)
-    assert (result == num.array([0, 254, 255], dtype=dtypes.uint8)).tolist() == [True, True, True]
+    assert (result == num.array([0, 254, 255], dtype=dtypes.uint8)).tolist() == [
+        True,
+        True,
+        True,
+    ]
 
 
 def test_unsigned_buffer_export_directly() -> None:
@@ -388,7 +408,9 @@ def test_big_endian_ingest_matches_little_endian_and_round_trips(
 
 
 @pytest.mark.parametrize("constructor", [Array, num.array])
-def test_float16_array_interface_remains_rejected(constructor: Callable[..., Array]) -> None:
+def test_float16_array_interface_remains_rejected(
+    constructor: Callable[..., Array],
+) -> None:
     with pytest.raises(TypeError, match="Unsupported dtype"):
         constructor(np.array([1.5], dtype=np.float16))
 
@@ -404,7 +426,10 @@ def test_native_array_unsigned_conversions_use_sequence_range_checks(
         Array([-1], dtype=target)
 
     source = Array([-1], dtype=dtypes.int64)
-    for conversion in (lambda: Array(source, dtype=target), lambda: source.astype(target)):
+    for conversion in (
+        lambda: Array(source, dtype=target),
+        lambda: source.astype(target),
+    ):
         with pytest.raises(type(sequence_error.value)) as native_error:
             conversion()
         assert str(native_error.value) == str(sequence_error.value)
@@ -513,7 +538,9 @@ def test_bool_dtype_scalar_likes_match_numpy(value: Any) -> None:
 
 
 @pytest.mark.parametrize("values", [[], [0, 1]])
-def test_bool_dtype_rejects_ambiguous_native_arrays_like_numpy_truth(values: list[int]) -> None:
+def test_bool_dtype_rejects_ambiguous_native_arrays_like_numpy_truth(
+    values: list[int],
+) -> None:
     oracle = np.array(values, dtype=np.uint8)
     with pytest.raises(ValueError, match="truth value") as numpy_error:
         bool(oracle)
@@ -639,7 +666,9 @@ def test_flatten_and_ravel_return_independent_copies(method_name: str) -> None:
 
 
 @pytest.mark.parametrize("method_name", ["flatten", "ravel"])
-def test_flatten_and_ravel_use_logical_c_order_for_transposed_arrays(method_name: str) -> None:
+def test_flatten_and_ravel_use_logical_c_order_for_transposed_arrays(
+    method_name: str,
+) -> None:
     source = np.arange(12, dtype=np.int64).reshape(3, 4).T
     actual = Array(source).T
     expected = np.asarray(source).T
@@ -673,7 +702,9 @@ def test_reshape_sequence_and_varargs_forms_match_numpy() -> None:
 
 
 @pytest.mark.parametrize("target_shape", [(-1,), (2, -1), (-1, 3, 2)])
-def test_reshape_minus_one_inference_matches_numpy(target_shape: tuple[int, ...]) -> None:
+def test_reshape_minus_one_inference_matches_numpy(
+    target_shape: tuple[int, ...],
+) -> None:
     source = np.arange(24, dtype=np.int64).reshape(2, 3, 4)
     actual = Array(source)
     expected = source.reshape(target_shape)
@@ -859,7 +890,9 @@ def test_fill_and_reshape_docstrings_state_deliberate_divergences() -> None:
 
 
 @pytest.mark.parametrize("shape", [(2, 12), (3, 2, 4), (24,)])
-def test_reshape_round_trips_and_flatten_restores_original_shape(shape: tuple[int, ...]) -> None:
+def test_reshape_round_trips_and_flatten_restores_original_shape(
+    shape: tuple[int, ...],
+) -> None:
     source = np.arange(24, dtype=np.int64).reshape(2, 3, 4)
     actual = Array(source)
 
@@ -1091,20 +1124,25 @@ def test_one_dimensional_boolean_mask_selects_rows_like_numpy() -> None:
     np.testing.assert_array_equal(np.asarray(actual), values[np.array(mask)])
 
 
-def test_multidimensional_boolean_mask_is_explicitly_unsupported() -> None:
-    values = Array([[1, 2], [3, 4]], dtype=dtypes.int64)
-    mask = Array([[True, False], [False, True]], dtype=dtypes.bool)
+@pytest.mark.parametrize("mask_ndim", [2, 3])
+@pytest.mark.parametrize("as_array", [False, True])
+def test_multidimensional_boolean_mask_read_and_write_match_numpy(mask_ndim: int, as_array: bool) -> None:
+    shape = (2, 3, 4)
+    expected = np.arange(np.prod(shape), dtype=np.int64).reshape(shape)
+    actual = Array(expected)
+    mask_shape = shape[:mask_ndim]
+    mask = np.arange(np.prod(mask_shape)).reshape(mask_shape) % 2 == 0
+    actual_mask: Any = Array(mask) if as_array else mask.tolist()
 
-    with pytest.raises(NotImplementedError, match="only one-dimensional masks"):
-        _ = values[mask]
+    expected_selection = expected[mask]
+    actual_selection = np.asarray(actual[actual_mask])
+    assert actual_selection.shape == expected_selection.shape
+    np.testing.assert_array_equal(actual_selection, expected_selection)
 
-
-def test_nested_list_boolean_mask_is_explicitly_unsupported() -> None:
-    values = Array([[1, 2], [3, 4]], dtype=dtypes.int64)
-    mask = [[True, False], [False, True]]
-
-    with pytest.raises(NotImplementedError, match=r"only one-dimensional masks; got 2 dimensions"):
-        _ = values[mask]
+    replacement = np.arange(expected_selection.size, dtype=np.int64).reshape(expected_selection.shape)
+    expected[mask] = replacement
+    actual[actual_mask] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
 
 
 def test_boolean_mask_assignment_falls_out_of_indexed_assignment() -> None:
@@ -1151,22 +1189,235 @@ def test_indexed_assignment_round_trip(index_form: str) -> None:
     assert actual[index].tolist() == [7, 9]
 
 
-def test_separated_advanced_indices_are_explicitly_unsupported() -> None:
+def test_separated_advanced_indices_read_and_write_match_numpy() -> None:
     values = np.arange(18, dtype=np.int64).reshape(2, 3, 3)
     actual = Array(values)
     index = (1, slice(0, 2), [0, 2])
 
     # NumPy moves the advanced-index dimension to the front for this layout.
     assert values[index].shape == (2, 2)
-    with pytest.raises(NotImplementedError, match="separated by a slice"):
-        _ = actual[index]
-    with pytest.raises(NotImplementedError, match="separated by a slice"):
-        actual[index] = np.arange(4, dtype=np.int64).reshape(2, 2)
+    assert actual[index].shape == values[index].shape
+    np.testing.assert_array_equal(np.asarray(actual[index]), values[index])
+    replacement = np.arange(4, dtype=np.int64).reshape(2, 2) + 100
+    values[index] = replacement
+    actual[index] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), values)
 
     unequal_length_index = (1, slice(0, 3), [0, 2])
     assert values[unequal_length_index].shape == (2, 3)
-    with pytest.raises(NotImplementedError, match="separated by a slice"):
-        _ = actual[unequal_length_index]
+    assert actual[unequal_length_index].shape == (2, 3)
+    np.testing.assert_array_equal(np.asarray(actual[unequal_length_index]), values[unequal_length_index])
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        (1, slice(0, 2), [0, 2], slice(1, 5, 2)),
+        ([0, 1], slice(0, 3), [1, 3], slice(None)),
+    ],
+)
+def test_separated_advanced_indices_in_four_dimensions_match_numpy(
+    index: tuple[Any, ...],
+) -> None:
+    shape = (2, 3, 4, 5)
+    expected = np.arange(np.prod(shape), dtype=np.int64).reshape(shape)
+    actual = Array(expected)
+    expected_selection = expected[index]
+
+    assert actual[index].shape == expected_selection.shape
+    np.testing.assert_array_equal(np.asarray(actual[index]), expected_selection)
+    replacement = np.arange(expected_selection.size, dtype=np.int64).reshape(expected_selection.shape)
+    expected[index] = replacement
+    actual[index] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    ("index", "expected_shape"),
+    [
+        ((slice(None), [0, 2, 1], [1, 3, 0], slice(None)), (2, 3, 5)),
+        ((slice(None), [0, 2, 1], slice(None), [1, 3, 4]), (3, 2, 4)),
+    ],
+    ids=["adjacent", "separated"],
+)
+def test_advanced_index_axis_placement_matches_numpy_shape(
+    index: tuple[Any, ...], expected_shape: tuple[int, ...]
+) -> None:
+    values = np.arange(2 * 3 * 4 * 5, dtype=np.int64).reshape(2, 3, 4, 5)
+    actual = Array(values)
+
+    assert values[index].shape == expected_shape
+    assert actual[index].shape == expected_shape
+    np.testing.assert_array_equal(np.asarray(actual[index]), values[index])
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        ([0, 2], [1, 3]),
+        ([[0], [2]], [[1, 3, 0]]),
+    ],
+    ids=["equal-shape", "broadcastable-shapes"],
+)
+def test_multiple_advanced_indices_read_and_write_match_numpy(
+    index: tuple[Any, ...],
+) -> None:
+    shape = (3, 4, 5)
+    expected = np.arange(np.prod(shape), dtype=np.int64).reshape(shape)
+    actual = Array(expected)
+    expected_selection = expected[index]
+
+    assert actual[index].shape == expected_selection.shape
+    np.testing.assert_array_equal(np.asarray(actual[index]), expected_selection)
+    replacement = np.arange(expected_selection.size, dtype=np.int64).reshape(expected_selection.shape)
+    expected[index] = replacement
+    actual[index] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize("as_native", [False, True])
+def test_multidimensional_integer_array_index_matches_numpy(as_native: bool) -> None:
+    expected = np.arange(3 * 4, dtype=np.int64).reshape(3, 4)
+    actual = Array(expected)
+    index = np.array([[0], [2]], dtype=np.int32)
+    actual_index: Any = Array(index) if as_native else index
+
+    assert actual[actual_index].shape == expected[index].shape
+    np.testing.assert_array_equal(np.asarray(actual[actual_index]), expected[index])
+    replacement = np.full(expected[index].shape, -1, dtype=np.int64)
+    expected[index] = replacement
+    actual[actual_index] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    ("shape", "index"),
+    [
+        ((5,), ([0, -1, 2],)),
+        ((3, 4), (1, [0, -1, 2])),
+        ((2, 3, 4), (slice(None), 1, [0, -1, 2])),
+        ((2, 3, 4, 5), ([0, 1], slice(None), 2, [0, -1])),
+    ],
+)
+def test_scalar_and_sequence_assignment_through_four_dimensions(shape: tuple[int, ...], index: tuple[Any, ...]) -> None:
+    expected = np.zeros(shape, dtype=np.int64)
+    actual = Array(expected)
+
+    expected[index] = 7
+    actual[index] = 7
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+    replacement = np.arange(expected[index].size, dtype=np.int64).reshape(expected[index].shape)
+    expected[index] = replacement
+    actual[index] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize("ndim", [3, 4])
+def test_boolean_row_mask_assignment_through_four_dimensions(ndim: int) -> None:
+    shape = (4, *([3] * (ndim - 1)))
+    expected = np.arange(np.prod(shape), dtype=np.int64).reshape(shape)
+    actual = Array(expected)
+    mask = np.array([False, True, False, True])
+    replacement = np.full(expected[mask].shape, -1, dtype=np.int64)
+
+    expected[mask] = replacement
+    actual[Array(mask)] = replacement
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    ("shape", "index"),
+    [
+        ((0,), ([],)),
+        ((0, 3), ([], slice(None))),
+        ((3, 0), ([0, 2], slice(None))),
+    ],
+)
+def test_empty_and_zero_length_advanced_selections_match_numpy(shape: tuple[int, ...], index: tuple[Any, ...]) -> None:
+    expected = np.zeros(shape, dtype=np.int64)
+    actual = Array(expected)
+
+    assert actual[index].shape == expected[index].shape
+    np.testing.assert_array_equal(np.asarray(actual[index]), expected[index])
+    actual[index] = np.empty(expected[index].shape, dtype=np.int64)
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+def test_all_false_multidimensional_mask_matches_numpy() -> None:
+    expected = np.arange(12, dtype=np.int64).reshape(3, 4)
+    actual = Array(expected)
+    mask = np.zeros((3, 4), dtype=np.bool_)
+
+    assert actual[Array(mask)].shape == expected[mask].shape == (0,)
+    actual[Array(mask)] = np.empty((0,), dtype=np.int64)
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    ("target", "source"),
+    [
+        ([3, 2, 1, 0], [0, 1, 2, 3]),
+        ([0, 1, 2, 3], [3, 2, 1, 0]),
+    ],
+)
+def test_selection_based_aliasing_and_overlap_match_numpy(target: list[int], source: list[int]) -> None:
+    expected = np.arange(4, dtype=np.int64)
+    actual = Array(expected)
+
+    expected[target] = expected[source]
+    actual[target] = actual[source]
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        np.arange(24, dtype=np.int64).reshape(4, 6).T,
+        np.arange(48, dtype=np.int64).reshape(6, 8)[::2, 1::2],
+    ],
+    ids=["transpose", "stepped-slice"],
+)
+def test_advanced_assignment_on_noncontiguous_input_matches_numpy(
+    values: np.ndarray[Any, Any],
+) -> None:
+    expected = values.copy(order="K")
+    actual = Array(values)
+    index = ([0, expected.shape[0] - 1], [0, expected.shape[1] - 1])
+
+    expected[index] = [100, 200]
+    actual[index] = [100, 200]
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+def test_advanced_indices_reject_nonbroadcastable_shapes() -> None:
+    actual = Array(np.arange(3 * 4, dtype=np.int64).reshape(3, 4))
+
+    with pytest.raises(IndexError, match=r"could not be broadcast.*\[2\].*\[3\]"):
+        _ = actual[[0, 1], [0, 1, 2]]
+    with pytest.raises(IndexError, match=r"could not be broadcast.*\[2\].*\[3\]"):
+        actual[[0, 1], [0, 1, 2]] = 0
+
+
+def test_advanced_indices_check_bounds_before_execution() -> None:
+    actual = Array(np.arange(3 * 4, dtype=np.int64).reshape(3, 4))
+
+    with pytest.raises(IndexError, match=r"index 4 .* axis 1 .* length 4"):
+        _ = actual[[0, 1], [0, 4]]
+    with pytest.raises(IndexError, match=r"index -5 .* axis 1 .* length 4"):
+        actual[[0, 1], [0, -5]] = 0
+
+
+@pytest.mark.parametrize("index", [(Ellipsis, 0), (None, 0)])
+def test_unverified_index_expansions_remain_explicitly_unsupported(
+    index: tuple[Any, ...],
+) -> None:
+    actual = Array(np.arange(6, dtype=np.int64).reshape(2, 3))
+
+    with pytest.raises(NotImplementedError, match=r"Ellipsis|newaxis"):
+        _ = actual[index]
+    with pytest.raises(NotImplementedError, match=r"Ellipsis|newaxis"):
+        actual[index] = 0
 
 
 def test_contiguous_advanced_indices_continue_to_match_numpy() -> None:
@@ -1254,6 +1505,11 @@ def test_float_aliases_preserve_double_precision(alias: object) -> None:
 
 def test_dtype_member_and_builtin_agree_for_every_alias() -> None:
     """The member spelling and the builtin must never diverge again."""
-    for name, builtin in [("float", float), ("int", int), ("bool", bool), ("complex", complex)]:
+    for name, builtin in [
+        ("float", float),
+        ("int", int),
+        ("bool", bool),
+        ("complex", complex),
+    ]:
         member = getattr(dtypes, name)
         assert str(pc.asarray([1], dtype=member).dtype) == str(pc.asarray([1], dtype=builtin).dtype)

--- a/python/pecos-rslib/tests/test_native_numeric_gaps.py
+++ b/python/pecos-rslib/tests/test_native_numeric_gaps.py
@@ -61,6 +61,22 @@ SCALAR_DTYPES = (
     ("complex128", np.complex128, 7.5 + 2.25j),
 )
 
+INDEX_ASSIGNMENT_DTYPES = (
+    ("bool", dtypes.bool, np.bool_, True, [True, False, True]),
+    ("int8", dtypes.int8, np.int8, 7, [2, 3, 4]),
+    ("int64", dtypes.int64, np.int64, 7, [2, 3, 4]),
+    ("uint8", dtypes.uint8, np.uint8, 7, [2, 3, 4]),
+    ("uint64", dtypes.uint64, np.uint64, 7, [2, 3, 4]),
+    ("float64", dtypes.float64, np.float64, 7.5, [2.5, 3.5, 4.5]),
+    (
+        "complex128",
+        dtypes.complex128,
+        np.complex128,
+        7.5 + 1.25j,
+        [2.5 + 1j, 3.5 - 2j, 4.5 + 3j],
+    ),
+)
+
 AXIS_REDUCTIONS = (
     ("sum", num.sum, np.sum),
     ("max", num.max, np.max),
@@ -959,3 +975,169 @@ def test_zero_dimensional_default_axis_reductions_match_numpy(dtype_name: str) -
     else:
         assert num.max(pecos_arr) == complex(np.max(np_arr))
         assert num.min(pecos_arr) == complex(np.min(np_arr))
+
+
+@pytest.mark.parametrize(
+    ("dtype_name", "pecos_dtype", "numpy_dtype", "scalar", "sequence"),
+    INDEX_ASSIGNMENT_DTYPES,
+)
+def test_indexed_assignment_1d_matches_numpy(
+    dtype_name: str,
+    pecos_dtype: Any,
+    numpy_dtype: Any,
+    scalar: Any,
+    sequence: list[Any],
+) -> None:
+    expected = np.zeros(5, dtype=numpy_dtype)
+    actual = Array([0] * 5, dtype=pecos_dtype)
+
+    expected[[0, -1]] = scalar
+    actual[[0, -1]] = scalar
+    np.testing.assert_array_equal(np.asarray(actual), expected, err_msg=dtype_name)
+
+    duplicate_indices = [1, 3, 1]
+    expected[duplicate_indices] = sequence
+    actual[duplicate_indices] = sequence
+    np.testing.assert_array_equal(np.asarray(actual), expected, err_msg=dtype_name)
+    assert actual[duplicate_indices].tolist() == expected[duplicate_indices].tolist()
+
+    expected[[]] = scalar
+    actual[[]] = scalar
+    expected[[]] = []
+    actual[[]] = []
+    np.testing.assert_array_equal(np.asarray(actual), expected, err_msg=dtype_name)
+
+
+@pytest.mark.parametrize(
+    ("dtype_name", "pecos_dtype", "numpy_dtype", "scalar", "sequence"),
+    INDEX_ASSIGNMENT_DTYPES,
+)
+def test_indexed_assignment_2d_matches_numpy(
+    dtype_name: str,
+    pecos_dtype: Any,
+    numpy_dtype: Any,
+    scalar: Any,
+    sequence: list[Any],
+) -> None:
+    expected = np.zeros((2, 4), dtype=numpy_dtype)
+    actual = Array([[0] * 4 for _ in range(2)], dtype=pecos_dtype)
+
+    expected[0, [0, -1]] = scalar
+    actual[0, [0, -1]] = scalar
+    expected[1, [0, 2, 0]] = sequence
+    actual[1, [0, 2, 0]] = sequence
+
+    np.testing.assert_array_equal(np.asarray(actual), expected, err_msg=dtype_name)
+    assert actual[1, [0, 2]].tolist() == expected[1, [0, 2]].tolist()
+
+
+def test_indexed_assignment_rejects_out_of_bounds_with_index_and_length() -> None:
+    actual = Array([0, 0, 0], dtype=dtypes.int64)
+
+    with pytest.raises(IndexError, match=r"index 3 .* length 3"):
+        actual[[0, 3]] = 1
+    actual_2d = Array([[0, 0, 0], [0, 0, 0]], dtype=dtypes.int64)
+    with pytest.raises(IndexError, match=r"index -4 .* length 3"):
+        actual_2d[1, [-4]] = 1
+
+
+def test_indexed_assignment_rejects_mismatched_rhs_length() -> None:
+    actual = Array([0, 0, 0], dtype=dtypes.int64)
+
+    with pytest.raises(ValueError, match=r"selection has shape \[2\].*source has shape \[1\]"):
+        actual[[0, 2]] = [7]
+
+
+def test_indexed_assignment_uses_checked_value_conversion() -> None:
+    actual = Array([0, 0], dtype=dtypes.uint8)
+
+    with pytest.raises(OverflowError, match=r"value 256 is out of range for uint8"):
+        actual[[0, 1]] = 256
+    with pytest.raises(OverflowError, match=r"value 256 is out of range for uint8"):
+        actual[[0, 1]] = [1, 256]
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        [True, True, True, True],
+        [False, False, False, False],
+        [False, True, False, True],
+    ],
+)
+@pytest.mark.parametrize("as_array", [False, True])
+def test_boolean_mask_reads_match_numpy(mask: list[bool], as_array: bool) -> None:
+    values = np.array([10, 20, 30, 40], dtype=np.int64)
+    actual = Array(values)
+    actual_mask: Any = Array(mask, dtype=dtypes.bool) if as_array else mask
+
+    np.testing.assert_array_equal(np.asarray(actual[actual_mask]), values[np.array(mask)])
+
+
+@pytest.mark.parametrize("as_array", [False, True])
+def test_boolean_mask_length_mismatch_raises(as_array: bool) -> None:
+    actual = Array([10, 20, 30], dtype=dtypes.int64)
+    mask: Any = Array([True, False], dtype=dtypes.bool) if as_array else [True, False]
+
+    with pytest.raises(IndexError, match=r"mask length 2 .* axis 0 length 3"):
+        _ = actual[mask]
+
+
+def test_one_dimensional_boolean_mask_selects_rows_like_numpy() -> None:
+    values = np.arange(12, dtype=np.int64).reshape(3, 4)
+    mask = [True, False, True]
+
+    actual = Array(values)[Array(mask, dtype=dtypes.bool)]
+    np.testing.assert_array_equal(np.asarray(actual), values[np.array(mask)])
+
+
+def test_multidimensional_boolean_mask_is_explicitly_unsupported() -> None:
+    values = Array([[1, 2], [3, 4]], dtype=dtypes.int64)
+    mask = Array([[True, False], [False, True]], dtype=dtypes.bool)
+
+    with pytest.raises(NotImplementedError, match="only one-dimensional masks"):
+        _ = values[mask]
+
+
+def test_boolean_mask_assignment_falls_out_of_indexed_assignment() -> None:
+    expected = np.zeros(4, dtype=np.uint8)
+    actual = Array([0, 0, 0, 0], dtype=dtypes.uint8)
+    mask = [False, True, False, True]
+
+    expected[np.array(mask)] = [3, 5]
+    actual[Array(mask, dtype=dtypes.bool)] = [3, 5]
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+def test_detection_events_detector_sequence_assignment() -> None:
+    detection_events = num.zeros((3, 6), dtype=dtypes.uint8)
+    index = 1
+    detectors = [0, 2, 5]
+
+    detection_events[index, detectors] = 1
+
+    assert detection_events.tolist() == [
+        [0, 0, 0, 0, 0, 0],
+        [1, 0, 1, 0, 0, 1],
+        [0, 0, 0, 0, 0, 0],
+    ]
+
+
+@pytest.mark.parametrize("index_form", ["sequence", "tuple", "bool_sequence", "bool_array"])
+def test_indexed_assignment_round_trip(index_form: str) -> None:
+    if index_form == "tuple":
+        actual = Array([[0, 0, 0], [0, 0, 0]], dtype=dtypes.int64)
+        actual[1, [0, 2]] = [7, 9]
+        assert actual[1, [0, 2]].tolist() == [7, 9]
+        return
+
+    actual = Array([0, 0, 0], dtype=dtypes.int64)
+    index: Any
+    if index_form == "sequence":
+        index = [0, 2]
+    elif index_form == "bool_sequence":
+        index = [True, False, True]
+    else:
+        index = Array([True, False, True], dtype=dtypes.bool)
+    actual[index] = [7, 9]
+    assert actual[index].tolist() == [7, 9]


### PR DESCRIPTION
## Summary

Closes #488. Replaces `Array`'s sequential axis-by-axis indexing with NumPy's advanced-indexing
execution model: parse the whole index tuple, broadcast the advanced components together, apply
the result-axis placement rule, then execute reads and writes through one resolved selection.

This removes three `NotImplementedError` refusals that were **workarounds, not principled
limits** -- the semantics were fully specified, PECOS simply could not express them:

| previously refused | now |
|---|---|
| advanced indices separated by a slice, `a[1, 0:2, [0, 2]]` | matches NumPy, read and write |
| multiple advanced indices, `a[[0, 1], [2, 0]]` | matches NumPy |
| multi-dimensional boolean masks, `a[mask_2d]` | matches NumPy |

#486 introduced the first refusal deliberately, to replace a *silently wrong* write its review
caught. Refusing was the right stopgap; this is the actual fix.

## The rule, made falsifiable

NumPy moves broadcast result dimensions to the **front** when advanced indices are separated by a
slice, and leaves them **in place** when adjacent. That distinction is asserted on result
*shapes*, not just contents, because shape is where the rule shows:

- adjacent: `(2, 3, 5)`
- separated: `(3, 2, 4)`
- the unequal-length case `a[1, 0:3, [0, 2]]` that #486 wrongly rejected: `(2, 3)`

Verified independently across reads and writes, 3-D and 4-D, with scalar and correctly-shaped
array right-hand sides.

## Still unsupported, and honestly so

`Ellipsis`, `newaxis`/`None`, and zero-dimensional boolean indices raise explicit
`NotImplementedError`. These are *shape-expansion* semantics -- a different feature from advanced
indexing -- and are refused rather than guessed at. Non-scalar assignment RHS must still match the
selection shape exactly.

## Regression bar

Everything #486's independent pass verified must still match, and does: 1-D through 4-D
assignment with scalar and sequence RHS, negative indices, duplicate indices (last-write-wins),
1-D mask reads and assignment, empty index lists, empty and all-false masks, zero-length arrays,
shapes `(0, 3)` and `(3, 0)`, selection-based aliasing and overlap, direct self-assignment, 52
dtype comparisons including Pauli and PauliString with native-Array and NumPy-object RHS, and
non-contiguous transpose / stepped-slice targets.

## Verification

clippy `-D warnings` clean; fmt clean; pecos-rslib **1631** passed; qec **1494**; docs **271**
passed, 0 failed; pre-commit two passes exit 0; 0 behind dev. Mutation table in the
implementation record covers the adjacent/separated decision, the broadcast-shape check, and
bounds.
