### PR TITLE
Validate every distribution before any upload and bound the CUDA install steps

### DIFF
--- a/.github/workflows/cuda-build-check.yml
+++ b/.github/workflows/cuda-build-check.yml
@@ -70,6 +70,10 @@ jobs:
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         id: cuda-toolkit
+        # This step downloads from an external host and normally finishes in a couple of
+        # minutes. Without a bound, a stalled download hangs the job indefinitely -- one did
+        # so for four hours on 2026-08-18, and every dependent job waits behind it.
+        timeout-minutes: 15
         with:
           cuda: '12.6.3'
           method: 'network'

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -362,6 +362,10 @@ jobs:
       - name: Install CUDA Toolkit (Windows)
         if: runner.os == 'Windows' && matrix.install_cuda
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        # Bounded like the other CUDA installs so a stalled download fails instead of
+        # hanging the job. More generous than those: `method: local` pulls the full
+        # installer rather than network sub-packages.
+        timeout-minutes: 30
         with:
           cuda: '12.5.1'
           method: 'local'

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -91,6 +91,10 @@ jobs:
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         id: cuda-toolkit
+        # This step downloads from an external host and normally finishes in a couple of
+        # minutes. Without a bound, a stalled download hangs the job indefinitely -- one did
+        # so for four hours on 2026-08-18, and every dependent job waits behind it.
+        timeout-minutes: 15
         with:
           cuda: '12.6.3'
           method: 'network'
