### PR TITLE
Add the Frontier parity port as an identity layer over the trellis engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pecos-frontier"
+version = "0.2.0-dev.0"
+dependencies = [
+ "pecos-decoder-core",
+ "pecos-trellis",
+ "rand 0.10.2",
+ "rand_xoshiro 0.8.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pecos-fusion-blossom"
 version = "0.2.0-dev.0"
 dependencies = [
@@ -4745,6 +4757,7 @@ dependencies = [
  "pecos-bp-trellis",
  "pecos-core",
  "pecos-eeg",
+ "pecos-frontier",
  "pecos-neo",
  "pecos-qec",
  "pecos-quantum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,7 @@ pecos-stab-tn = { version = "0.2.0-dev.0", path = "exp/pecos-stab-tn" }
 pecos-experimental = { version = "0.2.0-dev.0", path = "exp/pecos-experimental" }
 pecos-foreign = { version = "0.2.0-dev.0", path = "crates/pecos-foreign" }
 pecos-bp-trellis = { version = "0.2.0-dev.0", path = "exp/pecos-bp-trellis" }
+pecos-frontier = { version = "0.2.0-dev.0", path = "exp/pecos-frontier" }
 pecos-trellis = { version = "0.2.0-dev.0", path = "exp/pecos-trellis" }
 pecos-fusion-blossom = { version = "0.2.0-dev.0", path = "crates/pecos-fusion-blossom" }
 pecos-gpu-sims = { version = "0.2.0-dev.0", path = "crates/pecos-gpu-sims" }

--- a/exp/pecos-frontier/Cargo.toml
+++ b/exp/pecos-frontier/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pecos-frontier"
+version.workspace = true
+edition.workspace = true
+readme = "README.md"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Frontier approximate logical maximum-likelihood decoder for PECOS"
+publish = false
+
+[dependencies]
+pecos-decoder-core.workspace = true
+pecos-trellis.workspace = true
+
+[lib]
+name = "pecos_frontier"
+
+[dev-dependencies]
+rand.workspace = true
+rand_xoshiro.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/exp/pecos-frontier/README.md
+++ b/exp/pecos-frontier/README.md
@@ -1,0 +1,18 @@
+# PECOS Frontier Decoder
+
+Native Rust implementation of the Frontier approximate logical maximum-likelihood
+decoder (Leverrier & Urbanke, arXiv:2606.20513). Not a wrap of the upstream
+`frontier` package; the upstream implementation is used as a verification oracle.
+
+**Experimental** (`exp/`): the algorithm core is enumeration- and upstream-verified
+(per-shot parity on matched models), but the crate has not yet accumulated real-user
+mileage. Graduation to `crates/` and registration in the `pecos-decoders` meta-crate
+are planned once it has been exercised more broadly (larger code families, Python
+bindings, human users).
+
+Pruning ranks accumulated prefix log mass plus a `score_alpha`-weighted
+suffix-compatibility estimate. Unpruned results are exact and upstream-verified.
+
+Deterministic ordering and tie-breaking are bitwise reproducible for a fixed
+build and platform. The platform's `ln` and `exp` implementations may differ
+across platforms.

--- a/exp/pecos-frontier/examples/bridge_ab.rs
+++ b/exp/pecos-frontier/examples/bridge_ab.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Cross-implementation A/B harness: decode upstream-frontier sample shots
+//! with `FrontierDecoder` on the identical model and column order.
+//!
+//! Input JSON (produced by an external extraction script from the upstream
+//! `frontier` package): `{num_detectors, num_observables, mechanisms:
+//! [[p, [detectors], [observables]], ...], shots: [{syndrome, truth_logical}]}`
+//! where mechanism order IS the processing order and `syndrome` packs detector
+//! `i` into bit `i`.
+//!
+//! Usage: `bridge_ab <model.json> <k> <delta> <score_alpha> [bp_score_iterations]`
+//! Prints one `shot,predicted,truth,status,gap,log_evidence,seconds` line per
+//! shot (no-path rows leave the gap and evidence fields empty) plus a summary
+//! line.
+
+use pecos_decoder_core::dem::SparseDem;
+use pecos_frontier::{FrontierConfig, FrontierDecoder};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[derive(Deserialize)]
+struct BridgeModel {
+    num_detectors: usize,
+    num_observables: usize,
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    shots: Vec<Shot>,
+}
+
+#[derive(Deserialize)]
+struct Shot {
+    /// Fired detector indices (supports arbitrary detector counts).
+    fired: Vec<u32>,
+    truth_logical: u128,
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: bridge_ab <model.json> <k> <delta> <score_alpha>");
+    let k: usize = args.next().expect("missing k").parse().expect("k");
+    let delta: f64 = args.next().expect("missing delta").parse().expect("delta");
+    let score_alpha: f64 = args
+        .next()
+        .expect("missing score_alpha")
+        .parse()
+        .expect("score_alpha");
+    let bp_score_iterations: usize = args
+        .next()
+        .map_or(0, |raw| raw.parse().expect("bp_score_iterations"));
+
+    let model: BridgeModel =
+        serde_json::from_str(&std::fs::read_to_string(&path).expect("read model json"))
+            .expect("parse model json");
+    let dem = SparseDem {
+        mechanisms: model.mechanisms,
+        detector_coords: BTreeMap::new(),
+        num_detectors: model.num_detectors,
+        num_observables: model.num_observables,
+    };
+    let config = FrontierConfig {
+        k,
+        delta,
+        score_alpha,
+        column_order: None,
+        merge_indistinguishable: false,
+        bp_score_iterations,
+    };
+    let mut decoder = FrontierDecoder::from_sparse_dem(&dem, config).expect("build decoder");
+
+    let mut failures = 0_u32;
+    let mut no_path = 0_u32;
+    let started = std::time::Instant::now();
+    assert!(
+        model.num_observables <= 128,
+        "bridge truth_logical is u128; wider observables need a format change"
+    );
+    let mut syndrome = vec![0_u8; model.num_detectors];
+    for (shot, entry) in model.shots.iter().enumerate() {
+        syndrome.fill(0);
+        for &fired in &entry.fired {
+            syndrome[fired as usize] = 1;
+        }
+        let shot_started = std::time::Instant::now();
+        let outcome = decoder.decode(&syndrome);
+        let shot_seconds = shot_started.elapsed().as_secs_f64();
+        if let Ok(result) = outcome {
+            let words = result.predicted.words();
+            assert!(words.iter().skip(2).all(|&w| w == 0), "label fits u128");
+            let predicted = u128::from(words.first().copied().unwrap_or(0))
+                | (u128::from(words.get(1).copied().unwrap_or(0)) << 64);
+            let status = if predicted == entry.truth_logical {
+                "ok"
+            } else {
+                failures += 1;
+                "logical_fail"
+            };
+            let gap = result
+                .runner_up_gap
+                .map_or(String::from("inf"), |g| format!("{g:.6}"));
+            println!(
+                "{shot},{predicted},{},{status},{gap},{:.6},{shot_seconds:.6}",
+                entry.truth_logical, result.log_evidence
+            );
+        } else {
+            failures += 1;
+            no_path += 1;
+            println!(
+                "{shot},,{},no_path,,,{shot_seconds:.6}",
+                entry.truth_logical
+            );
+        }
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    let trials = u32::try_from(model.shots.len()).expect("shot count fits u32");
+    println!(
+        "SUMMARY trials={trials} fail={failures} no_path={no_path} fer={} k={k} delta={delta} alpha={score_alpha} decode_s_mean={}",
+        f64::from(failures) / f64::from(trials),
+        elapsed / f64::from(trials),
+    );
+}

--- a/exp/pecos-frontier/examples/bridge_ab.rs
+++ b/exp/pecos-frontier/examples/bridge_ab.rs
@@ -15,9 +15,9 @@
 //!
 //! Input JSON (produced by an external extraction script from the upstream
 //! `frontier` package): `{num_detectors, num_observables, mechanisms:
-//! [[p, [detectors], [observables]], ...], shots: [{syndrome, truth_logical}]}`
-//! where mechanism order IS the processing order and `syndrome` packs detector
-//! `i` into bit `i`.
+//! [[p, [detectors], [observables]], ...], shots: [{fired, truth_logical}]}`
+//! where mechanism order IS the processing order and `fired` lists the indices
+//! of the detectors that fired.
 //!
 //! Usage: `bridge_ab <model.json> <k> <delta> <score_alpha> [bp_score_iterations]`
 //! Prints one `shot,predicted,truth,status,gap,log_evidence,seconds` line per

--- a/exp/pecos-frontier/src/lib.rs
+++ b/exp/pecos-frontier/src/lib.rs
@@ -55,7 +55,8 @@ pub enum CommitteeDirection {
 pub enum CommitteeStatus {
     /// The leg retained at least one terminal state.
     Ok,
-    /// The leg found no retained path for the syndrome.
+    /// The leg found no retained path for the syndrome. Engine faults never
+    /// appear here: they abort the whole committee decode instead.
     NoPath,
 }
 
@@ -158,62 +159,26 @@ impl FrontierCommittee {
 
     /// Decode with both processing directions and select the stronger result.
     ///
+    /// Failure provenance comes from the engine's structured
+    /// [`TrellisDecodeAttempt`](FrontierDecodeAttempt): only a no-path outcome
+    /// lets the committee fall back to the other leg. Any other failure --
+    /// dimension mismatch, configuration or internal fault -- aborts the whole
+    /// committee even if the other leg produced a valid decode, because both
+    /// legs saw the same input and such a fault is a property of the call, not
+    /// of the processing direction.
+    ///
     /// # Errors
     ///
-    /// Returns the standard unexplainable-syndrome error if both legs find no
-    /// retained path.
+    /// Returns the engine's own no-path error when both legs find no retained
+    /// path, and propagates any non-no-path leg failure unchanged. When both
+    /// legs fail with engine faults, the forward leg's error is returned.
     pub fn decode(&mut self, syndrome: &[u8]) -> Result<FrontierCommitteeResult, DecoderError> {
         // Each leg owns its BP graph and scratch and runs independently on the
         // same syndrome. Their beliefs are expected to match, but are never
         // shared by reference between the two code paths.
-        let forward_result = self.forward.decode(syndrome);
-        let backward_result = self.backward.decode(syndrome);
-        let forward = committee_member(&forward_result);
-        let backward = committee_member(&backward_result);
-        let (selected, direction) = match (forward_result, backward_result) {
-            (Err(forward_error), Err(backward_error)) => {
-                // Surface the engine's own error rather than synthesizing one,
-                // and prefer a genuine fault over the no-path report so a
-                // malformed call is not reported as a pruning problem.
-                return Err(
-                    if is_absorbable_failure(&forward_error)
-                        && !is_absorbable_failure(&backward_error)
-                    {
-                        backward_error
-                    } else {
-                        forward_error
-                    },
-                );
-            }
-            (Ok(selected), Err(error)) => {
-                if !is_absorbable_failure(&error) {
-                    return Err(error);
-                }
-                (selected, CommitteeDirection::Forward)
-            }
-            (Err(error), Ok(selected)) => {
-                if !is_absorbable_failure(&error) {
-                    return Err(error);
-                }
-                (selected, CommitteeDirection::Backward)
-            }
-            (Ok(forward_result), Ok(backward_result)) => {
-                if compare_committee_legs(Some(&forward_result), Some(&backward_result))
-                    == Ordering::Less
-                {
-                    (backward_result, CommitteeDirection::Backward)
-                } else {
-                    (forward_result, CommitteeDirection::Forward)
-                }
-            }
-        };
-
-        Ok(FrontierCommitteeResult {
-            selected,
-            direction,
-            forward,
-            backward,
-        })
+        let forward_attempt = self.forward.decode_attempt(syndrome);
+        let backward_attempt = self.backward.decode_attempt(syndrome);
+        resolve_committee_attempts(forward_attempt, backward_attempt)
     }
 }
 
@@ -223,28 +188,60 @@ impl ObservableDecoder for FrontierCommittee {
     }
 }
 
-/// Whether a leg failure is one the committee may absorb by falling back to
-/// the other leg.
+/// Turn the two legs' structured attempts into a committee result.
 ///
-/// Only an unexplainable syndrome qualifies. A dimension mismatch or a BP
-/// preparation failure is a fault in the call itself: both legs would hit it,
-/// and reporting it as "this leg found no path" would send a caller tuning
-/// pruning parameters over a malformed input.
-fn is_absorbable_failure(error: &DecoderError) -> bool {
-    matches!(error, DecoderError::DecodingFailed(_))
+/// Provenance is the engine's own: [`FrontierDecodeAttempt::NoPath`] is the
+/// only failure the committee absorbs, and [`FrontierDecodeAttempt::Error`]
+/// always propagates -- checked before anything else, forward leg first --
+/// because an engine fault on a shared input can never be repaired by
+/// preferring the other processing direction.
+fn resolve_committee_attempts(
+    forward_attempt: FrontierDecodeAttempt,
+    backward_attempt: FrontierDecodeAttempt,
+) -> Result<FrontierCommitteeResult, DecoderError> {
+    use pecos_trellis::TrellisDecodeAttempt::{Error, NoPath, Success};
+
+    let forward = committee_member(&forward_attempt);
+    let backward = committee_member(&backward_attempt);
+    let (selected, direction) = match (forward_attempt, backward_attempt) {
+        // Pattern order is the precedence: a forward fault, then a backward
+        // fault, and only then the double no-path with the engine's own error.
+        (Error(error), _) | (_, Error(error)) | (NoPath { error, .. }, NoPath { .. }) => {
+            return Err(error);
+        }
+        (Success(selected), NoPath { .. }) => (selected, CommitteeDirection::Forward),
+        (NoPath { .. }, Success(selected)) => (selected, CommitteeDirection::Backward),
+        (Success(forward_result), Success(backward_result)) => {
+            if compare_committee_legs(Some(&forward_result), Some(&backward_result))
+                == Ordering::Less
+            {
+                (backward_result, CommitteeDirection::Backward)
+            } else {
+                (forward_result, CommitteeDirection::Forward)
+            }
+        }
+    };
+
+    Ok(FrontierCommitteeResult {
+        selected,
+        direction,
+        forward,
+        backward,
+    })
 }
 
 /// Summarize one leg for the committee result.
 ///
-/// A non-`Ok` status here is always an unexplainable syndrome: `decode`
-/// propagates every other failure before a member summary is returned.
-fn committee_member(result: &Result<FrontierResult, DecoderError>) -> CommitteeMember {
-    match result {
-        Ok(decoded) => CommitteeMember {
+/// A non-`Ok` status here is always a genuine no-path:
+/// [`resolve_committee_attempts`] propagates every engine fault before a
+/// member summary is returned.
+fn committee_member(attempt: &FrontierDecodeAttempt) -> CommitteeMember {
+    match attempt {
+        FrontierDecodeAttempt::Success(decoded) => CommitteeMember {
             status: CommitteeStatus::Ok,
             log_evidence: decoded.log_evidence,
         },
-        Err(_) => CommitteeMember {
+        FrontierDecodeAttempt::NoPath { .. } | FrontierDecodeAttempt::Error(_) => CommitteeMember {
             status: CommitteeStatus::NoPath,
             log_evidence: f64::NEG_INFINITY,
         },
@@ -310,11 +307,98 @@ fn committee_rank(result: Option<&FrontierResult>, is_forward: bool) -> [f64; 6]
 #[cfg(test)]
 mod tests {
     use super::{
-        FrontierCommittee, FrontierConfig, FrontierLogicalMass, FrontierResult, FrontierStatus,
-        SparseDem, committee_rank,
+        CommitteeStatus, DecoderError, FrontierCommittee, FrontierConfig, FrontierDecodeAttempt,
+        FrontierLogicalMass, FrontierResult, FrontierStatus, SparseDem, committee_rank,
+        resolve_committee_attempts,
     };
     use pecos_decoder_core::obs_mask::ObsMask;
     use std::collections::BTreeMap;
+
+    fn no_path_attempt() -> FrontierDecodeAttempt {
+        FrontierDecodeAttempt::NoPath {
+            error: DecoderError::DecodingFailed(
+                "syndrome is unexplainable at the given pruning parameters".into(),
+            ),
+            transitions: 0,
+            bp_seconds: 0.0,
+        }
+    }
+
+    fn fault_attempt(expected: usize, actual: usize) -> FrontierDecodeAttempt {
+        FrontierDecodeAttempt::Error(DecoderError::InvalidDimensions { expected, actual })
+    }
+
+    /// The full failure-arbitration matrix, on synthesized attempts so every
+    /// combination is reachable: an engine fault always propagates (forward
+    /// first), and only a double no-path returns the engine's no-path error.
+    #[test]
+    fn committee_arbitration_covers_every_failure_combination() {
+        // fault x fault -> the forward fault.
+        let error = resolve_committee_attempts(fault_attempt(1, 0), fault_attempt(2, 0))
+            .expect_err("two faults must not produce a result");
+        assert!(matches!(
+            error,
+            DecoderError::InvalidDimensions { expected: 1, .. }
+        ));
+
+        // fault x no-path (either order) -> the fault, never the no-path.
+        for (forward, backward) in [
+            (fault_attempt(1, 0), no_path_attempt()),
+            (no_path_attempt(), fault_attempt(1, 0)),
+        ] {
+            let error = resolve_committee_attempts(forward, backward)
+                .expect_err("a fault beside a no-path must not produce a result");
+            assert!(
+                matches!(error, DecoderError::InvalidDimensions { .. }),
+                "fault must win over no-path, got {error:?}"
+            );
+        }
+
+        // no-path x no-path -> the engine's own no-path error.
+        let error = resolve_committee_attempts(no_path_attempt(), no_path_attempt())
+            .expect_err("two no-paths must not produce a result");
+        assert!(matches!(error, DecoderError::DecodingFailed(_)));
+        assert!(error.to_string().contains("unexplainable"));
+    }
+
+    /// A leg fault aborts the committee even when the other leg SUCCEEDED:
+    /// both legs saw the same input, so the fault is the call's, and a valid
+    /// result from one direction must not hide it.
+    #[test]
+    fn committee_fault_beside_a_success_still_aborts() {
+        let dem = SparseDem {
+            mechanisms: vec![(0.2, vec![0], vec![0])],
+            detector_coords: BTreeMap::new(),
+            num_detectors: 1,
+            num_observables: 1,
+        };
+        let mut leg = super::FrontierDecoder::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                k: usize::MAX,
+                delta: f64::INFINITY,
+                score_alpha: 0.8,
+                column_order: None,
+                merge_indistinguishable: false,
+                bp_score_iterations: 0,
+            },
+        )
+        .unwrap();
+        let success = leg.decode_attempt(&[1]);
+        assert!(matches!(success, FrontierDecodeAttempt::Success(_)));
+
+        let error = resolve_committee_attempts(success, fault_attempt(1, 0))
+            .expect_err("a fault must abort even beside a success");
+        assert!(matches!(error, DecoderError::InvalidDimensions { .. }));
+
+        // A success beside a genuine no-path is still selected, with the
+        // failed leg reported honestly.
+        let success = leg.decode_attempt(&[1]);
+        let result = resolve_committee_attempts(success, no_path_attempt())
+            .expect("a success beside a no-path must be selected");
+        assert_eq!(result.backward.status, CommitteeStatus::NoPath);
+        assert!(result.backward.log_evidence.is_infinite() && result.backward.log_evidence < 0.0);
+    }
 
     #[test]
     fn committee_merges_both_legs() {

--- a/exp/pecos-frontier/src/lib.rs
+++ b/exp/pecos-frontier/src/lib.rs
@@ -171,9 +171,32 @@ impl FrontierCommittee {
         let forward = committee_member(&forward_result);
         let backward = committee_member(&backward_result);
         let (selected, direction) = match (forward_result, backward_result) {
-            (Err(_), Err(_)) => return Err(unexplainable_error()),
-            (Ok(selected), Err(_)) => (selected, CommitteeDirection::Forward),
-            (Err(_), Ok(selected)) => (selected, CommitteeDirection::Backward),
+            (Err(forward_error), Err(backward_error)) => {
+                // Surface the engine's own error rather than synthesizing one,
+                // and prefer a genuine fault over the no-path report so a
+                // malformed call is not reported as a pruning problem.
+                return Err(
+                    if is_absorbable_failure(&forward_error)
+                        && !is_absorbable_failure(&backward_error)
+                    {
+                        backward_error
+                    } else {
+                        forward_error
+                    },
+                );
+            }
+            (Ok(selected), Err(error)) => {
+                if !is_absorbable_failure(&error) {
+                    return Err(error);
+                }
+                (selected, CommitteeDirection::Forward)
+            }
+            (Err(error), Ok(selected)) => {
+                if !is_absorbable_failure(&error) {
+                    return Err(error);
+                }
+                (selected, CommitteeDirection::Backward)
+            }
             (Ok(forward_result), Ok(backward_result)) => {
                 if compare_committee_legs(Some(&forward_result), Some(&backward_result))
                     == Ordering::Less
@@ -200,6 +223,21 @@ impl ObservableDecoder for FrontierCommittee {
     }
 }
 
+/// Whether a leg failure is one the committee may absorb by falling back to
+/// the other leg.
+///
+/// Only an unexplainable syndrome qualifies. A dimension mismatch or a BP
+/// preparation failure is a fault in the call itself: both legs would hit it,
+/// and reporting it as "this leg found no path" would send a caller tuning
+/// pruning parameters over a malformed input.
+fn is_absorbable_failure(error: &DecoderError) -> bool {
+    matches!(error, DecoderError::DecodingFailed(_))
+}
+
+/// Summarize one leg for the committee result.
+///
+/// A non-`Ok` status here is always an unexplainable syndrome: `decode`
+/// propagates every other failure before a member summary is returned.
 fn committee_member(result: &Result<FrontierResult, DecoderError>) -> CommitteeMember {
     match result {
         Ok(decoded) => CommitteeMember {
@@ -267,10 +305,6 @@ fn committee_rank(result: Option<&FrontierResult>, is_forward: bool) -> [f64; 6]
         0.0,
         forward_bonus,
     ]
-}
-
-fn unexplainable_error() -> DecoderError {
-    DecoderError::DecodingFailed("syndrome is unexplainable at the given pruning parameters".into())
 }
 
 #[cfg(test)]

--- a/exp/pecos-frontier/src/lib.rs
+++ b/exp/pecos-frontier/src/lib.rs
@@ -1,0 +1,392 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Frontier approximate logical maximum-likelihood decoding.
+//!
+//! The decoder performs ordered dynamic programming over independent binary
+//! fault mechanisms. Prefixes with identical active detector boundary and
+//! logical labels are merged by log-sum-exp, preserving degeneracy mass. The
+//! configured frontier width and log-mass window provide deterministic pruning
+//! for a fixed build and platform; underlying `ln`/`exp` implementations may
+//! differ across platforms.
+//! [`FrontierDecoder`] is the parity port of Leverrier and Urbanke's Frontier
+//! decoder. Its input-order defaults remain those of that port.
+
+use pecos_decoder_core::ObservableDecoder;
+pub use pecos_trellis::{
+    DecoderError, ObsMask, SparseDem, backward_deadline_column_order, deadline_column_order,
+};
+use std::cmp::Ordering;
+use std::time::Instant;
+
+/// Parity-port name for [`pecos_trellis::TrellisDecoder`].
+pub type FrontierDecoder = pecos_trellis::TrellisDecoder;
+/// Parity-port name for [`pecos_trellis::TrellisConfig`].
+pub type FrontierConfig = pecos_trellis::TrellisConfig;
+/// Parity-port name for [`pecos_trellis::TrellisResult`].
+pub type FrontierResult = pecos_trellis::TrellisResult;
+/// Parity-port name for [`pecos_trellis::TrellisStatus`].
+pub type FrontierStatus = pecos_trellis::TrellisStatus;
+/// Parity-port name for [`pecos_trellis::TrellisDecodeAttempt`].
+pub type FrontierDecodeAttempt = pecos_trellis::TrellisDecodeAttempt;
+/// Parity-port name for [`pecos_trellis::TrellisLogicalMass`].
+pub type FrontierLogicalMass = pecos_trellis::TrellisLogicalMass;
+
+/// Direction selected by [`FrontierCommittee`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitteeDirection {
+    /// The configured processing order.
+    Forward,
+    /// The plain reverse of the configured processing order.
+    Backward,
+}
+
+/// Decode status for one committee leg.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitteeStatus {
+    /// The leg retained at least one terminal state.
+    Ok,
+    /// The leg found no retained path for the syndrome.
+    NoPath,
+}
+
+/// Summary of one committee leg.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CommitteeMember {
+    /// Decode status for this leg.
+    pub status: CommitteeStatus,
+    /// Total retained log evidence, or negative infinity for no path.
+    pub log_evidence: f64,
+}
+
+/// Result selected from the forward/backward committee.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrontierCommitteeResult {
+    /// Full result from the selected leg.
+    pub selected: FrontierResult,
+    /// Direction of the selected leg.
+    pub direction: CommitteeDirection,
+    /// Forward-leg status and evidence.
+    pub forward: CommitteeMember,
+    /// Backward-leg status and evidence.
+    pub backward: CommitteeMember,
+}
+
+/// Two-leg Frontier decoder using a processing order and its plain reverse.
+#[derive(Clone, Debug)]
+pub struct FrontierCommittee {
+    forward: FrontierDecoder,
+    backward: FrontierDecoder,
+    build_seconds: f64,
+}
+
+impl FrontierCommittee {
+    /// Construct a forward/backward committee from a sparse DEM.
+    ///
+    /// The forward leg uses `config.column_order` (or DEM order when absent).
+    /// The backward leg uses the plain reverse of that same sequence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecoderError::InvalidConfiguration`] when the configuration or
+    /// DEM is invalid.
+    pub fn from_sparse_dem(dem: &SparseDem, config: FrontierConfig) -> Result<Self, DecoderError> {
+        let build_started = Instant::now();
+        let FrontierConfig {
+            k,
+            delta,
+            score_alpha,
+            column_order,
+            merge_indistinguishable,
+            bp_score_iterations,
+        } = config;
+        let mut forward_order = column_order.unwrap_or_else(|| (0..dem.mechanisms.len()).collect());
+        let forward = FrontierDecoder::from_sparse_dem(
+            dem,
+            FrontierConfig {
+                k,
+                delta,
+                score_alpha,
+                column_order: Some(forward_order.clone()),
+                merge_indistinguishable,
+                bp_score_iterations,
+            },
+        )?;
+        forward_order.reverse();
+        let backward_config = FrontierConfig {
+            k,
+            delta,
+            score_alpha,
+            column_order: Some(forward_order),
+            merge_indistinguishable,
+            bp_score_iterations,
+        };
+        let backward = FrontierDecoder::from_sparse_dem(dem, backward_config)?;
+        let build_seconds = build_started.elapsed().as_secs_f64();
+        Ok(Self {
+            forward,
+            backward,
+            build_seconds,
+        })
+    }
+
+    /// Wall-clock seconds spent constructing both committee legs in
+    /// [`Self::from_sparse_dem`].
+    #[must_use]
+    pub fn build_seconds(&self) -> f64 {
+        self.build_seconds
+    }
+
+    /// Parse a Stim-format detector error model and construct a committee.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecoderError`] if parsing or committee construction fails.
+    pub fn from_dem_str(dem_str: &str, config: FrontierConfig) -> Result<Self, DecoderError> {
+        let dem = SparseDem::from_dem_str(dem_str)?;
+        Self::from_sparse_dem(&dem, config)
+    }
+
+    /// Decode with both processing directions and select the stronger result.
+    ///
+    /// # Errors
+    ///
+    /// Returns the standard unexplainable-syndrome error if both legs find no
+    /// retained path.
+    pub fn decode(&mut self, syndrome: &[u8]) -> Result<FrontierCommitteeResult, DecoderError> {
+        // Each leg owns its BP graph and scratch and runs independently on the
+        // same syndrome. Their beliefs are expected to match, but are never
+        // shared by reference between the two code paths.
+        let forward_result = self.forward.decode(syndrome);
+        let backward_result = self.backward.decode(syndrome);
+        let forward = committee_member(&forward_result);
+        let backward = committee_member(&backward_result);
+        let (selected, direction) = match (forward_result, backward_result) {
+            (Err(_), Err(_)) => return Err(unexplainable_error()),
+            (Ok(selected), Err(_)) => (selected, CommitteeDirection::Forward),
+            (Err(_), Ok(selected)) => (selected, CommitteeDirection::Backward),
+            (Ok(forward_result), Ok(backward_result)) => {
+                if compare_committee_legs(Some(&forward_result), Some(&backward_result))
+                    == Ordering::Less
+                {
+                    (backward_result, CommitteeDirection::Backward)
+                } else {
+                    (forward_result, CommitteeDirection::Forward)
+                }
+            }
+        };
+
+        Ok(FrontierCommitteeResult {
+            selected,
+            direction,
+            forward,
+            backward,
+        })
+    }
+}
+
+impl ObservableDecoder for FrontierCommittee {
+    fn decode_obs(&mut self, syndrome: &[u8]) -> Result<ObsMask, DecoderError> {
+        Ok(self.decode(syndrome)?.selected.predicted)
+    }
+}
+
+fn committee_member(result: &Result<FrontierResult, DecoderError>) -> CommitteeMember {
+    match result {
+        Ok(decoded) => CommitteeMember {
+            status: CommitteeStatus::Ok,
+            log_evidence: decoded.log_evidence,
+        },
+        Err(_) => CommitteeMember {
+            status: CommitteeStatus::NoPath,
+            log_evidence: f64::NEG_INFINITY,
+        },
+    }
+}
+
+fn compare_committee_legs(
+    forward: Option<&FrontierResult>,
+    backward: Option<&FrontierResult>,
+) -> Ordering {
+    let forward_rank = committee_rank(forward, true);
+    let backward_rank = committee_rank(backward, false);
+    forward_rank
+        .iter()
+        .zip(backward_rank)
+        .find_map(|(forward_component, backward_component)| {
+            let ordering = forward_component.total_cmp(&backward_component);
+            (ordering != Ordering::Equal).then_some(ordering)
+        })
+        .unwrap_or(Ordering::Equal)
+}
+
+fn committee_rank(result: Option<&FrontierResult>, is_forward: bool) -> [f64; 6] {
+    let forward_bonus = if is_forward { 1.0 } else { 0.0 };
+    let Some(result) = result else {
+        return [
+            1.0,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+            0.0,
+            forward_bonus,
+        ];
+    };
+
+    let terminal_gap = result.runner_up_gap.unwrap_or(f64::INFINITY);
+    let terminal_gap = if terminal_gap.is_nan() {
+        f64::NEG_INFINITY
+    } else {
+        terminal_gap
+    };
+    let top_one_posterior = result
+        .logical_masses
+        .first()
+        .map_or(f64::NEG_INFINITY, |winner| {
+            winner.log_mass - result.log_evidence
+        });
+    let top_one_posterior = if top_one_posterior.is_finite() {
+        top_one_posterior
+    } else {
+        f64::NEG_INFINITY
+    };
+    [
+        2.0,
+        result.log_evidence,
+        terminal_gap,
+        top_one_posterior,
+        0.0,
+        forward_bonus,
+    ]
+}
+
+fn unexplainable_error() -> DecoderError {
+    DecoderError::DecodingFailed("syndrome is unexplainable at the given pruning parameters".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FrontierCommittee, FrontierConfig, FrontierLogicalMass, FrontierResult, FrontierStatus,
+        SparseDem, committee_rank,
+    };
+    use pecos_decoder_core::obs_mask::ObsMask;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn committee_merges_both_legs() {
+        let dem = SparseDem {
+            mechanisms: vec![
+                (0.3, vec![0], vec![0]),
+                (0.2, vec![1], vec![]),
+                (0.4, vec![0], vec![0]),
+            ],
+            detector_coords: BTreeMap::new(),
+            num_detectors: 2,
+            num_observables: 1,
+        };
+        let mut committee = FrontierCommittee::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                k: usize::MAX,
+                delta: f64::INFINITY,
+                score_alpha: 0.8,
+                column_order: None,
+                merge_indistinguishable: true,
+                bp_score_iterations: 0,
+            },
+        )
+        .unwrap();
+        let forward = committee.forward.decode(&[0, 0]).unwrap();
+        let backward = committee.backward.decode(&[0, 0]).unwrap();
+
+        assert_eq!(forward.processed_columns, 2);
+        assert_eq!(backward.processed_columns, 2);
+        assert_eq!(forward.processed_columns, backward.processed_columns);
+    }
+
+    #[test]
+    fn committee_bp_legs_do_not_share_bp_state() {
+        let dem = SparseDem {
+            mechanisms: vec![
+                (0.15, vec![0], vec![]),
+                (0.15, vec![0, 1], vec![0]),
+                (0.08, vec![1], vec![]),
+            ],
+            detector_coords: BTreeMap::new(),
+            num_detectors: 2,
+            num_observables: 1,
+        };
+        let committee = FrontierCommittee::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                k: 1,
+                delta: f64::INFINITY,
+                score_alpha: 0.8,
+                column_order: None,
+                merge_indistinguishable: false,
+                bp_score_iterations: 5,
+            },
+        )
+        .unwrap();
+        let (forward_graph, forward_scratch) = committee.forward.bp_state_addrs().unwrap();
+        let (backward_graph, backward_scratch) = committee.backward.bp_state_addrs().unwrap();
+
+        assert_ne!(forward_graph, forward_scratch);
+        assert_ne!(forward_graph, backward_graph);
+        assert_ne!(forward_graph, backward_scratch);
+        assert_ne!(forward_scratch, backward_graph);
+        assert_ne!(forward_scratch, backward_scratch);
+        assert_ne!(backward_graph, backward_scratch);
+    }
+
+    #[test]
+    fn committee_rank_maps_special_terminal_statistics() {
+        let no_runner_up = FrontierResult {
+            predicted: ObsMask::new(),
+            log_evidence: -1.0,
+            runner_up_gap: None,
+            peak_retained_states: 1,
+            processed_columns: 0,
+            transitions: 0,
+            dropped_states: 0,
+            dropped_log_mass: f64::NEG_INFINITY,
+            bp_seconds: 0.0,
+            escalation_rungs_used: 0,
+            status: FrontierStatus::Exact,
+            logical_masses: vec![FrontierLogicalMass {
+                logical: ObsMask::new(),
+                log_mass: f64::NAN,
+            }],
+        };
+        let rank = committee_rank(Some(&no_runner_up), true);
+        assert_eq!(rank[2].to_bits(), f64::INFINITY.to_bits());
+        assert_eq!(rank[3].to_bits(), f64::NEG_INFINITY.to_bits());
+        assert_eq!(rank[5].to_bits(), 1.0_f64.to_bits());
+
+        let nan_gap = FrontierResult {
+            runner_up_gap: Some(f64::NAN),
+            logical_masses: vec![FrontierLogicalMass {
+                logical: ObsMask::new(),
+                log_mass: -1.5,
+            }],
+            ..no_runner_up
+        };
+        let rank = committee_rank(Some(&nan_gap), false);
+        assert_eq!(rank[2].to_bits(), f64::NEG_INFINITY.to_bits());
+        assert_eq!(rank[3].to_bits(), (-0.5_f64).to_bits());
+
+        let no_path_rank = committee_rank(None, false);
+        assert_eq!(no_path_rank[0].to_bits(), 1.0_f64.to_bits());
+        assert_eq!(no_path_rank[1].to_bits(), f64::NEG_INFINITY.to_bits());
+    }
+}

--- a/exp/pecos-frontier/tests/MUTANTS.md
+++ b/exp/pecos-frontier/tests/MUTANTS.md
@@ -1,0 +1,10 @@
+# Frontier port manual mutant checklist
+
+The repository has no mutation runner. Apply each compiling edit separately,
+run the named killer test(s), and restore the source before trying the next
+row. This file tracks mutations owned by the Frontier identity layer; engine
+mutations are tracked by `pecos-trellis`.
+
+| Mutant | Exact edit (quoted old → new) | Expected killer test(s) or disposition |
+|---|---|---|
+| `remove_committee_forward_bonus` | `"let forward_bonus = if is_forward { 1.0 } else { 0.0 };"` → `"let forward_bonus = 0.0;"` | **EQUIVALENT.** The bonus is consulted only after all preceding rank components tie, and `FrontierCommittee::decode` already selects forward when `compare_committee_legs` returns `Equal`. Removing the bonus therefore leaves every binary-committee selection unchanged. |

--- a/exp/pecos-frontier/tests/bitwise_snapshot.rs
+++ b/exp/pecos-frontier/tests/bitwise_snapshot.rs
@@ -1,0 +1,323 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use pecos_frontier::{
+    FrontierCommittee, FrontierConfig, FrontierDecoder, FrontierResult, SparseDem,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const UPSTREAM_FIXTURES_JSON: &str = include_str!("fixtures/upstream_fixtures.json");
+const ORDER_FIXTURES_JSON: &str = include_str!("fixtures/upstream_order_fixtures.json");
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile<T> {
+    fixtures: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    name: String,
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+    syndromes: Vec<u128>,
+    pruned: PruningConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrderFixture {
+    name: String,
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+    syndromes: Vec<u128>,
+    pruned: PruningConfig,
+    forward_ordering: Vec<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PruningConfig {
+    k: usize,
+    delta: f64,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct SnapshotFile {
+    scenarios: Vec<ScenarioSnapshot>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct ScenarioSnapshot {
+    name: String,
+    #[serde(flatten)]
+    outcome: SnapshotOutcome,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+enum SnapshotOutcome {
+    Ok {
+        predicted: Vec<String>,
+        log_evidence: String,
+        logical_masses: Vec<LogicalMassSnapshot>,
+    },
+    NoPath,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct LogicalMassSnapshot {
+    label: Vec<String>,
+    log_mass: String,
+}
+
+fn sparse_dem(
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+) -> SparseDem {
+    SparseDem {
+        mechanisms,
+        detector_coords: BTreeMap::new(),
+        num_detectors,
+        num_observables,
+    }
+}
+
+fn dense_syndrome(mask: u128, num_detectors: usize) -> Vec<u8> {
+    (0..num_detectors)
+        .map(|bit| u8::from(mask & (1_u128 << bit) != 0))
+        .collect()
+}
+
+fn hex_word(word: u64) -> String {
+    format!("0x{word:016x}")
+}
+
+fn snapshot_result(result: FrontierResult) -> SnapshotOutcome {
+    SnapshotOutcome::Ok {
+        predicted: result
+            .predicted
+            .words()
+            .iter()
+            .copied()
+            .map(hex_word)
+            .collect(),
+        log_evidence: hex_word(result.log_evidence.to_bits()),
+        logical_masses: result
+            .logical_masses
+            .into_iter()
+            .map(|mass| LogicalMassSnapshot {
+                label: mass.logical.words().iter().copied().map(hex_word).collect(),
+                log_mass: hex_word(mass.log_mass.to_bits()),
+            })
+            .collect(),
+    }
+}
+
+fn assert_results_bitwise_equal(left: &FrontierResult, right: &FrontierResult) {
+    assert_eq!(left.predicted, right.predicted);
+    assert_eq!(left.log_evidence.to_bits(), right.log_evidence.to_bits());
+    assert_eq!(
+        left.runner_up_gap.map(f64::to_bits),
+        right.runner_up_gap.map(f64::to_bits)
+    );
+    assert_eq!(left.peak_retained_states, right.peak_retained_states);
+    assert_eq!(left.processed_columns, right.processed_columns);
+    assert_eq!(left.transitions, right.transitions);
+    assert_eq!(left.dropped_states, right.dropped_states);
+    assert_eq!(
+        left.dropped_log_mass.to_bits(),
+        right.dropped_log_mass.to_bits()
+    );
+    assert_eq!(left.bp_seconds.to_bits(), right.bp_seconds.to_bits());
+    assert_eq!(left.status, right.status);
+    assert_eq!(left.logical_masses.len(), right.logical_masses.len());
+    for (left_mass, right_mass) in left.logical_masses.iter().zip(&right.logical_masses) {
+        assert_eq!(left_mass.logical, right_mass.logical);
+        assert_eq!(left_mass.log_mass.to_bits(), right_mass.log_mass.to_bits());
+    }
+}
+
+fn collect_snapshot() -> SnapshotFile {
+    let fixtures: FixtureFile<Fixture> =
+        serde_json::from_str(UPSTREAM_FIXTURES_JSON).expect("upstream fixtures must parse");
+    let order_fixtures: FixtureFile<OrderFixture> =
+        serde_json::from_str(ORDER_FIXTURES_JSON).expect("order fixtures must parse");
+    let mut scenarios = Vec::new();
+
+    for fixture in fixtures.fixtures {
+        let dem = sparse_dem(
+            fixture.mechanisms,
+            fixture.num_detectors,
+            fixture.num_observables,
+        );
+        for (regime, config) in [
+            (
+                "unpruned",
+                FrontierConfig {
+                    k: usize::MAX,
+                    delta: f64::INFINITY,
+                    score_alpha: 0.8,
+                    column_order: None,
+                    merge_indistinguishable: false,
+                    bp_score_iterations: 0,
+                },
+            ),
+            (
+                "pruned",
+                FrontierConfig {
+                    k: fixture.pruned.k,
+                    delta: fixture.pruned.delta,
+                    score_alpha: 0.8,
+                    column_order: None,
+                    merge_indistinguishable: false,
+                    bp_score_iterations: 0,
+                },
+            ),
+        ] {
+            let mut decoder = FrontierDecoder::from_sparse_dem(&dem, config)
+                .expect("fixture decoder construction must succeed");
+            for &syndrome_mask in &fixture.syndromes {
+                let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
+                let outcome = decoder
+                    .decode(&syndrome)
+                    .map_or(SnapshotOutcome::NoPath, snapshot_result);
+                scenarios.push(ScenarioSnapshot {
+                    name: format!(
+                        "upstream/{}/{regime}/syndrome=0x{syndrome_mask:x}",
+                        fixture.name
+                    ),
+                    outcome,
+                });
+            }
+        }
+    }
+
+    for fixture in order_fixtures.fixtures {
+        let dem = sparse_dem(
+            fixture.mechanisms,
+            fixture.num_detectors,
+            fixture.num_observables,
+        );
+        let mut committee = FrontierCommittee::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                k: fixture.pruned.k,
+                delta: fixture.pruned.delta,
+                score_alpha: 0.8,
+                column_order: Some(fixture.forward_ordering),
+                merge_indistinguishable: false,
+                bp_score_iterations: 0,
+            },
+        )
+        .expect("fixture committee construction must succeed");
+        for syndrome_mask in fixture.syndromes {
+            let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
+            let outcome = committee
+                .decode(&syndrome)
+                .map_or(SnapshotOutcome::NoPath, |result| {
+                    snapshot_result(result.selected)
+                });
+            scenarios.push(ScenarioSnapshot {
+                name: format!(
+                    "order/{}/committee/syndrome=0x{syndrome_mask:x}",
+                    fixture.name
+                ),
+                outcome,
+            });
+        }
+    }
+
+    SnapshotFile { scenarios }
+}
+
+fn snapshot_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/bitwise_snapshot.json")
+}
+
+#[test]
+fn decode_outputs_match_bitwise_snapshot() {
+    let snapshot_json = std::fs::read_to_string(snapshot_path())
+        .expect("bitwise snapshot must exist; run the ignored regeneration test");
+    let expected: SnapshotFile =
+        serde_json::from_str(&snapshot_json).expect("bitwise snapshot must parse");
+    let actual = collect_snapshot();
+
+    assert_eq!(actual.scenarios.len(), 128, "scenario corpus changed");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bp_flag_is_bitwise_inert_on_the_unpruned_fast_path() {
+    let fixtures: FixtureFile<Fixture> =
+        serde_json::from_str(UPSTREAM_FIXTURES_JSON).expect("upstream fixtures must parse");
+    assert!(fixtures.fixtures.len() >= 3, "need several fixture models");
+
+    for fixture in fixtures.fixtures {
+        let dem = sparse_dem(
+            fixture.mechanisms,
+            fixture.num_detectors,
+            fixture.num_observables,
+        );
+        let off_config = FrontierConfig {
+            k: usize::MAX,
+            delta: f64::INFINITY,
+            score_alpha: 0.8,
+            column_order: None,
+            merge_indistinguishable: false,
+            bp_score_iterations: 0,
+        };
+        let mut off = FrontierDecoder::from_sparse_dem(&dem, off_config.clone()).unwrap();
+        let mut on = FrontierDecoder::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                bp_score_iterations: 5,
+                ..off_config
+            },
+        )
+        .unwrap();
+
+        for syndrome_mask in fixture.syndromes {
+            let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
+            match (off.decode(&syndrome), on.decode(&syndrome)) {
+                (Ok(off_result), Ok(on_result)) => {
+                    assert_results_bitwise_equal(&off_result, &on_result);
+                    assert_eq!(on_result.bp_seconds.to_bits(), 0.0_f64.to_bits());
+                }
+                (Err(_), Err(_)) => {}
+                (off_result, on_result) => panic!(
+                    "{} syndrome {syndrome_mask}: off={off_result:?}, on={on_result:?}",
+                    fixture.name
+                ),
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "manually regenerates the committed bitwise snapshot"]
+fn regenerate_bitwise_snapshot() {
+    let path = snapshot_path();
+    assert!(
+        !path.exists() || std::env::var("PECOS_REGEN_SNAPSHOT").as_deref() == Ok("1"),
+        "refusing to overwrite {}; set PECOS_REGEN_SNAPSHOT=1 to allow it",
+        path.display()
+    );
+
+    let snapshot = collect_snapshot();
+    assert_eq!(snapshot.scenarios.len(), 128, "scenario corpus changed");
+    let mut json = serde_json::to_string_pretty(&snapshot).expect("snapshot must serialize");
+    json.push('\n');
+    std::fs::write(&path, json).expect("snapshot must be writable");
+}

--- a/exp/pecos-frontier/tests/error_text.rs
+++ b/exp/pecos-frontier/tests/error_text.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use pecos_frontier::{FrontierCommittee, FrontierConfig, FrontierDecoder, SparseDem};
+use std::collections::BTreeMap;
+
+fn sparse_dem(
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+) -> SparseDem {
+    SparseDem {
+        mechanisms,
+        detector_coords: BTreeMap::new(),
+        num_detectors,
+        num_observables,
+    }
+}
+
+fn exact_config() -> FrontierConfig {
+    FrontierConfig {
+        k: usize::MAX,
+        delta: f64::INFINITY,
+        score_alpha: 0.8,
+        column_order: None,
+        merge_indistinguishable: false,
+        bp_score_iterations: 0,
+    }
+}
+
+#[test]
+fn committee_and_direct_decoder_share_unexplainable_error_text() {
+    let dem = sparse_dem(vec![(0.2, vec![0, 1], vec![])], 2, 0);
+    let mut decoder = FrontierDecoder::from_sparse_dem(&dem, exact_config()).unwrap();
+    let mut committee = FrontierCommittee::from_sparse_dem(&dem, exact_config()).unwrap();
+
+    let direct_error = decoder.decode(&[1, 0]).unwrap_err();
+    let committee_error = committee.decode(&[1, 0]).unwrap_err();
+    assert_eq!(direct_error.to_string(), committee_error.to_string());
+}

--- a/exp/pecos-frontier/tests/error_text.rs
+++ b/exp/pecos-frontier/tests/error_text.rs
@@ -47,3 +47,31 @@ fn committee_and_direct_decoder_share_unexplainable_error_text() {
     let committee_error = committee.decode(&[1, 0]).unwrap_err();
     assert_eq!(direct_error.to_string(), committee_error.to_string());
 }
+
+/// A malformed call must reach the caller as itself, not as a pruning
+/// complaint. The committee used to synthesize an unexplainable-syndrome error
+/// whenever both legs failed, which reported a dimension mismatch as something
+/// the caller could fix by tuning `k` or `delta`.
+#[test]
+fn committee_propagates_a_dimension_error_instead_of_reporting_no_path() {
+    let dem = sparse_dem(vec![(0.2, vec![0, 1], vec![])], 2, 0);
+    let mut decoder = FrontierDecoder::from_sparse_dem(&dem, exact_config()).unwrap();
+    let mut committee = FrontierCommittee::from_sparse_dem(&dem, exact_config()).unwrap();
+
+    // One detector short of the model.
+    let direct_error = decoder.decode(&[1]).unwrap_err();
+    let committee_error = committee.decode(&[1]).unwrap_err();
+
+    assert!(
+        matches!(
+            direct_error,
+            pecos_frontier::DecoderError::InvalidDimensions { .. }
+        ),
+        "expected the engine to reject a short syndrome, got {direct_error:?}"
+    );
+    assert_eq!(direct_error.to_string(), committee_error.to_string());
+    assert!(
+        !committee_error.to_string().contains("unexplainable"),
+        "committee reported a dimension fault as an unexplainable syndrome: {committee_error}"
+    );
+}

--- a/exp/pecos-frontier/tests/fixtures/bitwise_snapshot.json
+++ b/exp/pecos-frontier/tests/fixtures/bitwise_snapshot.json
@@ -1,0 +1,2980 @@
+{
+  "scenarios": [
+    {
+      "name": "upstream/degeneracy_ml_vs_mle/unpruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfdbddbda52ed09b",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfe08f7acdac4fbc"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc007ceb433cefe42"
+        }
+      ]
+    },
+    {
+      "name": "upstream/degeneracy_ml_vs_mle/unpruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbff0a91cca471450",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbff96f2568a3c294"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xbffe760065d061cd"
+        }
+      ]
+    },
+    {
+      "name": "upstream/degeneracy_ml_vs_mle/pruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfe02909226982c2",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfe18ab3bdb1c744"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc00d5a44f38d8cbd"
+        }
+      ]
+    },
+    {
+      "name": "upstream/degeneracy_ml_vs_mle/pruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xbff66802ca2c2048",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xbffef39cddd31d91"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc002432374106fc6"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfd1bd12fa9a4cca",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfd1be066d369f94"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0241024b479f26f"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc009be0711507b0c",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc009c5e626c1797a"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0218fead28468d6"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc014ef4bcd569879",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01676324e035d12"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01986aaeff1e079"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00b97d0ed325490",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00ba44da7e1f7ed"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0211aab69d38a21"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x4",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01b0f05b25cddd9",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01b7ab2cd779bec"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0222364e1dcd2e0"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x5",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01b4fd7f84c508a",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01b84a61bbbbe41"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc023a3135635ad3e"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x6",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc00da35465f0ce81",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc00e069d415ba1c4"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01b05a740e53af4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x7",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01a754208a80774",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01aa8eb713d7221"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc02340b54d6ba8fe"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x8",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc0103e49406e4ef5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc010ace2297dfb1a"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0195c13b81510bc"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01bbe4183b49f7c",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01c28a583701223"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc02280d8445258fd"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xa",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc019bafd6f723b04",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc019ee04ac5265e6"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc022e9bbf26f6de3"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xb",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01c853ca4021596",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01ced6195041aa3"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc022eeb599917f0d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xc",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00835778f510cd5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0083ada6d383a72"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc021efb803ac9029"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xd",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc0153d36a742e35e",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc017dc91bc3fd469"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0182aebeb583bd0"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xe",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc006d46ac8fce1ae",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc006e94afc7553a6"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01dc784518ca505"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/unpruned/syndrome=0xf",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc01528a5b6d18ae9",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0173bb82ac7fc96"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc018c7108da191d2"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfd1be06cc1463be",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfd1be06cc1463be"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc009c5f6df873fa4",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc009c5f6df873fa4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc01986aaeff1e079",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01986aaeff1e079"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00ba4685614b970",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00ba4685614b970"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x4",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01b7ab2cd779bec",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01b7ab2cd779bec"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x5",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01b84a61bbbbe41",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01b84a61bbbbe41"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x6",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc00e06cdadf6a2e3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc00e06cdadf6a2e3"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x7",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01aa8eb713d7221",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01aa8eb713d7221"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x8",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc010ad19c3da7367",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc010ad19c3da7367"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01c28a583701223",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01c28a583701223"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xa",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01a04f95018890a",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01a04f95018890a"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xb",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01ced6195041aa3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01ced6195041aa3"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xc",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0083ae5cbbcfba9",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0083ae5cbbcfba9"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xd",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc017dc91bc3fd469",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc017dc91bc3fd469"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xe",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc006d830da170089",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc006e94b08510c2b"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01e94a02e147e9d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/rep_chain_hyperedge/pruned/syndrome=0xf",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc018c7108da191d2",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc018c7108da191d2"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/unpruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfca381a7a705aad",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfca89525915602d"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0192f79273859b2"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc021a6709eadc8a9"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0250a12ab8f1e7c"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/unpruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000040"
+      ],
+      "log_evidence": "0xc001c9e9133b45e3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0033c7fa03e590d"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0106583e9e1d82d"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01a82ec00050fcd"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0296f0d4a3a5f3f"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/unpruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001",
+        "0x0000000000000040"
+      ],
+      "log_evidence": "0xc0089a06e6a5f91e",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc00936cb2b96092f"
+        },
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01785c63a5937bc"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01e4d0a541be362"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0227b4a151d59a4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/unpruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00bd6340aaa44a5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00d77a1fa056c6e"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc015655ad321861d"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01c2c9eece431c3"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0238b7fc8b93274"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/pruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfca381a7a705aad",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfca89525915602d"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0192f79273859b2"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc021a6709eadc8a9"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0250a12ab8f1e7c"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/pruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000040"
+      ],
+      "log_evidence": "0xc001c9e9133b45e3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0033c7fa03e590d"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0106583e9e1d82d"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01a82ec00050fcd"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0296f0d4a3a5f3f"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/pruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001",
+        "0x0000000000000040"
+      ],
+      "log_evidence": "0xc0089a06e6a5f91e",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc00936cb2b96092f"
+        },
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01785c63a5937bc"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01e4d0a541be362"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0227b4a151d59a4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/wide_observable_70/pruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000",
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00bd6340aaa44a5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00d77a1fa056c6e"
+        },
+        {
+          "label": [
+            "0x0000000000000001",
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc015655ad321861d"
+        },
+        {
+          "label": [
+            "0x0000000000000009",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc01c2c9eece431c3"
+        },
+        {
+          "label": [
+            "0x0000000000000008",
+            "0x0000000000000040"
+          ],
+          "log_mass": "0xc0238b7fc8b93274"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbffabec4f0988108",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbffad32fe9d7fd9c"
+        },
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc01c22e1e1fefe5a"
+        },
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc024210983137b2a"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc026e58db09b5ddd"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000006"
+      ],
+      "log_evidence": "0xc01123d1b8f7f878",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc011942544ceae4b"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01a635f8aa9fbbc"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc02341485768f9dc"
+        },
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc02c553a55c7b54f"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc00927cc7eec44a9",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00a08739699b050"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc015d37411282599"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc020f9529aa80eca"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc02a0d449906ca3d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc0067f396b4fecca",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc006896ee7efab15"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0205966adc06a3e"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc02668ff3fd4663c"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc0292d836d5c48ee"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000004"
+      ],
+      "log_evidence": "0xc01248540e66e3bf",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc013373e3a347252"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc018c046954437b5"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0226fbbdcb617d9"
+        },
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc02d26c6d07a9752"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0xc",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc00b22cc9273a18d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00b48ed5dd6f2e5"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc01fcc5aaba8f058"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc020a93428d8be25"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc02510d14bc664de"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x12",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc01035fed7934d38",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc0113ebff2e0758f"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc016c7c84df03af3"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01db81f0dbc802e"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc029931a7aa2bf90"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x15",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc018953f5795ce8b",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01b1b3d2b7201b6"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc01cfb78c82ea04d"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc0205222c340e38d"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc02934c757dbcfa0"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x18",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000004"
+      ],
+      "log_evidence": "0xc0028cb2f7a3beb0",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc00298725947b18e"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01eba4f142cd7bb"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc022d552e9fc8e7a"
+        },
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc02599d71784712d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x1a",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000007"
+      ],
+      "log_evidence": "0xc00e3c8abf99a019",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc00f374dfaf56310"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0186ae14355fefa"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01f5b3803224434"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc028c18dffefdd8d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x1b",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc00bac89eaa76af7",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc00bb8494c4b5dd5"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc021a51d46d756ef"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc0251d48a6bd798c"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc027e1ccd4455c3e"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/unpruned/syndrome=0x1e",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000006"
+      ],
+      "log_evidence": "0xc013976d1461dd9d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc014e838bc8a678c"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01a0ea644128e30"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01db7730265b4fe"
+        },
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc0261b452068028b"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbffad32fe9d7fd9c",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbffad32fe9d7fd9c"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000006"
+      ],
+      "log_evidence": "0xc011299221605597",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc011942544ceae4b"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01a6b52fd829faa"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc009334d4fbcfee7",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00a08739699b050"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc015db678400c987"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc006896ee7efab15",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc006896ee7efab15"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000004"
+      ],
+      "log_evidence": "0xc01253d34f0d73d2",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc013373e3a347252"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc018c83a081cdba3"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0xc",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc00b48ed5dd6f2e5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00b48ed5dd6f2e5"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x12",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc0105b5507b9770f",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc0113ebff2e0758f"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc016cfbbc0c8dee1"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x15",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc01a37d2404b0336",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01b1b3d2b7201b6"
+        },
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc020561c7cad3584"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x18",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000004"
+      ],
+      "log_evidence": "0xc00298725947b18e",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000004"
+          ],
+          "log_mass": "0xc00298725947b18e"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x1a",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000007"
+      ],
+      "log_evidence": "0xc00e6227b418b1a8",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc00f374dfaf56310"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01872d4b62ea2e8"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x1b",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc00bb8494c4b5dd5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc00bb8494c4b5dd5"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed11/pruned/syndrome=0x1e",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000006"
+      ],
+      "log_evidence": "0xc0147da5991c0ed8",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc014e838bc8a678c"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01dbf66753e58ec"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x6",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc0190ba20d292d2d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01d4ff2ae688cac"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01d865982bd2830"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0200b5255f3ea50"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc02037c991c909e5"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc005f81b75729143",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00cacff000f8225"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc010a508e436ede6"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc010b67be6ecda69"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc014ce6270a5d0f6"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0xa",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc0134d7c8a63325f",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0150a51da34959b"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01ac8f20d0bd2c0"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01c5fe92adc6b00"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01cba10e632bdca"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0xf",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01912156381bd65",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01e02de1d2a13c8"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01e25d3d9da80f6"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01f35325d96cab7"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01f43c2a1873584"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x15",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00dd41fc5aadbef",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc012d2b508c6234d"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc012f7e6127ca93f"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0162f3df8934f60"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01831c797c5e717"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x18",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc0098f763bd60aed",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc010a09206af5aa0"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc010e70246a3b2f3"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc014cb43ee7f5dd7"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc015101fc1a9c50d"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x1c",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc010319623790f48",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc014a83236849878"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc014f78e7cfe513a"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc016a749e3d9a0d3"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0174698895739aa"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x22",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc017ad6ee87633b3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01b47aa391d9f54"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01d7ace22da2cc5"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01e09fdff955030"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01f1fe5ac878be0"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x25",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc01181cb872831e8",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01694db67529b7c"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0171830815b3125"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0173898cf34be83"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0175b00c02d3482"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x2f",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc019d118936fa55d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01eb548e9ae45e3"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01ee012e58bc0a9"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01ffd4c53b8d14e"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc02008ace95a5275"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x3a",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc019629776668798",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01e510dee14c438"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01e5fcf001e2eaa"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01f5cfbdbe76b0c"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01fe29eba5edbf7"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/unpruned/syndrome=0x3f",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc0192c2f62a004d4",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01e20c16101bc81"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01e31dfaee7de78"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01ed793525332e4"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01ff7252c86f6b1"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x6",
+      "outcome": "no_path"
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc007967c2ee479eb",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00d36c2c06c9177"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc010d35054836794"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc011d61b62f03509"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0xa",
+      "outcome": "no_path"
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0xf",
+      "outcome": "no_path"
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x15",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc012799206cc419f",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01376d2028bca2b"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0188c365492a498"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x18",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc00cec71d808fed3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc011827626a666e7"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc011f5e93dc29fef"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01711d24d1ea431"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x1c",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc017e1f2121340c9",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc018df320dd2c955"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01df4965fd9a3c2"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x22",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01b8e82e330ee54",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01c0688e8ecd8f7"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0222e95fd8164c4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x25",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0171497ba18b0b5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01a887f2ad29289"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01ab0892a383465"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01e1bdd68d384d4"
+        }
+      ]
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x2f",
+      "outcome": "no_path"
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x3a",
+      "outcome": "no_path"
+    },
+    {
+      "name": "upstream/random_seed23/pruned/syndrome=0x3f",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x0",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xbfd22455fb2dc151",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xbfd70e8197bdf1e0"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0071b2ab5caf037"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x1",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc00e1317dd77e132",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc00eb0a6a76ab1bb"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0197310f1d6d8c2"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc01b39897054a904",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01bd34947d9c3c8"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0218d8d7bc9c30e"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x3",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00bb0ebebae968d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00c4e59bff41408"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01842c923287781"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x4",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc01405cdd87bd6fe",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01609ce1b89cacb"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc017bace1fc80e4e"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x5",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01c4b85f5163f6e",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01d34ae76c02d46"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc021549477fccb9c"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x6",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc010b2ec00f97c45",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01101e2f8763da5"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01b1a1edc51a892"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x7",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc01cc30fb57216a6",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc01e05c2803f7204"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc020ff52810e84ae"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x8",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0020e80ba55f697",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc00611342bd108c7"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc009809f6759664a"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc016e1efd118a780",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc018ee8d2ca66505"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01a89edccea98c5"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xa",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc01b312db4f9dffe",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01bc9771a7b05c6"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0218de93e9baac8"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xb",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc015b67d6ec56778",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc017be0fb54d6bff"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0196610c2b199ed"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xc",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0084791cd08f31b",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc008e4e86b31770b"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0168ead5f0d2c31"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xd",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc019cfd7dd1c40df",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01a403cf0b4ec84"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0216f00f317da33"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xe",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc0187b353be97188",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc01a96358eb9cbf6"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01c0e120279c9e8"
+        }
+      ]
+    },
+    {
+      "name": "order/chain_reorder/committee/syndrome=0xf",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc018b8f27f21fd73",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0191a87a4fe7cce"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc021284566009cb0"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00e2cbd21fd87a5",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc011bf736cb1b69d"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0136a86476cbb0b"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc016c22dcc59dd47"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x9",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc002d9d5f01ab5f0",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc005753d75bb7918"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc010f95d2e5b3dd6"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc011b13031784b98"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0xa",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0xe",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000003"
+      ],
+      "log_evidence": "0xc00b9460c4c0c35c",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc00e2fc84a618684"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc01556a298ae448c"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0160e759bcb524d"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0xf",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x10",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x12",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x17",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x1c",
+      "outcome": "no_path"
+    },
+    {
+      "name": "order/order_random_seed7/committee/syndrome=0x1f",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc00db6c172688f43",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0122102cc0142d2"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc0130556f4fad2be"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0152f4613636a5d"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x2",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc00d8c83b276708f",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc011c23ea9a927e8"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc01410d2ba0279a3"
+        },
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0142c0b6bf0bfb9"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x4",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc0123596321e1e5a",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc014078195887996"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc0165615a5e1cb51"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0227d562cd547fb"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x8",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0216b95f50a4aa1",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc022f14f01ad2e87"
+        },
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc024090884e3c9f5"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc024189909d9d765"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0xb",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000006"
+      ],
+      "log_evidence": "0xc01b88749875a891",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc01b88749875a891"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x29",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000002"
+      ],
+      "log_evidence": "0xc012a23bc3607153",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0147a620b97705f"
+        },
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc016c8f61bf0c21a"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc021b175b0ef630f"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x2b",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc015e75b189e0e62",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc017afd91bfbd4ee"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc019fe6d2c5526a9"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x2d",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000001"
+      ],
+      "log_evidence": "0xc013a2182cbebcb3",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000001"
+          ],
+          "log_mass": "0xc0156a96301c833f"
+        },
+        {
+          "label": [
+            "0x0000000000000003"
+          ],
+          "log_mass": "0xc017b92a4075d4fa"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x2e",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc0139880cd27c75c",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc015d44342df6c74"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01822d75338be2f"
+        },
+        {
+          "label": [
+            "0x0000000000000006"
+          ],
+          "log_mass": "0xc01c8e3c210b46ab"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x33",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000005"
+      ],
+      "log_evidence": "0xc01302e155c2897d",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000005"
+          ],
+          "log_mass": "0xc014d98c4a5ba4a2"
+        },
+        {
+          "label": [
+            "0x0000000000000007"
+          ],
+          "log_mass": "0xc01728205ab4f65d"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc0221450d26bb275"
+        }
+      ]
+    },
+    {
+      "name": "order/order_random_seed41/committee/syndrome=0x37",
+      "outcome": "ok",
+      "predicted": [
+        "0x0000000000000000"
+      ],
+      "log_evidence": "0xc00e85bd1e307055",
+      "logical_masses": [
+        {
+          "label": [
+            "0x0000000000000000"
+          ],
+          "log_mass": "0xc0110b5c9275feb6"
+        },
+        {
+          "label": [
+            "0x0000000000000002"
+          ],
+          "log_mass": "0xc01359f0a2cf5072"
+        }
+      ]
+    }
+  ]
+}

