### PR TITLE
Track the MPS orthogonality center and certify gauge-shifted primary SVD factors

### DIFF
--- a/exp/pecos-stab-tn/examples/canonical_cost_workloads.rs
+++ b/exp/pecos-stab-tn/examples/canonical_cost_workloads.rs
@@ -1,0 +1,236 @@
+//! Fixed-seed workloads for measuring canonical-form overhead.
+//!
+//! This is deliberately an example rather than a library benchmark so the
+//! same source can be copied into historical worktrees without changing the
+//! library under test. Run one case at a time with, for example:
+//!
+//! `CANON_WORKLOAD=qec8 cargo run --release -p pecos-stab-tn --example canonical_cost_workloads`
+
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
+use pecos_stab_tn::stab_mps::{PauliKind, StabMps, StabMpsStats};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Default)]
+struct Counts {
+    multi_disent: u64,
+    multi_std: u64,
+    single_site: u64,
+}
+
+impl Counts {
+    fn add(&mut self, stats: StabMpsStats) {
+        self.multi_disent += stats.multi_disent;
+        self.multi_std += stats.multi_std;
+        self.single_site += stats.single_site;
+    }
+}
+
+fn next(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+fn distinct_pair(state: &mut u64, n: usize) -> (usize, usize) {
+    let first = (next(state) % n as u64) as usize;
+    let mut second = (next(state) % (n - 1) as u64) as usize;
+    if second >= first {
+        second += 1;
+    }
+    (first, second)
+}
+
+fn mix_hash(hash: &mut u64, value: u64) {
+    *hash ^= value;
+    *hash = hash.wrapping_mul(0x100_0000_01b3);
+}
+
+fn mix_measurement(hash: &mut u64, outcome: bool, deterministic: bool) {
+    mix_hash(hash, (u64::from(outcome) << 1) | u64::from(deterministic));
+}
+
+fn qec_generators(num_data: usize, num_checks: usize) -> Vec<Vec<(usize, PauliKind)>> {
+    (0..num_checks)
+        .map(|check| {
+            // Sparse, overlapping parity checks with both local and long-range
+            // data couplings. All generators are Z-type and commute.
+            let first = (2 * check) % num_data;
+            let second = (first + 1) % num_data;
+            let third = (first + num_data / 2) % num_data;
+            vec![
+                (first, PauliKind::Z),
+                (second, PauliKind::Z),
+                (third, PauliKind::Z),
+            ]
+        })
+        .collect()
+}
+
+fn run_qec(total_qubits: usize, repeats: usize) -> (Counts, u64, usize, usize, f64) {
+    let num_checks = total_qubits / 4;
+    let num_data = total_qubits - num_checks;
+    let rounds = if total_qubits == 8 { 12 } else { 8 };
+    let generators = qec_generators(num_data, num_checks);
+    let ancillas: Vec<QubitId> = (num_data..total_qubits).map(QubitId).collect();
+    let circuits = 4 * repeats;
+    let mut counts = Counts::default();
+    let mut trajectory_hash = 0xcbf2_9ce4_8422_2325;
+    let start = Instant::now();
+
+    for circuit in 0..circuits {
+        let seed = 0x0cec_0000_0000_0000 ^ (total_qubits as u64) << 32 ^ circuit as u64;
+        let mut random = seed.wrapping_add(1);
+        let mut stn = StabMps::builder(total_qubits)
+            .seed(seed)
+            .max_bond_dim(64)
+            .merge_rz(false)
+            .build();
+
+        // Prepare an entangled data block before repeated extraction.
+        stn.h(&[QubitId(0)]);
+        for q in 1..num_data {
+            stn.cx(&[(QubitId(0), QubitId(q))]);
+        }
+
+        for round in 0..rounds {
+            // Coherent memory noise forces the stabilizer-tensor path while
+            // retaining the repeated-syndrome shape of the workload.
+            for q in 0..num_data {
+                let angle = if (q + round) & 1 == 0 {
+                    Angle64::QUARTER_TURN / 2_u64
+                } else {
+                    Angle64::from_radians(0.03125)
+                };
+                stn.rz(angle, &[QubitId(q)]);
+            }
+            let (control, target) = distinct_pair(&mut random, num_data);
+            stn.cx(&[(QubitId(control), QubitId(target))]);
+
+            for bit in stn.extract_syndromes(&generators, &ancillas) {
+                mix_hash(&mut trajectory_hash, u64::from(bit));
+            }
+
+            // Explicit data-qubit measure/reset in the middle, in addition to
+            // the ancilla measurements and resets inside extract_syndromes.
+            if round + 1 == rounds / 2 {
+                let q = (next(&mut random) % num_data as u64) as usize;
+                let outcome = stn.reset_qubit(QubitId(q));
+                mix_hash(&mut trajectory_hash, u64::from(outcome));
+                stn.h(&[QubitId(q)]);
+            }
+        }
+        counts.add(stn.stats);
+    }
+
+    (
+        counts,
+        trajectory_hash,
+        circuits,
+        rounds,
+        start.elapsed().as_secs_f64(),
+    )
+}
+
+fn run_deep(
+    num_qubits: usize,
+    t_multiplier: usize,
+    repeats: usize,
+) -> (Counts, u64, usize, usize, f64) {
+    let t_count = t_multiplier * num_qubits;
+    let circuits = 4 * repeats;
+    let mut counts = Counts::default();
+    let mut trajectory_hash = 0xcbf2_9ce4_8422_2325;
+    let start = Instant::now();
+
+    for circuit in 0..circuits {
+        let seed = 0xc11f_0000_0000_0000
+            ^ (num_qubits as u64) << 32
+            ^ (t_multiplier as u64) << 24
+            ^ circuit as u64;
+        let mut random = seed.wrapping_add(1);
+        let mut stn = StabMps::builder(num_qubits)
+            .seed(seed)
+            .max_bond_dim(64)
+            .merge_rz(false)
+            .build();
+
+        let all_qubits: Vec<QubitId> = (0..num_qubits).map(QubitId).collect();
+        stn.h(&all_qubits);
+        for injection in 0..t_count {
+            // Three Clifford operations per T, including a deliberately
+            // long-range two-qubit layer.
+            let q = (next(&mut random) % num_qubits as u64) as usize;
+            if next(&mut random) & 1 == 0 {
+                stn.h(&[QubitId(q)]);
+            } else {
+                stn.sz(&[QubitId(q)]);
+            }
+            let (control, target) = distinct_pair(&mut random, num_qubits);
+            stn.cx(&[(QubitId(control), QubitId(target))]);
+            let (first, second) = distinct_pair(&mut random, num_qubits);
+            stn.cz(&[(QubitId(first), QubitId(second))]);
+
+            let tq = (next(&mut random) % num_qubits as u64) as usize;
+            stn.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(tq)]);
+
+            if injection + 1 == t_count / 2 {
+                for _ in 0..2 {
+                    let measured = (next(&mut random) % num_qubits as u64) as usize;
+                    let outcome = stn.reset_qubit(QubitId(measured));
+                    mix_hash(&mut trajectory_hash, u64::from(outcome));
+                    stn.h(&[QubitId(measured)]);
+                }
+            }
+        }
+        for result in stn.mz(&all_qubits) {
+            mix_measurement(
+                &mut trajectory_hash,
+                result.outcome,
+                result.is_deterministic,
+            );
+        }
+        counts.add(stn.stats);
+    }
+
+    (
+        counts,
+        trajectory_hash,
+        circuits,
+        t_count,
+        start.elapsed().as_secs_f64(),
+    )
+}
+
+fn main() {
+    let workload = std::env::var("CANON_WORKLOAD").unwrap_or_else(|_| "all".to_owned());
+    let repeats = std::env::var("CANON_REPEATS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1);
+
+    for n in [8_usize, 16] {
+        let name = format!("qec{n}");
+        if workload == "all" || workload == name {
+            let (counts, hash, circuits, rounds, seconds) = run_qec(n, repeats);
+            println!(
+                "QEC n={n} circuits={circuits} rounds={rounds} multi_disent={} multi_std={} single_site={} trajectory_hash={hash:016x} wall_s={seconds:.6}",
+                counts.multi_disent, counts.multi_std, counts.single_site
+            );
+        }
+    }
+
+    for n in [12_usize, 20] {
+        for multiplier in [1_usize, 2] {
+            let name = format!("deep{n}_{multiplier}n");
+            if workload == "all" || workload == name {
+                let (counts, hash, circuits, t_count, seconds) = run_deep(n, multiplier, repeats);
+                println!(
+                    "DEEP n={n} circuits={circuits} t_count={t_count} multi_disent={} multi_std={} single_site={} trajectory_hash={hash:016x} wall_s={seconds:.6}",
+                    counts.multi_disent, counts.multi_std, counts.single_site
+                );
+            }
+        }
+    }
+}

--- a/exp/pecos-stab-tn/src/mps.rs
+++ b/exp/pecos-stab-tn/src/mps.rs
@@ -35,6 +35,11 @@ use tensor::{
     contract_two_sites, phys_block, reshape_left_ungroup, reshape_two_site_for_svd, set_phys_block,
 };
 
+// Analytic gates are unitary to machine precision. Keep this materially below
+// the debug validator's 1e-9 budget so repeated preserved mutations cannot
+// consume that entire budget one boundary-passing gate at a time.
+const ISOMETRY_PRESERVING_UNITARY_TOLERANCE: f64 = 1e-12;
+
 /// Configuration for MPS truncation.
 #[derive(Clone, Debug)]
 pub struct MpsConfig {
@@ -78,6 +83,10 @@ pub struct Mps {
     num_sites: usize,
     phys_dim: usize,
     tensors: Vec<DMatrix<Complex64>>,
+    /// Claimed mixed-canonical orthogonality center. When this is `Some(k)`,
+    /// every site left of `k` is a left-isometry and every site right of `k`
+    /// is a right-isometry. `None` makes no canonical-form claim.
+    center: Option<usize>,
     /// Bond dimensions: length `num_sites + 1`.
     /// `bond_dims[0] = 1` (left boundary), `bond_dims[num_sites] = 1` (right boundary).
     bond_dims: Vec<usize>,
@@ -196,6 +205,7 @@ impl Mps {
             num_sites,
             phys_dim: d,
             tensors,
+            center: (num_sites > 0).then_some(0),
             bond_dims,
             config,
             truncation_error: 0.0,
@@ -278,6 +288,7 @@ impl Mps {
             return;
         }
         self.tensors[0] *= scalar;
+        self.center = None;
     }
 
     /// Apply a single-site gate (d x d unitary matrix) to site `q`.
@@ -309,6 +320,22 @@ impl Mps {
             });
         }
 
+        // The public operation historically accepts any square matrix even
+        // though its documented gate contract is unitary. Keep that behavior,
+        // but retain a canonical claim only when the supplied matrix actually
+        // preserves the physical-index inner product.
+        let preserves_isometries = self.center.is_some()
+            && (0..d).all(|row| {
+                (0..d).all(|column| {
+                    let inner = (0..d)
+                        .map(|index| gate[(index, row)].conj() * gate[(index, column)])
+                        .sum::<Complex64>();
+                    let expected = if row == column { 1.0 } else { 0.0 };
+                    (inner - Complex64::new(expected, 0.0)).norm()
+                        <= ISOMETRY_PRESERVING_UNITARY_TOLERANCE
+                })
+            });
+
         let chi_r = self.bond_dims[q + 1];
 
         // Collect old blocks
@@ -326,6 +353,9 @@ impl Mps {
                 }
             }
             set_phys_block(&mut self.tensors[q], sigma_out, chi_r, &new_block);