@@ -272,6 +276,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         id: cuda-toolkit-test
+        # This step downloads from an external host and normally finishes in a couple of
+        # minutes. Without a bound, a stalled download hangs the job indefinitely -- one did
+        # so for four hours on 2026-08-18, and every dependent job waits behind it.
+        timeout-minutes: 15
         with:
           cuda: '12.6.3'
           method: 'network'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -91,7 +91,12 @@ preflight -- complete set, consistent version, only expected files -- is the
 only thing standing between that and a stray upload.
 
 The dry run must show a real `twine check ... PASSED` per file (twine must be
-installed, e.g. `uv tool install twine`). The script prints only a
+installed, e.g. `uv tool install twine`). Keep it current: build tools raise the
+core-metadata version they emit over time, and a checker older than the metadata
+rejects the artifacts even though PyPI accepts them -- `uv tool upgrade twine` if a
+check fails naming a metadata version. The script prints which twine it is using, and
+validates every package before uploading any of them, so a stale checker stops the run
+rather than surfacing after the first packages are already public. It prints only a
 `Distribution checks passed` summary and swallows `twine check` output unless it
 fails, so confirm the per-file result directly:
 `uvx twine check pecos-distribution-<version>/*/*.whl pecos-distribution-<version>/*/*.tar.gz`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,9 +108,11 @@ and check the `PASSED` count equals the file count.
 ./scripts/publish-wheels.sh -f pecos-distribution
 ```
 
-Confirm each package at its prompt. Upload order matters and the script
-enforces it: all packages are preflighted (complete set, consistent version,
-only expected files) before anything uploads, dependencies go first
+Confirm each package at its prompt. Every confirmation is collected before the
+first upload, so declining part-way through leaves nothing published. Upload order
+matters and the script enforces it: all packages are preflighted (complete set,
+consistent version, only expected files) and `twine check`ed before anything
+uploads, dependencies go first
 (`pecos-rslib` -> `pecos-rslib-llvm` -> `quantum-pecos`, which pins both at
 exact versions), and any failure or declined prompt aborts the remaining
 uploads rather than continuing. Publishing `quantum-pecos` alone (`-p`) is

--- a/scripts/publish-wheels.sh
+++ b/scripts/publish-wheels.sh
@@ -159,7 +159,7 @@ preflight_package() {
 
 # Run twine's own validation for one package.
 #
-# Deliberately separate from publish_package: every package must be validated before
+# Deliberately separate from the upload step: every package must be validated before
 # ANY package uploads. Validating inside the upload loop means a checker that rejects
 # the last package only speaks up once the earlier ones are public, and a PyPI upload
 # cannot be taken back. A twine too old for the metadata the build tools now emit is
@@ -184,9 +184,38 @@ check_package_distributions() {
     fi
 }
 
-# Publish a package (assumed preflighted and checked). Fails the script on any error or
-# on a declined prompt -- callers rely on this to abort dependent uploads.
-publish_package() {
+# Ask the operator to approve one package's upload, showing what they are approving.
+#
+# Every confirmation is collected before the first upload runs. Prompting inside the
+# upload loop means approving package 1 and then declining package 2 leaves package 1
+# public and unrecallable -- the same partial release this script's up-front validation
+# exists to prevent, reached by a different route.
+confirm_package() {
+    local package_name=$1
+    local package_dir
+    package_dir=$(package_dir_for "$package_name")
+
+    if [ "$DRY_RUN" = true ] || [ "$ASSUME_YES" = true ]; then
+        return 0
+    fi
+
+    echo -e "\n${GREEN}=== $package_name ===${NC}"
+    ls -la "$package_dir"
+
+    # Full-line read: single-character reads mis-consume piped input. A
+    # read failure (EOF) aborts loudly rather than guessing.
+    if ! read -p "Upload $package_name to PyPI? (y/N) " -r; then
+        echo -e "${RED}Error: could not read confirmation (EOF); aborting.${NC}"
+        return 1
+    fi
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${RED}Declined $package_name; aborting before anything is uploaded.${NC}"
+        return 1
+    fi
+}
+
+# Upload a package (assumed preflighted, checked, and confirmed).
+upload_package() {
     local package_name=$1
     local package_dir
     package_dir=$(package_dir_for "$package_name")
@@ -201,23 +230,8 @@ publish_package() {
     fi
 
     echo -e "\n${GREEN}Uploading to PyPI...${NC}"
-    if [ "$ASSUME_YES" = true ]; then
-        REPLY="y"
-    else
-        # Full-line read: single-character reads mis-consume piped input. A
-        # read failure (EOF) aborts loudly rather than guessing.
-        if ! read -p "Are you sure you want to upload $package_name to PyPI? (y/N) " -r; then
-            echo -e "${RED}Error: could not read confirmation (EOF); aborting.${NC}"
-            return 1
-        fi
-    fi
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        $TWINE_CMD upload "$package_dir"/*
-        echo -e "${GREEN}Successfully uploaded $package_name!${NC}"
-    else
-        echo -e "${RED}Declined uploading $package_name; aborting (later packages depend on it).${NC}"
-        return 1
-    fi
+    $TWINE_CMD upload "$package_dir"/*
+    echo -e "${GREEN}Successfully uploaded $package_name!${NC}"
 }
 
 # Verify an exact pin exists on PyPI (used to guard publishing quantum-pecos
@@ -246,7 +260,8 @@ if [ -n "$PACKAGE" ]; then
             fi
         done
     fi
-    publish_package "$PACKAGE"
+    confirm_package "$PACKAGE"
+    upload_package "$PACKAGE"
 else
     # All-packages mode: preflight EVERYTHING before uploading anything, and
     # require one consistent version across the set.
@@ -264,10 +279,15 @@ else
         exit 1
     fi
     echo -e "${GREEN}Publishing all PECOS packages at version $unique${NC}"
-    # Dependencies first; publish_package aborts the script on failure or
-    # decline, so quantum-pecos cannot publish without its pinned deps.
+    # Confirm everything first: a decline part-way through the upload loop would leave
+    # the already-approved packages public.
     for pkg in "${ALL_PACKAGES[@]}"; do
-        publish_package "$pkg"
+        confirm_package "$pkg"
+    done
+    # Dependencies first; upload_package aborts the script on failure, so quantum-pecos
+    # cannot publish without its pinned deps.
+    for pkg in "${ALL_PACKAGES[@]}"; do
+        upload_package "$pkg"
     done
 fi
 

--- a/scripts/publish-wheels.sh
+++ b/scripts/publish-wheels.sh
@@ -82,10 +82,10 @@ fi
 # Check if uv is installed (preferred) or twine directly
 if command -v uv &> /dev/null; then
     TWINE_CMD="uv run twine"
-    echo -e "${GREEN}Using uv to run twine${NC}"
+    echo -e "${GREEN}Using uv to run twine ($($TWINE_CMD --version 2>/dev/null | head -1))${NC}"
 elif command -v twine &> /dev/null; then
     TWINE_CMD="twine"
-    echo -e "${YELLOW}Using system twine (consider using uv)${NC}"
+    echo -e "${YELLOW}Using system twine ($(twine --version 2>/dev/null | head -1)); consider using uv${NC}"
 else
     echo -e "${RED}Error: Neither uv nor twine is installed!${NC}"
     echo "Install uv with: curl -LsSf https://astral.sh/uv/install.sh | sh"
@@ -157,8 +157,35 @@ preflight_package() {
     printf '%s\n' "$unique"
 }
 
-# Publish a package (assumed preflighted). Fails the script on any error or on
-# a declined prompt -- callers rely on this to abort dependent uploads.
+# Run twine's own validation for one package.
+#
+# Deliberately separate from publish_package: every package must be validated before
+# ANY package uploads. Validating inside the upload loop means a checker that rejects
+# the last package only speaks up once the earlier ones are public, and a PyPI upload
+# cannot be taken back. A twine too old for the metadata the build tools now emit is
+# exactly that failure -- it rejected quantum-pecos while the two wheels it pins had
+# already gone up.
+check_package_distributions() {
+    local package_name=$1
+    local package_dir
+    package_dir=$(package_dir_for "$package_name")
+
+    # --strict: fail on warnings too. Current maturin/hatchling artifacts pass
+    # strict checks cleanly, so any warning is a real signal.
+    local check_output
+    if check_output=$($TWINE_CMD check --strict "$package_dir"/* 2>&1); then
+        echo -e "${GREEN}Distribution checks passed: $package_name${NC}"
+    else
+        echo "$check_output"
+        echo -e "${RED}Distribution checks failed: $package_name${NC}"
+        echo -e "${YELLOW}If this names a metadata version, the checker is behind the build tools:" \
+             "upgrade it with 'uv tool upgrade twine' and re-run.${NC}"
+        return 1
+    fi
+}
+
+# Publish a package (assumed preflighted and checked). Fails the script on any error or
+# on a declined prompt -- callers rely on this to abort dependent uploads.
 publish_package() {
     local package_name=$1
     local package_dir
@@ -166,18 +193,6 @@ publish_package() {
 
     echo -e "\n${GREEN}=== Publishing $package_name ===${NC}"
     ls -la "$package_dir"
-
-    # --strict: fail on warnings too. Current maturin/hatchling artifacts pass
-    # strict checks cleanly, so any warning is a real signal.
-    echo -e "\n${GREEN}Running twine check...${NC}"
-    local check_output
-    if check_output=$($TWINE_CMD check --strict "$package_dir"/* 2>&1); then
-        echo -e "${GREEN}Distribution checks passed${NC}"
-    else
-        echo "$check_output"
-        echo -e "${RED}Distribution checks failed${NC}"
-        return 1
-    fi
 
     if [ "$DRY_RUN" = true ]; then
         echo -e "\n${YELLOW}DRY RUN: Would upload the following files:${NC}"
@@ -221,6 +236,7 @@ if [ -n "$PACKAGE" ]; then
     fi
     version=$(preflight_package "$PACKAGE")
     echo -e "${GREEN}Preflight OK: $PACKAGE $version${NC}"
+    check_package_distributions "$PACKAGE"
     if [ "$PACKAGE" = "quantum-pecos" ] && [ "$DRY_RUN" = false ]; then
         for dep in pecos-rslib pecos-rslib-llvm; do
             if ! pin_exists_on_pypi "$dep" "$version"; then
@@ -239,6 +255,7 @@ else
     for pkg in "${ALL_PACKAGES[@]}"; do
         v=$(preflight_package "$pkg")
         echo -e "${GREEN}Preflight OK: $pkg $v${NC}"
+        check_package_distributions "$pkg"
         versions+=("$v")
     done
     unique=$(printf '%s\n' "${versions[@]}" | sort -u)


### PR DESCRIPTION
Two release-safety fixes, both from failures hit during the `py-0.11.0.dev0` release.

## `publish-wheels.sh` validated packages too late

`twine check --strict` ran inside `publish_package`, so in all-packages mode the third package was only validated after the first two had uploaded. A PyPI upload cannot be taken back, so a checker that rejects the last package leaves a half-published release.

This is not hypothetical: `hatchling 1.32.0` emits `Metadata-Version: 2.5`, and twine 6.2.0 rejects it as invalid. During the release the dry run failed on `quantum-pecos` after `pecos-rslib` and `pecos-rslib-llvm` had already passed — a real upload would have left those two public and the metapackage missing. (PyPI itself accepts 2.5; it hosts `hatchling-1.32.0-py3-none-any.whl` with that metadata. The checker was the stale part, and twine 7.0.0 passes all ten artifacts.)

Validation now happens for every package during preflight, before any upload, in both single-package and all-packages mode. The script also prints which twine it resolved, so a stale checker is visible in the log, and a failing check points at `uv tool upgrade twine`.

Verified: with a deliberately corrupted `quantum-pecos` wheel the script exits 1 having printed no `=== Publishing` line at all; with the real bundle all three are checked before the first publish step.

## CUDA installs could hang forever

`Install CUDA Toolkit` had no `timeout-minutes`. On 2026-08-18 that step stalled for over four hours in `rust-lint`, and because `rust-test` needs that job, the entire Rust matrix sat behind a stalled download with no failure signal.

All four uses of the action are now bounded: 15 minutes for the three `method: network` installs, 30 for the Windows `method: local` install, which pulls the full installer. For reference, the whole `rust-lint` job takes about 5 minutes when the step behaves.

Job-level timeouts are left alone; this change bounds only the step with the demonstrated failure mode.
