### PR TITLE
Saturate BP prior LLRs and fail loud when pruning empties the frontier

### DIFF
--- a/crates/pecos-decoder-core/src/bp.rs
+++ b/crates/pecos-decoder-core/src/bp.rs
@@ -402,14 +402,40 @@ fn prior_llr(probability: f64) -> f64 {
     } else if probability >= 1.0 {
         -30.0
     } else {
-        ((1.0 - probability) / probability).ln()
+        // The clamp keeps the computed branch inside the same +-30 saturation
+        // the boundary branches already use. Without it, a subnormal
+        // probability overflows the ratio to infinity before `ln`, and one
+        // infinite prior turns downstream exponentially-weighted updates into
+        // NaN -- which a consumer then misreads as "no retained path".
+        // Clamp returns the input bit-identically whenever it is in range.
+        ((1.0 - probability) / probability).ln().clamp(-30.0, 30.0)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BpGraph, BpScratch, min_sum_bp_into};
+    use super::{BpGraph, BpScratch, min_sum_bp_into, prior_llr};
     use crate::dem::DemCheckMatrix;
+
+    /// A subnormal probability overflows `(1 - p) / p` to infinity before the
+    /// logarithm; the prior must saturate at the same +-30 the boundary
+    /// branches use, or one infinite prior poisons every downstream
+    /// exponentially-weighted update with NaN.
+    #[test]
+    fn prior_llr_is_finite_and_saturated_for_subnormal_probabilities() {
+        assert_eq!(prior_llr(5e-324).to_bits(), 30.0_f64.to_bits());
+        // The mirrored extreme saturates at the negative bound.
+        assert_eq!(
+            prior_llr(1.0 - f64::EPSILON).to_bits(),
+            (-30.0_f64).to_bits()
+        );
+        // Ordinary probabilities are untouched bit-for-bit.
+        let ordinary = 0.03_f64;
+        assert_eq!(
+            prior_llr(ordinary).to_bits(),
+            ((1.0 - ordinary) / ordinary).ln().to_bits()
+        );
+    }
 
     #[test]
     fn scratch_is_reset_between_calls() {

--- a/crates/pecos-decoder-core/src/bp.rs
+++ b/crates/pecos-decoder-core/src/bp.rs
@@ -111,6 +111,11 @@ impl BpGraph {
     }
 
     /// Prior per-mechanism log-likelihood ratios, in graph mechanism order.
+    ///
+    /// Saturated to `[-30.0, 30.0]`: probabilities below about `9.36e-14` (or
+    /// above one minus that) produce the bound rather than the exact ratio,
+    /// matching the values used for out-of-range probabilities. Everything
+    /// inside that regime is the exact `ln((1 - p) / p)`.
     #[must_use]
     pub fn prior_llrs(&self) -> &[f64] {
         &self.prior_llr
@@ -393,6 +398,17 @@ pub fn min_sum_bp_into(
         }
     }
 
+    // Finite priors do not guarantee finite arithmetic: message sums over
+    // high-degree variables can still overflow, and `prior + total - c_to_v`
+    // then evaluates infinity minus infinity. Garbage beliefs must not steer a
+    // consumer silently, so non-finite posteriors are a loud failure here, at
+    // the layer that produced them.
+    if let Some(variable) = posterior.iter().position(|belief| !belief.is_finite()) {
+        return Err(DecoderError::InternalError(format!(
+            "belief propagation produced a non-finite posterior for mechanism {variable};              the model's degree and prior regime exceeds what min-sum message              accumulation can represent"
+        )));
+    }
+
     Ok(())
 }
 