+        }
+        if !preserves_isometries {
+            self.center = None;
         }
         Ok(())
     }
@@ -358,6 +388,10 @@ impl Mps {
             });
         }
 
+        let preserves_isometries = self.center.is_some()
+            && coeffs.iter().all(|coefficient| {
+                (coefficient.norm() - 1.0).abs() <= ISOMETRY_PRESERVING_UNITARY_TOLERANCE
+            });
         let chi_r = self.bond_dims[q + 1];
         for (sigma, &c) in coeffs.iter().enumerate() {
             let start_col = sigma * chi_r;
@@ -366,6 +400,9 @@ impl Mps {
                     self.tensors[q][(i, start_col + j)] *= c;
                 }
             }
+        }
+        if !preserves_isometries {
+            self.center = None;
         }
         Ok(())
     }
@@ -418,6 +455,14 @@ impl Mps {
         if q + 1 >= self.num_sites {
             return Err(MpsError::NonAdjacentSites { q0: q, q1: q + 1 });
         }
+
+        // Replacing the two-site center by an SVD preserves the outer
+        // canonical environments exactly when the old center lies inside the
+        // updated pair. A two-site MPS has no outer environments to preserve.
+        let can_track_absorption = self.num_sites == 2
+            || self
+                .center
+                .is_some_and(|center| center == q || center == q + 1);
 
         let chi_l = self.bond_dims[q];
         let chi_mid = self.bond_dims[q + 1];
@@ -492,6 +537,7 @@ impl Mps {
 
         // Update bond dimension
         self.bond_dims[q + 1] = new_chi;
+        self.center = can_track_absorption.then_some(if absorb_right { q + 1 } else { q });
 
         Ok(())
     }
@@ -750,6 +796,7 @@ impl Mps {
         if norm_sq > 0.0 {
             let inv_norm = Complex64::new(1.0 / norm_sq.sqrt(), 0.0);
             self.tensors[0] *= inv_norm;
+            self.center = None;
         }
     }
 
@@ -875,6 +922,7 @@ impl Mps {
             num_sites: n,
             phys_dim: d,
             tensors: new_tensors,
+            center: None,
             bond_dims: new_bond_dims,
             config: self.config.clone(),
             truncation_error: self.truncation_error.max(other.truncation_error),
@@ -890,7 +938,34 @@ impl Mps {
 
     /// Mutable access to the internal tensors.
     pub fn tensors_mut(&mut self) -> &mut [DMatrix<Complex64>] {
+        self.center = None;
         &mut self.tensors
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tracked_center_for_test(&self) -> Option<usize> {
+        self.center
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_tracked_center_for_test(&mut self, center: Option<usize>) {
+        self.center = center;
+    }
+
+    /// Replace one physical block of a site tensor.
+    ///
+    /// This is the owner-mediated path for projection code that must mutate a
+    /// tensor without canonicalizing first. An arbitrary block replacement
+    /// invalidates any mixed-canonical claim.
+    pub(crate) fn set_physical_block(
+        &mut self,
+        site: usize,
+        physical_index: usize,
+        block: &DMatrix<Complex64>,
+    ) {
+        self.center = None;
+        let chi_r = self.bond_dims[site + 1];
+        set_phys_block(&mut self.tensors[site], physical_index, chi_r, block);
     }
 
     /// Access the bond dimensions (for testing).
@@ -902,11 +977,13 @@ impl Mps {
     /// Left-canonicalize the entire MPS.
     pub fn left_canonicalize(&mut self) {
         canon::left_canonicalize_all(&mut self.tensors, &mut self.bond_dims, self.phys_dim);
+        self.center = self.num_sites.checked_sub(1);
     }
 
     /// Right-canonicalize the entire MPS.
     pub fn right_canonicalize(&mut self) {
         canon::right_canonicalize_all(&mut self.tensors, &mut self.bond_dims, self.phys_dim);
+        self.center = (self.num_sites > 0).then_some(0);
     }
 
     /// Put the environments bordering `(q, q + 1)` in canonical form.
@@ -918,22 +995,93 @@ impl Mps {
     /// even when the input MPS had an arbitrary or rank-redundant gauge.
     pub(crate) fn canonicalize_around_bond(&mut self, q: usize) {
         assert!(q + 1 < self.num_sites, "bond must join two valid sites");
-        for site in 0..=q {
-            canon::left_canonicalize_site(
-                &mut self.tensors,
-                &mut self.bond_dims,
-                site,
-                self.phys_dim,
+        let target = q + 1;
+        if let Some(center) = self.center {
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                self.claimed_center_is_valid(center),
+                "tracked MPS orthogonality center {center} is stale"
             );
+
+            if center < target {
+                for site in center..target {
+                    canon::left_canonicalize_site(
+                        &mut self.tensors,
+                        &mut self.bond_dims,
+                        site,
+                        self.phys_dim,
+                    );
+                    self.center = Some(site + 1);
+                }
+            } else {
+                for site in (target + 1..=center).rev() {
+                    canon::right_canonicalize_site(
+                        &mut self.tensors,
+                        &mut self.bond_dims,
+                        site,
+                        self.phys_dim,
+                    );
+                    self.center = Some(site - 1);
+                }
+            }
+        } else {
+            for site in 0..=q {
+                canon::left_canonicalize_site(
+                    &mut self.tensors,
+                    &mut self.bond_dims,
+                    site,
+                    self.phys_dim,
+                );
+            }
+            for site in (q + 2..self.num_sites).rev() {
+                canon::right_canonicalize_site(
+                    &mut self.tensors,
+                    &mut self.bond_dims,
+                    site,
+                    self.phys_dim,
+                );
+            }
+            self.center = Some(target);
         }
-        for site in (q + 2..self.num_sites).rev() {
-            canon::right_canonicalize_site(
-                &mut self.tensors,
-                &mut self.bond_dims,
-                site,
-                self.phys_dim,
-            );
+    }
+
+    /// Validate a tracked center to an absolute max-entry Gram tolerance of
+    /// `1e-9`. This is compiled only when debug assertions are enabled and is
+    /// called only before a canonicalization sweep trusts the claim to skip
+    /// work.
+    #[cfg(debug_assertions)]
+    fn claimed_center_is_valid(&self, center: usize) -> bool {
+        const TOLERANCE: f64 = 1e-9;
+
+        if center >= self.num_sites {
+            return false;
         }
+        for site in 0..self.num_sites {
+            if site == center {
+                continue;
+            }
+            let gram = if site < center {
+                let grouped = tensor::reshape_left_group(
+                    &self.tensors[site],
+                    self.bond_dims[site],
+                    self.phys_dim,
+                    self.bond_dims[site + 1],
+                );
+                grouped.adjoint() * grouped
+            } else {
+                &self.tensors[site] * self.tensors[site].adjoint()
+            };
+            for row in 0..gram.nrows() {
+                for column in 0..gram.ncols() {
+                    let expected = if row == column { 1.0 } else { 0.0 };
+                    let error = (gram[(row, column)] - Complex64::new(expected, 0.0)).norm();
+                    if !error.is_finite() || error > TOLERANCE {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 
     /// Compress the MPS by SVD truncation at each bond.
@@ -951,6 +1099,7 @@ impl Mps {
     /// callers must not treat a partial sweep as successful compression.
     pub fn compress(&mut self) -> Result<(), MpsError> {
         if self.num_sites <= 1 {
+            self.center = (self.num_sites == 1).then_some(0);
             return Ok(());
         }
 
@@ -997,6 +1146,7 @@ impl Mps {
                 }
             }
             self.tensors[q - 1] = new_prev;
+            self.center = Some(q - 1);
         }
 
         // Preserve the established post-compression left-canonical contract
@@ -1014,6 +1164,7 @@ impl Clone for Mps {
             num_sites: self.num_sites,
             phys_dim: self.phys_dim,
             tensors: self.tensors.clone(),
+            center: self.center,
             bond_dims: self.bond_dims.clone(),
             config: self.config.clone(),
             truncation_error: self.truncation_error,
@@ -1036,6 +1187,30 @@ mod tests {
         let first_norm = first.iter().map(Complex64::norm_sqr).sum::<f64>();
         let second_norm = second.iter().map(Complex64::norm_sqr).sum::<f64>();
         overlap.norm_sqr() / (first_norm * second_norm)
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn apply_adjacent_dense_gate(
+        state: &[Complex64],
+        num_sites: usize,
+        q: usize,
+        gate: &DMatrix<Complex64>,
+    ) -> Vec<Complex64> {
+        let left_shift = num_sites - 1 - q;
+        let right_shift = left_shift - 1;
+        let mut result = vec![Complex64::new(0.0, 0.0); state.len()];
+        for (input_index, &amplitude) in state.iter().enumerate() {
+            let input_left = input_index >> left_shift & 1;
+            let input_right = input_index >> right_shift & 1;
+            let input = 2 * input_left + input_right;
+            let cleared = input_index & !(1 << left_shift) & !(1 << right_shift);
+            for output in 0..4 {
+                let output_index =
+                    cleared | (output >> 1 & 1) << left_shift | (output & 1) << right_shift;
+                result[output_index] += gate[(output, input)] * amplitude;
+            }
+        }
+        result
     }
 
     fn seeded_random_mps(num_sites: usize, bond: usize, seed: u64, config: MpsConfig) -> Mps {
@@ -1097,6 +1272,7 @@ mod tests {
                 mps.tensors[q - 1] = new_prev;
             }
         }
+        mps.center = None;
     }
 
     fn apply_diagonal_bond_gauge(mps: &mut Mps, bond: usize, scales: &[f64]) {
@@ -1125,6 +1301,7 @@ mod tests {
         }
         mps.tensors[left_site] = gauged_left;
         mps.tensors[bond] = gauge_inverse * &mps.tensors[bond];
+        mps.center = None;
     }
 
     fn legacy_off_center_long_range_gate(
@@ -1168,9 +1345,208 @@ mod tests {
     }
 
     #[test]
+    fn test_center_tracks_canonical_moves_and_unitary_updates() {
+        let mut mps = Mps::new(5, MpsConfig::default());
+        assert_eq!(mps.center, Some(0));
+
+        let h = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(-std::f64::consts::FRAC_1_SQRT_2, 0.0),
+            ],
+        );
+        mps.apply_one_site_gate(3, &h).unwrap();
+        assert_eq!(mps.center, Some(0));
+
+        mps.canonicalize_around_bond(3);
+        assert_eq!(mps.center, Some(4));
+        #[cfg(debug_assertions)]
+        assert!(mps.claimed_center_is_valid(4));
+        mps.canonicalize_around_bond(1);
+        assert_eq!(mps.center, Some(2));
+        #[cfg(debug_assertions)]
+        assert!(mps.claimed_center_is_valid(2));
+        assert_eq!(mps.clone().center, Some(2));
+    }
+
+    #[test]
+    fn test_one_site_gate_invalidates_when_unitarity_error_exceeds_preservation_budget() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        mps.left_canonicalize();
+        let almost_unitary = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0 + 1e-10, 0.0),
+            Complex64::new(1.0, 0.0),
+        ]));
+
+        mps.apply_one_site_gate(1, &almost_unitary).unwrap();
+
+        assert_eq!(mps.tracked_center_for_test(), None);
+    }
+
+    #[test]
+    fn test_unit_modulus_diagonal_preserves_center() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        mps.left_canonicalize();
+        let center = mps.tracked_center_for_test();
+        let phases = [
+            Complex64::new(0.0, 1.0),
+            Complex64::new(
+                std::f64::consts::FRAC_1_SQRT_2,
+                -std::f64::consts::FRAC_1_SQRT_2,
+            ),
+        ];
+
+        mps.apply_diagonal_one_site(1, &phases).unwrap();
+
+        assert_eq!(mps.tracked_center_for_test(), center);
+        #[cfg(debug_assertions)]
+        assert!(mps.claimed_center_is_valid(center.unwrap()));
+    }
+
+    #[test]
+    fn test_non_unit_modulus_diagonal_invalidates_center() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        mps.left_canonicalize();
+
+        mps.apply_diagonal_one_site(1, &[Complex64::new(1.0, 0.0), Complex64::new(0.5, 0.0)])
+            .unwrap();
+
+        assert_eq!(mps.tracked_center_for_test(), None);
+    }
+
+    #[test]
+    fn test_scale_invalidates_center() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        mps.left_canonicalize();
+
+        mps.scale(Complex64::new(2.0, 0.0));
+
+        assert_eq!(mps.tracked_center_for_test(), None);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_claimed_center_validator_rejects_broken_left_isometry() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        mps.left_canonicalize();
+        let center = mps.tracked_center_for_test().unwrap();
+        mps.tensors[0] *= Complex64::new(2.0, 0.0);
+
+        assert!(!mps.claimed_center_is_valid(center));
+    }
+
+    #[test]
+    fn test_add_invalidation_guards_canonical_routing() {
+        let config = MpsConfig {
+            max_bond_dim: 64,
+            svd_cutoff: 0.0,
+            max_truncation_error: Some(0.0),
+            parallel: false,
+        };
+        let mut first = seeded_random_mps(5, 4, 0xadd0_0001, config.clone());
+        let mut second = seeded_random_mps(5, 4, 0xadd0_0002, config);
+        first.left_canonicalize();
+        second.left_canonicalize();
+
+        let sum = first.add(&second);
+
+        assert_eq!(sum.tracked_center_for_test(), None);
+    }
+
+    #[test]
+    fn test_mutable_tensor_access_invalidation_guards_canonical_routing() {
+        let config = MpsConfig {
+            max_bond_dim: 64,
+            svd_cutoff: 0.0,
+            max_truncation_error: Some(0.0),
+            parallel: false,
+        };
+        let mut mps = seeded_random_mps(5, 4, 0xd1ec_7001, config);
+        mps.left_canonicalize();
+        assert_eq!(mps.center, Some(4));
+
+        mps.tensors_mut()[0] *= Complex64::new(2.0, 0.0);
+
+        assert_eq!(mps.tracked_center_for_test(), None);
+    }
+
+    #[test]
+    fn test_stale_center_guard_prevents_gauge_dependent_truncation() {
+        let config = MpsConfig {
+            max_bond_dim: 2,
+            svd_cutoff: 0.0,
+            max_truncation_error: Some(0.0),
+            parallel: false,
+        };
+        let mut poisoned = seeded_random_mps(6, 8, 0x57a1_e000_0000_0001, config);
+        poisoned.canonicalize_around_bond(2);
+        let exact_before = poisoned.state_vector();
+        apply_diagonal_bond_gauge(&mut poisoned, 2, &[1e-3, 1e-1, 10.0, 1e3]);
+        assert!(normalized_fidelity(&exact_before, &poisoned.state_vector()) > 1.0 - 1e-12);
+        poisoned.set_tracked_center_for_test(Some(3));
+
+        #[cfg(debug_assertions)]
+        {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                poisoned.canonicalize_around_bond(2);
+            }));
+            assert!(result.is_err(), "the consult must reject the stale claim");
+        }
+
+        #[cfg(not(debug_assertions))]
+        {
+            let zero = Complex64::new(0.0, 0.0);
+            let one = Complex64::new(1.0, 0.0);
+            let cnot = DMatrix::from_row_slice(
+                4,
+                4,
+                &[
+                    one, zero, zero, zero, zero, one, zero, zero, zero, zero, zero, one, zero,
+                    zero, one, zero,
+                ],
+            );
+            let dense_oracle = apply_adjacent_dense_gate(&exact_before, 6, 2, &cnot);
+
+            let mut stale = poisoned.clone();
+            stale.canonicalize_around_bond(2);
+            stale.apply_two_site_gate(2, &cnot).unwrap();
+            assert_eq!(stale.bond_dim(3), 2, "the stale path must truncate");
+
+            let mut correctly_invalidated = poisoned;
+            correctly_invalidated.set_tracked_center_for_test(None);
+            correctly_invalidated.canonicalize_around_bond(2);
+            correctly_invalidated.apply_two_site_gate(2, &cnot).unwrap();
+            assert_eq!(
+                correctly_invalidated.bond_dim(3),
+                2,
+                "the guarded path must truncate"
+            );
+
+            let stale_fidelity = normalized_fidelity(&dense_oracle, &stale.state_vector());
+            let correct_fidelity =
+                normalized_fidelity(&dense_oracle, &correctly_invalidated.state_vector());
+            eprintln!(
+                "release stale-center blast radius: guarded fidelity={correct_fidelity:.16}, stale fidelity={stale_fidelity:.16}"
+            );
+            assert!(
+                1.0 - stale_fidelity > 1e-6,
+                "stale truncation unexpectedly matched the dense oracle: {stale_fidelity:.16}"
+            );
+            assert!(
+                correct_fidelity > stale_fidelity + 1e-4,
+                "guarded={correct_fidelity:.16}, stale={stale_fidelity:.16}"
+            );
+        }
+    }
+
+    #[test]
     fn test_compress_surfaces_svd_failure() {
         let mut mps = Mps::new(2, MpsConfig::default());
-        mps.tensors[1][(0, 0)] = Complex64::new(f64::NAN, 0.0);
+        mps.tensors_mut()[1][(0, 0)] = Complex64::new(f64::NAN, 0.0);
 
         assert!(matches!(mps.compress(), Err(MpsError::SvdFailed)));
     }

--- a/exp/pecos-stab-tn/src/mps/svd.rs
+++ b/exp/pecos-stab-tn/src/mps/svd.rs
@@ -70,7 +70,7 @@ fn dimension_scaled_backward_error_tolerance(matrix: &DMatrix<Complex64>, multip
 type SvdFactors = (DMatrix<Complex64>, DVector<f64>, DMatrix<Complex64>);
 
 fn direct_svd_factors(matrix: &DMatrix<Complex64>) -> Result<SvdFactors, MpsError> {
-    let svd = SVD::try_new(
+    let mut svd = SVD::try_new(
         matrix.clone(),
         true,
         true,
@@ -78,6 +78,7 @@ fn direct_svd_factors(matrix: &DMatrix<Complex64>) -> Result<SvdFactors, MpsErro
         iteration_limit(matrix.nrows(), matrix.ncols()),
     )
     .ok_or(MpsError::SvdFailed)?;
+    svd.sort_by_singular_values();
     Ok((
         svd.u.ok_or(MpsError::SvdFailed)?,
         svd.singular_values,
@@ -86,7 +87,7 @@ fn direct_svd_factors(matrix: &DMatrix<Complex64>) -> Result<SvdFactors, MpsErro
 }
 
 fn adjoint_svd_factors(matrix: &DMatrix<Complex64>) -> Result<SvdFactors, MpsError> {
-    let svd = SVD::try_new(
+    let mut svd = SVD::try_new(
         matrix.adjoint(),
         true,
         true,
@@ -94,6 +95,7 @@ fn adjoint_svd_factors(matrix: &DMatrix<Complex64>) -> Result<SvdFactors, MpsErr
         iteration_limit(matrix.nrows(), matrix.ncols()),
     )
     .ok_or(MpsError::SvdFailed)?;
+    svd.sort_by_singular_values();
     Ok((
         svd.v_t.ok_or(MpsError::SvdFailed)?.adjoint().into_owned(),
         svd.singular_values,
@@ -470,24 +472,37 @@ fn stable_svd_factors(
         .iter()
         .map(|value| value.norm())
         .fold(0.0_f64, f64::max);
-    // Keep the unvalidated primary path on its deliberately stricter
-    // max-element, dimension-free gate. Rejecting it only advances to the
-    // fallbacks, where the looser normwise bound is paired with independent
-    // retained-triplet and isometry validation.
+    // Keep the cheap, unvalidated primary path on its deliberately stricter
+    // max-element, dimension-free gate. If that gauge-sensitive check fails,
+    // the same normwise reconstruction, retained-triplet, and isometry checks
+    // used for the derived fallbacks can still certify the nalgebra factors.
+    // Accepting those already-computed factors trades up to roughly four
+    // orders of max-entry reconstruction residual (while remaining inside the
+    // certified backward-error bound) for skipping the more accurate fallback
+    // recomputation.
     let reconstruction_tolerance = max_element * (256.0 * f64::EPSILON);
     let fallback_reconstruction_tolerance =
         dimension_scaled_backward_error_tolerance(matrix, SVD_FALLBACK_RECONSTRUCTION_MULTIPLIER);
-    if let Ok(adjoint) = adjoint_svd_factors(matrix)
-        && reconstruction_error(matrix, &adjoint.0, &adjoint.1, &adjoint.2)
-            <= reconstruction_tolerance
-    {
-        return Ok(adjoint);
+    if let Ok(adjoint) = adjoint_svd_factors(matrix) {
+        let reconstruction_error = reconstruction_error(matrix, &adjoint.0, &adjoint.1, &adjoint.2);
+        let retained_rank = compute_rank(&adjoint.1, max_rank, cutoff, max_trunc_error);
+        if reconstruction_error <= reconstruction_tolerance
+            || (reconstruction_error <= fallback_reconstruction_tolerance
+                && retained_spectrum_is_trustworthy(matrix, &adjoint, retained_rank))
+        {
+            return Ok(adjoint);
+        }
     }
 
-    if let Ok(direct) = direct_svd_factors(matrix)
-        && reconstruction_error(matrix, &direct.0, &direct.1, &direct.2) <= reconstruction_tolerance
-    {
-        return Ok(direct);
+    if let Ok(direct) = direct_svd_factors(matrix) {
+        let reconstruction_error = reconstruction_error(matrix, &direct.0, &direct.1, &direct.2);
+        let retained_rank = compute_rank(&direct.1, max_rank, cutoff, max_trunc_error);
+        if reconstruction_error <= reconstruction_tolerance
+            || (reconstruction_error <= fallback_reconstruction_tolerance
+                && retained_spectrum_is_trustworthy(matrix, &direct, retained_rank))
+        {
+            return Ok(direct);
+        }
     }
 
     if let Ok(gram) = gram_svd_factors(matrix, numerical_zero_threshold(matrix)) {

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -881,8 +881,8 @@ fn collapse_projected_flip_site(mps: &mut Mps, id: usize) {
     let block_0 = crate::mps::tensor::phys_block(&mps.tensors()[id], 0, chi_r)
         * Complex64::new(std::f64::consts::SQRT_2, 0.0);
     let zero = DMatrix::zeros(mps.tensors()[id].nrows(), chi_r);
-    crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[id], 0, chi_r, &block_0);
-    crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[id], 1, chi_r, &zero);
+    mps.set_physical_block(id, 0, &block_0);
+    mps.set_physical_block(id, 1, &zero);
 }
 
 /// Project a real single-site X branch and absorb its measurement-basis H
@@ -903,8 +903,8 @@ fn project_single_flip_without_sign(
     let denominator = Complex64::new((2.0 * probability).max(1e-20).sqrt(), 0.0);
     let projected = (block_0 + block_1 * signed_phase) / denominator;
     let zero = DMatrix::zeros(mps.tensors()[id].nrows(), chi_r);
-    crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[id], 0, chi_r, &projected);
-    crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[id], 1, chi_r, &zero);
+    mps.set_physical_block(id, 0, &projected);
+    mps.set_physical_block(id, 1, &zero);
 }
 
 /// Remove the direct-sum projector's structurally oversized virtual bonds
@@ -1556,8 +1556,8 @@ pub(super) fn measure_qubit_stab_mps_with_update(
                     / Complex64::new((2.0 * prob).max(1e-20).sqrt(), 0.0);
 
                 let zero = DMatrix::zeros(mps.tensors()[k].nrows(), chi_r);
-                crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[k], 0, chi_r, &projected);
-                crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[k], 1, chi_r, &zero);
+                mps.set_physical_block(k, 0, &projected);
+                mps.set_physical_block(k, 1, &zero);
                 mps.normalize();
             } else {
                 // Multi-site case with sign_sites: use MPS addition then collapse flip site.
@@ -1597,7 +1597,7 @@ pub(super) fn measure_qubit_stab_mps_with_update(
                     let k = flip_sites[0];
                     let chi_r = mps.bond_dim(k + 1);
                     let zero = DMatrix::zeros(mps.tensors()[k].nrows(), chi_r);
-                    crate::mps::tensor::set_phys_block(&mut mps.tensors_mut()[k], 1, chi_r, &zero);
+                    mps.set_physical_block(k, 1, &zero);
                 }
 
                 mps.normalize();
@@ -1645,6 +1645,17 @@ mod tests {
     fn sort_dedup(v: &mut Vec<usize>) {
         v.sort_unstable();
         v.dedup();
+    }
+
+    #[test]
+    fn projection_block_replacement_invalidation_guards_canonical_routing() {
+        let product = Mps::new(4, MpsConfig::default());
+        let mut mps = product.add(&product);
+        mps.left_canonicalize();
+
+        project_single_flip_without_sign(&mut mps, 0, Complex64::new(1.0, 0.0), 0.5);
+
+        assert_eq!(mps.tracked_center_for_test(), None);
     }
 
     #[test]


### PR DESCRIPTION
Recovers the wall-time cost of the canonical-form correctness work (merged in #547) with two
independent changes, split into separate commits so each can be judged on its own evidence. An
independent adversarial review drove one round of revisions; its findings and their resolutions
are summarized below.

## Commit 1 — certify gauge-shifted primary SVD factors

The primary SVD acceptance gate is a max-element residual, which is gauge-sensitive: entries
redistributed by a unitary gauge change can push accurate nalgebra factorizations into expensive
fallback recomputation (instrumented attribution found one 126x128 Gram fallback costing 320 ms).
When the cheap strict gate rejects, the already-computed factors may now be accepted through the
same independent certification required for derived fallback factors: the dimension-scaled
normwise reconstruction bound plus retained singular-triplet residual and isometry checks.

This is a documented trade, not an equivalence: over the 54 widened acceptances observed across
the six benchmark workloads (0.4% of all SVDs), the old fallback chain succeeded in every case
and was more accurate in 51, by up to ~4 orders of max-entry residual — all within the certified
backward-error bound, with identical retained ranks and discarded-weight perturbations four
orders below the default truncation-error budget. Both nalgebra paths now also sort singular
values explicitly rather than relying on undocumented ordering.

## Commit 2 — track the MPS orthogonality center

`Mps` gains a private `center: Option<usize>` (mixed-canonical invariant), moved with
O(|k - j|) local QR steps at the single consult point instead of full sweeps. Every mutation
path preserves, moves, or invalidates it; all tensor writes are owner-mediated; unit-modulus
diagonal gates preserve (checked at 1e-12), near-unitary one-site gates are accepted only at
1e-12 (materially below the 1e-9 debug validator, so accumulation cannot silently exhaust the
validation budget). Debug builds numerically validate every claim consumed to skip work.

Guard tests, each proven binding by mutation: add, projection block replacement, direct tensor
borrow, scale, and non-unit diagonal all assert the tracked center directly; a negative test
pins the validator's false branch; and a blast-radius test demonstrates the harm class the guard
exists for — an injected stale center followed by a wrong-gauge truncating SVD measurably
corrupts the state (fidelity 0.734 vs 0.819 against a dense oracle), and the debug validator
catches it at the consult.

## Per-component attribution (7-run pinned medians, contemporaneous four-build split)

The two changes are complementary: each carries a different workload, and center tracking's
gauge diversity is exactly what exposes the SVD gate's sensitivity that commit 1 fixes.

| Workload | SVD-only vs dev | Center-only vs dev | Combined vs dev |
|---|---:|---:|---:|
| deep20_2n | -21.3% | +16.2% | -14.4% |
| qec16 | +1.2% | -2.7% | -2.9% |
| STN probe | +3.3% | -15.0% | -15.4% |
| MAST probe | +1.0% | +0.5% | +0.4% |

Final combined battery vs the recorded dev baselines (7-run pinned medians): qec8 -4.4%,
qec16 -6.3%, deep12_1n -5.9%, deep12_2n -14.6%, deep20_1n -6.6%, deep20_2n -16.3%, STN probe
-10.9%, MAST probe -2.5%. Every emitted trajectory hash was identical across its seven runs.
Hashes differ from the parent build as expected: skipping a redundant QR preserves the state but
reorders floating-point operations, so individual stochastic measurement draws can flip; this
matches the established cross-revision behavior of these hashes.

## Verification

- Full suite: 306 lib + 92 integration + 3 doc; release-ignored lane 2 + 8.
- Issue #557 sweep, 640 circuits: worst prob_bitstring and |amplitude_iterative|^2 deltas both
  5.551e-16 (ceiling 3.3e-15).
- 1,200-circuit stability census: 0 panics.
- Debug-validator lane (optimized build, debug assertions live): 400 8-qubit circuits, 0 stale
  center detections.
- Distributional spot-check: 20,000 shots x 3 seeds vs exact probabilities; worst deviation
  2.93 sigma, consistent with shot noise.
- clippy --all-targets -D warnings, fmt, both feature lanes clean.

The STN and MAST probe rows come from the in-tree `disent_firing_rate` example's probe legs (exp/pecos-stab-tn/examples/disent_firing_rate.rs), measured with the same 7-run pinned-median methodology as the canonical_cost_workloads rows.