--- a/exp/pecos-frontier/tests/fixtures/generate_upstream_fixtures.py
+++ b/exp/pecos-frontier/tests/fixtures/generate_upstream_fixtures.py
@@ -1,0 +1,200 @@
+"""Golden-fixture generator for pecos-frontier, run against the upstream frontier package.
+
+Orchestrator-owned oracle: this script and its JSON output are authored and
+committed by the reviewer, not by the implementation. The implementation must
+never edit them.
+
+Usage (from a clone of the upstream repo with its venv built):
+  .venv/bin/python generate_upstream_fixtures.py > upstream_fixtures.json
+
+Each fixture: a binary-fault model given as mechanisms [p, [detectors],
+[observables]] in processing order (identical to the column order PECOS uses),
+decoded for every syndrome bitmask in `syndromes`, unpruned (K=10^9,
+Delta=inf) and pruned (K/Delta from the fixture). Expected values come from
+upstream FrontierResult: status, logical_hat, log_evidence, and
+terminal_log_masses (logical label -> log mass, unnormalized).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import sys
+
+from frontier import FrontierModel, decode_frontier
+from frontier.progressive import (
+    FactorTransition,
+    OutcomeTransition,
+    build_frontier_layout,
+    columns_from_factor_transitions,
+)
+
+UNPRUNED_K = 10**9
+
+
+def build_model(
+    mechanisms: list,
+    num_detectors: int,
+    num_observables: int,
+) -> FrontierModel:
+    """Build an upstream FrontierModel from binary (p, detectors, observables) mechanisms."""
+    factors = []
+    for idx, (p, dets, obs) in enumerate(mechanisms):
+        det_mask = 0
+        for d in dets:
+            det_mask |= 1 << d
+        log_mask = 0
+        for o in obs:
+            log_mask |= 1 << o
+        factors.append(
+            FactorTransition(
+                factor_id=idx,
+                outcomes=(
+                    OutcomeTransition(probability=1.0 - p, detector_mask=0, logical_mask=0),
+                    OutcomeTransition(probability=p, detector_mask=det_mask, logical_mask=log_mask),
+                ),
+                instruction_offset=idx,
+                label=f"f{idx}",
+            ),
+        )
+    columns = tuple(columns_from_factor_transitions(tuple(factors)))
+    return FrontierModel(
+        columns=columns,
+        layout=build_frontier_layout(list(columns), num_detectors=num_detectors),
+        num_detectors=num_detectors,
+        num_observables=num_observables,
+    )
+
+
+def decode_all(model: FrontierModel, syndromes: list, k: int, delta: float) -> list:
+    """Decode each syndrome and record upstream expected results as JSON-safe dicts."""
+    out = []
+    for syndrome in syndromes:
+        r = decode_frontier(model, syndrome, K=k, Delta=delta)
+        # Keep the JSON strictly standard: no-path decodes report -inf
+        # log_evidence upstream; emit null instead (allow_nan=False enforces).
+        out.append(
+            {
+                "syndrome": syndrome,
+                "status": r.status,
+                "logical_hat": r.logical_hat,
+                "log_evidence": r.log_evidence if math.isfinite(r.log_evidence) else None,
+                "terminal_log_masses": {
+                    str(k_): v for k_, v in sorted(r.terminal_log_masses.items()) if math.isfinite(v)
+                },
+                "engine": r.engine,
+            },
+        )
+    return out
+
+
+def random_mechanisms(
+    rng: random.Random,
+    num_mechs: int,
+    num_detectors: int,
+    num_observables: int,
+) -> list:
+    """Sample a seeded random binary-mechanism list."""
+    mechs = []
+    for _ in range(num_mechs):
+        n_d = rng.choice([1, 1, 2, 2, 3])
+        dets = sorted(rng.sample(range(num_detectors), min(n_d, num_detectors)))
+        obs = sorted(rng.sample(range(num_observables), rng.choice([0, 0, 1, 1, 2])))
+        p = rng.uniform(0.01, 0.4)
+        mechs.append((round(p, 6), dets, obs))
+    return mechs
+
+
+def main() -> int:
+    """Emit the fixture JSON to stdout."""
+    fixtures = []
+
+    # F1: hand-built degeneracy case -- logical-ML differs from most-likely-error.
+    # Mechanism 0: p=0.20, flips detector 0, flips observable 0.
+    # Mechanisms 1,2: p=0.15 each, flip detector 0, no observable flip.
+    # Syndrome {det0}: MLE representative is mech 0 (0.20 > 0.15), but coset mass
+    # of label 0 (mech1 alone + mech2 alone + all three) exceeds label 1's mass.
+    fixtures.append(
+        {
+            "name": "degeneracy_ml_vs_mle",
+            "mechanisms": [[0.20, [0], [0]], [0.15, [0], []], [0.15, [0], []]],
+            "num_detectors": 1,
+            "num_observables": 1,
+            "syndromes": [0, 1],
+            "pruned": {"k": 2, "delta": 100.0},
+        },
+    )
+
+    # F2: repetition-code-like chain with hyperedge, two observables.
+    fixtures.append(
+        {
+            "name": "rep_chain_hyperedge",
+            "mechanisms": [
+                [0.05, [0], [0]],
+                [0.04, [0, 1], []],
+                [0.03, [1, 2], [1]],
+                [0.06, [2, 3], []],
+                [0.02, [3], [0, 1]],
+                [0.07, [1, 2, 3], []],
+            ],
+            "num_detectors": 4,
+            "num_observables": 2,
+            "syndromes": list(range(16)),
+            "pruned": {"k": 4, "delta": 30.0},
+        },
+    )
+
+    # F3: wide observables -- winning label flips observable index 70.
+    fixtures.append(
+        {
+            "name": "wide_observable_70",
+            "mechanisms": [
+                [0.10, [0], [70]],
+                [0.02, [0], [3]],
+                [0.05, [1], [0, 70]],
+                [0.03, [0, 1], []],
+            ],
+            "num_detectors": 2,
+            "num_observables": 71,
+            "syndromes": [0, 1, 2, 3],
+            "pruned": {"k": 8, "delta": 100.0},
+        },
+    )
+
+    # F4/F5: seeded random models.
+    for seed, num_mechs, num_dets, num_obs in ((11, 8, 5, 3), (23, 12, 6, 2)):
+        rng = random.Random(seed)
+        fixtures.append(
+            {
+                "name": f"random_seed{seed}",
+                "mechanisms": random_mechanisms(rng, num_mechs, num_dets, num_obs),
+                "num_detectors": num_dets,
+                "num_observables": num_obs,
+                "syndromes": sorted(rng.sample(range(1 << num_dets), 12)),
+                "pruned": {"k": 3, "delta": 20.0},
+            },
+        )
+
+    for fx in fixtures:
+        model = build_model(fx["mechanisms"], fx["num_detectors"], fx["num_observables"])
+        fx["expected_unpruned"] = decode_all(model, fx["syndromes"], UNPRUNED_K, math.inf)
+        fx["expected_pruned"] = decode_all(
+            model,
+            fx["syndromes"],
+            fx["pruned"]["k"],
+            fx["pruned"]["delta"],
+        )
+
+    json.dump(
+        {"generator": "generate_upstream_fixtures.py", "fixtures": fixtures},
+        sys.stdout,
+        indent=1,
+        allow_nan=False,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/exp/pecos-frontier/tests/fixtures/generate_upstream_order_fixtures.py
+++ b/exp/pecos-frontier/tests/fixtures/generate_upstream_order_fixtures.py
@@ -1,0 +1,173 @@
+"""Ordering + committee golden-fixture generator, run against the upstream frontier package.
+
+Orchestrator-owned oracle: this script and its JSON output are authored and
+committed by the reviewer, not by the implementation. The implementation must
+never edit them.
+
+Usage (from a clone of the upstream repo with its venv built):
+  .venv/bin/python generate_upstream_order_fixtures.py > upstream_order_fixtures.json
+
+Per fixture: mechanisms in TIME order. Expected values from upstream:
+- forward_ordering: optimize_column_order permutation over the time-ordered
+  columns (deadline reorder). ordering[target] = source index.
+- backward_ordering: reverse the forward-ordered columns, then
+  optimize_column_order again (build_backward_deadline_ordered_family
+  semantics), composed back to original mechanism indices.
+- committee: decode_frontier_committee on the forward-ordered model per
+  syndrome: status, logical_hat, direction, log_evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import sys
+
+from frontier import FrontierModel, decode_frontier_committee
+from frontier.progressive import (
+    FactorTransition,
+    OutcomeTransition,
+    build_frontier_layout,
+    columns_from_factor_transitions,
+    optimize_column_order,
+)
+from tools.frontier_progressive import _reverse_progressive_columns
+
+
+def build_columns(mechanisms: list) -> list:
+    """Build upstream progressive columns from binary mechanisms in time order."""
+    factors = []
+    for idx, (p, dets, obs) in enumerate(mechanisms):
+        det_mask = 0
+        for d in dets:
+            det_mask |= 1 << d
+        log_mask = 0
+        for o in obs:
+            log_mask |= 1 << o
+        factors.append(
+            FactorTransition(
+                factor_id=idx,
+                outcomes=(
+                    OutcomeTransition(probability=1.0 - p, detector_mask=0, logical_mask=0),
+                    OutcomeTransition(probability=p, detector_mask=det_mask, logical_mask=log_mask),
+                ),
+                instruction_offset=idx,
+                label=f"f{idx}",
+            ),
+        )
+    return list(columns_from_factor_transitions(tuple(factors)))
+
+
+def random_mechanisms(
+    rng: random.Random,
+    num_mechs: int,
+    num_detectors: int,
+    num_observables: int,
+) -> list:
+    """Sample a seeded random binary-mechanism list (detector-free allowed)."""
+    mechs = []
+    for _ in range(num_mechs):
+        n_d = rng.choice([0, 1, 1, 2, 2, 3])
+        dets = sorted(rng.sample(range(num_detectors), min(n_d, num_detectors)))
+        obs = sorted(rng.sample(range(num_observables), rng.choice([0, 0, 1, 1, 2])))
+        p = rng.uniform(0.01, 0.4)
+        mechs.append((round(p, 6), dets, obs))
+    return mechs
+
+
+def main() -> int:
+    """Emit the ordering/committee fixture JSON to stdout."""
+    fixtures = []
+
+    # F1: hand-built chain where time order != deadline order.
+    fixtures.append(
+        {
+            "name": "chain_reorder",
+            "mechanisms": [
+                [0.05, [3], [0]],
+                [0.04, [0, 1], []],
+                [0.03, [0], [1]],
+                [0.06, [2, 3], []],
+                [0.02, [1, 2], [0, 1]],
+                [0.07, [], [0]],
+                [0.08, [3], []],
+            ],
+            "num_detectors": 4,
+            "num_observables": 2,
+            "syndromes": list(range(16)),
+            "pruned": {"k": 3, "delta": 25.0},
+        },
+    )
+
+    # F2/F3: seeded random models (include detector-free mechanisms).
+    for seed, num_mechs, num_dets, num_obs in ((7, 10, 5, 2), (41, 14, 6, 3)):
+        rng = random.Random(seed)
+        fixtures.append(
+            {
+                "name": f"order_random_seed{seed}",
+                "mechanisms": random_mechanisms(rng, num_mechs, num_dets, num_obs),
+                "num_detectors": num_dets,
+                "num_observables": num_obs,
+                "syndromes": sorted(rng.sample(range(1 << num_dets), 10)),
+                "pruned": {"k": 3, "delta": 25.0},
+            },
+        )
+
+    for fx in fixtures:
+        time_columns = build_columns(fx["mechanisms"])
+        forward_columns, forward_ordering = optimize_column_order(
+            list(time_columns),
+            num_detectors=fx["num_detectors"],
+        )
+        fx["forward_ordering"] = [int(v) for v in forward_ordering]
+
+        reversed_columns = _reverse_progressive_columns(forward_columns)
+        _backward_columns, backward_ordering_local = optimize_column_order(
+            list(reversed_columns),
+            num_detectors=fx["num_detectors"],
+        )
+        # Compose back to original mechanism indices: reversed[i] came from
+        # forward position len-1-i, which came from mechanism forward_ordering[...].
+        n = len(forward_ordering)
+        backward_in_original = [int(forward_ordering[n - 1 - int(local)]) for local in backward_ordering_local]
+        fx["backward_ordering"] = backward_in_original
+
+        model = FrontierModel(
+            columns=tuple(forward_columns),
+            layout=build_frontier_layout(list(forward_columns), num_detectors=fx["num_detectors"]),
+            num_detectors=fx["num_detectors"],
+            num_observables=fx["num_observables"],
+        )
+        committee = []
+        for syndrome in fx["syndromes"]:
+            r = decode_frontier_committee(
+                model,
+                syndrome,
+                K=fx["pruned"]["k"],
+                Delta=fx["pruned"]["delta"],
+            )
+            committee.append(
+                {
+                    "syndrome": syndrome,
+                    "status": r.status,
+                    "logical_hat": r.logical_hat,
+                    "direction": r.direction,
+                    "log_evidence": r.log_evidence if math.isfinite(r.log_evidence) else None,
+                    "engine": r.engine,
+                },
+            )
+        fx["expected_committee"] = committee
+
+    json.dump(
+        {"generator": "generate_upstream_order_fixtures.py", "fixtures": fixtures},
+        sys.stdout,
+        indent=1,
+        allow_nan=False,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/exp/pecos-frontier/tests/fixtures/upstream_fixtures.json
+++ b/exp/pecos-frontier/tests/fixtures/upstream_fixtures.json
@@ -1,0 +1,1488 @@
+{
+ "generator": "generate_upstream_fixtures.py",
+ "fixtures": [
+  {
+   "name": "degeneracy_ml_vs_mle",
+   "mechanisms": [
+    [
+     0.2,
+     [
+      0
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.15,
+     [
+      0
+     ],
+     []
+    ],
+    [
+     0.15,
+     [
+      0
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 1,
+   "num_observables": 1,
+   "syndromes": [
+    0,
+    1
+   ],
+   "pruned": {
+    "k": 2,
+    "delta": 100.0
+   },
+   "expected_unpruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.4354089844812365,
+     "terminal_log_masses": {
+      "0": -0.5175146119167873,
+      "1": -2.9759296462578115
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -1.0412872220488403,
+     "terminal_log_masses": {
+      "0": -1.5896352851379207,
+      "1": -1.9038089730366778
+     },
+     "engine": "native_binary"
+    }
+   ],
+   "expected_pruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.5050092384445508,
+     "terminal_log_masses": {
+      "0": -0.5481814103097595,
+      "1": -3.6690768268177565
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -1.4003932854993923,
+     "terminal_log_masses": {
+      "0": -2.282782465697866,
+      "1": -1.93447577142965
+     },
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "rep_chain_hyperedge",
+   "mechanisms": [
+    [
+     0.05,
+     [
+      0
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.04,
+     [
+      0,
+      1
+     ],
+     []
+    ],
+    [
+     0.03,
+     [
+      1,
+      2
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.06,
+     [
+      2,
+      3
+     ],
+     []
+    ],
+    [
+     0.02,
+     [
+      3
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.07,
+     [
+      1,
+      2,
+      3
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 4,
+   "num_observables": 2,
+   "syndromes": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
+   ],
+   "pruned": {
+    "k": 4,
+    "delta": 30.0
+   },
+   "expected_unpruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.27716516945765746,
+     "terminal_log_masses": {
+      "0": -0.27722321191185384,
+      "1": -10.031530036817655
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -3.217786917942595,
+     "terminal_log_masses": {
+      "0": -8.78108842722251,
+      "1": -3.221630385188459
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -5.233687599573494,
+     "terminal_log_masses": {
+      "0": -5.615426272349639,
+      "1": -6.381511448991767
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.4491289645180316,
+     "terminal_log_masses": {
+      "0": -3.455226241668234,
+      "1": -8.552089030335141
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 4,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -6.764670168798568,
+     "terminal_log_masses": {
+      "2": -9.069129045682928,
+      "3": -6.86982270281349
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 5,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.82797229734218,
+     "terminal_log_masses": {
+      "2": -6.879539903005537,
+      "3": -9.818506902744613
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 6,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -3.7047508205521926,
+     "terminal_log_masses": {
+      "2": -3.7532296281899296,
+      "3": -6.7555208339606345
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 7,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -6.6145097115094025,
+     "terminal_log_masses": {
+      "2": -9.626383227722268,
+      "3": -6.664960641265254
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 8,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -4.0608263079955025,
+     "terminal_log_masses": {
+      "2": -6.339918972287872,
+      "3": -4.168831489862692
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.9357967928880235,
+     "terminal_log_masses": {
+      "2": -7.039693883624326,
+      "3": -9.251649985363196
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.432607404086188,
+     "terminal_log_masses": {
+      "2": -6.482439701584985,
+      "3": -9.456512046911433
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 11,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -7.130114138247697,
+     "terminal_log_masses": {
+      "2": -9.46622924710348,
+      "3": -7.231817558646671
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 12,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.026106948529199,
+     "terminal_log_masses": {
+      "0": -3.028736928251697,
+      "1": -8.968200793089709
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 13,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -5.309778798539666,
+     "terminal_log_masses": {
+      "0": -6.041915585766176,
+      "1": -5.965399686237199
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 14,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -2.8537193014310196,
+     "terminal_log_masses": {
+      "0": -2.8639125560097964,
+      "1": -7.444840692719713
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -5.289694649257151,
+     "terminal_log_masses": {
+      "0": -6.194399083124567,
+      "1": -5.808319729286401
+     },
+     "engine": "native_binary"
+    }
+   ],
+   "expected_pruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.27722330026295683,
+     "terminal_log_masses": {
+      "0": -0.27722330026295683
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -3.221662279429397,
+     "terminal_log_masses": {
+      "1": -3.221662279429397
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -6.381511448991767,
+     "terminal_log_masses": {
+      "1": -6.381511448991767
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.4552771306109022,
+     "terminal_log_masses": {
+      "0": -3.4552771306109022
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 4,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -6.86982270281349,
+     "terminal_log_masses": {
+      "3": -6.86982270281349
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 5,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.879539903005537,
+     "terminal_log_masses": {
+      "2": -6.879539903005537
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 6,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -3.75332199009823,
+     "terminal_log_masses": {
+      "2": -3.75332199009823
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 7,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -6.664960641265254,
+     "terminal_log_masses": {
+      "3": -6.664960641265254
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 8,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -4.169043598373583,
+     "terminal_log_masses": {
+      "3": -4.169043598373583
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -7.039693883624326,
+     "terminal_log_masses": {
+      "2": -7.039693883624326
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.504857303140179,
+     "terminal_log_masses": {
+      "2": -6.504857303140179
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 11,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -7.231817558646671,
+     "terminal_log_masses": {
+      "3": -7.231817558646671
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 12,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.028758613304906,
+     "terminal_log_masses": {
+      "0": -3.028758613304906
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 13,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -5.965399686237199,
+     "terminal_log_masses": {
+      "1": -5.965399686237199
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 14,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -2.855561927630394,
+     "terminal_log_masses": {
+      "0": -2.8639126443608993,
+      "1": -7.645142288208857
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -6.194399083124567,
+     "terminal_log_masses": {
+      "0": -6.194399083124567
+     },
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "wide_observable_70",
+   "mechanisms": [
+    [
+     0.1,
+     [
+      0
+     ],
+     [
+      70
+     ]
+    ],
+    [
+     0.02,
+     [
+      0
+     ],
+     [
+      3
+     ]
+    ],
+    [
+     0.05,
+     [
+      1
+     ],
+     [
+      0,
+      70
+     ]
+    ],
+    [
+     0.03,
+     [
+      0,
+      1
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 2,
+   "num_observables": 71,
+   "syndromes": [
+    0,
+    1,
+    2,
+    3
+   ],
+   "pruned": {
+    "k": 8,
+    "delta": 100.0
+   },
+   "expected_unpruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.20483714083157648,
+     "terminal_log_masses": {
+      "0": -0.20731572484760488,
+      "1": -8.825077971185538,
+      "1180591620717411303432": -6.2963606002944505,
+      "1180591620717411303433": -10.519673691959945
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 1180591620717411303424,
+     "log_evidence": -2.2235890867675474,
+     "terminal_log_masses": {
+      "8": -4.099136022958231,
+      "9": -12.716898269296165,
+      "1180591620717411303424": -2.404540302183824,
+      "1180591620717411303425": -6.6278533938493185
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 1180591620717411303425,
+     "log_evidence": -3.0752084750557875,
+     "terminal_log_masses": {
+      "8": -7.575234712793504,
+      "9": -9.24079957946089,
+      "1180591620717411303424": -5.880638992019097,
+      "1180591620717411303425": -3.1517547040140452
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.4795914490901674,
+     "terminal_log_masses": {
+      "0": -3.6834144146828782,
+      "1": -5.348979281350265,
+      "1180591620717411303432": -9.772459290129724,
+      "1180591620717411303433": -7.043575002124672
+     },
+     "engine": "native_binary"
+    }
+   ],
+   "expected_pruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -0.20483714083157648,
+     "terminal_log_masses": {
+      "0": -0.20731572484760488,
+      "1": -8.825077971185538,
+      "1180591620717411303432": -6.2963606002944505,
+      "1180591620717411303433": -10.519673691959945
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 1180591620717411303424,
+     "log_evidence": -2.2235890867675474,
+     "terminal_log_masses": {
+      "8": -4.099136022958231,
+      "9": -12.716898269296165,
+      "1180591620717411303424": -2.404540302183824,
+      "1180591620717411303425": -6.6278533938493185
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 1180591620717411303425,
+     "log_evidence": -3.0752084750557875,
+     "terminal_log_masses": {
+      "8": -7.575234712793504,
+      "9": -9.24079957946089,
+      "1180591620717411303424": -5.880638992019097,
+      "1180591620717411303425": -3.1517547040140452
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.4795914490901674,
+     "terminal_log_masses": {
+      "0": -3.6834144146828782,
+      "1": -5.348979281350265,
+      "1180591620717411303432": -9.772459290129724,
+      "1180591620717411303433": -7.043575002124672
+     },
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "random_seed11",
+   "mechanisms": [
+    [
+     0.343468,
+     [
+      3,
+      4
+     ],
+     [
+      2
+     ]
+    ],
+    [
+     0.046708,
+     [
+      1
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.24222,
+     [
+      0,
+      1
+     ],
+     [
+      0,
+      2
+     ]
+    ],
+    [
+     0.033225,
+     [
+      1,
+      3
+     ],
+     [
+      0,
+      2
+     ]
+    ],
+    [
+     0.137254,
+     [
+      1
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.011792,
+     [
+      1,
+      2,
+      4
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.399086,
+     [
+      3
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.210025,
+     [
+      2
+     ],
+     [
+      0
+     ]
+    ]
+   ],
+   "num_detectors": 5,
+   "num_observables": 3,
+   "syndromes": [
+    0,
+    1,
+    2,
+    3,
+    9,
+    12,
+    18,
+    21,
+    24,
+    26,
+    27,
+    30
+   ],
+   "pruned": {
+    "k": 3,
+    "delta": 20.0
+   },
+   "expected_unpruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -1.671574535204913,
+     "terminal_log_masses": {
+      "0": -1.6765593657035884,
+      "2": -11.448346632924705,
+      "4": -7.034064799488613,
+      "6": -10.064525695922914
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 6,
+     "log_evidence": -4.284979715475963,
+     "terminal_log_masses": {
+      "0": -9.627505046429114,
+      "2": -6.597044149994812,
+      "4": -14.166460686329314,
+      "6": -4.394673419108197
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.144433013520559,
+     "terminal_log_masses": {
+      "1": -13.02591398437391,
+      "3": -3.2541267171527934,
+      "5": -8.48695834447371,
+      "7": -5.456497448039408
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 5,
+     "log_evidence": -2.812121237160317,
+     "terminal_log_masses": {
+      "1": -8.174611501444016,
+      "3": -11.205072397878318,
+      "5": -2.8171060676589925,
+      "7": -12.588893334880108
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 4,
+     "log_evidence": -4.570633149175533,
+     "terminal_log_masses": {
+      "0": -6.187769253052399,
+      "2": -9.218230149486702,
+      "4": -4.80394831605061,
+      "6": -14.575735583271726
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 12,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.391991752771167,
+     "terminal_log_masses": {
+      "1": -10.532846801727313,
+      "3": -3.4106089907858057,
+      "5": -8.330476070840698,
+      "7": -7.949564630686005
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 18,
+     "status": "ok",
+     "logical_hat": 5,
+     "log_evidence": -4.052729957929209,
+     "terminal_log_masses": {
+      "1": -5.695100038325779,
+      "3": -7.429805960302515,
+      "5": -4.311279101323989,
+      "7": -12.787311394087538
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 21,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -6.145749443548663,
+     "terminal_log_masses": {
+      "1": -6.776600531419197,
+      "3": -12.603083367903139,
+      "5": -8.160421468420987,
+      "7": -7.245577934118114
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 24,
+     "status": "ok",
+     "logical_hat": 4,
+     "log_evidence": -2.318700728115651,
+     "terminal_log_masses": {
+      "0": -7.681942286717397,
+      "2": -9.41664820869413,
+      "4": -2.3244368529323713,
+      "6": -10.800469145695923
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 26,
+     "status": "ok",
+     "logical_hat": 7,
+     "log_evidence": -3.779561516643309,
+     "terminal_log_masses": {
+      "1": -7.839080857244927,
+      "3": -6.104374935268192,
+      "5": -12.378036497145127,
+      "7": -3.9020042043815764
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 27,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -3.459247430071055,
+     "terminal_log_masses": {
+      "1": -3.4649835548877754,
+      "3": -11.941015847651325,
+      "5": -8.8224889886728,
+      "7": -10.557194910649535
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 30,
+     "status": "ok",
+     "logical_hat": 6,
+     "log_evidence": -4.89787704322171,
+     "terminal_log_masses": {
+      "0": -6.5143061291051225,
+      "2": -7.429149663407996,
+      "4": -11.053261769005323,
+      "6": -5.2267789325213805
+     },
+     "engine": "native_binary"
+    }
+   ],
+   "expected_pruned": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -1.6765593657035884,
+     "terminal_log_masses": {
+      "0": -1.6765593657035884
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 6,
+     "log_evidence": -4.290596505646497,
+     "terminal_log_masses": {
+      "2": -6.604808770272863,
+      "6": -4.394673419108197
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.150049803691093,
+     "terminal_log_masses": {
+      "3": -3.2541267171527934,
+      "7": -5.464262068317459
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 5,
+     "log_evidence": -2.8171060676589925,
+     "terminal_log_masses": {
+      "5": -2.8171060676589925
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 4,
+     "log_evidence": -4.581860766597815,
+     "terminal_log_masses": {
+      "0": -6.19553387333045,
+      "4": -4.80394831605061
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 12,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.4106089907858057,
+     "terminal_log_masses": {
+      "3": -3.4106089907858057
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 18,
+     "status": "ok",
+     "logical_hat": 5,
+     "log_evidence": -4.0891915518711945,
+     "terminal_log_masses": {
+      "1": -5.70286465860383,
+      "5": -4.311279101323989
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 21,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -6.554512981966402,
+     "terminal_log_masses": {
+      "1": -6.776600531419197,
+      "5": -8.168186088699038
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 24,
+     "status": "ok",
+     "logical_hat": 4,
+     "log_evidence": -2.3244368529323713,
+     "terminal_log_masses": {
+      "4": -2.3244368529323713
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 26,
+     "status": "ok",
+     "logical_hat": 7,
+     "log_evidence": -3.7979272909198762,
+     "terminal_log_masses": {
+      "3": -6.112139555546243,
+      "7": -3.9020042043815764
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 27,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -3.4649835548877754,
+     "terminal_log_masses": {
+      "1": -3.4649835548877754
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 30,
+     "status": "ok",
+     "logical_hat": 6,
+     "log_evidence": -5.12270201905968,
+     "terminal_log_masses": {
+      "2": -7.436914283686047,
+      "6": -5.2267789325213805
+     },
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "random_seed23",
+   "mechanisms": [
+    [
+     0.157882,
+     [
+      0,
+      5
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.01549,
+     [
+      1,
+      5
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.392697,
+     [
+      0,
+      3,
+      4
+     ],
+     []
+    ],
+    [
+     0.310602,
+     [
+      0,
+      3
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.252187,
+     [
+      0
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.233464,
+     [
+      2,
+      4
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.080991,
+     [
+      1,
+      3
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.237096,
+     [
+      4
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.231524,
+     [
+      0
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.154165,
+     [
+      2,
+      4,
+      5
+     ],
+     []
+    ],
+    [
+     0.110783,
+     [
+      2,
+      4
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.285786,
+     [
+      4
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 6,
+   "num_observables": 2,
+   "syndromes": [
+    6,
+    9,
+    10,
+    15,
+    21,
+    24,
+    28,
+    34,
+    37,
+    47,
+    58,
+    63
+   ],
+   "pruned": {
+    "k": 3,
+    "delta": 20.0
+   },
+   "expected_unpruned": [
+    {
+     "syndrome": 6,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -6.261360364568913,
+     "terminal_log_masses": {
+      "0": -8.022112546944442,
+      "1": -7.381200831217981,
+      "2": -8.108959728041507,
+      "3": -7.328074193125911
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -2.746146123465367,
+     "terminal_log_masses": {
+      "0": -4.161166730740183,
+      "1": -4.178207023817416,
+      "2": -5.201547393913861,
+      "3": -3.5844707493527204
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -4.825670397095194,
+     "terminal_log_masses": {
+      "0": -7.181705090376861,
+      "1": -6.69623585114158,
+      "2": -7.093662900641675,
+      "3": -5.260077866992471
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.267659716409388,
+     "terminal_log_masses": {
+      "0": -7.536940959893618,
+      "1": -7.801949941948513,
+      "2": -7.502800422375863,
+      "3": -7.816172145726686
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 21,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -3.728576225544649,
+     "terminal_log_masses": {
+      "0": -4.705768715947511,
+      "1": -6.048612948850653,
+      "2": -4.742088593348227,
+      "3": -5.546134838095753
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 24,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.195049731702389,
+     "terminal_log_masses": {
+      "0": -5.198501326106871,
+      "1": -4.225594619504352,
+      "2": -5.2657461414212445,
+      "3": -4.156807045414695
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 28,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -4.048424295677088,
+     "terminal_log_masses": {
+      "0": -5.663367805631611,
+      "1": -5.241754487058921,
+      "2": -5.818941255520636,
+      "3": -5.164254047244065
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 34,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -5.919368393148876,
+     "terminal_log_masses": {
+      "0": -7.509757989395482,
+      "1": -7.781149574063392,
+      "2": -6.8199852871255935,
+      "3": -7.369926971975649
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 37,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -4.376752960041338,
+     "terminal_log_masses": {
+      "0": -5.645368208329156,
+      "1": -5.805270421594858,
+      "2": -5.838870051154233,
+      "3": -5.773622533026615
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 47,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -6.454195312203719,
+     "terminal_log_masses": {
+      "0": -8.016944210315367,
+      "1": -7.677035952817707,
+      "2": -7.997361477046367,
+      "3": -7.718822085051365
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 58,
+     "status": "ok",
+     "logical_hat": 1,
+     "log_evidence": -6.346280908592142,
+     "terminal_log_masses": {
+      "0": -7.840804515838283,
+      "1": -7.5791547012495855,
+      "2": -7.971308624305485,
+      "3": -7.593563081590824
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 63,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.293149510399605,
+     "terminal_log_masses": {
+      "0": -7.548704846288836,
+      "1": -7.991352744805838,
+      "2": -7.53198768208597,
+      "3": -7.710522924736072
+     },
+     "engine": "native_binary"
+    }
+   ],
+   "expected_pruned": [
+    {
+     "syndrome": 6,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -2.9484790481067105,
+     "terminal_log_masses": {
+      "0": -4.206361122627545,
+      "1": -4.459088846121866,
+      "3": -3.6517386468059914
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 21,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -4.618721109597032,
+     "terminal_log_masses": {
+      "0": -6.136926003885628,
+      "2": -4.866035499364936
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 24,
+     "status": "ok",
+     "logical_hat": 3,
+     "log_evidence": -3.615451514982718,
+     "terminal_log_masses": {
+      "1": -4.490147557262374,
+      "2": -5.767403798098758,
+      "3": -4.377403835207338
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 28,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -5.970649988579859,
+     "terminal_log_masses": {
+      "0": -7.488854882868454,
+      "2": -6.217964378347763
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 34,
+     "status": "ok",
+     "logical_hat": 2,
+     "log_evidence": -6.8891711710562795,
+     "terminal_log_masses": {
+      "2": -7.006381644683862,
+      "3": -9.09098808483612
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 37,
+     "status": "ok",
+     "logical_hat": 0,
+     "log_evidence": -5.770110042340254,
+     "terminal_log_masses": {
+      "0": -6.6332976046584315,
+      "1": -6.672398242645703,
+      "2": -7.527211797628485
+     },
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 47,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 58,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 63,
+     "status": "no_path",
+     "logical_hat": null,
+     "log_evidence": null,
+     "terminal_log_masses": {},
+     "engine": "native_binary"
+    }
+   ]
+  }
+ ]
+}

--- a/exp/pecos-frontier/tests/fixtures/upstream_order_fixtures.json
+++ b/exp/pecos-frontier/tests/fixtures/upstream_order_fixtures.json
@@ -1,0 +1,721 @@
+{
+ "generator": "generate_upstream_order_fixtures.py",
+ "fixtures": [
+  {
+   "name": "chain_reorder",
+   "mechanisms": [
+    [
+     0.05,
+     [
+      3
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.04,
+     [
+      0,
+      1
+     ],
+     []
+    ],
+    [
+     0.03,
+     [
+      0
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.06,
+     [
+      2,
+      3
+     ],
+     []
+    ],
+    [
+     0.02,
+     [
+      1,
+      2
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.07,
+     [],
+     [
+      0
+     ]
+    ],
+    [
+     0.08,
+     [
+      3
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 4,
+   "num_observables": 2,
+   "syndromes": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
+   ],
+   "pruned": {
+    "k": 3,
+    "delta": 25.0
+   },
+   "forward_ordering": [
+    2,
+    1,
+    4,
+    3,
+    0,
+    6,
+    5
+   ],
+   "backward_ordering": [
+    0,
+    6,
+    3,
+    4,
+    1,
+    2,
+    5
+   ],
+   "expected_committee": [
+    {
+     "syndrome": 0,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -0.28346776513264615,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 1,
+     "status": "ok",
+     "logical_hat": 2,
+     "direction": "forward",
+     "log_evidence": -3.759322862835824,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 2,
+     "direction": "forward",
+     "log_evidence": -6.806188349883318,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 3,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -3.4613874828963334,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 4,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -5.005668051298697,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 5,
+     "status": "ok",
+     "logical_hat": 3,
+     "direction": "forward",
+     "log_evidence": -7.073753194315811,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 6,
+     "status": "ok",
+     "logical_hat": 3,
+     "direction": "forward",
+     "log_evidence": -4.174728408076651,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 7,
+     "status": "ok",
+     "logical_hat": 1,
+     "direction": "forward",
+     "log_evidence": -7.1904896117099835,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 8,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -2.2570814664348506,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 2,
+     "direction": "forward",
+     "log_evidence": -5.720641390924243,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "ok",
+     "logical_hat": 3,
+     "direction": "forward",
+     "log_evidence": -6.7980259206306055,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 11,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -5.42821286277637,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 12,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -3.0349460619312487,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 13,
+     "status": "ok",
+     "logical_hat": 2,
+     "direction": "forward",
+     "log_evidence": -6.452971892213298,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 14,
+     "status": "ok",
+     "logical_hat": 3,
+     "direction": "forward",
+     "log_evidence": -6.120320259211788,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -6.180612551164233,
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "order_random_seed7",
+   "mechanisms": [
+    [
+     0.03825,
+     [
+      1
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.024623,
+     [
+      0,
+      2
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.045378,
+     [
+      0,
+      3
+     ],
+     []
+    ],
+    [
+     0.255944,
+     [
+      0,
+      4
+     ],
+     []
+    ],
+    [
+     0.390739,
+     [
+      0,
+      3
+     ],
+     []
+    ],
+    [
+     0.173464,
+     [],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.236824,
+     [
+      0,
+      2
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.251414,
+     [
+      0,
+      1,
+      2
+     ],
+     [
+      0,
+      1
+     ]
+    ],
+    [
+     0.238369,
+     [
+      3,
+      4
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.319808,
+     [
+      2,
+      4
+     ],
+     []
+    ]
+   ],
+   "num_detectors": 5,
+   "num_observables": 2,
+   "syndromes": [
+    2,
+    9,
+    10,
+    14,
+    15,
+    16,
+    18,
+    23,
+    28,
+    31
+   ],
+   "pruned": {
+    "k": 3,
+    "delta": 25.0
+   },
+   "forward_ordering": [
+    0,
+    2,
+    4,
+    7,
+    1,
+    3,
+    6,
+    8,
+    9,
+    5
+   ],
+   "backward_ordering": [
+    9,
+    3,
+    8,
+    1,
+    6,
+    7,
+    2,
+    4,
+    0,
+    5
+   ],
+   "expected_committee": [
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -3.7718451171394514,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 9,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -2.356365085425516,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 10,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 14,
+     "status": "ok",
+     "logical_hat": 3,
+     "direction": "forward",
+     "log_evidence": -3.447450196392692,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 15,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 16,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 18,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 23,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 28,
+     "status": "no_path",
+     "logical_hat": null,
+     "direction": "forward",
+     "log_evidence": null,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 31,
+     "status": "ok",
+     "logical_hat": 1,
+     "direction": "forward",
+     "log_evidence": -3.7142361581954058,
+     "engine": "native_binary"
+    }
+   ]
+  },
+  {
+   "name": "order_random_seed41",
+   "mechanisms": [
+    [
+     0.361782,
+     [
+      1,
+      2
+     ],
+     []
+    ],
+    [
+     0.342266,
+     [
+      2,
+      4
+     ],
+     [
+      1,
+      2
+     ]
+    ],
+    [
+     0.181364,
+     [
+      0,
+      1
+     ],
+     []
+    ],
+    [
+     0.11043,
+     [
+      1
+     ],
+     [
+      0
+     ]
+    ],
+    [
+     0.315883,
+     [
+      0,
+      4,
+      5
+     ],
+     []
+    ],
+    [
+     0.338008,
+     [],
+     [
+      1
+     ]
+    ],
+    [
+     0.195322,
+     [
+      0
+     ],
+     [
+      2
+     ]
+    ],
+    [
+     0.048489,
+     [
+      0,
+      5
+     ],
+     []
+    ],
+    [
+     0.030877,
+     [
+      5
+     ],
+     []
+    ],
+    [
+     0.17961,
+     [
+      1
+     ],
+     [
+      0,
+      2
+     ]
+    ],
+    [
+     0.066904,
+     [],
+     [
+      1
+     ]
+    ],
+    [
+     0.099857,
+     [
+      0,
+      3,
+      5
+     ],
+     [
+      1
+     ]
+    ],
+    [
+     0.040368,
+     [],
+     []
+    ],
+    [
+     0.265496,
+     [
+      2,
+      3,
+      5
+     ],
+     [
+      0,
+      2
+     ]
+    ]
+   ],
+   "num_detectors": 6,
+   "num_observables": 3,
+   "syndromes": [
+    2,
+    4,
+    8,
+    11,
+    41,
+    43,
+    45,
+    46,
+    51,
+    55
+   ],
+   "pruned": {
+    "k": 3,
+    "delta": 25.0
+   },
+   "forward_ordering": [
+    1,
+    4,
+    3,
+    9,
+    2,
+    0,
+    6,
+    7,
+    11,
+    13,
+    8,
+    5,
+    10,
+    12
+   ],
+   "backward_ordering": [
+    11,
+    13,
+    3,
+    9,
+    2,
+    0,
+    7,
+    8,
+    6,
+    4,
+    1,
+    5,
+    10,
+    12
+   ],
+   "expected_committee": [
+    {
+     "syndrome": 2,
+     "status": "ok",
+     "logical_hat": 5,
+     "direction": "forward",
+     "log_evidence": -3.6936105673212936,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 4,
+     "status": "ok",
+     "logical_hat": 5,
+     "direction": "forward",
+     "log_evidence": -4.552330763901034,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 8,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -8.710128457552232,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 11,
+     "status": "ok",
+     "logical_hat": 6,
+     "direction": "backward",
+     "log_evidence": -6.883257276707938,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 41,
+     "status": "ok",
+     "logical_hat": 2,
+     "direction": "forward",
+     "log_evidence": -4.658431103478807,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 43,
+     "status": "ok",
+     "logical_hat": 1,
+     "direction": "forward",
+     "log_evidence": -5.475933441779121,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 45,
+     "status": "ok",
+     "logical_hat": 1,
+     "direction": "forward",
+     "log_evidence": -4.908295344487828,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 46,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "forward",
+     "log_evidence": -4.898928838303473,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 51,
+     "status": "ok",
+     "logical_hat": 5,
+     "direction": "forward",
+     "log_evidence": -4.7528127098070145,
+     "engine": "native_binary"
+    },
+    {
+     "syndrome": 55,
+     "status": "ok",
+     "logical_hat": 0,
+     "direction": "backward",
+     "log_evidence": -3.815302120068774,
+     "engine": "native_binary"
+    }
+   ]
+  }
+ ]
+}

--- a/exp/pecos-frontier/tests/order_committee.rs
+++ b/exp/pecos-frontier/tests/order_committee.rs
@@ -1,0 +1,256 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use pecos_decoder_core::ObservableDecoder;
+use pecos_decoder_core::dem::SparseDem;
+use pecos_decoder_core::obs_mask::ObsMask;
+use pecos_frontier::{
+    CommitteeDirection, CommitteeStatus, FrontierCommittee, FrontierConfig,
+    backward_deadline_column_order, deadline_column_order,
+};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+const FIXTURES_JSON: &str = include_str!("fixtures/upstream_order_fixtures.json");
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FixtureFile {
+    generator: String,
+    fixtures: Vec<Fixture>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Fixture {
+    name: String,
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+    syndromes: Vec<u128>,
+    pruned: PruningConfig,
+    forward_ordering: Vec<usize>,
+    backward_ordering: Vec<usize>,
+    expected_committee: Vec<ExpectedCommitteeResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PruningConfig {
+    k: usize,
+    delta: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExpectedCommitteeResult {
+    syndrome: u128,
+    status: String,
+    logical_hat: Option<u128>,
+    direction: String,
+    log_evidence: Option<f64>,
+    engine: String,
+}
+
+fn sparse_dem(
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+) -> SparseDem {
+    SparseDem {
+        mechanisms,
+        detector_coords: BTreeMap::new(),
+        num_detectors,
+        num_observables,
+    }
+}
+
+fn dense_syndrome(mask: u128, num_detectors: usize) -> Vec<u8> {
+    (0..num_detectors)
+        .map(|bit| u8::from(mask & (1_u128 << bit) != 0))
+        .collect()
+}
+
+fn mask_as_u128(mask: &ObsMask) -> u128 {
+    assert!(
+        mask.words().iter().skip(2).all(|&word| word == 0),
+        "fixture labels must fit in u128"
+    );
+    u128::from(mask.words().first().copied().unwrap_or(0))
+        | (u128::from(mask.words().get(1).copied().unwrap_or(0)) << 64)
+}
+
+fn expected_direction(direction: &str) -> CommitteeDirection {
+    match direction {
+        "forward" => CommitteeDirection::Forward,
+        "backward" => CommitteeDirection::Backward,
+        unknown => panic!("unknown committee direction {unknown}"),
+    }
+}
+
+#[test]
+fn ordering_and_committee_match_upstream_fixtures() {
+    let fixture_file: FixtureFile =
+        serde_json::from_str(FIXTURES_JSON).expect("order fixtures must parse");
+    assert_eq!(
+        fixture_file.generator,
+        "generate_upstream_order_fixtures.py"
+    );
+    let mut backward_selections = 0;
+    let mut single_leg_selections = 0;
+
+    for fixture in fixture_file.fixtures {
+        let dem = sparse_dem(
+            fixture.mechanisms,
+            fixture.num_detectors,
+            fixture.num_observables,
+        );
+        assert_eq!(
+            deadline_column_order(&dem).unwrap(),
+            fixture.forward_ordering,
+            "{}: forward ordering",
+            fixture.name
+        );
+        assert_eq!(
+            backward_deadline_column_order(&dem).unwrap(),
+            fixture.backward_ordering,
+            "{}: backward ordering",
+            fixture.name
+        );
+
+        // The fixture mechanisms are in time order. Passing forward_ordering
+        // builds the same forward-ordered model used by the upstream generator;
+        // FrontierCommittee then makes its second leg by plain reversal.
+        let mut committee = FrontierCommittee::from_sparse_dem(
+            &dem,
+            FrontierConfig {
+                k: fixture.pruned.k,
+                delta: fixture.pruned.delta,
+                score_alpha: 0.8,
+                column_order: Some(fixture.forward_ordering.clone()),
+                merge_indistinguishable: false,
+                bp_score_iterations: 0,
+            },
+        )
+        .unwrap();
+
+        let mut expected_by_syndrome = BTreeMap::new();
+        for expected in fixture.expected_committee {
+            assert!(
+                expected_by_syndrome
+                    .insert(expected.syndrome, expected)
+                    .is_none(),
+                "{}: duplicate expected syndrome",
+                fixture.name
+            );
+        }
+        assert_eq!(
+            expected_by_syndrome.len(),
+            fixture.syndromes.len(),
+            "{}: committee result count",
+            fixture.name
+        );
+
+        for syndrome_mask in fixture.syndromes {
+            let expected = expected_by_syndrome
+                .remove(&syndrome_mask)
+                .unwrap_or_else(|| panic!("{}: missing expected syndrome", fixture.name));
+            assert_eq!(expected.engine, "native_binary");
+            let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
+            let decoded = committee.decode(&syndrome);
+
+            match expected.status.as_str() {
+                "ok" => {
+                    let result = decoded.unwrap_or_else(|error| {
+                        panic!(
+                            "{} syndrome {syndrome_mask}: expected success, got {error}",
+                            fixture.name
+                        )
+                    });
+                    let direction = expected_direction(&expected.direction);
+                    assert_eq!(
+                        result.direction, direction,
+                        "{} syndrome {syndrome_mask}: direction",
+                        fixture.name
+                    );
+                    assert_eq!(
+                        mask_as_u128(&result.selected.predicted),
+                        expected.logical_hat.expect("ok result needs logical_hat"),
+                        "{} syndrome {syndrome_mask}: logical label",
+                        fixture.name
+                    );
+                    let expected_evidence =
+                        expected.log_evidence.expect("ok result needs log_evidence");
+                    assert!(
+                        (result.selected.log_evidence - expected_evidence).abs() <= 1e-9,
+                        "{} syndrome {syndrome_mask}: expected evidence {expected_evidence}, got {}",
+                        fixture.name,
+                        result.selected.log_evidence
+                    );
+                    let selected_member = match result.direction {
+                        CommitteeDirection::Forward => result.forward,
+                        CommitteeDirection::Backward => result.backward,
+                    };
+                    assert_eq!(selected_member.status, CommitteeStatus::Ok);
+                    assert_eq!(
+                        selected_member.log_evidence.to_bits(),
+                        result.selected.log_evidence.to_bits()
+                    );
+                    if result.direction == CommitteeDirection::Backward {
+                        backward_selections += 1;
+                    }
+                    if result.forward.status != result.backward.status {
+                        single_leg_selections += 1;
+                        let failed_member = if result.forward.status == CommitteeStatus::NoPath {
+                            result.forward
+                        } else {
+                            result.backward
+                        };
+                        assert_eq!(
+                            failed_member.log_evidence.to_bits(),
+                            f64::NEG_INFINITY.to_bits()
+                        );
+                    }
+                }
+                "no_path" => {
+                    assert!(expected.logical_hat.is_none());
+                    assert!(expected.log_evidence.is_none());
+                    assert!(
+                        decoded.is_err(),
+                        "{} syndrome {syndrome_mask}",
+                        fixture.name
+                    );
+                }
+                status => panic!("{}: unknown committee status {status}", fixture.name),
+            }
+        }
+        assert!(expected_by_syndrome.is_empty());
+    }
+
+    assert!(backward_selections > 0, "fixtures must select backward");
+    assert!(
+        single_leg_selections > 0,
+        "fixtures must exercise one-leg no-path selection"
+    );
+}
+
+#[test]
+fn committee_ties_select_forward_and_trait_uses_selected_mask() {
+    let mut committee = FrontierCommittee::from_dem_str("", FrontierConfig::default()).unwrap();
+    let result = committee.decode(&[]).unwrap();
+    assert_eq!(result.direction, CommitteeDirection::Forward);
+    assert_eq!(result.forward.status, CommitteeStatus::Ok);
+    assert_eq!(result.backward.status, CommitteeStatus::Ok);
+
+    let mut boxed: Box<dyn ObservableDecoder> = Box::new(committee);
+    assert!(boxed.decode_obs(&[]).unwrap().is_zero());
+}

--- a/exp/pecos-frontier/tests/upstream_fixtures.rs
+++ b/exp/pecos-frontier/tests/upstream_fixtures.rs
@@ -1,0 +1,257 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use pecos_decoder_core::dem::SparseDem;
+use pecos_decoder_core::obs_mask::ObsMask;
+use pecos_frontier::{FrontierConfig, FrontierDecoder, FrontierResult};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+const FIXTURES_JSON: &str = include_str!("fixtures/upstream_fixtures.json");
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FixtureFile {
+    generator: String,
+    fixtures: Vec<Fixture>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Fixture {
+    name: String,
+    mechanisms: Vec<(f64, Vec<u32>, Vec<u32>)>,
+    num_detectors: usize,
+    num_observables: usize,
+    syndromes: Vec<u128>,
+    pruned: PruningConfig,
+    expected_unpruned: Vec<ExpectedResult>,
+    expected_pruned: Vec<ExpectedResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PruningConfig {
+    k: usize,
+    delta: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExpectedResult {
+    syndrome: u128,
+    status: String,
+    logical_hat: Option<u128>,
+    log_evidence: Option<f64>,
+    terminal_log_masses: BTreeMap<String, f64>,
+    engine: String,
+}
+
+fn parse_fixtures() -> FixtureFile {
+    serde_json::from_str(FIXTURES_JSON).expect("upstream fixture file must parse")
+}
+
+fn dense_syndrome(mask: u128, num_detectors: usize) -> Vec<u8> {
+    (0..num_detectors)
+        .map(|bit| u8::from(mask & (1_u128 << bit) != 0))
+        .collect()
+}
+
+fn mask_as_u128(mask: &ObsMask) -> u128 {
+    assert!(
+        mask.words().iter().skip(2).all(|&word| word == 0),
+        "fixture labels must fit in u128"
+    );
+    u128::from(mask.words().first().copied().unwrap_or(0))
+        | (u128::from(mask.words().get(1).copied().unwrap_or(0)) << 64)
+}
+
+fn actual_masses(result: &FrontierResult) -> BTreeMap<u128, f64> {
+    result
+        .logical_masses
+        .iter()
+        .map(|entry| (mask_as_u128(&entry.logical), entry.log_mass))
+        .collect()
+}
+
+fn assert_expected_results(
+    fixture: &Fixture,
+    config: FrontierConfig,
+    expected_results: &[ExpectedResult],
+    regime: &str,
+) {
+    let dem = SparseDem {
+        mechanisms: fixture.mechanisms.clone(),
+        detector_coords: BTreeMap::new(),
+        num_detectors: fixture.num_detectors,
+        num_observables: fixture.num_observables,
+    };
+    let mut decoder = FrontierDecoder::from_sparse_dem(&dem, config).unwrap_or_else(|error| {
+        panic!(
+            "{} {regime}: decoder construction failed: {error}",
+            fixture.name
+        )
+    });
+
+    let mut expected_by_syndrome = BTreeMap::new();
+    for expected in expected_results {
+        assert!(
+            expected_by_syndrome
+                .insert(expected.syndrome, expected)
+                .is_none(),
+            "{} {regime}: duplicate expected syndrome",
+            fixture.name
+        );
+    }
+    assert_eq!(
+        expected_by_syndrome.len(),
+        fixture.syndromes.len(),
+        "{} {regime}: expected result count differs from syndrome count",
+        fixture.name
+    );
+
+    for &syndrome_mask in &fixture.syndromes {
+        let expected = expected_by_syndrome
+            .remove(&syndrome_mask)
+            .unwrap_or_else(|| panic!("{} {regime}: missing expected result", fixture.name));
+        assert_eq!(
+            expected.engine, "native_binary",
+            "{} {regime} syndrome {syndrome_mask}: unexpected engine",
+            fixture.name
+        );
+        let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
+        let decoded = decoder.decode(&syndrome);
+
+        match expected.status.as_str() {
+            "ok" => {
+                let result = decoded.unwrap_or_else(|error| {
+                    panic!(
+                        "{} {regime} syndrome {syndrome_mask}: expected success, got {error}",
+                        fixture.name
+                    )
+                });
+                let logical_hat = expected.logical_hat.expect("ok result needs logical_hat");
+                assert_eq!(
+                    mask_as_u128(&result.predicted),
+                    logical_hat,
+                    "{} {regime} syndrome {syndrome_mask}: predicted label",
+                    fixture.name
+                );
+
+                let expected_masses: BTreeMap<u128, f64> = expected
+                    .terminal_log_masses
+                    .iter()
+                    .map(|(label, &mass)| {
+                        (label.parse().expect("logical label must fit in u128"), mass)
+                    })
+                    .collect();
+                let actual_masses = actual_masses(&result);
+                assert_eq!(
+                    actual_masses.len(),
+                    expected_masses.len(),
+                    "{} {regime} syndrome {syndrome_mask}: terminal-label count",
+                    fixture.name
+                );
+                for (label, expected_mass) in expected_masses {
+                    let actual_mass = actual_masses.get(&label).unwrap_or_else(|| {
+                        panic!(
+                            "{} {regime} syndrome {syndrome_mask}: missing label {label}",
+                            fixture.name
+                        )
+                    });
+                    assert!(
+                        (actual_mass - expected_mass).abs() <= 1e-9,
+                        "{} {regime} syndrome {syndrome_mask}, label {label}: expected {expected_mass}, got {actual_mass}",
+                        fixture.name
+                    );
+                }
+
+                let expected_evidence = expected
+                    .log_evidence
+                    .expect("ok result needs finite log_evidence");
+                assert!(
+                    (result.log_evidence - expected_evidence).abs() <= 1e-9,
+                    "{} {regime} syndrome {syndrome_mask}: expected evidence {expected_evidence}, got {}",
+                    fixture.name,
+                    result.log_evidence
+                );
+            }
+            "no_path" => {
+                assert!(
+                    expected.logical_hat.is_none(),
+                    "{} {regime} syndrome {syndrome_mask}: no-path logical_hat must be null",
+                    fixture.name
+                );
+                assert!(
+                    expected.log_evidence.is_none(),
+                    "{} {regime} syndrome {syndrome_mask}: no-path log_evidence must be null",
+                    fixture.name
+                );
+                assert!(
+                    expected.terminal_log_masses.is_empty(),
+                    "{} {regime} syndrome {syndrome_mask}: no-path masses must be empty",
+                    fixture.name
+                );
+                assert!(
+                    decoded.is_err(),
+                    "{} {regime} syndrome {syndrome_mask}: expected no path",
+                    fixture.name
+                );
+            }
+            status => panic!(
+                "{} {regime} syndrome {syndrome_mask}: unknown fixture status {status}",
+                fixture.name
+            ),
+        }
+    }
+
+    assert!(
+        expected_by_syndrome.is_empty(),
+        "{} {regime}: expected results contain extra syndromes",
+        fixture.name
+    );
+}
+
+#[test]
+fn unpruned_and_pruned_results_match_upstream_golden_fixtures() {
+    let fixture_file = parse_fixtures();
+    assert_eq!(fixture_file.generator, "generate_upstream_fixtures.py");
+
+    for fixture in fixture_file.fixtures {
+        assert_expected_results(
+            &fixture,
+            FrontierConfig {
+                k: usize::MAX,
+                delta: f64::INFINITY,
+                score_alpha: 0.8,
+                column_order: None,
+                merge_indistinguishable: false,
+                bp_score_iterations: 0,
+            },
+            &fixture.expected_unpruned,
+            "unpruned",
+        );
+        assert_expected_results(
+            &fixture,
+            FrontierConfig {
+                k: fixture.pruned.k,
+                delta: fixture.pruned.delta,
+                score_alpha: 0.8,
+                column_order: None,
+                merge_indistinguishable: false,
+                bp_score_iterations: 0,
+            },
+            &fixture.expected_pruned,
+            "pruned",
+        );
+    }
+}

--- a/python/pecos-rslib-exp/Cargo.toml
+++ b/python/pecos-rslib-exp/Cargo.toml
@@ -28,6 +28,7 @@ extension-module = [
 pecos-bp-trellis.workspace = true
 pecos-core.workspace = true
 pecos-eeg.workspace = true
+pecos-frontier.workspace = true
 pecos-neo.workspace = true
 pecos-qec.workspace = true
 pecos-quantum.workspace = true

--- a/python/pecos-rslib-exp/src/frontier_bindings.rs
+++ b/python/pecos-rslib-exp/src/frontier_bindings.rs
@@ -1,0 +1,612 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use pecos_frontier::{
+    CommitteeDirection, CommitteeMember, CommitteeStatus, DecoderError,
+    FrontierCommittee as RustFrontierCommittee,
+    FrontierCommitteeResult as RustFrontierCommitteeResult, FrontierConfig as RustFrontierConfig,
+    FrontierDecoder as RustFrontierDecoder, FrontierResult as RustFrontierResult, FrontierStatus,
+    ObsMask, SparseDem, backward_deadline_column_order, deadline_column_order,
+};
+use pyo3::Borrowed;
+use pyo3::exceptions::{PyAttributeError, PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyBytes, PyInt, PyList};
+
+enum ColumnOrderArgument {
+    Name(String),
+    Explicit(Vec<usize>),
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for ColumnOrderArgument {
+    type Error = PyErr;
+
+    fn extract(object: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        if let Ok(name) = object.extract::<String>() {
+            return Ok(Self::Name(name));
+        }
+        if let Ok(order) = object.extract::<Vec<usize>>() {
+            return Ok(Self::Explicit(order));
+        }
+        Err(PyValueError::new_err(
+            "column_order must be 'deadline_reorder', 'time_order', \
+             'backward_deadline_reorder', or a list of mechanism indices",
+        ))
+    }
+}
+
+impl Default for ColumnOrderArgument {
+    fn default() -> Self {
+        Self::Name("deadline_reorder".to_owned())
+    }
+}
+
+fn runtime_error(error: &DecoderError) -> PyErr {
+    PyRuntimeError::new_err(error.to_string())
+}
+
+fn sparse_index_error(index: u64, num_detectors: usize) -> PyErr {
+    PyRuntimeError::new_err(format!(
+        "Invalid node index {index}: must be < {num_detectors}"
+    ))
+}
+
+fn sparse_to_dense(indices: &[u64], num_detectors: usize) -> PyResult<Vec<u8>> {
+    let mut syndrome = vec![0; num_detectors];
+    for &index in indices {
+        let detector =
+            usize::try_from(index).map_err(|_| sparse_index_error(index, num_detectors))?;
+        let bit = syndrome
+            .get_mut(detector)
+            .ok_or_else(|| sparse_index_error(index, num_detectors))?;
+        *bit = 1;
+    }
+    Ok(syndrome)
+}
+
+fn resolve_column_order(
+    dem: &SparseDem,
+    column_order: ColumnOrderArgument,
+) -> PyResult<Option<Vec<usize>>> {
+    match column_order {
+        ColumnOrderArgument::Name(name) => match name.as_str() {
+            "deadline_reorder" => deadline_column_order(dem)
+                .map(Some)
+                .map_err(|e| runtime_error(&e)),
+            "time_order" => Ok(None),
+            "backward_deadline_reorder" => backward_deadline_column_order(dem)
+                .map(Some)
+                .map_err(|e| runtime_error(&e)),
+            _ => Err(PyValueError::new_err(format!(
+                "invalid column_order {name:?}; expected 'deadline_reorder', 'time_order', \
+                 'backward_deadline_reorder', or a list of mechanism indices"
+            ))),
+        },
+        ColumnOrderArgument::Explicit(order) => Ok(Some(order)),
+    }
+}
+
+fn parse_dem_and_config(
+    dem_str: &str,
+    k: usize,
+    delta: f64,
+    score_alpha: f64,
+    bp_score_iterations: usize,
+    column_order: ColumnOrderArgument,
+    merge_indistinguishable: bool,
+) -> PyResult<(SparseDem, RustFrontierConfig)> {
+    let dem = SparseDem::from_dem_str(dem_str).map_err(|e| runtime_error(&e))?;
+    let column_order = resolve_column_order(&dem, column_order)?;
+    Ok((
+        dem,
+        RustFrontierConfig {
+            k,
+            delta,
+            score_alpha,
+            column_order,
+            merge_indistinguishable,
+            bp_score_iterations,
+        },
+    ))
+}
+
+fn obs_mask_to_py(py: Python<'_>, mask: &ObsMask) -> PyResult<Py<PyAny>> {
+    if let Some(value) = mask.to_u64() {
+        return Ok(value.into_pyobject(py)?.into_any().unbind());
+    }
+
+    let mut bytes = Vec::with_capacity(std::mem::size_of_val(mask.words()));
+    for &word in mask.words() {
+        bytes.extend_from_slice(&word.to_le_bytes());
+    }
+    let py_bytes = PyBytes::new(py, &bytes);
+    Ok(py
+        .get_type::<PyInt>()
+        .call_method1("from_bytes", (py_bytes, "little"))?
+        .unbind())
+}
+
+/// Logical-observable flips returned by a Frontier decoder.
+#[pyclass(
+    name = "FrontierObservableFlips",
+    module = "pecos_rslib_exp",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone)]
+pub struct PyFrontierObservableFlips {
+    mask: ObsMask,
+    num_observables: usize,
+}
+
+#[pymethods]
+impl PyFrontierObservableFlips {
+    fn __len__(&self) -> usize {
+        self.num_observables
+    }
+
+    fn __getitem__(&self, index: isize) -> PyResult<bool> {
+        let normalized = if index < 0 {
+            self.num_observables.checked_add_signed(index)
+        } else {
+            usize::try_from(index).ok()
+        };
+        normalized
+            .filter(|&normalized_index| normalized_index < self.num_observables)
+            .map(|normalized_index| self.mask.get(normalized_index))
+            .ok_or_else(|| {
+                pyo3::exceptions::PyIndexError::new_err(format!(
+                    "Observable index {index} out of range (num_observables={})",
+                    self.num_observables
+                ))
+            })
+    }
+
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let bits = (0..self.num_observables).map(|index| self.mask.get(index));
+        Ok(PyList::new(py, bits)?.call_method0("__iter__")?.unbind())
+    }
+
+    fn indices(&self) -> Vec<usize> {
+        self.mask.iter_set_bits().collect()
+    }
+
+    #[getter]
+    fn mask(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        obs_mask_to_py(py, &self.mask)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        let mask = obs_mask_to_py(py, &self.mask)?;
+        Ok(format!(
+            "FrontierObservableFlips(num_observables={}, mask={})",
+            self.num_observables,
+            mask.bind(py).str()?.to_str()?
+        ))
+    }
+}
+
+fn logical_masses(py: Python<'_>, result: &RustFrontierResult) -> PyResult<Vec<(Py<PyAny>, f64)>> {
+    result
+        .logical_masses
+        .iter()
+        .map(|mass| Ok((obs_mask_to_py(py, &mass.logical)?, mass.log_mass)))
+        .collect()
+}
+
+fn member_log_evidence(member: CommitteeMember) -> Option<f64> {
+    match member.status {
+        CommitteeStatus::Ok => Some(member.log_evidence),
+        CommitteeStatus::NoPath => None,
+    }
+}
+
+fn frontier_status(status: FrontierStatus) -> &'static str {
+    match status {
+        FrontierStatus::Exact => "exact",
+        FrontierStatus::Pruned {
+            k_capped: true,
+            delta_pruned: false,
+        } => "pruned:k",
+        FrontierStatus::Pruned {
+            k_capped: false,
+            delta_pruned: true,
+        } => "pruned:delta",
+        FrontierStatus::Pruned {
+            k_capped: true,
+            delta_pruned: true,
+        } => "pruned:k+delta",
+        FrontierStatus::Pruned {
+            k_capped: false,
+            delta_pruned: false,
+        } => unreachable!("pruned status must name at least one pruning mechanism"),
+    }
+}
+
+/// Result returned by the native experimental Frontier decoder.
+#[pyclass(name = "FrontierResult", module = "pecos_rslib_exp")]
+pub struct PyFrontierResult {
+    inner: RustFrontierResult,
+    num_observables: usize,
+}
+
+#[pymethods]
+impl PyFrontierResult {
+    /// Predicted logical-observable flips with their intrinsic width.
+    #[getter]
+    fn observable_flips(&self) -> PyFrontierObservableFlips {
+        PyFrontierObservableFlips {
+            mask: self.inner.predicted.clone(),
+            num_observables: self.num_observables,
+        }
+    }
+
+    /// Total retained log evidence.
+    #[getter]
+    fn log_evidence(&self) -> f64 {
+        self.inner.log_evidence
+    }
+
+    /// Winner-to-runner-up retained-mass gap, if a runner-up survives pruning.
+    /// At small K this is often absent and is not an escalation trigger.
+    #[getter]
+    fn runner_up_gap(&self) -> Option<f64> {
+        self.inner.runner_up_gap
+    }
+
+    /// Peak number of retained dynamic-programming states.
+    #[getter]
+    fn peak_retained_states(&self) -> usize {
+        self.inner.peak_retained_states
+    }
+
+    /// Number of probabilistic columns processed.
+    #[getter]
+    fn processed_columns(&self) -> usize {
+        self.inner.processed_columns
+    }
+
+    /// Number of candidate branch evaluations, including all attempted rungs
+    /// for an escalated BP-trellis result.
+    #[getter]
+    fn transitions(&self) -> u64 {
+        self.inner.transitions
+    }
+
+    /// Number of merged states discarded by the successful rung.
+    #[getter]
+    fn dropped_states(&self) -> u64 {
+        self.inner.dropped_states
+    }
+
+    /// Log-sum-exp of masses discarded by the successful rung at pruning time.
+    #[getter]
+    fn dropped_log_mass(&self) -> f64 {
+        self.inner.dropped_log_mass
+    }
+
+    /// Wall-clock seconds spent producing BP-informed pruning scores,
+    /// including all attempted rungs for an escalated BP-trellis result.
+    #[getter]
+    fn bp_seconds(&self) -> f64 {
+        self.inner.bp_seconds
+    }
+
+    /// Number of no-path escalation rungs attempted before success.
+    #[getter]
+    fn escalation_rungs_used(&self) -> u32 {
+        self.inner.escalation_rungs_used
+    }
+
+    /// Completeness status of the successful rung.
+    #[getter]
+    fn status(&self) -> &'static str {
+        frontier_status(self.inner.status)
+    }
+
+    /// Terminal logical labels and their unnormalized joint log masses.
+    #[getter]
+    fn logical_masses(&self, py: Python<'_>) -> PyResult<Vec<(Py<PyAny>, f64)>> {
+        logical_masses(py, &self.inner)
+    }
+}
+
+/// Result returned by the native experimental forward/backward committee.
+#[pyclass(name = "FrontierCommitteeResult", module = "pecos_rslib_exp")]
+pub struct PyFrontierCommitteeResult {
+    inner: RustFrontierCommitteeResult,
+    num_observables: usize,
+}
+
+#[pymethods]
+impl PyFrontierCommitteeResult {
+    /// Predicted logical-observable flips from the selected leg.
+    #[getter]
+    fn observable_flips(&self) -> PyFrontierObservableFlips {
+        PyFrontierObservableFlips {
+            mask: self.inner.selected.predicted.clone(),
+            num_observables: self.num_observables,
+        }
+    }
+
+    /// Total retained log evidence from the selected leg.
+    #[getter]
+    fn log_evidence(&self) -> f64 {
+        self.inner.selected.log_evidence
+    }
+
+    /// Winner-to-runner-up retained-mass gap from the selected leg, if a
+    /// runner-up survives pruning. At small K this is often absent and is not
+    /// an escalation trigger.
+    #[getter]
+    fn runner_up_gap(&self) -> Option<f64> {
+        self.inner.selected.runner_up_gap
+    }
+
+    /// Peak number of states retained by the selected leg.
+    #[getter]
+    fn peak_retained_states(&self) -> usize {
+        self.inner.selected.peak_retained_states
+    }
+
+    /// Number of probabilistic columns processed by the selected leg.
+    #[getter]
+    fn processed_columns(&self) -> usize {
+        self.inner.selected.processed_columns
+    }
+
+    /// Number of candidate branch evaluations in the selected leg.
+    #[getter]
+    fn transitions(&self) -> u64 {
+        self.inner.selected.transitions
+    }
+
+    /// Number of states discarded by the selected leg.
+    #[getter]
+    fn dropped_states(&self) -> u64 {
+        self.inner.selected.dropped_states
+    }
+
+    /// Log-sum-exp of masses discarded by the selected leg at pruning time.
+    #[getter]
+    fn dropped_log_mass(&self) -> f64 {
+        self.inner.selected.dropped_log_mass
+    }
+
+    /// Wall-clock seconds spent by the selected leg producing BP-informed
+    /// pruning scores.
+    #[getter]
+    fn bp_seconds(&self) -> f64 {
+        self.inner.selected.bp_seconds
+    }
+
+    /// Completeness status of the selected leg.
+    #[getter]
+    fn status(&self) -> &'static str {
+        frontier_status(self.inner.selected.status)
+    }
+
+    /// Terminal logical labels and log masses from the selected leg.
+    #[getter]
+    fn logical_masses(&self, py: Python<'_>) -> PyResult<Vec<(Py<PyAny>, f64)>> {
+        logical_masses(py, &self.inner.selected)
+    }
+
+    /// Selected committee direction: `"forward"` or `"backward"`.
+    #[getter]
+    fn direction(&self) -> &'static str {
+        match self.inner.direction {
+            CommitteeDirection::Forward => "forward",
+            CommitteeDirection::Backward => "backward",
+        }
+    }
+
+    /// Forward-leg evidence, or `None` when that leg found no path.
+    #[getter]
+    fn forward_log_evidence(&self) -> Option<f64> {
+        member_log_evidence(self.inner.forward)
+    }
+
+    /// Backward-leg evidence, or `None` when that leg found no path.
+    #[getter]
+    fn backward_log_evidence(&self) -> Option<f64> {
+        member_log_evidence(self.inner.backward)
+    }
+}
+
+/// Native implementation of the Frontier decoder (Leverrier & Urbanke,
+/// arXiv:2606.20513). This experimental decoder is implemented in Rust and does
+/// not wrap the upstream `frontier` package.
+#[pyclass(name = "FrontierDecoder", module = "pecos_rslib_exp", unsendable)]
+pub struct PyFrontierDecoder {
+    inner: RustFrontierDecoder,
+    num_detectors: usize,
+    num_observables: usize,
+}
+
+#[pymethods]
+impl PyFrontierDecoder {
+    /// Construct a native Frontier decoder from a Stim-format DEM string.
+    #[staticmethod]
+    #[pyo3(
+        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false),
+        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False)"
+    )]
+    fn from_dem(
+        dem: &str,
+        k: usize,
+        delta: f64,
+        score_alpha: f64,
+        bp_score_iterations: usize,
+        column_order: ColumnOrderArgument,
+        merge_indistinguishable: bool,
+    ) -> PyResult<Self> {
+        let (dem, config) = parse_dem_and_config(
+            dem,
+            k,
+            delta,
+            score_alpha,
+            bp_score_iterations,
+            column_order,
+            merge_indistinguishable,
+        )?;
+        let num_detectors = dem.num_detectors;
+        let num_observables = dem.num_observables;
+        let inner = RustFrontierDecoder::from_sparse_dem(&dem, config)
+            .map_err(|error| runtime_error(&error))?;
+        Ok(Self {
+            inner,
+            num_detectors,
+            num_observables,
+        })
+    }
+
+    /// Wall-clock seconds spent constructing the decoder model.
+    #[getter]
+    fn build_seconds(&self) -> f64 {
+        self.inner.build_seconds()
+    }
+
+    /// Decode sparse fired-detector indices.
+    fn decode_from_defects(&mut self, defects: Vec<u64>) -> PyResult<PyFrontierResult> {
+        let syndrome = sparse_to_dense(&defects, self.num_detectors)?;
+        self.decode_syndrome(syndrome)
+    }
+
+    /// Decode one dense detector syndrome.
+    fn decode_syndrome(&mut self, syndrome: Vec<u8>) -> PyResult<PyFrontierResult> {
+        self.inner
+            .decode(&syndrome)
+            .map(|inner| PyFrontierResult {
+                inner,
+                num_observables: self.num_observables,
+            })
+            .map_err(|error| runtime_error(&error))
+    }
+
+    /// Decode a batch of dense detector syndromes in input order.
+    fn decode_batch(&mut self, shots: Vec<Vec<u8>>) -> PyResult<Vec<PyFrontierResult>> {
+        shots
+            .into_iter()
+            .map(|syndrome| self.decode_syndrome(syndrome))
+            .collect()
+    }
+
+    fn __getattr__(&self, name: &str) -> PyResult<()> {
+        if name == "decode" {
+            Err(PyAttributeError::new_err(
+                "FrontierDecoder has no attribute 'decode'; use decode_syndrome(...) for a dense \
+                 vector or decode_from_defects(...) for sparse detector indices",
+            ))
+        } else {
+            Err(PyAttributeError::new_err(format!(
+                "'FrontierDecoder' object has no attribute '{name}'"
+            )))
+        }
+    }
+}
+
+/// Native experimental forward/backward committee of two Frontier decoders.
+/// The implementation is Rust-native and does not wrap the upstream
+/// `frontier` package (Leverrier & Urbanke, arXiv:2606.20513).
+#[pyclass(
+    name = "FrontierCommitteeDecoder",
+    module = "pecos_rslib_exp",
+    unsendable
+)]
+pub struct PyFrontierCommitteeDecoder {
+    inner: RustFrontierCommittee,
+    num_detectors: usize,
+    num_observables: usize,
+}
+
+#[pymethods]
+impl PyFrontierCommitteeDecoder {
+    /// Construct a native forward/backward committee from a Stim-format DEM.
+    #[staticmethod]
+    #[pyo3(
+        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false),
+        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False)"
+    )]
+    fn from_dem(
+        dem: &str,
+        k: usize,
+        delta: f64,
+        score_alpha: f64,
+        bp_score_iterations: usize,
+        column_order: ColumnOrderArgument,
+        merge_indistinguishable: bool,
+    ) -> PyResult<Self> {
+        let (dem, config) = parse_dem_and_config(
+            dem,
+            k,
+            delta,
+            score_alpha,
+            bp_score_iterations,
+            column_order,
+            merge_indistinguishable,
+        )?;
+        let num_detectors = dem.num_detectors;
+        let num_observables = dem.num_observables;
+        let inner = RustFrontierCommittee::from_sparse_dem(&dem, config)
+            .map_err(|error| runtime_error(&error))?;
+        Ok(Self {
+            inner,
+            num_detectors,
+            num_observables,
+        })
+    }
+
+    /// Wall-clock seconds spent constructing both committee legs.
+    #[getter]
+    fn build_seconds(&self) -> f64 {
+        self.inner.build_seconds()
+    }
+
+    /// Decode sparse fired-detector indices with both committee legs.
+    fn decode_from_defects(&mut self, defects: Vec<u64>) -> PyResult<PyFrontierCommitteeResult> {
+        let syndrome = sparse_to_dense(&defects, self.num_detectors)?;
+        self.decode_syndrome(syndrome)
+    }
+
+    /// Decode one dense detector syndrome with both committee legs.
+    fn decode_syndrome(&mut self, syndrome: Vec<u8>) -> PyResult<PyFrontierCommitteeResult> {
+        self.inner
+            .decode(&syndrome)
+            .map(|inner| PyFrontierCommitteeResult {
+                inner,
+                num_observables: self.num_observables,
+            })
+            .map_err(|error| runtime_error(&error))
+    }
+
+    /// Decode a batch of dense detector syndromes in input order.
+    fn decode_batch(&mut self, shots: Vec<Vec<u8>>) -> PyResult<Vec<PyFrontierCommitteeResult>> {
+        shots
+            .into_iter()
+            .map(|syndrome| self.decode_syndrome(syndrome))
+            .collect()
+    }
+
+    fn __getattr__(&self, name: &str) -> PyResult<()> {
+        if name == "decode" {
+            Err(PyAttributeError::new_err(
+                "FrontierCommitteeDecoder has no attribute 'decode'; use decode_syndrome(...) for \
+                 a dense vector or decode_from_defects(...) for sparse detector indices",
+            ))
+        } else {
+            Err(PyAttributeError::new_err(format!(
+                "'FrontierCommitteeDecoder' object has no attribute '{name}'"
+            )))
+        }
+    }
+}

--- a/python/pecos-rslib-exp/src/lib.rs
+++ b/python/pecos-rslib-exp/src/lib.rs
@@ -27,11 +27,13 @@
 //! Python bindings for experimental PECOS components.
 //!
 //! Exposes `StabMps` (stabilizer + MPS hybrid) and `Mast` (magic state
-//! injection) from `pecos-stab-tn`, plus the BP-trellis decoder, via `PyO3`.
+//! injection) from `pecos-stab-tn`, plus the Frontier and BP-trellis decoders,
+//! via `PyO3`.
 
 mod bp_trellis_bindings;
 mod coherent_idle_channel;
 mod eeg_bindings;
+mod frontier_bindings;
 mod mast_bindings;
 mod sim_neo_bindings;
 mod stab_mps_bindings;
@@ -68,6 +70,11 @@ fn pecos_rslib_exp(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<bp_trellis_bindings::PyBpTrellisDecoder>()?;
     m.add_class::<bp_trellis_bindings::PyBpTrellisResult>()?;
     m.add_class::<bp_trellis_bindings::PyBpTrellisObservableFlips>()?;
+    m.add_class::<frontier_bindings::PyFrontierDecoder>()?;
+    m.add_class::<frontier_bindings::PyFrontierCommitteeDecoder>()?;
+    m.add_class::<frontier_bindings::PyFrontierResult>()?;
+    m.add_class::<frontier_bindings::PyFrontierCommitteeResult>()?;
+    m.add_class::<frontier_bindings::PyFrontierObservableFlips>()?;
     m.add_class::<stab_mps_bindings::PyStabMps>()?;
     m.add_class::<mast_bindings::PyMast>()?;
     m.add_class::<sim_neo_bindings::PySimNeoBuilder>()?;

--- a/python/quantum-pecos/tests/qec/test_frontier_decoder.py
+++ b/python/quantum-pecos/tests/qec/test_frontier_decoder.py
@@ -1,0 +1,195 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Tests for the experimental native Frontier decoder bindings."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pecos_rslib_exp = pytest.importorskip("pecos_rslib_exp")
+
+from pecos_rslib_exp import (  # noqa: E402
+    FrontierCommitteeDecoder,
+    FrontierDecoder,
+)
+
+SMALL_DEM = """\
+error(0.1) D0 L0
+error(0.2) D1
+"""
+
+
+def test_sparse_and_dense_decode_agree() -> None:
+    decoder = FrontierDecoder.from_dem(SMALL_DEM)
+
+    # Syndrome D0=1, D1=0 forces the first mechanism on and the second off,
+    # so logical observable L0 flips and the expected mask is 1.
+    dense = decoder.decode_syndrome([1, 0])
+    sparse = decoder.decode_from_defects([0])
+
+    assert dense.observable_flips.mask == 1
+    assert sparse.observable_flips.mask == dense.observable_flips.mask
+    assert sparse.log_evidence == dense.log_evidence
+    assert sparse.logical_masses == dense.logical_masses
+    assert list(dense.observable_flips) == [True]
+    assert dense.transitions == 4
+    assert dense.dropped_states == 0
+    assert dense.dropped_log_mass == float("-inf")
+    assert dense.status == "exact"
+    assert dense.bp_seconds == 0.0
+    assert dense.escalation_rungs_used == 0
+    assert decoder.build_seconds >= 0.0
+    assert not hasattr(decoder, "decode")
+
+
+def test_wide_observable_mask_is_a_python_int() -> None:
+    decoder = FrontierDecoder.from_dem("error(0.9) D0 L64\n")
+
+    result = decoder.decode_syndrome([1])
+
+    assert isinstance(result.observable_flips.mask, int)
+    assert result.observable_flips.mask == 1 << 64
+    assert len(result.observable_flips) == 65
+    assert result.observable_flips[64]
+    assert result.logical_masses[0][0] == 1 << 64
+
+
+def test_column_order_variants_and_validation() -> None:
+    expected = 1
+    for column_order in (
+        "deadline_reorder",
+        "time_order",
+        "backward_deadline_reorder",
+        [1, 0],
+    ):
+        decoder = FrontierDecoder.from_dem(SMALL_DEM, column_order=column_order)
+        assert decoder.decode_syndrome([1, 0]).observable_flips.mask == expected
+
+    with pytest.raises(ValueError, match="invalid column_order"):
+        FrontierDecoder.from_dem(SMALL_DEM, column_order="not_an_order")
+    with pytest.raises(ValueError, match="column_order must be"):
+        FrontierDecoder.from_dem(SMALL_DEM, column_order=object())
+    with pytest.raises(RuntimeError, match="permutation"):
+        FrontierDecoder.from_dem(SMALL_DEM, column_order=[0, 0])
+
+
+def test_committee_easy_tie_selects_forward() -> None:
+    committee = FrontierCommitteeDecoder.from_dem("error(0.1) D0 L0\n", column_order="time_order")
+
+    result = committee.decode_from_defects([0])
+
+    assert result.observable_flips.mask == 1
+    assert result.direction == "forward"
+    assert result.forward_log_evidence == result.log_evidence
+    assert result.backward_log_evidence == result.log_evidence
+    assert result.status == "exact"
+    assert result.transitions == 2
+    assert committee.build_seconds >= 0.0
+    assert not hasattr(committee, "decode")
+
+
+def test_bp_score_iterations_and_telemetry_are_exposed() -> None:
+    decoder = FrontierDecoder.from_dem(
+        SMALL_DEM,
+        k=1,
+        delta=float("inf"),
+        bp_score_iterations=3,
+    )
+    committee = FrontierCommitteeDecoder.from_dem(
+        SMALL_DEM,
+        k=1,
+        delta=float("inf"),
+        bp_score_iterations=3,
+    )
+
+    assert decoder.decode_syndrome([1, 0]).bp_seconds >= 0.0
+    assert committee.decode_syndrome([1, 0]).bp_seconds >= 0.0
+
+
+def test_pruning_telemetry_and_status_strings() -> None:
+    width = FrontierDecoder.from_dem("error(0.25) L0\n", k=1, delta=float("inf"))
+    width_result = width.decode_syndrome([])
+    assert width_result.dropped_states == 1
+    assert math.exp(width_result.dropped_log_mass) == pytest.approx(0.25)
+    assert width_result.status == "pruned:k"
+
+    delta = FrontierDecoder.from_dem("error(0.25) L0\n", k=2, delta=0.5)
+    assert delta.decode_syndrome([]).status == "pruned:delta"
+
+    both = FrontierDecoder.from_dem(
+        "error(0.5) L0\nerror(0.1) L1\n",
+        k=3,
+        delta=0.5,
+    )
+    assert both.decode_syndrome([]).status == "pruned:k+delta"
+
+
+def test_unexplainable_and_out_of_range_syndromes_raise_runtime_error() -> None:
+    decoder = FrontierDecoder.from_dem("error(0.1) D0 D1\n")
+
+    with pytest.raises(RuntimeError, match="unexplainable"):
+        decoder.decode_syndrome([1, 0])
+    with pytest.raises(RuntimeError, match="Invalid node index"):
+        decoder.decode_from_defects([2])
+
+
+def test_decode_batch_matches_individual_decodes() -> None:
+    shots = [[0, 0], [1, 0], [0, 1], [1, 1]]
+    batch_decoder = FrontierDecoder.from_dem(SMALL_DEM)
+    individual_decoder = FrontierDecoder.from_dem(SMALL_DEM)
+
+    batch = batch_decoder.decode_batch(shots)
+    individual = [individual_decoder.decode_syndrome(shot) for shot in shots]
+
+    assert [result.observable_flips.mask for result in batch] == [result.observable_flips.mask for result in individual]
+    assert [result.log_evidence for result in batch] == [result.log_evidence for result in individual]
+    assert [result.logical_masses for result in batch] == [result.logical_masses for result in individual]
+
+
+DUPLICATE_DEM = """\
+error(0.3) D0 L0
+error(0.3) D0 L0
+"""
+
+
+def test_merge_indistinguishable_kwarg_defaults_off_and_merges_when_enabled() -> None:
+    default_decoder = FrontierDecoder.from_dem(DUPLICATE_DEM, column_order="time_order")
+    merged_decoder = FrontierDecoder.from_dem(
+        DUPLICATE_DEM,
+        column_order="time_order",
+        merge_indistinguishable=True,
+    )
+
+    default_result = default_decoder.decode_from_defects([0])
+    merged_result = merged_decoder.decode_from_defects([0])
+    assert default_result.processed_columns == 2
+    assert merged_result.processed_columns == 1
+    # decode_from_defects([0]) passes sparse fired-detector indices: detector 0 fired. The only
+    # explanation is the merged mechanism firing, whose XOR probability is
+    # 0.3*0.7 + 0.7*0.3 = 0.42, so the total evidence is exactly 0.42.
+    assert math.isclose(math.exp(merged_result.log_evidence), 0.42, abs_tol=1e-15)
+
+
+def test_committee_merge_kwarg_defaults_off_and_merges_when_enabled() -> None:
+    default_committee = FrontierCommitteeDecoder.from_dem(DUPLICATE_DEM, column_order="time_order")
+    merged_committee = FrontierCommitteeDecoder.from_dem(
+        DUPLICATE_DEM,
+        column_order="time_order",
+        merge_indistinguishable=True,
+    )
+
+    assert default_committee.decode_from_defects([0]).processed_columns == 2
+    assert merged_committee.decode_from_defects([0]).processed_columns == 1

--- a/ruff.toml
+++ b/ruff.toml
@@ -127,8 +127,9 @@ ignore = [
 "examples/surface_code_thresholds.ipynb" = ["TID251"]
 
 # Standalone offline oracle-fixture generators inside Rust crate test dirs -
-# scripts run via uv, not an importable package
-"crates/*/tests/fixtures/*.py" = [
+# scripts run via uv, not an importable package. Experimental crates live under
+# exp/ and carry the same kind of generator.
+"{crates,exp}/*/tests/fixtures/*.py" = [
     "INP001",   # Implicit namespace package - standalone scripts, not a package
     "S311",     # Standard pseudo-random - fixed-seed case sampling, not crypto
     "TID251",   # NumPy allowed - these generate oracle fixtures for the test suite


### PR DESCRIPTION
The last piece of the experimental decoder work. **Stacked on #475** because it is the only part that genuinely needs the trellis engine; GitHub will retarget this to `dev` once #475 merges.

### What this crate is

`exp/pecos-frontier` is the parity port of Leverrier and Urbanke's Frontier decoder. Now that the engine lives in `pecos-trellis` (#475), the port is reduced to what is actually port-specific: type aliases onto the engine types, `FrontierCommittee` and its companion types, the `bridge_ab` A/B harness, and the golden fixtures that pin behavior against the external implementation.

It is a native implementation, not a wrap: nothing from the upstream project is vendored. Upstream is used only as an oracle, through fixtures generated by the committed scripts under `tests/fixtures/`.

### Why aliases rather than wrapper types

`FrontierDecoder` **is** `TrellisDecoder` — same type, not an adapter. That makes behavioral drift impossible by construction, and it means the frozen bitwise snapshot and the upstream golden fixtures pin the *engine*, not a shim in front of it. A wrapper could silently diverge; an alias cannot.

### The evidence that extracting the engine changed nothing

All three fixture files are byte-identical to their pre-split versions, and the snapshot suite passes against them unmodified:

| fixture | git hash |
|---|---|
| `bitwise_snapshot.json` | `c03c8a1830…` |
| `upstream_fixtures.json` | `82027a65b0…` |
| `upstream_order_fixtures.json` | `393f529938…` |

That is the whole point of the split being safe: 128 snapshot scenarios and both upstream parity suites still reproduce bit-for-bit after the engine moved crates.

### Test ownership

Engine-level tests moved to the engine crate in #475 and are **not** duplicated here. This crate keeps the port-owned suites — upstream fixture parity, ordering/committee parity, the bitwise snapshot — plus one deliberate cross-layer test asserting that `FrontierCommittee` and a direct decoder report the *same* unexplainable-syndrome error text, since the port carries its own copy of that helper rather than exposing an engine internal.

`MUTANTS.md` here lists port-only mutants; the engine rows live with the engine.

### Verification

9 port tests (including the frozen snapshot and both upstream suites), 41 engine and 11 BpTrellis tests confirmed unchanged, 13 Python tests, cold clippy pedantic with `-D warnings` across four crates, `cargo check --workspace`, and repo-wide pre-commit. No engine or BpTrellis file was modified, and no visibility change was needed.

### Research context

The design record and the decoder-evaluation campaign live in `pecos-docs` (`design/frontier-decoder-port-plan.md`, `design/trellis-engine-crate-layering.md`, `design/bp-trellis-evaluation-campaign.md`), including the BB144-scale per-shot parity results against upstream and the honest accounting of where this decoder class wins and where it does not.