### PR TITLE
Migrate the threshold sweep off runtime NumPy (#458 step 3b)

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -172,10 +172,8 @@ assert flat == [1, 0, 0, 1]
 - `fill()` does not coerce values by truthiness or parse numeric strings. Convert values
   explicitly instead of relying on behavior such as a non-empty string becoming `True`.
 
-Three more migration boundaries currently need local workarounds:
+Two more migration boundaries currently need local workarounds:
 
-- Advanced indexed assignment and boolean-mask reads are not available yet (#482). Use scalar
-  assignment or explicit selection locally, and collapse the workaround when indexed access lands.
 - Elementwise `Array ^ Array` is not available yet (#458). For arrays already known to contain only
   binary values, elementwise inequality has the same result; do not use that substitution for general integers.
 - Spell NumPy's `dtype=float` as `dtype=dtypes.float64`, especially with `asarray()`, to preserve
@@ -191,6 +189,20 @@ predicted = array([1, 0, 1], dtype=dtypes.uint8)
 expected = array([1, 1, 1], dtype=dtypes.uint8)
 logical_errors = int(array_sum(predicted != expected))
 assert logical_errors == 1
+```
+
+Seed `pecos.random` immediately before a reproducible draw. Its stream deliberately differs from
+NumPy's for the same seed, so migrate statistical tests by re-baselining pinned samples and retaining
+distributional invariants instead of asserting cross-library sample equality:
+
+```python
+from pecos import random
+
+random.seed(458)
+first = random.binomial(20, 0.25, size=8)
+random.seed(458)
+repeated = random.binomial(20, 0.25, size=8)
+assert first.tolist() == repeated.tolist()
 ```
 
 ## Dependency and Security Checks

--- a/examples/surface/native_dem_threshold_sweep.py
+++ b/examples/surface/native_dem_threshold_sweep.py
@@ -66,13 +66,16 @@ from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pecos import array, asarray, dtypes, linspace, random, zeros
+from pecos import sum as array_sum
+
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
     from matplotlib.patches import Rectangle
+    from pecos import Array
 
 
 @dataclass(frozen=True)
@@ -411,21 +414,18 @@ def _percentile_interval(
 def _fit_summary_confidence_intervals(points: list[SweepPoint]) -> tuple[float, float, float, float]:
     """Bootstrap fit uncertainty for one ``(d, basis, p)`` point group."""
     ordered = sorted(points, key=lambda point: point.total_rounds)
-    fitted_per_round = _fit_per_round_rate(ordered)
-    fitted_projected = ler_over_rounds(fitted_per_round, ordered[0].distance)
 
-    try:
-        import numpy as np
-    except ImportError:  # pragma: no cover
-        return fitted_per_round, fitted_per_round, fitted_projected, fitted_projected
-
-    shot_counts = np.asarray([point.num_shots for point in ordered], dtype=np.int64)
-    observed_rates = np.asarray(
+    shot_counts = asarray([point.num_shots for point in ordered], dtype=dtypes.int64)
+    observed_rates = asarray(
         [min(max(point.logical_error_rate, 0.0), 1.0) for point in ordered],
-        dtype=np.float64,
+        dtype=dtypes.float64,
     )
-    rng = np.random.default_rng(_stable_bootstrap_seed(ordered))
-    bootstrap_counts = rng.binomial(n=shot_counts, p=observed_rates, size=(_FIT_BOOTSTRAP_SAMPLES, len(ordered)))
+    random.seed(_stable_bootstrap_seed(ordered))
+    bootstrap_counts = random.binomial(
+        n=shot_counts,
+        p=observed_rates,
+        size=(_FIT_BOOTSTRAP_SAMPLES, len(ordered)),
+    )
 
     bootstrap_per_round: list[float] = []
     bootstrap_projected: list[float] = []
@@ -499,12 +499,10 @@ def _duration_rounds_for_distance(
 
 def _reshape_round_values(flat_values: list[int], num_rounds: int, width: int, label: str) -> list[Any]:
     """Reshape a flattened per-shot result register into round slices."""
-    import numpy as np
-
     if width <= 0:
         return []
     expected = num_rounds * width
-    values = np.asarray(flat_values, dtype=np.uint8)
+    values = asarray(flat_values, dtype=dtypes.uint8)
     if values.size != expected:
         msg = (
             f"Register {label!r} has {values.size} bits for one shot, "
@@ -591,41 +589,39 @@ def _decode_one_shot(dem_decoder: Any, events_flat: list[int]) -> object:
 
 def _decode_all_shots(
     dem_decoder: object,
-    detection_events: np.ndarray,
-    observable_flips: np.ndarray,
+    detection_events: Array,
+    observable_flips: Array,
     num_shots: int,
 ) -> int:
     """Decode all shots using the fastest available path.
 
-    For PyMatching: uses decode_batch with flattened numpy array (no Python loop).
+    For PyMatching: uses decode_batch with a flattened native array (no Python loop).
     For Tesseract: uses decode_batch with parallel rayon workers.
     For others: falls back to per-shot Python loop.
 
     Returns the number of logical errors.
     """
-    import numpy as np
-
     true_flips = (
-        observable_flips[:, 0].astype(np.uint8)
+        observable_flips[:, 0].astype(dtypes.uint8)
         if observable_flips.shape[1] > 0
-        else np.zeros(num_shots, dtype=np.uint8)
+        else zeros(num_shots, dtype=dtypes.uint8)
     )
 
     # PyMatching batch: takes flattened (num_shots * num_detectors) u8 array
     from pecos.decoders import PyMatchingDecoder
 
     if isinstance(dem_decoder, PyMatchingDecoder):
-        flat = detection_events.astype(np.uint8).flatten().tolist()
+        flat = detection_events.astype(dtypes.uint8).flatten().tolist()
         predictions = dem_decoder.decode_batch(flat, num_shots)
         # Each prediction is a list of observables; check index 0
-        predicted = np.array([p[0] if p else 0 for p in predictions], dtype=np.uint8)
-        return int(np.sum(predicted != true_flips))
+        predicted = array([p[0] if p else 0 for p in predictions], dtype=dtypes.uint8)
+        return int(array_sum(predicted != true_flips))
 
     # Tesseract batch: takes list of syndromes, parallel rayon
     from pecos.decoders import TesseractDecoder
 
     if isinstance(dem_decoder, TesseractDecoder):
-        syndromes = [detection_events[i].astype(np.uint8).tolist() for i in range(num_shots)]
+        syndromes = [detection_events[i].astype(dtypes.uint8).tolist() for i in range(num_shots)]
         batch_results = dem_decoder.decode_batch(syndromes)
         num_errors = 0
         for shot_idx, result in enumerate(batch_results):
@@ -636,7 +632,7 @@ def _decode_all_shots(
     # Fallback: per-shot loop (DemAwareDecoder, etc.)
     num_errors = 0
     for shot_idx in range(num_shots):
-        events_flat = detection_events[shot_idx].astype(np.uint8).tolist()
+        events_flat = detection_events[shot_idx].astype(dtypes.uint8).tolist()
         decode_result = _decode_one_shot(dem_decoder, events_flat)
         predicted_flip = _predicted_observable_flip(decode_result)
         num_errors += int(predicted_flip != true_flips[shot_idx])
@@ -783,7 +779,6 @@ def _sim_reference_trajectory(
     sim_noise_model: str,
 ) -> tuple[tuple[tuple[int, ...], ...], tuple[tuple[int, ...], ...], tuple[int, ...], tuple[int, ...]]:
     """Cache a noiseless gate-level trajectory used as a decoding reference."""
-    import numpy as np
     from pecos.qec.surface import SurfacePatch
 
     patch = SurfacePatch.create(distance=distance)
@@ -811,9 +806,9 @@ def _sim_reference_trajectory(
         len(patch.geometry.z_stabilizers),
         "synz",
     )
-    final = np.asarray(_result_rows_for_key(result_dict, "final")[0], dtype=np.uint8)
+    final = asarray(_result_rows_for_key(result_dict, "final")[0], dtype=dtypes.uint8)
     init_key = "init_synx" if basis.upper() == "Z" else "init_synz"
-    init = np.asarray(_result_rows_for_key(result_dict, init_key)[0], dtype=np.uint8)
+    init = asarray(_result_rows_for_key(result_dict, init_key)[0], dtype=dtypes.uint8)
 
     return (
         tuple(tuple(int(v) for v in row) for row in synx_rows),
@@ -1160,8 +1155,6 @@ def _run_memory_point(
     sim_noise_model: str = "depolarizing",
 ) -> SweepPoint:
     """Run one surface-memory point and decode it with native PECOS DEMs."""
-    import numpy as np
-
     basis = basis.upper()
     decoder_runtime = _decoder_runtime(
         distance,
@@ -1195,10 +1188,10 @@ def _run_memory_point(
             interaction_basis,
             sim_noise_model,
         )
-        ref_synx_list = [np.asarray(row, dtype=np.uint8) for row in ref_synx_rows]
-        ref_synz_list = [np.asarray(row, dtype=np.uint8) for row in ref_synz_rows]
-        ref_final = np.asarray(ref_final_row, dtype=np.uint8)
-        ref_init = np.asarray(ref_init_row, dtype=np.uint8)
+        ref_synx_list = [asarray(row, dtype=dtypes.uint8) for row in ref_synx_rows]
+        ref_synz_list = [asarray(row, dtype=dtypes.uint8) for row in ref_synz_rows]
+        ref_final = asarray(ref_final_row, dtype=dtypes.uint8)
+        ref_init = asarray(ref_init_row, dtype=dtypes.uint8)
         result_dict = _run_gate_backend_result_dict(
             sample_backend=sample_backend,
             distance=distance,
@@ -1238,8 +1231,8 @@ def _run_memory_point(
         for shot_idx in range(num_shots):
             synx_list = _reshape_round_values(synx_rows[shot_idx], total_rounds, num_x_stab, "synx")
             synz_list = _reshape_round_values(synz_rows[shot_idx], total_rounds, num_z_stab, "synz")
-            final = np.asarray(final_rows[shot_idx], dtype=np.uint8)
-            init = np.asarray(init_rows[shot_idx], dtype=np.uint8)
+            final = asarray(final_rows[shot_idx], dtype=dtypes.uint8)
+            init = asarray(init_rows[shot_idx], dtype=dtypes.uint8)
 
             if final.size != patch.geometry.num_data:
                 msg = f"Register 'final' has {final.size} bits for one shot, expected {patch.geometry.num_data}"
@@ -1252,16 +1245,17 @@ def _run_memory_point(
 
             # Decode relative to the noiseless gate-level baseline so the native
             # DEM sees deviations from the actual circuit trajectory.
+            # Array lacks elementwise XOR (#458); inequality is XOR for these binary bits.
             synx_list = [
-                np.asarray(synx, dtype=np.uint8) ^ ref_synx
+                asarray(synx, dtype=dtypes.uint8) != ref_synx
                 for synx, ref_synx in zip(synx_list, ref_synx_list, strict=True)
             ]
             synz_list = [
-                np.asarray(synz, dtype=np.uint8) ^ ref_synz
+                asarray(synz, dtype=dtypes.uint8) != ref_synz
                 for synz, ref_synz in zip(synz_list, ref_synz_list, strict=True)
             ]
-            final = final ^ ref_final
-            init = init ^ ref_init
+            final = final != ref_final
+            init = init != ref_init
 
             raw_parity = int(sum(int(final[q]) for q in logical_qubits) % 2)
             if num_raw_errors is None:
@@ -4405,9 +4399,8 @@ def main() -> int:
             p_low = median_th * (1.0 - half_w)
             p_high = median_th * (1.0 + half_w)
             n_pts = args.refine_points
-            import numpy as np
 
-            refined_rates = sorted({float(f"{r:.6g}") for r in np.linspace(p_low, p_high, n_pts)})
+            refined_rates = sorted({float(f"{r:.6g}") for r in linspace(p_low, p_high, n_pts)})
             # Exclude rates already in the initial sweep
             refined_rates = [r for r in refined_rates if r not in error_rates and r > 0]
 

--- a/python/quantum-pecos/tests/qec/test_native_dem_threshold_sweep.py
+++ b/python/quantum-pecos/tests/qec/test_native_dem_threshold_sweep.py
@@ -1,0 +1,331 @@
+# Copyright 2026 The PECOS Developers
+# Licensed under the Apache License, Version 2.0
+
+"""NumPy-oracle tests for the native DEM threshold-sweep example."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import numpy as np
+import pecos.decoders
+from pecos import asarray, dtypes
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "Justfile").is_file() and (candidate / "examples").is_dir():
+            return candidate
+    msg = f"Could not locate repo root above {current}"
+    raise RuntimeError(msg)
+
+
+def _load_sweep_module() -> ModuleType:
+    module_path = _repo_root() / "examples" / "surface" / "native_dem_threshold_sweep.py"
+    module_name = "_native_dem_threshold_sweep_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load threshold-sweep module from {module_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _captured_points(sweep: ModuleType) -> list[Any]:
+    return [
+        sweep.SweepPoint(
+            backend="native_sampler",
+            distance=5,
+            basis="Z",
+            physical_error_rate=0.006,
+            total_rounds=rounds,
+            num_shots=2000,
+            num_logical_errors=errors,
+            num_raw_errors=None,
+            logical_error_rate=errors / 2000,
+            raw_error_rate=None,
+        )
+        for rounds, errors in [(10, 91), (12, 111), (14, 137), (15, 144)]
+    ]
+
+
+def _private(sweep: ModuleType, name: str) -> Any:
+    return getattr(sweep, name)
+
+
+def test_deterministic_fit_values_match_captured_numpy_baseline() -> None:
+    sweep = _load_sweep_module()
+    summary = asdict(_private(sweep, "_fit_summary_from_points")(_captured_points(sweep)))
+    for bootstrap_field in [
+        "fitted_logical_error_rate_per_round_ci_low",
+        "fitted_logical_error_rate_per_round_ci_high",
+        "fitted_projected_logical_error_rate_over_d_rounds_ci_low",
+        "fitted_projected_logical_error_rate_over_d_rounds_ci_high",
+    ]:
+        summary.pop(bootstrap_field)
+
+    assert summary == {
+        "backend": "native_sampler",
+        "basis": "Z",
+        "distance": 5,
+        "fit_root_mean_square_error": 0.0021243697782072015,
+        "fitted_logical_error_rate_per_round": 0.005051183185870917,
+        "fitted_projected_logical_error_rate_over_d_rounds": 0.024750756037684896,
+        "num_shots_per_round_point": 2000,
+        "observed_logical_error_counts": (91, 111, 137, 144),
+        "observed_logical_error_rate_lower_bounds": (
+            0.03720527135020145,
+            0.04629144858684902,
+            0.05823636538977862,
+            0.06147313331726136,
+        ),
+        "observed_logical_error_rate_upper_bounds": (
+            0.05553732462845745,
+            0.06641280644618483,
+            0.08041804641394268,
+            0.08416785915549113,
+        ),
+        "observed_logical_error_rates": (0.0455, 0.0555, 0.0685, 0.072),
+        "observed_raw_error_rates": (None, None, None, None),
+        "physical_error_rate": 0.006,
+        "round_values": (10, 12, 14, 15),
+    }
+
+
+def test_native_array_transforms_match_numpy_exactly() -> None:
+    sweep = _load_sweep_module()
+    flat_values = list(range(12))
+    reshaped = _private(sweep, "_reshape_round_values")(flat_values, 3, 4, "synx")
+
+    assert [row.tolist() for row in reshaped] == np.asarray(flat_values, dtype=np.uint8).reshape(3, 4).tolist()
+    assert tuple(
+        _private(sweep, "_duration_rounds_for_distance")(
+            5,
+            explicit_multipliers=None,
+            duration_min_multiplier=2.0,
+            duration_max_multiplier=3.0,
+            duration_num_points=4,
+        ),
+    ) == (10, 12, 13, 15)
+    assert [float(value) for value in sweep.linspace(0.003, 0.009, 4)] == np.linspace(0.003, 0.009, 4).tolist()
+
+
+class _FakePyMatchingDecoder:
+    predictions: ClassVar[list[list[int]]] = []
+    seen_flat: ClassVar[list[int] | None] = None
+
+    def decode_batch(self, flat: list[int], num_shots: int) -> list[list[int]]:
+        type(self).seen_flat = flat
+        assert num_shots == len(type(self).predictions)
+        return type(self).predictions
+
+
+def test_batch_decoding_matches_numpy_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    sweep = _load_sweep_module()
+    numpy_events = np.array(
+        [[0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1], [1, 1, 1]],
+        dtype=np.uint8,
+    )
+    numpy_observables = np.array([[0], [0], [1], [1], [1]], dtype=np.uint8)
+    _FakePyMatchingDecoder.predictions = [[0], [1], [], [1], [0]]
+    _FakePyMatchingDecoder.seen_flat = None
+    monkeypatch.setattr(pecos.decoders, "PyMatchingDecoder", _FakePyMatchingDecoder)
+
+    logical_errors = _private(sweep, "_decode_all_shots")(
+        _FakePyMatchingDecoder(),
+        asarray(numpy_events, dtype=dtypes.uint8),
+        asarray(numpy_observables, dtype=dtypes.uint8),
+        len(numpy_events),
+    )
+    normalized_predictions = np.array([0, 1, 0, 1, 0], dtype=np.uint8)
+
+    assert logical_errors == int(np.sum(normalized_predictions != numpy_observables[:, 0])) == 3
+    assert _FakePyMatchingDecoder.seen_flat == numpy_events.flatten().tolist()
+
+
+class _CapturingMemoryDecoder:
+    calls: list[tuple[list[list[bool]], list[list[bool]], list[bool], list[bool]]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def decode_memory_z(
+        self,
+        synx: list[Any],
+        synz: list[Any],
+        final: Any,
+        *,
+        init_synx: Any,
+    ) -> tuple[bool, None]:
+        self.calls.append(
+            (
+                [row.tolist() for row in synx],
+                [row.tolist() for row in synz],
+                final.tolist(),
+                init_synx.tolist(),
+            ),
+        )
+        return len(self.calls) == 1, None
+
+
+def test_gate_trajectory_xor_matches_captured_numpy_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    sweep = _load_sweep_module()
+    decoder = _CapturingMemoryDecoder()
+    runtime = SimpleNamespace(
+        patch=SimpleNamespace(geometry=SimpleNamespace(num_data=4)),
+        num_x_stab=2,
+        num_z_stab=1,
+        logical_qubits=(0, 3),
+        decoder=decoder,
+    )
+    result_dict = {
+        "synx": [[1, 1, 0, 1], [0, 0, 1, 1]],
+        "synz": [[0, 0], [1, 1]],
+        "final": [[0, 0, 1, 1], [1, 1, 0, 0]],
+        "init_synx": [[1, 1], [0, 0]],
+    }
+    monkeypatch.setattr(sweep, "_decoder_runtime", lambda *_args, **_kwargs: runtime)
+    monkeypatch.setattr(
+        sweep,
+        "_sim_reference_trajectory",
+        lambda *_args, **_kwargs: (((1, 0), (0, 1)), ((1,), (0,)), (1, 0, 1, 0), (1, 0)),
+    )
+    monkeypatch.setattr(sweep, "_run_gate_backend_result_dict", lambda **_kwargs: result_dict)
+
+    point = _private(sweep, "_run_memory_point")(
+        sample_backend="sim",
+        distance=3,
+        basis="Z",
+        physical_error_rate=0.006,
+        total_rounds=2,
+        num_shots=2,
+        dem_mode="native_decomposed",
+        native_circuit_source="abstract",
+        seed=123,
+    )
+
+    assert decoder.calls == [
+        ([[False, True], [False, False]], [[True], [False]], [True, False, False, True], [False, True]),
+        ([[True, False], [True, False]], [[False], [True]], [False, True, True, False], [True, False]),
+    ]
+    assert asdict(point) == {
+        "backend": "sim",
+        "basis": "Z",
+        "distance": 3,
+        "logical_error_rate": 0.5,
+        "num_logical_errors": 1,
+        "num_raw_errors": 0,
+        "num_shots": 2,
+        "physical_error_rate": 0.006,
+        "raw_error_rate": 0.0,
+        "total_rounds": 2,
+    }
+
+
+def test_native_dem_point_matches_captured_pre_migration_values() -> None:
+    sweep = _load_sweep_module()
+
+    point = _private(sweep, "_run_memory_point")(
+        sample_backend="native_sampler",
+        distance=3,
+        basis="Z",
+        physical_error_rate=0.01,
+        total_rounds=6,
+        num_shots=20,
+        dem_mode="native_decomposed",
+        native_circuit_source="abstract",
+        seed=124,
+        p1_scale=1.0 / 30.0,
+        p_meas_scale=1.0 / 3.0,
+        p_prep_scale=1.0 / 3.0,
+    )
+
+    assert asdict(point) == {
+        "backend": "native_sampler",
+        "basis": "Z",
+        "distance": 3,
+        "logical_error_rate": 0.15,
+        "num_logical_errors": 3,
+        "num_raw_errors": None,
+        "num_shots": 20,
+        "physical_error_rate": 0.01,
+        "raw_error_rate": None,
+        "total_rounds": 6,
+    }
+
+
+def test_bootstrap_ci_is_deliberately_rebaselined_for_pecos_rng() -> None:
+    sweep = _load_sweep_module()
+    summary = _private(sweep, "_fit_summary_from_points")(_captured_points(sweep))
+
+    # Deliberate re-baseline: PECOS's seeded RNG stream is expected to differ from NumPy's.
+    assert (
+        summary.fitted_logical_error_rate_per_round_ci_low,
+        summary.fitted_logical_error_rate_per_round_ci_high,
+        summary.fitted_projected_logical_error_rate_over_d_rounds_ci_low,
+        summary.fitted_projected_logical_error_rate_over_d_rounds_ci_high,
+    ) == (
+        0.004567745863951806,
+        0.005495604203696777,
+        0.02242523794681137,
+        0.02688059024790983,
+    )
+
+
+def test_bootstrap_ci_properties_and_reproducibility() -> None:
+    sweep = _load_sweep_module()
+    point = sweep.SweepPoint(
+        backend="native_sampler",
+        distance=3,
+        basis="Z",
+        physical_error_rate=0.006,
+        total_rounds=5,
+        num_shots=2000,
+        num_logical_errors=200,
+        num_raw_errors=None,
+        logical_error_rate=0.1,
+        raw_error_rate=None,
+    )
+    first = _private(sweep, "_fit_summary_confidence_intervals")([point])
+    repeated = _private(sweep, "_fit_summary_confidence_intervals")([point])
+    per_round = _private(sweep, "_fit_per_round_rate")([point])
+    projected = sweep.ler_over_rounds(per_round, point.distance)
+
+    assert first == repeated
+    assert first[0] <= per_round <= first[1]
+    assert first[2] <= projected <= first[3]
+
+    observed_standard_error = math.sqrt(point.logical_error_rate * (1.0 - point.logical_error_rate) / point.num_shots)
+    per_round_derivative = (1.0 / point.total_rounds) * (1.0 - 2.0 * point.logical_error_rate) ** (
+        1.0 / point.total_rounds - 1.0
+    )
+    per_round_standard_error = per_round_derivative * observed_standard_error
+    projected_derivative = point.distance * (1.0 - 2.0 * per_round) ** (point.distance - 1.0)
+    projected_standard_error = projected_derivative * per_round_standard_error
+
+    assert 2.0 * per_round_standard_error < first[1] - first[0] < 6.0 * per_round_standard_error
+    assert 2.0 * projected_standard_error < first[3] - first[2] < 6.0 * projected_standard_error
+
+
+def test_stable_bootstrap_seed_matches_captured_value() -> None:
+    sweep = _load_sweep_module()
+
+    assert _private(sweep, "_stable_bootstrap_seed")(_captured_points(sweep)) == 1869656115688596537

--- a/ruff.toml
+++ b/ruff.toml
@@ -120,7 +120,6 @@ ignore = [
 # Do not add to it: new non-test NumPy use is the thing the ban exists to stop.
 # (decode.py's TID251 lives in its existing entry further down, to avoid a duplicate key.)
 "python/quantum-pecos/src/pecos/qec/reliable_observables.py" = ["TID251"]
-"examples/surface/native_dem_threshold_sweep.py" = ["TID251"]
 "examples/measurement_throughput_benchmark.ipynb" = ["TID251"]
 "examples/surface_code_experiments.ipynb" = ["TID251"]
 "examples/surface_code_noisy_decoding.ipynb" = ["TID251"]


### PR DESCRIPTION
## Summary

#458 step 3b: `examples/surface/native_dem_threshold_sweep.py` off runtime NumPy -- 25 sites, now
zero. **`examples/surface/` has no allowlist entries left**, so the whole directory is NumPy-free
with the #460 ban enforcing it.

This file was blocked until `pecos.random.binomial` landed (#481/#487); its bootstrap uses the
vectorised `binomial(n, p, size=...)` form over per-point arrays.

## Two oracles, because one does not fit

**Deterministic paths kept exact equality**, captured before the change and asserted after:
stable bootstrap seed, fitted per-round rate, projected d-round rate, fit RMS, observed counts
and rates, round values, duration schedule, the native DEM smoke point, and both Wilson bound
vectors -- all bit-identical.

**Bootstrapped confidence intervals could not**, and that is by design: PECOS's RNG is its own
implementation and its stream deliberately differs from NumPy's for the same seed. Those
constants are re-baselined and labelled as such in the test, with the shifts being:

| CI value | NumPy | PECOS | shift |
|---|---:|---:|---:|
| per-round low | 0.004578116 | 0.004567746 | 0.23% |
| per-round high | 0.005504737 | 0.005495604 | 0.17% |
| projected low | 0.022475218 | 0.022425238 | 0.22% |
| projected high | 0.026924279 | 0.026880590 | 0.16% |

Sub-percent, consistent in direction, on 2000-resample statistics -- the signature of a different
stream rather than a defect. The decisive evidence is what did **not** move: point estimates and
Wilson bounds are exactly unchanged, so only bootstrap-derived values shifted.

Because a re-baselined constant and a regression produce the same red test, the intervals are
also pinned by stream-independent properties: each brackets its point estimate, each width sits
between 2x and 6x the propagated analytic binomial standard error, two pinned-seed runs are
exactly reproducible, and `_stable_bootstrap_seed` still yields the same seed for the same input
points.

## Verification

qec **1502** passed; rslib **1656**; docs **272** passed, 0 failed; the script runs end to end;
`ruff check` clean with the allowlist entry removed; pre-commit two passes exit 0; Rust untouched.

Remaining in #458: step 4, `decode.py` (113 sites), the last file.
