### PR TITLE
Harden apt against mirror flakiness on hosted runners

### DIFF
--- a/.github/workflows/cuda-build-check.yml
+++ b/.github/workflows/cuda-build-check.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Harden apt against mirror flakiness
+        run: ./scripts/ci/harden-apt.sh
+
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc

--- a/.github/workflows/dependency-integrity-check.yml
+++ b/.github/workflows/dependency-integrity-check.yml
@@ -46,6 +46,9 @@ jobs:
           enable-cache: true
           save-cache: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'development' || github.ref_name == 'dev') }}
 
+      - name: Harden apt against mirror flakiness
+        run: ./scripts/ci/harden-apt.sh
+
       - name: Install integrity check tools
         run: |
           sudo apt-get update

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -96,6 +96,9 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
+    - name: Harden apt against mirror flakiness
+      run: ./scripts/ci/harden-apt.sh
+
     - name: Ensure ripgrep is available
       run: |
         if ! command -v rg >/dev/null 2>&1; then

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Harden apt against mirror flakiness
+        run: ./scripts/ci/harden-apt.sh
+
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -181,6 +184,9 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version-file: ".github/uv.toml"
+      - name: Harden apt against mirror flakiness
+        run: ./scripts/ci/harden-apt.sh
+
       - name: Install integrity check tools
         run: |
           sudo apt-get update
@@ -208,6 +214,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Harden apt against mirror flakiness
+        if: matrix.os == 'ubuntu-latest'
+        run: ./scripts/ci/harden-apt.sh
 
       - name: Free disk space (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/scripts/ci/harden-apt.sh
+++ b/scripts/ci/harden-apt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2026 The PECOS Developers
+# Licensed under the Apache License, Version 2.0
+#
+# Make apt survive a flaky mirror on hosted runners.
+#
+# GitHub's Ubuntu images point apt at azure.archive.ubuntu.com, which goes unreachable
+# often enough that runner-images carries long-running issues about it. When it does, a
+# fetch can stall rather than fail: on 2026-08-18 the CUDA install step sat for over four
+# hours on apt with no output, and on 2026-08-19 it burned its 15-minute budget the same
+# way. Neither is a slow download -- the step takes about 40 seconds when the mirror
+# answers.
+#
+# Three settings, each aimed at that failure:
+#   ForceIPv4  - apt prefers IPv6 when the runner advertises it, and a blackholed IPv6
+#                route is the usual cause of a hang rather than an error.
+#   Timeout    - bounds a stalled connection so it fails and can be retried, instead of
+#                hanging until the step's own timeout kills it.
+#   Retries    - apt 2.3.2+ retries 3 times by default; 5 covers a mirror that is
+#                flapping rather than down.
+set -euo pipefail
+
+sudo tee /etc/apt/apt.conf.d/99-pecos-ci >/dev/null <<'CONF'
+Acquire::ForceIPv4 "true";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+Acquire::Retries "5";
+CONF
+
+echo "apt hardened for CI:"
+cat /etc/apt/apt.conf.d/99-pecos-ci


### PR DESCRIPTION
Follow-up to #560. That PR bounded the CUDA install steps so a stalled `apt` fails in 15 minutes instead of hanging for hours; this one attacks the stall itself.

## What was happening

`Install CUDA Toolkit` runs `apt` internally. On 2026-08-18 it sat for over four hours with no output, and on 2026-08-19 it burned the new 15-minute budget the same way. Both logs show apt ignoring `azure.archive.ubuntu.com` and falling back, then stalling mid-fetch. The step takes about 40 seconds when the mirror answers, so neither run was a slow download.

`azure.archive.ubuntu.com` being unreachable from hosted runners is long-running and well documented upstream — see actions/runner-images [#7048](https://github.com/actions/runner-images/issues/7048), [#6913](https://github.com/actions/runner-images/issues/6913), [#3433](https://github.com/actions/runner-images/issues/3433).

## The change

`scripts/ci/harden-apt.sh` writes `/etc/apt/apt.conf.d/99-pecos-ci` before any apt use:

- `Acquire::ForceIPv4 "true"` — apt prefers IPv6 when the runner advertises it, and a blackholed IPv6 route produces exactly this symptom: a hang rather than an error.
- `Acquire::http::Timeout "30"` / `https::Timeout "30"` — bounds a stalled connection so it fails and can be retried, rather than hanging until the step timeout kills it.
- `Acquire::Retries "5"` — apt 2.3.2+ already retries 3 times; 5 covers a mirror that is flapping rather than down.

Worst case is now about 2.5 minutes per URI, still well inside the 15-minute step bound from #560. The two mechanisms are complementary: this one makes the stall unlikely, that one guarantees it can never eat an evening again.

No new third-party action. A retry-wrapper action would have added supply-chain surface for a problem apt can be told to handle itself.

## Scope

Applied to every job in the repository that shells out to apt, not only the CUDA ones — `rust-lint`, `rust-test`, `pre-commit`, `cuda-build-check`, `dependency-integrity-check`, and `python-lint`. The remaining jobs install ripgrep from the same mirrors and would fail the same way; an audit in the PR confirms zero apt-using jobs are left unhardened.

## Verification

Shell syntax checked and pre-commit clean. The real proof is CI: these workflows exercise the script on every run, and the step prints the config it wrote.