@@ -403,11 +419,12 @@ fn prior_llr(probability: f64) -> f64 {
         -30.0
     } else {
         // The clamp keeps the computed branch inside the same +-30 saturation
-        // the boundary branches already use. Without it, a subnormal
-        // probability overflows the ratio to infinity before `ln`, and one
-        // infinite prior turns downstream exponentially-weighted updates into
-        // NaN -- which a consumer then misreads as "no retained path".
-        // Clamp returns the input bit-identically whenever it is in range.
+        // the boundary branches already use, which changes the result exactly
+        // for probabilities below ~9.36e-14 or above one minus that. Without
+        // it, a subnormal probability overflows the ratio to infinity before
+        // `ln`, and one infinite prior turns downstream exponentially-weighted
+        // updates into NaN. Clamp returns the input bit-identically whenever
+        // it is in range.
         ((1.0 - probability) / probability).ln().clamp(-30.0, 30.0)
     }
 }

--- a/exp/pecos-frontier/examples/bridge_ab.rs
+++ b/exp/pecos-frontier/examples/bridge_ab.rs
@@ -95,6 +95,15 @@ fn main() {
         let shot_started = std::time::Instant::now();
         let outcome = decoder.decode(&syndrome);
         let shot_seconds = shot_started.elapsed().as_secs_f64();
+        if let Err(error) = &outcome {
+            // Only a genuine no-path is a shot outcome. Anything else is an
+            // engine fault, and recording it as no_path would silently skew
+            // the A/B comparison.
+            assert!(
+                matches!(error, pecos_frontier::DecoderError::DecodingFailed(_)),
+                "engine fault on shot {shot}: {error}"
+            );
+        }
         if let Ok(result) = outcome {
             let words = result.predicted.words();
             assert!(words.iter().skip(2).all(|&w| w == 0), "label fits u128");

--- a/exp/pecos-frontier/tests/bitwise_snapshot.rs
+++ b/exp/pecos-frontier/tests/bitwise_snapshot.rs
@@ -190,9 +190,16 @@ fn collect_snapshot() -> SnapshotFile {
                 .expect("fixture decoder construction must succeed");
             for &syndrome_mask in &fixture.syndromes {
                 let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
-                let outcome = decoder
-                    .decode(&syndrome)
-                    .map_or(SnapshotOutcome::NoPath, snapshot_result);
+                let outcome = decoder.decode(&syndrome).map_or_else(
+                    |error| {
+                        assert!(
+                            matches!(error, pecos_frontier::DecoderError::DecodingFailed(_)),
+                            "snapshot scenario hit an engine fault: {error}"
+                        );
+                        SnapshotOutcome::NoPath
+                    },
+                    snapshot_result,
+                );
                 scenarios.push(ScenarioSnapshot {
                     name: format!(
                         "upstream/{}/{regime}/syndrome=0x{syndrome_mask:x}",
@@ -224,11 +231,16 @@ fn collect_snapshot() -> SnapshotFile {
         .expect("fixture committee construction must succeed");
         for syndrome_mask in fixture.syndromes {
             let syndrome = dense_syndrome(syndrome_mask, fixture.num_detectors);
-            let outcome = committee
-                .decode(&syndrome)
-                .map_or(SnapshotOutcome::NoPath, |result| {
-                    snapshot_result(result.selected)
-                });
+            let outcome = committee.decode(&syndrome).map_or_else(
+                |error| {
+                    assert!(
+                        matches!(error, pecos_frontier::DecoderError::DecodingFailed(_)),
+                        "snapshot scenario hit an engine fault: {error}"
+                    );
+                    SnapshotOutcome::NoPath
+                },
+                |result| snapshot_result(result.selected),
+            );
             scenarios.push(ScenarioSnapshot {
                 name: format!(
                     "order/{}/committee/syndrome=0x{syndrome_mask:x}",

--- a/exp/pecos-frontier/tests/upstream_fixtures.rs
+++ b/exp/pecos-frontier/tests/upstream_fixtures.rs
@@ -202,8 +202,12 @@ fn assert_expected_results(
                     fixture.name
                 );
                 assert!(
-                    decoded.is_err(),
-                    "{} {regime} syndrome {syndrome_mask}: expected no path",
+                    matches!(
+                        decoded,
+                        Err(pecos_frontier::DecoderError::DecodingFailed(_))
+                    ),
+                    "{} {regime} syndrome {syndrome_mask}: expected a genuine \
+                     no-path, got {decoded:?}",
                     fixture.name
                 );
             }

--- a/exp/pecos-trellis/src/lib.rs
+++ b/exp/pecos-trellis/src/lib.rs
@@ -651,11 +651,14 @@ impl TrellisDecoder {
             k_capped |= pruned.k_capped;
             delta_pruned |= pruned.delta_pruned;
             if frontier.is_empty() {
-                return TrellisDecodeAttempt::NoPath {
-                    error: unexplainable_error(),
-                    transitions,
-                    bp_seconds,
-                };
+                // Pruning always retains the best-scoring candidate of a
+                // nonempty set, so an empty frontier here means the scores
+                // themselves were unusable (non-finite) -- an engine fault,
+                // not an unexplainable syndrome. Genuine no-path exits happen
+                // above, before pruning, when no branch is compatible.
+                return TrellisDecodeAttempt::Error(DecoderError::InternalError(
+                    "pruning emptied a nonempty frontier; candidate scores were not finite".into(),
+                ));
             }
             peak_retained_states = peak_retained_states.max(frontier.len());
         }

--- a/exp/pecos-trellis/tests/trellis.rs
+++ b/exp/pecos-trellis/tests/trellis.rs
@@ -1214,3 +1214,46 @@ fn bp_flag_is_bitwise_inert_on_the_unpruned_fast_path() {
         );
     }
 }
+
+/// A subnormal mechanism probability used to overflow the BP prior to
+/// infinity, poison the posterior updates with NaN, empty the frontier at
+/// prune time, and surface as "no path" -- a numerical engine fault wearing an
+/// unexplainable-syndrome costume. With saturated priors the BP-on decode must
+/// succeed and agree with the BP-off decode; and if scores ever go non-finite
+/// again, the engine must report an internal error, not a no-path.
+#[test]
+fn subnormal_priors_decode_with_bp_scoring_instead_of_reporting_no_path() {
+    let dem = sparse_dem(
+        vec![(5e-324, vec![0], vec![]), (5e-324, vec![0], vec![0])],
+        1,
+        1,
+    );
+    let mut with_bp = TrellisDecoder::from_sparse_dem(
+        &dem,
+        TrellisConfig {
+            k: 1,
+            delta: 10.0,
+            score_alpha: 0.8,
+            column_order: None,
+            merge_indistinguishable: false,
+            bp_score_iterations: 1,
+        },
+    )
+    .unwrap();
+    let mut without_bp = TrellisDecoder::from_sparse_dem(
+        &dem,
+        TrellisConfig {
+            k: 1,
+            delta: 10.0,
+            score_alpha: 0.8,
+            column_order: None,
+            merge_indistinguishable: false,
+            bp_score_iterations: 0,
+        },
+    )
+    .unwrap();
+
+    let with_bp = with_bp.decode(&[0]).expect("BP-on decode must succeed");
+    let without_bp = without_bp.decode(&[0]).expect("BP-off decode must succeed");
+    assert_eq!(with_bp.predicted, without_bp.predicted);
+}

--- a/exp/pecos-trellis/tests/trellis.rs
+++ b/exp/pecos-trellis/tests/trellis.rs
@@ -13,7 +13,9 @@
 use pecos_decoder_core::dem::SparseDem;
 use pecos_decoder_core::obs_mask::ObsMask;
 use pecos_decoder_core::{DecoderError, ObservableDecoder};
-use pecos_trellis::{TrellisConfig, TrellisDecoder, TrellisResult, TrellisStatus};
+use pecos_trellis::{
+    TrellisConfig, TrellisDecodeAttempt, TrellisDecoder, TrellisResult, TrellisStatus,
+};
 use rand::{RngExt, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::collections::{BTreeMap, BTreeSet};
@@ -1256,4 +1258,53 @@ fn subnormal_priors_decode_with_bp_scoring_instead_of_reporting_no_path() {
     let with_bp = with_bp.decode(&[0]).expect("BP-on decode must succeed");
     let without_bp = without_bp.decode(&[0]).expect("BP-off decode must succeed");
     assert_eq!(with_bp.predicted, without_bp.predicted);
+}
+
+/// High variable degree can overflow BP message sums even with saturated
+/// priors, minting NaN through infinity-minus-infinity. Unusable beliefs must
+/// surface as an engine fault -- never as a no-path, which a committee or an
+/// escalation ladder would absorb and a caller would misread as a pruning
+/// problem.
+#[test]
+fn non_finite_bp_posteriors_are_an_engine_fault_not_a_no_path() {
+    let detectors: Vec<u32> = (0..1600).collect();
+    let dem = sparse_dem(
+        vec![
+            (5e-324, detectors.clone(), vec![]),
+            (5e-324, detectors, vec![0]),
+        ],
+        1600,
+        1,
+    );
+    let mut decoder = TrellisDecoder::from_sparse_dem(
+        &dem,
+        TrellisConfig {
+            k: 1,
+            delta: 10.0,
+            score_alpha: 0.8,
+            column_order: None,
+            merge_indistinguishable: false,
+            bp_score_iterations: 5,
+        },
+    )
+    .unwrap();
+
+    let syndrome = vec![0_u8; 1600];
+    match decoder.decode_attempt(&syndrome) {
+        TrellisDecodeAttempt::Error(DecoderError::InternalError(message)) => {
+            assert!(
+                message.contains("non-finite"),
+                "fault must say what broke, got: {message}"
+            );
+        }
+        TrellisDecodeAttempt::NoPath { error, .. } => {
+            panic!("non-finite BP beliefs were misreported as no-path: {error}")
+        }
+        TrellisDecodeAttempt::Success(_) => {
+            panic!("expected an internal-error fault, got a successful decode")
+        }
+        TrellisDecodeAttempt::Error(other) => {
+            panic!("expected an internal-error fault, got: {other}")
+        }
+    }
 }


### PR DESCRIPTION
Fixes an engine fault found by an adversarial review of #504, reproduced by execution: a detector error model containing a **subnormal mechanism probability** (`p = 5e-324`) made every BP-scored decode report *"syndrome is unexplainable at the given pruning parameters"* — while the identical decode with BP scoring disabled succeeded.

### The chain

`prior_llr` computes `((1 - p) / p).ln()`. For a subnormal `p` the ratio overflows to infinity **before** the logarithm, so one prior becomes `+inf`. The first exponentially-weighted posterior update then evaluates a zero-weighted infinite term and produces NaN; NaN passes through the score clamp (NaN.clamp is NaN); every `score >= cutoff` comparison goes false; pruning empties the frontier; and the decode exits through the no-path branch. A numerical engine fault wearing an unexplainable-syndrome costume — the caller would tune `k` and `delta` forever.

### The fix, at both layers

**Root cause:** `prior_llr` already saturates its boundary branches at ±30; the computed branch now honors the same ceiling. `clamp` returns its input bit-identically whenever in range, and the bitwise-pinned BP posterior fixtures confirm ordinary priors are untouched — the promotion fixture suite passes unchanged.

**Defense in depth:** pruning always retains the best-scoring candidate of a nonempty set, so an empty frontier *after* pruning can only mean the scores themselves were unusable. That exit now reports `InternalError` instead of a no-path. Genuine no-path outcomes are unaffected — they exit earlier, before pruning, when no branch is compatible — and the overpruning and escalation-ladder tests confirm their trigger semantics are unchanged. This also matters for `BpTrellisDecoder`'s escalation ladder: it retries no-paths, and retrying a NaN at higher K can never help; now the fault propagates immediately.

### Tests

A unit test pins the saturation at both extremes (by bit comparison) and pins that ordinary probabilities are bit-for-bit untouched. An end-to-end regression decodes the reproducing model with BP scoring on and asserts it succeeds and agrees with the BP-off decode.

Verified: 190 tests across `pecos-decoder-core`, `pecos-trellis`, `pecos-bp-trellis` (including the bitwise posterior fixtures), plus `pecos-uf-decoder`; cold clippy pedantic with `-D warnings`; repo-wide pre-commit.