### PR TITLE
Track the Clifford basis scalar through forced projections for exact amplitude_iterative phases

### DIFF
--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -29,6 +29,7 @@
 //! Quantum Simulator on a Basis of Stabilizer States." PRL 133, 230601 (2024).
 //! arXiv:2403.08724.
 
+mod canonical_ket;
 pub mod compile;
 pub mod disentangle;
 pub mod mast;
@@ -1155,9 +1156,16 @@ impl StabMps {
         let mut tab = self.tableau.clone();
         let mut mps = self.mps.clone();
         let mut projected_norm = 1.0;
+        let mut projection_phase = Complex64::new(1.0, 0.0);
         for (q, &s_q) in bitstring.iter().enumerate() {
             let probability = expect_mps_operation(
-                measure::project_forced_z(&mut tab, &mut mps, q, s_q),
+                measure::project_forced_z_with_phase(
+                    &mut tab,
+                    &mut mps,
+                    q,
+                    s_q,
+                    &mut projection_phase,
+                ),
                 "StabMps::amplitude_iterative forced projection",
             );
             if probability < 1e-20 {
@@ -1183,7 +1191,11 @@ impl StabMps {
             );
             return Complex64::new(0.0, 0.0);
         }
-        self.global_phase * coefficient / coefficient_norm * projected_norm
+        let terminal_tableau_phase =
+            canonical_ket::terminal_tableau_basis_phase(&tab, &mps_index, bitstring);
+        self.global_phase * projection_phase * terminal_tableau_phase * coefficient
+            / coefficient_norm
+            * projected_norm
     }
 
     /// Probability of measuring `bitstring` in the computational basis.
@@ -3124,44 +3136,116 @@ mod tests {
     }
 
     #[test]
-    fn test_amplitude_iterative_h_after_rotation_randomized() {
-        for n in 3..=5 {
-            for circuit_seed in 0..4_u64 {
-                let mut stn = StabMps::builder(n)
-                    .seed(circuit_seed)
-                    .merge_rz(false)
-                    .max_truncation_error(0.0)
-                    .build();
-                let mut rng_state = 0x9e37_79b9_7f4a_7c15_u64 ^ circuit_seed ^ n as u64;
-                let random = |state: &mut u64| {
-                    *state ^= *state << 13;
-                    *state ^= *state >> 7;
-                    *state ^= *state << 17;
-                    *state
-                };
+    fn test_amplitude_iterative_h_t_sz_phase_regression() {
+        let mut stn = StabMps::builder(1)
+            .merge_rz(false)
+            .svd_cutoff(0.0)
+            .max_truncation_error(0.0)
+            .build();
+        stn.h(&[QubitId(0)]);
+        stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
+        stn.sz(&[QubitId(0)]);
+        stn.flush();
 
-                for rotation_qubit in 0..n {
-                    let theta = 0.17 + (random(&mut rng_state) % 101) as f64 * 0.011;
-                    stn.h(&[QubitId(rotation_qubit)]);
-                    stn.rz(Angle64::from_radians(theta), &[QubitId(rotation_qubit)]);
-                    stn.h(&[QubitId(rotation_qubit)]);
+        let expected = stn.state_vector()[1];
+        let actual = stn.amplitude_iterative(&[true]);
+        assert!(
+            (actual - expected).norm() <= 1e-12,
+            "H-T-SZ |1>: iterative={actual:?}, dense={expected:?}"
+        );
+    }
 
-                    if rotation_qubit + 1 < n {
-                        let pair = if random(&mut rng_state) & 1 == 0 {
-                            (rotation_qubit, rotation_qubit + 1)
-                        } else {
-                            (rotation_qubit + 1, rotation_qubit)
-                        };
-                        stn.cx(&[(QubitId(pair.0), QubitId(pair.1))]);
-                    }
+    #[test]
+    fn test_amplitude_iterative_h_t_cx_h_phase_regression() {
+        let mut stn = StabMps::builder(2)
+            .merge_rz(false)
+            .svd_cutoff(0.0)
+            .max_truncation_error(0.0)
+            .build();
+        stn.h(&[QubitId(0)]);
+        stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
+        stn.cx(&[(QubitId(0), QubitId(1))]);
+        stn.h(&[QubitId(0)]);
+        stn.flush();
+
+        let expected = stn.state_vector()[3];
+        let actual = stn.amplitude_iterative(&[true, true]);
+        assert!(
+            (actual - expected).norm() <= 1e-12,
+            "H-T-CX-H |11>: iterative={actual:?}, dense={expected:?}"
+        );
+    }
+
+    fn amplitude_phase_randomized_circuit(n: usize, circuit_seed: u64) -> StabMps {
+        let mut stn = StabMps::builder(n)
+            .seed(circuit_seed)
+            .merge_rz(false)
+            .max_truncation_error(0.0)
+            .build();
+        let mut rng_state = 0x9e37_79b9_7f4a_7c15_u64 ^ circuit_seed ^ n as u64;
+        let random = |state: &mut u64| {
+            *state ^= *state << 13;
+            *state ^= *state >> 7;
+            *state ^= *state << 17;
+            *state
+        };
+
+        for rotation_qubit in 0..n {
+            let theta = 0.17 + (random(&mut rng_state) % 101) as f64 * 0.011;
+            stn.h(&[QubitId(rotation_qubit)]);
+            stn.rz(Angle64::from_radians(theta), &[QubitId(rotation_qubit)]);
+            let neighbour = (rotation_qubit + 1) % n;
+            match rotation_qubit % 3 {
+                0 => {
+                    stn.sz(&[QubitId(rotation_qubit)]);
                 }
+                1 => {
+                    stn.x(&[QubitId(neighbour)]);
+                }
+                _ => {
+                    stn.cz(&[(QubitId(rotation_qubit), QubitId(neighbour))]);
+                }
+            }
+            stn.h(&[QubitId(rotation_qubit)]);
+
+            if rotation_qubit + 1 < n {
+                let pair = if random(&mut rng_state) & 1 == 0 {
+                    (rotation_qubit, rotation_qubit + 1)
+                } else {
+                    (rotation_qubit + 1, rotation_qubit)
+                };
+                stn.cx(&[(QubitId(pair.0), QubitId(pair.1))]);
+            }
+        }
+        stn
+    }
+
+    /// This case has phase-exact forced-projection steps but a terminal
+    /// destabilizer-basis factor of +i. It binds the terminal scalar in the
+    /// amplitude return independently of the two right-H regressions above.
+    #[test]
+    fn test_amplitude_iterative_terminal_tableau_phase_regression() {
+        let stn = amplitude_phase_randomized_circuit(4, 0);
+        let expected = stn.state_vector()[0];
+        let actual = stn.amplitude_iterative(&[false; 4]);
+        assert!(
+            (actual - expected).norm() <= 1e-12,
+            "n=4 seed=0 index=0 terminal phase: iterative={actual}, state-vector={expected}"
+        );
+    }
+
+    #[test]
+    fn test_amplitude_iterative_h_after_rotation_randomized() {
+        for n in 3..=6 {
+            for circuit_seed in 0..4_u64 {
+                let stn = amplitude_phase_randomized_circuit(n, circuit_seed);
 
                 let state_vector = stn.state_vector();
                 for (index, &expected) in state_vector.iter().enumerate() {
                     let bitstring: Vec<bool> = (0..n).map(|q| (index >> q) & 1 == 1).collect();
                     let actual = stn.amplitude_iterative(&bitstring);
                     assert!(
-                        (actual - expected).norm() < 1e-10,
+                        (actual - expected).norm() <= 1e-12,
                         "n={n} seed={circuit_seed} index={index}: iterative={actual}, state-vector={expected}"
                     );
                 }
@@ -3348,7 +3432,9 @@ mod tests {
 
     /// Reproduce the full-random generator used by
     /// `examples/disent_firing_rate.rs` and the stability census.
-    fn stability_census_random_circuit(seed: u64) -> StabMps {
+    // Test-only visibility lets the #562 phase harness reuse the exact census
+    // generator instead of maintaining a subtly different copy.
+    pub(super) fn stability_census_random_circuit(seed: u64) -> StabMps {
         let mut stn = StabMps::with_seed(8, seed);
         let mut rng_state = seed.wrapping_add(1);
         let next_rng = |state: &mut u64| {

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -1123,7 +1123,8 @@ impl StabMps {
         acc / f64::from(u32::try_from(group_size).expect("group_size fits in u32"))
     }
 
-    /// Complex amplitude ⟨s|Ψ⟩ via iterative forced projection without
+    /// Complex amplitude ⟨s|Ψ⟩ in [`Self::state_vector`]'s canonical
+    /// global-phase convention, via iterative forced projection without
     /// renormalization (Liu-Clark 2412.17209 Section VI.B).
     /// `bitstring[q]` specifies qubit `q`; see the crate-level
     /// **Bitstring convention** section.
@@ -1135,12 +1136,27 @@ impl StabMps {
     /// MPS + tableau. The product of conditional probabilities supplies the
     /// amplitude magnitude. After forcing all N outcomes, the final tableau's
     /// GF(2) sign equations identify the virtual-basis coefficient whose phase
-    /// supplies the complex amplitude phase without enumerating the state.
+    /// supplies the complex relative phase without enumerating the state. All
+    /// returned amplitudes share the physical state's one arbitrary global
+    /// phase; this method does not define an absolute ket phase.
     ///
     /// # Correctness
     /// Exact match to `amplitude` (SV-based) at n ≤ 14 for Clifford+T
-    /// circuits. Scales to arbitrary n via MPS operations. Probabilities
-    /// via `prob_bitstring` are always correct.
+    /// circuits, including relative phase in `state_vector`'s convention.
+    /// Scales to arbitrary n via MPS operations. Probabilities via
+    /// `prob_bitstring` are always correct.
+    ///
+    /// # Performance
+    ///
+    /// Relative-phase tracking performs O(n^3) canonical-ket elimination at
+    /// each stabilizer-group change, while reusing the post-change ket across
+    /// intervening generator rebases and virtual gates that preserve the
+    /// group. In a release dense-generator benchmark (H on every qubit,
+    /// triangular CX network, all-zero amplitude; three-run medians), cache
+    /// reuse reduced n=32/64/128/192 calls from 2.028/18.903/239.150/1120.132 ms
+    /// to 1.195/10.395/127.186/557.597 ms. The cached path still scaled about
+    /// n^3.4 and was 2.9x/6.0x/28.4x/35.9x slower than the phase-insensitive
+    /// dev parent on that adversarial generator basis.
     ///
     /// # Panics
     ///
@@ -1156,7 +1172,7 @@ impl StabMps {
         let mut tab = self.tableau.clone();
         let mut mps = self.mps.clone();
         let mut projected_norm = 1.0;
-        let mut projection_phase = Complex64::new(1.0, 0.0);
+        let mut phase_tracker = canonical_ket::CanonicalPhaseTracker::new();
         for (q, &s_q) in bitstring.iter().enumerate() {
             let probability = expect_mps_operation(
                 measure::project_forced_z_with_phase(
@@ -1164,7 +1180,7 @@ impl StabMps {
                     &mut mps,
                     q,
                     s_q,
-                    &mut projection_phase,
+                    &mut phase_tracker,
                 ),
                 "StabMps::amplitude_iterative forced projection",
             );
@@ -1192,8 +1208,8 @@ impl StabMps {
             return Complex64::new(0.0, 0.0);
         }
         let terminal_tableau_phase =
-            canonical_ket::terminal_tableau_basis_phase(&tab, &mps_index, bitstring);
-        self.global_phase * projection_phase * terminal_tableau_phase * coefficient
+            phase_tracker.terminal_tableau_basis_phase(&tab, &mps_index, bitstring);
+        self.global_phase * phase_tracker.scalar() * terminal_tableau_phase * coefficient
             / coefficient_norm
             * projected_norm
     }
@@ -3220,9 +3236,9 @@ mod tests {
         stn
     }
 
-    /// This case has phase-exact forced-projection steps but a terminal
-    /// destabilizer-basis factor of +i. It binds the terminal scalar in the
-    /// amplitude return independently of the two right-H regressions above.
+    /// This case matches `state_vector`'s phase convention at every forced
+    /// projection step but has a terminal destabilizer-basis factor of +i. It
+    /// binds the terminal scalar independently of the two right-H regressions.
     #[test]
     fn test_amplitude_iterative_terminal_tableau_phase_regression() {
         let stn = amplitude_phase_randomized_circuit(4, 0);
@@ -3247,6 +3263,93 @@ mod tests {
                     assert!(
                         (actual - expected).norm() <= 1e-12,
                         "n={n} seed={circuit_seed} index={index}: iterative={actual}, state-vector={expected}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn assert_all_iterative_amplitudes_match_state_vector(stn: &StabMps, label: &str) {
+        for (index, expected) in stn.state_vector().into_iter().enumerate() {
+            let bits = [(index & 1) != 0, (index & 2) != 0];
+            let actual = stn.amplitude_iterative(&bits);
+            assert!(
+                (actual - expected).norm() <= 1e-12,
+                "{label} index={index}: iterative={actual:?}, state-vector={expected:?}"
+            );
+        }
+    }
+
+    /// A live measurement can leave the trivial coefficient MPS in a nonzero
+    /// virtual basis state. The next iterative walk must retain the scalar
+    /// while `canonicalize_trivial_mps_basis` right-composes its X.
+    #[test]
+    fn test_amplitude_iterative_mid_measurement_right_compose_x_scalar() {
+        let mut stn = StabMps::builder(2)
+            .seed(28)
+            .merge_rz(false)
+            .max_truncation_error(0.0)
+            .build();
+        stn.y(&[QubitId(1), QubitId(0)]);
+        stn.rx(Angle64::from_radians(0.61), &[QubitId(0)]);
+        stn.sz(&[QubitId(0)]).szdg(&[QubitId(0)]);
+        stn.rx(Angle64::from_radians(0.61), &[QubitId(0)]);
+        stn.rz(Angle64::from_radians(0.37), &[QubitId(1), QubitId(0)]);
+        let measurement = stn.mz(&[QubitId(0)]).remove(0);
+        assert!(!measurement.outcome && !measurement.is_deterministic);
+        stn.flush();
+
+        assert_all_iterative_amplitudes_match_state_vector(&stn, "right-compose-X scalar");
+    }
+
+    /// A live measurement can also select a pure-stabilizer ket whose later
+    /// forced projection is recanonicalized by `mz_forced`; that scalar must
+    /// survive in `amplitude_iterative`.
+    #[test]
+    fn test_amplitude_iterative_mid_measurement_forced_measurement_scalar() {
+        let mut stn = StabMps::builder(2)
+            .seed(9)
+            .merge_rz(false)
+            .max_truncation_error(0.0)
+            .build();
+        stn.h(&[QubitId(1)]);
+        stn.szdg(&[QubitId(0)]).szdg(&[QubitId(0)]);
+        stn.rx(Angle64::from_radians(0.61), &[QubitId(0)]);
+        stn.y(&[QubitId(1)]).h(&[QubitId(0)]).sz(&[QubitId(0)]);
+        stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
+        let measurement = stn.mz(&[QubitId(0)]).remove(0);
+        assert!(!measurement.outcome && !measurement.is_deterministic);
+        stn.flush();
+
+        assert_all_iterative_amplitudes_match_state_vector(&stn, "forced-measurement scalar");
+    }
+
+    #[test]
+    fn test_amplitude_iterative_bare_h_rz_cx_family() {
+        for n in 3..=4 {
+            for seed in 0..3_u64 {
+                let mut stn = StabMps::builder(n)
+                    .seed(seed)
+                    .merge_rz(false)
+                    .max_truncation_error(0.0)
+                    .build();
+                for q in 0..n {
+                    stn.h(&[QubitId(q)]);
+                    let theta = 0.19 + 0.07 * (seed * n as u64 + q as u64) as f64;
+                    stn.rz(Angle64::from_radians(theta), &[QubitId(q)]);
+                    stn.h(&[QubitId(q)]);
+                    if q + 1 < n {
+                        stn.cx(&[(QubitId(q), QubitId(q + 1))]);
+                    }
+                }
+                stn.flush();
+
+                for (index, expected) in stn.state_vector().into_iter().enumerate() {
+                    let bits = (0..n).map(|q| (index >> q) & 1 != 0).collect::<Vec<_>>();
+                    let actual = stn.amplitude_iterative(&bits);
+                    assert!(
+                        (actual - expected).norm() <= 1e-12,
+                        "bare H/RZ/CX n={n} seed={seed} index={index}: iterative={actual:?}, state-vector={expected:?}"
                     );
                 }
             }

--- a/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
@@ -1,0 +1,477 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Polynomial-time amplitudes of the canonical ket represented by a stabilizer tableau.
+//!
+//! `StabMps::state_vector` fixes a tableau's otherwise arbitrary ket phase by
+//! normalizing the first nonzero column of `prod_k (I + S_k) / 2`. Equivalently,
+//! the numerically first computational-basis word in the support has a positive
+//! real amplitude. This module implements that same convention without building
+//! a dense projector.
+
+use num_complex::Complex64;
+use pecos_simulators::{Gens, SparseStabY};
+
+use super::tableau_compose::multiply_row_within;
+
+/// An exact fourth root of unity, represented by its exponent in `i^exponent`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct QuarterPhase(u8);
+
+impl QuarterPhase {
+    const ONE: Self = Self(0);
+
+    fn times_i_pow(&mut self, exponent: usize) {
+        self.0 = (self.0 + (exponent & 3) as u8) & 3;
+    }
+
+    fn to_complex(self) -> Complex64 {
+        match self.0 {
+            0 => Complex64::new(1.0, 0.0),
+            1 => Complex64::new(0.0, 1.0),
+            2 => Complex64::new(-1.0, 0.0),
+            3 => Complex64::new(0.0, -1.0),
+            _ => unreachable!("quarter-phase exponent is reduced modulo four"),
+        }
+    }
+}
+
+/// Row-reduced description of the canonical ket selected by a tableau.
+pub(super) struct CanonicalKet {
+    num_qubits: usize,
+    reduced_stabs: Gens,
+    /// `(pivot_qubit, generator_row)` in increasing qubit order.
+    x_pivots: Vec<(usize, usize)>,
+    first_support: Vec<bool>,
+    support_amplitude_magnitude: f64,
+}
+
+impl CanonicalKet {
+    /// Build the canonical ket in O(n^3) bit operations.
+    pub(super) fn new(tableau: &SparseStabY) -> Self {
+        let num_qubits = tableau.num_qubits();
+        let mut reduced_stabs = tableau.stabs().clone();
+        let mut pivot_rows = vec![false; num_qubits];
+        let mut x_pivots = Vec::new();
+
+        // Reduced row echelon form of the stabilizer X block. Stabilizer rows
+        // commute, so signed generator multiplication is a valid GF(2) row op.
+        for qubit in 0..num_qubits {
+            let Some(pivot_row) = (0..num_qubits)
+                .find(|&row| !pivot_rows[row] && reduced_stabs.row_x[row].contains(qubit))
+            else {
+                continue;
+            };
+            for row in 0..num_qubits {
+                if row != pivot_row && reduced_stabs.row_x[row].contains(qubit) {
+                    multiply_row_within(&mut reduced_stabs, row, pivot_row, num_qubits);
+                }
+            }
+            pivot_rows[pivot_row] = true;
+            x_pivots.push((qubit, pivot_row));
+        }
+
+        // Rows outside the X-pivot basis are diagonal stabilizers. Their +1
+        // eigenvalue equations determine an affine computational-basis coset.
+        let mut equations = Vec::with_capacity(num_qubits - x_pivots.len());
+        for (row, &is_pivot) in pivot_rows.iter().enumerate() {
+            if is_pivot {
+                continue;
+            }
+            assert!(
+                reduced_stabs.row_x[row].is_empty(),
+                "X reduction left a non-pivot stabilizer row with X support"
+            );
+            let sign_exponent = usize::from(reduced_stabs.signs_i.contains(row))
+                + 2 * usize::from(reduced_stabs.signs_minus.contains(row));
+            assert_eq!(
+                sign_exponent & 1,
+                0,
+                "a diagonal stabilizer generator cannot have an imaginary eigenvalue"
+            );
+            let mut equation = vec![false; num_qubits + 1];
+            for qubit in &reduced_stabs.row_z[row] {
+                equation[qubit] = true;
+            }
+            equation[num_qubits] = sign_exponent == 2;
+            equations.push(equation);
+        }
+
+        let mut first_support = solve_affine_system(equations, num_qubits)
+            .expect("a valid stabilizer tableau must have nonempty computational support");
+
+        // The solution set differs by the row space of the X block. Clearing
+        // its pivots from q0 upward gives the smallest MSB-first projector
+        // column, exactly matching state_vector's scan order.
+        for &(pivot_qubit, row) in &x_pivots {
+            if first_support[pivot_qubit] {
+                for qubit in &reduced_stabs.row_x[row] {
+                    first_support[qubit] ^= true;
+                }
+            }
+        }
+
+        let support_amplitude_magnitude = 2.0_f64.powf(-(x_pivots.len() as f64) / 2.0);
+        Self {
+            num_qubits,
+            reduced_stabs,
+            x_pivots,
+            first_support,
+            support_amplitude_magnitude,
+        }
+    }
+
+    pub(super) fn first_support(&self) -> &[bool] {
+        &self.first_support
+    }
+
+    /// Return the phase-exact canonical amplitude of one computational word.
+    pub(super) fn amplitude(&self, bitstring: &[bool]) -> Complex64 {
+        assert_eq!(
+            bitstring.len(),
+            self.num_qubits,
+            "bitstring length mismatch"
+        );
+        let mut remaining = bitstring
+            .iter()
+            .zip(&self.first_support)
+            .map(|(&target, &first)| target ^ first)
+            .collect::<Vec<_>>();
+        let mut current = self.first_support.clone();
+        let mut phase = QuarterPhase::ONE;
+
+        for &(pivot_qubit, row) in &self.x_pivots {
+            if !remaining[pivot_qubit] {
+                continue;
+            }
+            phase.times_i_pow(pauli_row_action_exponent(
+                &self.reduced_stabs,
+                row,
+                &current,
+            ));
+            for qubit in &self.reduced_stabs.row_x[row] {
+                current[qubit] ^= true;
+                remaining[qubit] ^= true;
+            }
+        }
+
+        if remaining.into_iter().any(|bit| bit) {
+            return Complex64::new(0.0, 0.0);
+        }
+        debug_assert_eq!(current, bitstring);
+        phase.to_complex() * self.support_amplitude_magnitude
+    }
+}
+
+/// Return `<target|P|ket>` for one signed Y-convention Pauli generator row.
+pub(super) fn pauli_applied_amplitude_at(
+    gens: &Gens,
+    row: usize,
+    ket: &CanonicalKet,
+    target: &[bool],
+) -> Complex64 {
+    assert_eq!(target.len(), ket.num_qubits, "bitstring length mismatch");
+    let mut source = target.to_vec();
+    for qubit in &gens.row_x[row] {
+        source[qubit] ^= true;
+    }
+    let source_amplitude = ket.amplitude(&source);
+    if source_amplitude == Complex64::new(0.0, 0.0) {
+        return source_amplitude;
+    }
+    let phase = QuarterPhase((pauli_row_action_exponent(gens, row, &source) & 3) as u8);
+    phase.to_complex() * source_amplitude
+}
+
+/// Return `<target|D_0^x0 ... D_{n-1}^xn|phi>` in the same effective
+/// multiplication order used by `StabMps::state_vector`.
+pub(super) fn destabilizer_basis_amplitude(
+    tableau: &SparseStabY,
+    coefficient_bits: &[u8],
+    target: &[bool],
+) -> Complex64 {
+    let num_qubits = tableau.num_qubits();
+    assert_eq!(
+        coefficient_bits.len(),
+        num_qubits,
+        "coefficient bitstring length mismatch"
+    );
+    assert_eq!(target.len(), num_qubits, "target bitstring length mismatch");
+
+    // Determine the source basis word which the selected destabilizer product
+    // maps to target. X support composes by XOR independently of row order.
+    let mut source = target.to_vec();
+    for (row, &selected) in coefficient_bits.iter().enumerate() {
+        assert!(selected <= 1, "coefficient bit must be zero or one");
+        if selected == 1 {
+            for qubit in &tableau.destabs().row_x[row] {
+                source[qubit] ^= true;
+            }
+        }
+    }
+
+    let ket = CanonicalKet::new(tableau);
+    let source_amplitude = ket.amplitude(&source);
+    if source_amplitude == Complex64::new(0.0, 0.0) {
+        return source_amplitude;
+    }
+
+    // state_vector applies row 0 first, then row 1, etc. Track the phase of
+    // that same left-multiplication sequence on the source computational ket.
+    let mut current = source;
+    let mut phase = QuarterPhase::ONE;
+    for (row, &selected) in coefficient_bits.iter().enumerate() {
+        if selected == 0 {
+            continue;
+        }
+        phase.times_i_pow(pauli_row_action_exponent(tableau.destabs(), row, &current));
+        for qubit in &tableau.destabs().row_x[row] {
+            current[qubit] ^= true;
+        }
+    }
+    debug_assert_eq!(current, target);
+    phase.to_complex() * source_amplitude
+}
+
+/// Unit phase of the terminal tableau basis vector selected after a complete
+/// forced-projection walk.
+pub(super) fn terminal_tableau_basis_phase(
+    tableau: &SparseStabY,
+    coefficient_bits: &[u8],
+    target: &[bool],
+) -> Complex64 {
+    let amplitude = destabilizer_basis_amplitude(tableau, coefficient_bits, target);
+    let magnitude = amplitude.norm();
+    assert!(
+        magnitude.is_finite() && magnitude > 0.0,
+        "projected tableau basis vector must have nonzero target amplitude"
+    );
+    amplitude / magnitude
+}
+
+/// Phase relating the concrete `C H_q |0>` ket to the canonical ket after
+/// `right_compose_h`. The numerator is `(I + D_q)|phi_old>/sqrt(2)`.
+pub(super) fn right_compose_h_scalar(
+    before: &SparseStabY,
+    after: &SparseStabY,
+    q: usize,
+) -> Complex64 {
+    let before_ket = CanonicalKet::new(before);
+    let after_ket = CanonicalKet::new(after);
+    let target = after_ket.first_support();
+    let denominator = after_ket.amplitude(target);
+    let numerator = (before_ket.amplitude(target)
+        + pauli_applied_amplitude_at(before.destabs(), q, &before_ket, target))
+        * std::f64::consts::FRAC_1_SQRT_2;
+    normalized_scalar(
+        numerator,
+        denominator,
+        "right-composed H canonical-ket scalar",
+    )
+}
+
+/// Phase relating `D_q |phi_old>` to the canonical ket after
+/// `right_compose_x`. This is needed only by the trivial-MPS canonicalizer.
+pub(super) fn right_compose_x_scalar(
+    before: &SparseStabY,
+    after: &SparseStabY,
+    q: usize,
+) -> Complex64 {
+    let before_ket = CanonicalKet::new(before);
+    let after_ket = CanonicalKet::new(after);
+    let target = after_ket.first_support();
+    normalized_scalar(
+        pauli_applied_amplitude_at(before.destabs(), q, &before_ket, target),
+        after_ket.amplitude(target),
+        "right-composed X canonical-ket scalar",
+    )
+}
+
+/// Phase lost when `mz_forced` replaces a pure stabilizer ket by the
+/// canonical ket for its normalized projected state.
+pub(super) fn forced_measurement_scalar(
+    before: &SparseStabY,
+    after: &SparseStabY,
+    q: usize,
+    outcome: bool,
+    probability: f64,
+) -> Complex64 {
+    assert!(
+        probability > 0.0,
+        "cannot phase-track a zero-probability branch"
+    );
+    let before_ket = CanonicalKet::new(before);
+    let after_ket = CanonicalKet::new(after);
+    let target = after_ket.first_support();
+    assert_eq!(
+        target[q], outcome,
+        "projected canonical ket must have the forced measurement outcome"
+    );
+    normalized_scalar(
+        before_ket.amplitude(target) / probability.sqrt(),
+        after_ket.amplitude(target),
+        "forced stabilizer measurement canonical-ket scalar",
+    )
+}
+
+fn normalized_scalar(numerator: Complex64, denominator: Complex64, context: &str) -> Complex64 {
+    assert!(
+        denominator.norm_sqr() > 0.0 && numerator.norm_sqr() > 0.0,
+        "{context} must compare nonzero amplitudes"
+    );
+    let scalar = numerator / denominator;
+    let magnitude = scalar.norm();
+    assert!(
+        magnitude.is_finite() && (magnitude - 1.0).abs() <= 1e-10,
+        "{context} must be unit magnitude, got {scalar:?}"
+    );
+    scalar / magnitude
+}
+
+/// Exponent `e` such that a signed row maps `|bits>` to `i^e |bits xor x>`.
+fn pauli_row_action_exponent(gens: &Gens, row: usize, bits: &[bool]) -> usize {
+    let mut exponent =
+        usize::from(gens.signs_i.contains(row)) + 2 * usize::from(gens.signs_minus.contains(row));
+    for (qubit, &bit) in bits.iter().enumerate() {
+        let x = gens.row_x[row].contains(qubit);
+        let z = gens.row_z[row].contains(qubit);
+        exponent += usize::from(x && z); // Y = iXZ.
+        exponent += 2 * usize::from(z && bit);
+    }
+    exponent & 3
+}
+
+/// Solve `A x = b` over GF(2), choosing zero for every free variable.
+fn solve_affine_system(mut equations: Vec<Vec<bool>>, num_variables: usize) -> Option<Vec<bool>> {
+    let mut pivot_row = 0usize;
+    let mut pivots = Vec::new();
+    for column in 0..num_variables {
+        let Some(found) = (pivot_row..equations.len()).find(|&row| equations[row][column]) else {
+            continue;
+        };
+        equations.swap(pivot_row, found);
+        let pivot = equations[pivot_row].clone();
+        for (row, equation) in equations.iter_mut().enumerate() {
+            if row == pivot_row || !equation[column] {
+                continue;
+            }
+            for (entry, &pivot_entry) in equation[column..].iter_mut().zip(&pivot[column..]) {
+                *entry ^= pivot_entry;
+            }
+        }
+        pivots.push((column, pivot_row));
+        pivot_row += 1;
+    }
+
+    if equations.iter().any(|equation| {
+        !equation[..num_variables].iter().any(|&value| value) && equation[num_variables]
+    }) {
+        return None;
+    }
+
+    let mut solution = vec![false; num_variables];
+    for (column, row) in pivots {
+        solution[column] = equations[row][num_variables];
+    }
+    Some(solution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stab_mps::StabMps;
+    use nalgebra::DMatrix;
+    use pecos_core::QubitId;
+    use pecos_simulators::CliffordGateable;
+
+    #[test]
+    fn known_y_state_uses_positive_first_amplitude() {
+        let mut tableau = SparseStabY::new(1).with_destab_sign_tracking();
+        tableau.h(&[QubitId(0)]).sz(&[QubitId(0)]);
+        let ket = CanonicalKet::new(&tableau);
+        assert_eq!(ket.first_support(), &[false]);
+        assert_eq!(
+            ket.amplitude(&[false]),
+            Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0)
+        );
+        assert_eq!(
+            ket.amplitude(&[true]),
+            Complex64::new(0.0, std::f64::consts::FRAC_1_SQRT_2)
+        );
+    }
+
+    #[test]
+    fn pauli_action_includes_both_stored_sign_bits() {
+        for (minus, i_bit, expected) in [
+            (false, false, Complex64::new(1.0, 0.0)),
+            (true, false, Complex64::new(-1.0, 0.0)),
+            (false, true, Complex64::new(0.0, 1.0)),
+            (true, true, Complex64::new(0.0, -1.0)),
+        ] {
+            let mut stn = StabMps::new(1);
+            if minus {
+                stn.tableau.destabs_mut().signs_minus.insert(0);
+            }
+            if i_bit {
+                stn.tableau.destabs_mut().signs_i.insert(0);
+            }
+            let x = DMatrix::from_row_slice(
+                2,
+                2,
+                &[
+                    Complex64::new(0.0, 0.0),
+                    Complex64::new(1.0, 0.0),
+                    Complex64::new(1.0, 0.0),
+                    Complex64::new(0.0, 0.0),
+                ],
+            );
+            stn.mps.apply_one_site_gate(0, &x).unwrap();
+            let dense = stn.state_vector();
+            assert_eq!(
+                destabilizer_basis_amplitude(&stn.tableau, &[1], &[true]),
+                expected
+            );
+            assert_eq!(dense[1], expected);
+        }
+    }
+
+    #[test]
+    fn destabilizer_product_uses_state_vector_row_order() {
+        let mut tableau = SparseStabY::new(2).with_destab_sign_tracking();
+        tableau.h(&[QubitId(0)]);
+        tableau.sz(&[QubitId(0)]);
+        tableau.cx(&[(QubitId(0), QubitId(1))]);
+        let bits = [1, 1];
+        let mut stn = StabMps::new(2);
+        stn.tableau = tableau;
+        let x = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(0.0, 0.0),
+            ],
+        );
+        stn.mps.apply_one_site_gate(0, &x).unwrap();
+        stn.mps.apply_one_site_gate(1, &x).unwrap();
+        let dense = stn.state_vector();
+        for (index, expected) in dense.into_iter().enumerate() {
+            let target = [index & 1 != 0, index & 2 != 0];
+            assert_eq!(
+                destabilizer_basis_amplitude(&stn.tableau, &bits, &target),
+                expected
+            );
+        }
+    }
+}

--- a/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
@@ -355,7 +355,20 @@ impl CanonicalPhaseTracker {
     }
 
     fn take_before_ket(&mut self, before: &SparseStabY) -> CanonicalKet {
-        self.ket.take().unwrap_or_else(|| CanonicalKet::new(before))
+        let ket = self.ket.take().unwrap_or_else(|| CanonicalKet::new(before));
+        // Self-enforce the reuse invariant: the cache is only valid across
+        // operations that preserve the stabilizer group, so the cached ket's
+        // support must match one rebuilt from the current tableau. A mismatch
+        // means a group-changing operation was inserted between scalar sites
+        // without refreshing the cache -- the silent-phase failure class of
+        // issue #562.
+        debug_assert_eq!(
+            ket.first_support(),
+            CanonicalKet::new(before).first_support(),
+            "cached canonical ket is stale: a group-changing tableau operation \
+             ran without refreshing the phase tracker"
+        );
+        ket
     }
 
     /// Track the unit-modulus scalar introduced by a right-composed H.

--- a/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/canonical_ket.rs
@@ -10,13 +10,15 @@
 // either express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Polynomial-time amplitudes of the canonical ket represented by a stabilizer tableau.
+//! Polynomial-time relative amplitudes of the canonical ket represented by a stabilizer tableau.
 //!
 //! `StabMps::state_vector` fixes a tableau's otherwise arbitrary ket phase by
 //! normalizing the first nonzero column of `prod_k (I + S_k) / 2`. Equivalently,
 //! the numerically first computational-basis word in the support has a positive
 //! real amplitude. This module implements that same convention without building
-//! a dense projector.
+//! a dense projector. The resulting amplitudes are exact relative to that
+//! convention; the represented physical state, like every ket, still has one
+//! arbitrary global phase.
 
 use num_complex::Complex64;
 use pecos_simulators::{Gens, SparseStabY};
@@ -45,7 +47,8 @@ impl QuarterPhase {
     }
 }
 
-/// Row-reduced description of the canonical ket selected by a tableau.
+/// Row-reduced description of the canonical representative selected by a tableau.
+#[derive(Clone)]
 pub(super) struct CanonicalKet {
     num_qubits: usize,
     reduced_stabs: Gens,
@@ -130,11 +133,14 @@ impl CanonicalKet {
         }
     }
 
-    pub(super) fn first_support(&self) -> &[bool] {
+    fn first_support(&self) -> &[bool] {
         &self.first_support
     }
 
-    /// Return the phase-exact canonical amplitude of one computational word.
+    /// Return one amplitude in `state_vector`'s canonical representative.
+    ///
+    /// Relative phases within the ket are exact; the physical state remains
+    /// defined only up to a common global phase.
     pub(super) fn amplitude(&self, bitstring: &[bool]) -> Complex64 {
         assert_eq!(
             bitstring.len(),
@@ -173,7 +179,7 @@ impl CanonicalKet {
 }
 
 /// Return `<target|P|ket>` for one signed Y-convention Pauli generator row.
-pub(super) fn pauli_applied_amplitude_at(
+fn pauli_applied_amplitude_at(
     gens: &Gens,
     row: usize,
     ket: &CanonicalKet,
@@ -194,10 +200,21 @@ pub(super) fn pauli_applied_amplitude_at(
 
 /// Return `<target|D_0^x0 ... D_{n-1}^xn|phi>` in the same effective
 /// multiplication order used by `StabMps::state_vector`.
-pub(super) fn destabilizer_basis_amplitude(
+#[cfg(test)]
+fn destabilizer_basis_amplitude(
     tableau: &SparseStabY,
     coefficient_bits: &[u8],
     target: &[bool],
+) -> Complex64 {
+    let ket = CanonicalKet::new(tableau);
+    destabilizer_basis_amplitude_with_ket(tableau, coefficient_bits, target, &ket)
+}
+
+fn destabilizer_basis_amplitude_with_ket(
+    tableau: &SparseStabY,
+    coefficient_bits: &[u8],
+    target: &[bool],
+    ket: &CanonicalKet,
 ) -> Complex64 {
     let num_qubits = tableau.num_qubits();
     assert_eq!(
@@ -219,7 +236,6 @@ pub(super) fn destabilizer_basis_amplitude(
         }
     }
 
-    let ket = CanonicalKet::new(tableau);
     let source_amplitude = ket.amplitude(&source);
     if source_amplitude == Complex64::new(0.0, 0.0) {
         return source_amplitude;
@@ -242,14 +258,13 @@ pub(super) fn destabilizer_basis_amplitude(
     phase.to_complex() * source_amplitude
 }
 
-/// Unit phase of the terminal tableau basis vector selected after a complete
-/// forced-projection walk.
-pub(super) fn terminal_tableau_basis_phase(
+fn normalized_terminal_phase(
     tableau: &SparseStabY,
     coefficient_bits: &[u8],
     target: &[bool],
+    ket: &CanonicalKet,
 ) -> Complex64 {
-    let amplitude = destabilizer_basis_amplitude(tableau, coefficient_bits, target);
+    let amplitude = destabilizer_basis_amplitude_with_ket(tableau, coefficient_bits, target, ket);
     let magnitude = amplitude.norm();
     assert!(
         magnitude.is_finite() && magnitude > 0.0,
@@ -258,19 +273,16 @@ pub(super) fn terminal_tableau_basis_phase(
     amplitude / magnitude
 }
 
-/// Phase relating the concrete `C H_q |0>` ket to the canonical ket after
-/// `right_compose_h`. The numerator is `(I + D_q)|phi_old>/sqrt(2)`.
-pub(super) fn right_compose_h_scalar(
+fn right_compose_h_scalar(
     before: &SparseStabY,
-    after: &SparseStabY,
+    before_ket: &CanonicalKet,
+    after_ket: &CanonicalKet,
     q: usize,
 ) -> Complex64 {
-    let before_ket = CanonicalKet::new(before);
-    let after_ket = CanonicalKet::new(after);
     let target = after_ket.first_support();
     let denominator = after_ket.amplitude(target);
     let numerator = (before_ket.amplitude(target)
-        + pauli_applied_amplitude_at(before.destabs(), q, &before_ket, target))
+        + pauli_applied_amplitude_at(before.destabs(), q, before_ket, target))
         * std::f64::consts::FRAC_1_SQRT_2;
     normalized_scalar(
         numerator,
@@ -279,28 +291,23 @@ pub(super) fn right_compose_h_scalar(
     )
 }
 
-/// Phase relating `D_q |phi_old>` to the canonical ket after
-/// `right_compose_x`. This is needed only by the trivial-MPS canonicalizer.
-pub(super) fn right_compose_x_scalar(
+fn right_compose_x_scalar(
     before: &SparseStabY,
-    after: &SparseStabY,
+    before_ket: &CanonicalKet,
+    after_ket: &CanonicalKet,
     q: usize,
 ) -> Complex64 {
-    let before_ket = CanonicalKet::new(before);
-    let after_ket = CanonicalKet::new(after);
     let target = after_ket.first_support();
     normalized_scalar(
-        pauli_applied_amplitude_at(before.destabs(), q, &before_ket, target),
+        pauli_applied_amplitude_at(before.destabs(), q, before_ket, target),
         after_ket.amplitude(target),
         "right-composed X canonical-ket scalar",
     )
 }
 
-/// Phase lost when `mz_forced` replaces a pure stabilizer ket by the
-/// canonical ket for its normalized projected state.
-pub(super) fn forced_measurement_scalar(
-    before: &SparseStabY,
-    after: &SparseStabY,
+fn forced_measurement_scalar(
+    before_ket: &CanonicalKet,
+    after_ket: &CanonicalKet,
     q: usize,
     outcome: bool,
     probability: f64,
@@ -309,8 +316,6 @@ pub(super) fn forced_measurement_scalar(
         probability > 0.0,
         "cannot phase-track a zero-probability branch"
     );
-    let before_ket = CanonicalKet::new(before);
-    let after_ket = CanonicalKet::new(after);
     let target = after_ket.first_support();
     assert_eq!(
         target[q], outcome,
@@ -321,6 +326,84 @@ pub(super) fn forced_measurement_scalar(
         after_ket.amplitude(target),
         "forced stabilizer measurement canonical-ket scalar",
     )
+}
+
+/// Scalar accumulator for the phase-sensitive forced-projection walk.
+///
+/// The cached ket is valid across generator rebasing and right-composed
+/// CX/Z/CZ/SZ/SZ-dagger operations: those operations preserve the stabilizer
+/// group because their virtual gates fix `|0...0>`. Every operation that does
+/// change that group (the tracked X/H rotations and `mz_forced`) refreshes the
+/// cache before it can be reused. This avoids rebuilding the incoming
+/// O(n^3) canonical ket at each consecutive scalar site.
+#[derive(Clone)]
+pub(super) struct CanonicalPhaseTracker {
+    scalar: Complex64,
+    ket: Option<CanonicalKet>,
+}
+
+impl CanonicalPhaseTracker {
+    pub(super) fn new() -> Self {
+        Self {
+            scalar: Complex64::new(1.0, 0.0),
+            ket: None,
+        }
+    }
+
+    pub(super) fn scalar(&self) -> Complex64 {
+        self.scalar
+    }
+
+    fn take_before_ket(&mut self, before: &SparseStabY) -> CanonicalKet {
+        self.ket.take().unwrap_or_else(|| CanonicalKet::new(before))
+    }
+
+    /// Track the unit-modulus scalar introduced by a right-composed H.
+    pub(super) fn right_compose_h(&mut self, before: &SparseStabY, after: &SparseStabY, q: usize) {
+        let before_ket = self.take_before_ket(before);
+        let after_ket = CanonicalKet::new(after);
+        self.scalar *= right_compose_h_scalar(before, &before_ket, &after_ket, q);
+        self.ket = Some(after_ket);
+    }
+
+    /// Track the unit-modulus scalar introduced by a right-composed X.
+    pub(super) fn right_compose_x(&mut self, before: &SparseStabY, after: &SparseStabY, q: usize) {
+        let before_ket = self.take_before_ket(before);
+        let after_ket = CanonicalKet::new(after);
+        self.scalar *= right_compose_x_scalar(before, &before_ket, &after_ket, q);
+        self.ket = Some(after_ket);
+    }
+
+    /// Track the unit-modulus scalar introduced by pure-stabilizer projection.
+    pub(super) fn forced_measurement(
+        &mut self,
+        before: &SparseStabY,
+        after: &SparseStabY,
+        q: usize,
+        outcome: bool,
+        probability: f64,
+    ) {
+        let before_ket = self.take_before_ket(before);
+        let after_ket = CanonicalKet::new(after);
+        self.scalar *= forced_measurement_scalar(&before_ket, &after_ket, q, outcome, probability);
+        self.ket = Some(after_ket);
+    }
+
+    /// Unit phase of the selected terminal tableau basis vector, relative to
+    /// `state_vector`'s canonical representative.
+    pub(super) fn terminal_tableau_basis_phase(
+        &self,
+        tableau: &SparseStabY,
+        coefficient_bits: &[u8],
+        target: &[bool],
+    ) -> Complex64 {
+        if let Some(ket) = &self.ket {
+            normalized_terminal_phase(tableau, coefficient_bits, target, ket)
+        } else {
+            let ket = CanonicalKet::new(tableau);
+            normalized_terminal_phase(tableau, coefficient_bits, target, &ket)
+        }
+    }
 }
 
 fn normalized_scalar(numerator: Complex64, denominator: Complex64, context: &str) -> Complex64 {

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -78,7 +78,7 @@ fn is_mps_trivial(mps: &Mps) -> bool {
 fn canonicalize_trivial_mps_basis(
     tableau: &mut SparseStabY,
     mps: &mut Mps,
-    mut phase_accumulator: Option<&mut Complex64>,
+    mut phase_accumulator: Option<&mut crate::stab_mps::canonical_ket::CanonicalPhaseTracker>,
 ) -> Vec<usize> {
     let norm_squared = mps.norm_squared();
     debug_assert!(
@@ -107,10 +107,10 @@ fn canonicalize_trivial_mps_basis(
             // C|...1...> = (C X_site)(X_site|...1...>).
             let before = phase_accumulator.as_ref().map(|_| tableau.clone());
             crate::stab_mps::tableau_compose::right_compose_x(tableau, site);
-            if let (Some(accumulator), Some(before)) = (phase_accumulator.as_mut(), before.as_ref())
+            if let (Some(accumulator), Some(before)) =
+                (phase_accumulator.as_deref_mut(), before.as_ref())
             {
-                **accumulator *=
-                    crate::stab_mps::canonical_ket::right_compose_x_scalar(before, tableau, site);
+                accumulator.right_compose_x(before, tableau, site);
             }
             mps.apply_one_site_gate(site, &x_gate)
                 .expect("MPS op on valid site");
@@ -765,7 +765,7 @@ fn right_compose_measurement_basis_rotation(
     phase: Complex64,
     sign_sites: &[usize],
     outcome: bool,
-    phase_accumulator: Option<&mut Complex64>,
+    phase_accumulator: Option<&mut crate::stab_mps::canonical_ket::CanonicalPhaseTracker>,
 ) {
     let signed_phase = Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase;
     let id_in_sign = sign_sites.contains(&id);
@@ -806,8 +806,7 @@ fn right_compose_measurement_basis_rotation(
     let before_h = phase_accumulator.as_ref().map(|_| tableau.clone());
     crate::stab_mps::tableau_compose::right_compose_h(tableau, id);
     if let (Some(accumulator), Some(before_h)) = (phase_accumulator, before_h.as_ref()) {
-        *accumulator *=
-            crate::stab_mps::canonical_ket::right_compose_h_scalar(before_h, tableau, id);
+        accumulator.right_compose_h(before_h, tableau, id);
     }
 }
 
@@ -939,22 +938,13 @@ fn reduce_exact_projection_bonds(mps: &mut Mps) -> Result<(), MpsError> {
     Ok(())
 }
 
-/// Project qubit `q_idx` onto a forced Z-basis outcome and return its
-/// probability together with the affected virtual coefficient-MPS sites.
-///
-/// Mirrors `measure_qubit_stab_mps` but deterministic: no RNG, the outcome is
-/// supplied by the caller. Useful for bitstring-probability computation
-/// (Liu-Clark 2412.17209 Algorithm 3 / VI.A).
-///
-/// # Errors
-///
-/// Returns an [`MpsError`] if compensation or compression fails.
+/// Shared implementation for tracked and phase-insensitive forced projection.
 fn project_forced_z_with_update_impl(
     tableau: &mut SparseStabY,
     mps: &mut Mps,
     q_idx: usize,
     outcome: bool,
-    mut phase_accumulator: Option<&mut Complex64>,
+    mut phase_accumulator: Option<&mut crate::stab_mps::canonical_ket::CanonicalPhaseTracker>,
 ) -> Result<ForcedProjectionResult, MpsError> {
     if is_mps_trivial(mps) {
         // A trivial coefficient MPS represents a pure stabilizer state. First
@@ -976,10 +966,11 @@ fn project_forced_z_with_update_impl(
         if probability > 0.0 {
             let before_measurement = phase_accumulator.as_ref().map(|_| tableau.clone());
             tableau.mz_forced(q_idx, outcome);
-            if let (Some(accumulator), Some(before_measurement)) =
-                (phase_accumulator.as_mut(), before_measurement.as_ref())
-            {
-                **accumulator *= crate::stab_mps::canonical_ket::forced_measurement_scalar(
+            if let (Some(accumulator), Some(before_measurement)) = (
+                phase_accumulator.as_deref_mut(),
+                before_measurement.as_ref(),
+            ) {
+                accumulator.forced_measurement(
                     before_measurement,
                     tableau,
                     q_idx,
@@ -1100,6 +1091,11 @@ fn project_forced_z_with_update_impl(
             let result = tableau.mz_forced(q_idx, outcome);
             debug_assert_eq!(result.outcome, outcome);
             let gauge_sites = compensate_measurement_pauli_gauge(mps, &predicted_tableau, tableau);
+            // `mz_forced` produces the same projected stabilizer group as the
+            // predicted basis rotation; compensation changes only the
+            // destabilizer gauge. Therefore the post-H canonical ket cached
+            // by the phase tracker remains valid for the measured tableau and
+            // can be the before-ket of the next scalar site.
             if !is_local_projection {
                 reduce_exact_projection_bonds(mps)?;
             }
@@ -1120,6 +1116,16 @@ fn project_forced_z_with_update_impl(
     }
 }
 
+/// Project qubit `q_idx` onto a forced Z-basis outcome and return its
+/// probability together with the affected virtual coefficient-MPS sites.
+///
+/// Mirrors `measure_qubit_stab_mps` but is deterministic: the caller supplies
+/// the outcome. This is the phase-insensitive Liu-Clark 2412.17209 Algorithm 3
+/// / VI.A path used by probability and measurement callers.
+///
+/// # Errors
+///
+/// Returns an [`MpsError`] if compensation or compression fails.
 pub(super) fn project_forced_z_with_update(
     tableau: &mut SparseStabY,
     mps: &mut Mps,
@@ -1137,7 +1143,7 @@ pub(super) fn project_forced_z_with_phase(
     mps: &mut Mps,
     q_idx: usize,
     outcome: bool,
-    phase_accumulator: &mut Complex64,
+    phase_accumulator: &mut crate::stab_mps::canonical_ket::CanonicalPhaseTracker,
 ) -> Result<f64, MpsError> {
     Ok(
         project_forced_z_with_update_impl(tableau, mps, q_idx, outcome, Some(phase_accumulator))?

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -75,7 +75,11 @@ fn is_mps_trivial(mps: &Mps) -> bool {
 /// The tableau-only measurement fast path is valid for `C|0...0>`, not for a
 /// general `C|b>`. Non-Clifford evolution and earlier exact projections can
 /// produce the latter even though every MPS bond is one.
-fn canonicalize_trivial_mps_basis(tableau: &mut SparseStabY, mps: &mut Mps) -> Vec<usize> {
+fn canonicalize_trivial_mps_basis(
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    mut phase_accumulator: Option<&mut Complex64>,
+) -> Vec<usize> {
     let norm_squared = mps.norm_squared();
     debug_assert!(
         (norm_squared - 1.0).abs() < 1e-8,
@@ -101,7 +105,13 @@ fn canonicalize_trivial_mps_basis(tableau: &mut SparseStabY, mps: &mut Mps) -> V
         // absolute zero threshold is intentional.
         if block_0_norm < 1e-12 {
             // C|...1...> = (C X_site)(X_site|...1...>).
+            let before = phase_accumulator.as_ref().map(|_| tableau.clone());
             crate::stab_mps::tableau_compose::right_compose_x(tableau, site);
+            if let (Some(accumulator), Some(before)) = (phase_accumulator.as_mut(), before.as_ref())
+            {
+                **accumulator *=
+                    crate::stab_mps::canonical_ket::right_compose_x_scalar(before, tableau, site);
+            }
             mps.apply_one_site_gate(site, &x_gate)
                 .expect("MPS op on valid site");
             modified_sites.push(site);
@@ -755,6 +765,7 @@ fn right_compose_measurement_basis_rotation(
     phase: Complex64,
     sign_sites: &[usize],
     outcome: bool,
+    phase_accumulator: Option<&mut Complex64>,
 ) {
     let signed_phase = Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase;
     let id_in_sign = sign_sites.contains(&id);
@@ -792,7 +803,12 @@ fn right_compose_measurement_basis_rotation(
             crate::stab_mps::tableau_compose::right_compose_szdg(tableau, id);
         }
     }
+    let before_h = phase_accumulator.as_ref().map(|_| tableau.clone());
     crate::stab_mps::tableau_compose::right_compose_h(tableau, id);
+    if let (Some(accumulator), Some(before_h)) = (phase_accumulator, before_h.as_ref()) {
+        *accumulator *=
+            crate::stab_mps::canonical_ket::right_compose_h_scalar(before_h, tableau, id);
+    }
 }
 
 /// Apply the inverse of the virtual Pauli gauge between two structurally
@@ -933,17 +949,19 @@ fn reduce_exact_projection_bonds(mps: &mut Mps) -> Result<(), MpsError> {
 /// # Errors
 ///
 /// Returns an [`MpsError`] if compensation or compression fails.
-pub(super) fn project_forced_z_with_update(
+fn project_forced_z_with_update_impl(
     tableau: &mut SparseStabY,
     mps: &mut Mps,
     q_idx: usize,
     outcome: bool,
+    mut phase_accumulator: Option<&mut Complex64>,
 ) -> Result<ForcedProjectionResult, MpsError> {
     if is_mps_trivial(mps) {
         // A trivial coefficient MPS represents a pure stabilizer state. First
         // absorb a possible nonzero virtual basis word into the tableau; only
         // then can its forced update supply the exact probability and state.
-        let modified_sites = canonicalize_trivial_mps_basis(tableau, mps);
+        let modified_sites =
+            canonicalize_trivial_mps_basis(tableau, mps, phase_accumulator.as_deref_mut());
         let decomp = decompose_z(tableau.stabs(), tableau.destabs(), q_idx);
         let probability = match decomp {
             ZDecomposition::Stabilizer { phase, .. } => {
@@ -956,7 +974,19 @@ pub(super) fn project_forced_z_with_update(
             ZDecomposition::DestabilizerFlip { .. } => 0.5,
         };
         if probability > 0.0 {
+            let before_measurement = phase_accumulator.as_ref().map(|_| tableau.clone());
             tableau.mz_forced(q_idx, outcome);
+            if let (Some(accumulator), Some(before_measurement)) =
+                (phase_accumulator.as_mut(), before_measurement.as_ref())
+            {
+                **accumulator *= crate::stab_mps::canonical_ket::forced_measurement_scalar(
+                    before_measurement,
+                    tableau,
+                    q_idx,
+                    outcome,
+                    probability,
+                );
+            }
             mps.normalize();
         }
         return Ok(ForcedProjectionResult {
@@ -1064,6 +1094,7 @@ pub(super) fn project_forced_z_with_update(
                 phase,
                 &sign_sites,
                 outcome,
+                phase_accumulator,
             );
 
             let result = tableau.mz_forced(q_idx, outcome);
@@ -1087,6 +1118,31 @@ pub(super) fn project_forced_z_with_update(
             })
         }
     }
+}
+
+pub(super) fn project_forced_z_with_update(
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    q_idx: usize,
+    outcome: bool,
+) -> Result<ForcedProjectionResult, MpsError> {
+    project_forced_z_with_update_impl(tableau, mps, q_idx, outcome, None)
+}
+
+/// Forced projection with canonical-ket scalar tracking for phase-sensitive
+/// amplitude reconstruction. Measurement and probability paths deliberately
+/// use the untracked sibling above.
+pub(super) fn project_forced_z_with_phase(
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    q_idx: usize,
+    outcome: bool,
+    phase_accumulator: &mut Complex64,
+) -> Result<f64, MpsError> {
+    Ok(
+        project_forced_z_with_update_impl(tableau, mps, q_idx, outcome, Some(phase_accumulator))?
+            .probability,
+    )
 }
 
 /// Project qubit `q_idx` onto a forced Z-basis outcome and return the
@@ -1761,3 +1817,9 @@ mod tests {
         }
     }
 }
+
+// Issue #562 diagnostics intentionally live outside the shipped measurement
+// path.  The module is kept as a separate file because it reconstructs dense
+// intermediate states and is far too expensive for production use.
+#[cfg(test)]
+mod phase_diagnostic;

--- a/exp/pecos-stab-tn/src/stab_mps/measure/phase_diagnostic.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure/phase_diagnostic.rs
@@ -1,9 +1,12 @@
-//! Phase-exactness diagnostics for PECOS issue #562.
+//! Archival phase-exactness investigation record for PECOS issue #562.
 //!
-//! This module deliberately calls the shipped forced-projection routine and
-//! reconstructs every intermediate `(tableau, MPS)` pair through
-//! `StabMps::state_vector`.  It is test-only: none of these dense operations or
-//! access paths are compiled into the library.
+//! Most helpers below deliberately shadow the production forced-projection
+//! branches so the original localization remains inspectable; they can drift
+//! as production evolves and are not the primary regression boundary. The
+//! durable checks are `canonical_ket_amplitude_matches_dense_projector_exhaustively`
+//! and `extended_phase_census_report`, which exercise the production primitive
+//! and step-exact walk respectively. None of these dense operations or access
+//! paths are compiled into the library.
 
 use super::*;
 use crate::stab_mps::StabMps;
@@ -48,12 +51,18 @@ fn normalized_projected_dense(
 
 #[derive(Clone, Copy, Debug)]
 struct PhaseComparison {
-    power: u8,
-    phase_error: f64,
+    /// Nearest eighth-root bucket for diagnostic reporting only.
+    octant: u8,
+    identity_error: f64,
     vector_error: f64,
 }
 
-fn compare_up_to_quarter_phase(actual: &[Complex64], expected: &[Complex64]) -> PhaseComparison {
+/// Compare vectors up to their measured unit-modulus scalar.
+///
+/// The octant does not constrain correctness: reachable right-H scalars can
+/// be eighth roots of unity, and the vector comparison uses the measured
+/// scalar itself rather than snapping it to any discrete root.
+fn compare_up_to_unit_scalar(actual: &[Complex64], expected: &[Complex64]) -> PhaseComparison {
     assert_eq!(actual.len(), expected.len());
     let pivot = expected
         .iter()
@@ -63,34 +72,39 @@ fn compare_up_to_quarter_phase(actual: &[Complex64], expected: &[Complex64]) -> 
         .unwrap();
     assert!(expected[pivot].norm() > 1e-12);
     let raw_ratio = actual[pivot] / expected[pivot];
-    let phase = raw_ratio / Complex64::new(raw_ratio.norm(), 0.0);
-    let roots = [
-        Complex64::new(1.0, 0.0),
-        Complex64::new(0.0, 1.0),
-        Complex64::new(-1.0, 0.0),
-        Complex64::new(0.0, -1.0),
-    ];
-    let (power, phase_error) = roots
-        .iter()
-        .enumerate()
-        .map(|(power, root)| (power as u8, (phase - root).norm()))
-        .min_by(|left, right| left.1.total_cmp(&right.1))
-        .unwrap();
-    let root = roots[usize::from(power)];
+    let ratio_magnitude = raw_ratio.norm();
+    assert!(ratio_magnitude > 1e-12);
+    let phase = raw_ratio / Complex64::new(ratio_magnitude, 0.0);
+    let octant = ((phase.arg() * 4.0 / std::f64::consts::PI).round() as i8).rem_euclid(8) as u8;
     let vector_error = actual
         .iter()
         .zip(expected)
-        .map(|(actual, expected)| (*actual - root * *expected).norm())
+        .map(|(actual, expected)| (*actual - phase * *expected).norm())
         .fold(0.0, f64::max);
     PhaseComparison {
-        power,
-        phase_error,
+        octant,
+        identity_error: (phase - Complex64::new(1.0, 0.0)).norm(),
         vector_error,
     }
 }
 
 fn bits_from_index(index: usize, n: usize) -> Vec<bool> {
     (0..n).map(|qubit| (index >> qubit) & 1 != 0).collect()
+}
+
+#[test]
+fn unit_scalar_comparison_accepts_eighth_root_phase() {
+    let expected = [Complex64::new(0.5, -0.25), Complex64::new(-0.125, 0.75)];
+    let eighth_root = Complex64::new(
+        std::f64::consts::FRAC_1_SQRT_2,
+        std::f64::consts::FRAC_1_SQRT_2,
+    );
+    let actual = expected.map(|amplitude| eighth_root * amplitude);
+    let comparison = compare_up_to_unit_scalar(&actual, &expected);
+
+    assert_eq!(comparison.octant, 1);
+    assert!(comparison.vector_error <= 1e-15);
+    assert!(comparison.identity_error > 0.5);
 }
 
 fn xorshift(state: &mut u64) -> u64 {
@@ -270,7 +284,7 @@ fn record_internal(
 ) {
     records.push((
         label.to_string(),
-        compare_up_to_quarter_phase(actual, expected),
+        compare_up_to_unit_scalar(actual, expected),
     ));
 }
 
@@ -552,7 +566,7 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
             before: &[Complex64],
             qubit: usize,
             projected_norm: f64,
-            accumulated_phase: Complex64,
+            phase_tracker: &crate::stab_mps::canonical_ket::CanonicalPhaseTracker,
         ) {
             let n = self.template.num_qubits;
             if qubit == n {
@@ -568,26 +582,24 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                 let mps_index = projected_mps_basis_index(tableau, &self.bits);
                 let coefficient = mps.amplitude(&mps_index);
                 let terminal_tableau_phase =
-                    crate::stab_mps::canonical_ket::terminal_tableau_basis_phase(
-                        tableau, &mps_index, &self.bits,
-                    );
+                    phase_tracker.terminal_tableau_basis_phase(tableau, &mps_index, &self.bits);
                 let actual = self.template.global_phase
-                    * accumulated_phase
+                    * phase_tracker.scalar()
                     * terminal_tableau_phase
                     * coefficient
                     / coefficient.norm()
                     * projected_norm;
-                let comparison = compare_up_to_quarter_phase(&[actual], &[expected]);
-                assert!(comparison.phase_error <= PHASE_TOLERANCE);
+                let comparison = compare_up_to_unit_scalar(&[actual], &[expected]);
+                assert!(comparison.identity_error <= PHASE_TOLERANCE);
                 assert!(comparison.vector_error <= VECTOR_TOLERANCE);
                 self.summary.max_phase_error =
-                    self.summary.max_phase_error.max(comparison.phase_error);
+                    self.summary.max_phase_error.max(comparison.identity_error);
                 self.summary.max_vector_error =
                     self.summary.max_vector_error.max(comparison.vector_error);
                 *self
                     .summary
                     .final_phases
-                    .entry(comparison.power)
+                    .entry(comparison.octant)
                     .or_default() += 1;
                 return;
             }
@@ -599,7 +611,7 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                 };
                 let mut next_tableau = tableau.clone();
                 let mut next_mps = mps.clone();
-                let mut next_phase = accumulated_phase;
+                let mut next_phase = phase_tracker.clone();
                 let probability = project_forced_z_with_phase(
                     &mut next_tableau,
                     &mut next_mps,
@@ -613,22 +625,22 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                 }
                 let mut actual_after = dense_pair(self.template, &next_tableau, &next_mps);
                 for amplitude in &mut actual_after {
-                    *amplitude *= next_phase;
+                    *amplitude *= next_phase.scalar();
                 }
-                let comparison = compare_up_to_quarter_phase(&actual_after, &expected_after);
+                let comparison = compare_up_to_unit_scalar(&actual_after, &expected_after);
                 assert!(
-                    comparison.phase_error <= PHASE_TOLERANCE
+                    comparison.identity_error <= PHASE_TOLERANCE
                         && comparison.vector_error <= VECTOR_TOLERANCE,
                     "q={qubit} outcome={outcome} phase={comparison:?}"
                 );
                 self.summary.max_phase_error =
-                    self.summary.max_phase_error.max(comparison.phase_error);
+                    self.summary.max_phase_error.max(comparison.identity_error);
                 self.summary.max_vector_error =
                     self.summary.max_vector_error.max(comparison.vector_error);
                 *self
                     .summary
                     .step_phases
-                    .entry(comparison.power)
+                    .entry(comparison.octant)
                     .or_default() += 1;
                 let features = step_features(tableau, mps, qubit, outcome);
                 *self
@@ -636,10 +648,11 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                     .step_features
                     .entry(features)
                     .or_default()
-                    .entry(comparison.power)
+                    .entry(comparison.octant)
                     .or_default() += 1;
                 self.bits.push(outcome);
-                if comparison.power != 0 && self.summary.first_leak.is_none() {
+                if comparison.identity_error > PHASE_TOLERANCE && self.summary.first_leak.is_none()
+                {
                     self.summary.first_leak =
                         Some((qubit, usize::from(outcome), self.bits.clone(), comparison));
                 }
@@ -653,7 +666,7 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                                 .internal_phases
                                 .entry(label)
                                 .or_default()
-                                .entry(internal.power)
+                                .entry(internal.octant)
                                 .or_default() += 1;
                         } else {
                             *self.summary.internal_non_scalar.entry(label).or_default() += 1;
@@ -666,7 +679,7 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                     &actual_after,
                     qubit + 1,
                     projected_norm * probability.sqrt(),
-                    next_phase,
+                    &next_phase,
                 );
                 self.bits.pop();
             }
@@ -681,14 +694,8 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
         collect_internal,
         bits: Vec::new(),
     };
-    walker.descend(
-        &stn.tableau,
-        &stn.mps,
-        &original,
-        0,
-        1.0,
-        Complex64::new(1.0, 0.0),
-    );
+    let phase_tracker = crate::stab_mps::canonical_ket::CanonicalPhaseTracker::new();
+    walker.descend(&stn.tableau, &stn.mps, &original, 0, 1.0, &phase_tracker);
     for (index, &expected) in original.iter().enumerate() {
         let bits = bits_from_index(index, stn.num_qubits);
         let actual = stn.amplitude_iterative(&bits);
@@ -700,11 +707,11 @@ fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> W
                 "zero dense amplitude had nonzero iterative result: bits={bits:?} actual={actual}"
             );
         } else {
-            let comparison = compare_up_to_quarter_phase(&[actual], &[expected]);
+            let comparison = compare_up_to_unit_scalar(&[actual], &[expected]);
             assert!(
-                comparison.phase_error <= PHASE_TOLERANCE
+                comparison.identity_error <= PHASE_TOLERANCE
                     && comparison.vector_error <= VECTOR_TOLERANCE,
-                "end-to-end amplitude was not a fourth-root phase ratio: bits={bits:?} comparison={comparison:?}"
+                "end-to-end amplitude did not match state_vector's phase convention: bits={bits:?} comparison={comparison:?}"
             );
         }
     }
@@ -716,10 +723,10 @@ fn walk_all_bitstrings(stn: &StabMps) -> WalkSummary {
 }
 
 fn print_comparison(label: &str, actual: &[Complex64], expected: &[Complex64]) {
-    let comparison = compare_up_to_quarter_phase(actual, expected);
+    let comparison = compare_up_to_unit_scalar(actual, expected);
     eprintln!(
-        "    {label:34} i^{} phase_err={:.2e} vector_err={:.2e}",
-        comparison.power, comparison.phase_error, comparison.vector_error
+        "    {label:34} exp(i*pi/4*{}) identity_err={:.2e} vector_err={:.2e}",
+        comparison.octant, comparison.identity_error, comparison.vector_error
     );
 }
 
@@ -1307,7 +1314,7 @@ fn smallest_reproducer_localizes_to_right_compose_h() {
     assert_eq!(summary.final_phases, BTreeMap::from([(0, 2)]));
     assert_eq!(
         summary.internal_phases["right_compose_h + MPS H"],
-        BTreeMap::from([(0, 1), (3, 1)])
+        BTreeMap::from([(0, 1), (6, 1)])
     );
     for (label, phases) in &summary.internal_phases {
         if label != "right_compose_h + MPS H"

--- a/exp/pecos-stab-tn/src/stab_mps/measure/phase_diagnostic.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure/phase_diagnostic.rs
@@ -1,0 +1,1357 @@
+//! Phase-exactness diagnostics for PECOS issue #562.
+//!
+//! This module deliberately calls the shipped forced-projection routine and
+//! reconstructs every intermediate `(tableau, MPS)` pair through
+//! `StabMps::state_vector`.  It is test-only: none of these dense operations or
+//! access paths are compiled into the library.
+
+use super::*;
+use crate::stab_mps::StabMps;
+use num_complex::Complex64;
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
+use std::collections::BTreeMap;
+
+const PHASE_TOLERANCE: f64 = 5e-12;
+const VECTOR_TOLERANCE: f64 = 5e-12;
+
+/// Reconstruct an intermediate pair by reusing the production dense
+/// reconstruction, including both stabilizer and destabilizer row phases.
+fn dense_pair(template: &StabMps, tableau: &SparseStabY, mps: &Mps) -> Vec<Complex64> {
+    let mut snapshot = template.clone();
+    snapshot.tableau = tableau.clone();
+    snapshot.mps = mps.clone();
+    snapshot.state_vector()
+}
+
+fn normalized_projected_dense(
+    before: &[Complex64],
+    qubit: usize,
+    outcome: bool,
+) -> Option<Vec<Complex64>> {
+    let mut projected = before.to_vec();
+    for (index, amplitude) in projected.iter_mut().enumerate() {
+        if ((index >> qubit) & 1 != 0) != outcome {
+            *amplitude = Complex64::new(0.0, 0.0);
+        }
+    }
+    let norm_squared: f64 = projected.iter().map(Complex64::norm_sqr).sum();
+    if norm_squared <= 1e-20 {
+        return None;
+    }
+    let inverse_norm = Complex64::new(norm_squared.sqrt().recip(), 0.0);
+    for amplitude in &mut projected {
+        *amplitude *= inverse_norm;
+    }
+    Some(projected)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PhaseComparison {
+    power: u8,
+    phase_error: f64,
+    vector_error: f64,
+}
+
+fn compare_up_to_quarter_phase(actual: &[Complex64], expected: &[Complex64]) -> PhaseComparison {
+    assert_eq!(actual.len(), expected.len());
+    let pivot = expected
+        .iter()
+        .enumerate()
+        .max_by(|(_, left), (_, right)| left.norm_sqr().total_cmp(&right.norm_sqr()))
+        .map(|(index, _)| index)
+        .unwrap();
+    assert!(expected[pivot].norm() > 1e-12);
+    let raw_ratio = actual[pivot] / expected[pivot];
+    let phase = raw_ratio / Complex64::new(raw_ratio.norm(), 0.0);
+    let roots = [
+        Complex64::new(1.0, 0.0),
+        Complex64::new(0.0, 1.0),
+        Complex64::new(-1.0, 0.0),
+        Complex64::new(0.0, -1.0),
+    ];
+    let (power, phase_error) = roots
+        .iter()
+        .enumerate()
+        .map(|(power, root)| (power as u8, (phase - root).norm()))
+        .min_by(|left, right| left.1.total_cmp(&right.1))
+        .unwrap();
+    let root = roots[usize::from(power)];
+    let vector_error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (*actual - root * *expected).norm())
+        .fold(0.0, f64::max);
+    PhaseComparison {
+        power,
+        phase_error,
+        vector_error,
+    }
+}
+
+fn bits_from_index(index: usize, n: usize) -> Vec<bool> {
+    (0..n).map(|qubit| (index >> qubit) & 1 != 0).collect()
+}
+
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+/// Census-shaped circuit family.  The extended family deliberately retains
+/// SZ/CZ/X after non-Clifford gates; the clean family uses only H/RZ/CX.
+#[derive(Clone, Copy, Debug, Default)]
+#[allow(clippy::struct_excessive_bools)] // Independent census feature flags, not simulator state.
+struct CircuitFeatures {
+    sz_after_nonclifford: bool,
+    x_after_nonclifford: bool,
+    cz_after_nonclifford: bool,
+    rx: bool,
+}
+
+fn random_circuit_with_features(n: usize, seed: u64, extended: bool) -> (StabMps, CircuitFeatures) {
+    let mut stn = StabMps::builder(n)
+        .seed(seed)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    let mut rng = seed.wrapping_add(1);
+    let mut features = CircuitFeatures::default();
+    let mut has_nonclifford = false;
+    for _ in 0..32 {
+        let gate_type = xorshift(&mut rng) % if extended { 8 } else { 4 };
+        let q0 = (xorshift(&mut rng) % n as u64) as usize;
+        let q1 = loop {
+            let candidate = (xorshift(&mut rng) % n as u64) as usize;
+            if candidate != q0 {
+                break candidate;
+            }
+        };
+        match gate_type {
+            0 => {
+                stn.h(&[QubitId(q0)]);
+            }
+            1 => {
+                stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(q0)]);
+                has_nonclifford = true;
+            }
+            2 => {
+                let angle_bits = xorshift(&mut rng);
+                let angle = Angle64::from_radians(
+                    (angle_bits % 1000) as f64 * 0.001 * std::f64::consts::TAU,
+                );
+                stn.rz(angle, &[QubitId(q0)]);
+                has_nonclifford = true;
+            }
+            3 => {
+                stn.cx(&[(QubitId(q0), QubitId(q1))]);
+            }
+            4 => {
+                stn.sz(&[QubitId(q0)]);
+                features.sz_after_nonclifford |= has_nonclifford;
+            }
+            5 => {
+                stn.x(&[QubitId(q0)]);
+                features.x_after_nonclifford |= has_nonclifford;
+            }
+            6 => {
+                stn.cz(&[(QubitId(q0), QubitId(q1))]);
+                features.cz_after_nonclifford |= has_nonclifford;
+            }
+            _ => {
+                let angle_bits = xorshift(&mut rng);
+                let angle = Angle64::from_radians(
+                    (angle_bits % 1000) as f64 * 0.001 * std::f64::consts::TAU,
+                );
+                stn.rx(angle, &[QubitId(q0)]);
+                features.rx = true;
+                has_nonclifford = true;
+            }
+        }
+    }
+    stn.flush();
+    (stn, features)
+}
+
+fn random_circuit(n: usize, seed: u64, extended: bool) -> StabMps {
+    random_circuit_with_features(n, seed, extended).0
+}
+
+#[derive(Default)]
+struct WalkSummary {
+    step_phases: BTreeMap<u8, usize>,
+    final_phases: BTreeMap<u8, usize>,
+    step_features: BTreeMap<String, BTreeMap<u8, usize>>,
+    internal_phases: BTreeMap<String, BTreeMap<u8, usize>>,
+    internal_non_scalar: BTreeMap<String, usize>,
+    first_leak: Option<(usize, usize, Vec<bool>, PhaseComparison)>,
+    max_phase_error: f64,
+    max_vector_error: f64,
+    bitstrings_checked: usize,
+    zero_bitstrings: usize,
+}
+
+fn row_has_y(gens: &pecos_simulators::Gens, row: usize) -> bool {
+    gens.row_x[row]
+        .iter()
+        .any(|qubit| gens.row_z[row].contains(qubit))
+}
+
+fn step_features(
+    input_tableau: &SparseStabY,
+    input_mps: &Mps,
+    qubit: usize,
+    outcome: bool,
+) -> String {
+    if is_mps_trivial(input_mps) {
+        return "branch=trivial".to_string();
+    }
+    let pre_reduce = input_tableau.stabs().col_x[qubit].len().saturating_sub(1);
+    let mut tableau = input_tableau.clone();
+    let mut mps = input_mps.clone();
+    pre_reduce_for_measurement(&mut tableau, &mut mps, qubit, true).unwrap();
+    let any_y = (0..tableau.num_qubits())
+        .any(|row| row_has_y(tableau.stabs(), row) || row_has_y(tableau.destabs(), row));
+    let any_i = !tableau.stabs().signs_i.is_empty() || !tableau.destabs().signs_i.is_empty();
+    match decompose_z(tableau.stabs(), tableau.destabs(), qubit) {
+        ZDecomposition::Stabilizer { sign_sites, .. } => {
+            let relevant_y = sign_sites
+                .iter()
+                .any(|&row| row_has_y(tableau.stabs(), row));
+            let relevant_i = sign_sites.iter().any(|&row| {
+                tableau.stabs().signs_i.contains(row) || tableau.destabs().signs_i.contains(row)
+            });
+            format!(
+                "branch=stabilizer pre_reduce={} any_y={any_y} relevant_y={relevant_y} any_i={any_i} relevant_i={relevant_i}",
+                pre_reduce > 0
+            )
+        }
+        ZDecomposition::DestabilizerFlip {
+            flip_sites,
+            phase,
+            sign_sites,
+        } => {
+            let id = flip_sites[0];
+            let signed_phase = Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase;
+            let rotation = if signed_phase.im > 0.5 {
+                "imag+"
+            } else if signed_phase.im < -0.5 {
+                "imag-"
+            } else if signed_phase.re < 0.0 {
+                "real-"
+            } else {
+                "real+"
+            };
+            let relevant_y = row_has_y(tableau.destabs(), id)
+                || sign_sites
+                    .iter()
+                    .any(|&row| row_has_y(tableau.stabs(), row));
+            let relevant_i = tableau.destabs().signs_i.contains(id)
+                || sign_sites.iter().any(|&row| {
+                    tableau.stabs().signs_i.contains(row) || tableau.destabs().signs_i.contains(row)
+                });
+            format!(
+                "branch=flip local={} rotation={rotation} pre_reduce={} any_y={any_y} relevant_y={relevant_y} any_i={any_i} relevant_i={relevant_i}",
+                sign_sites.is_empty(),
+                pre_reduce > 0
+            )
+        }
+    }
+}
+
+fn record_internal(
+    records: &mut Vec<(String, PhaseComparison)>,
+    label: &str,
+    actual: &[Complex64],
+    expected: &[Complex64],
+) {
+    records.push((
+        label.to_string(),
+        compare_up_to_quarter_phase(actual, expected),
+    ));
+}
+
+fn diagnostic_pre_reduce(
+    template: &StabMps,
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    qubit: usize,
+    records: &mut Vec<(String, PhaseComparison)>,
+) {
+    if tableau.stabs().col_x[qubit].len() <= 1 {
+        return;
+    }
+    let replaced = find_replaced_stabilizer(tableau, qubit);
+    let anticommuting: Vec<usize> = tableau.stabs().col_x[qubit]
+        .iter()
+        .filter(|&row| row != replaced)
+        .collect();
+    for other in anticommuting {
+        let before = dense_pair(template, tableau, mps);
+        apply_cnot_to_mps(mps, replaced, other).unwrap();
+        crate::stab_mps::tableau_compose::right_compose_cx(tableau, replaced, other);
+        record_internal(
+            records,
+            "pre_reduce right_compose_cx + MPS CNOT",
+            &dense_pair(template, tableau, mps),
+            &before,
+        );
+    }
+}
+
+fn rotation_operations(
+    id: usize,
+    phase: Complex64,
+    sign_sites: &[usize],
+    outcome: bool,
+) -> Vec<(&'static str, DeferredOp)> {
+    let signed_phase = Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase;
+    let mut operations = Vec::new();
+    if signed_phase.im.abs() < 1e-9 {
+        if signed_phase.re < 0.0 {
+            operations.push(("right_compose_z + MPS Z", DeferredOp::Z(id)));
+        }
+        for &site in sign_sites {
+            if site != id {
+                operations.push(("right_compose_cz + MPS CZ", DeferredOp::Cz(id, site)));
+            }
+        }
+    } else {
+        for &site in sign_sites {
+            if site != id {
+                operations.push(("right_compose_cz + MPS CZ", DeferredOp::Cz(id, site)));
+            }
+        }
+        operations.push(if signed_phase.im > 0.0 {
+            ("right_compose_sz + MPS SZdg", DeferredOp::SZ(id))
+        } else {
+            ("right_compose_szdg + MPS SZ", DeferredOp::SZdg(id))
+        });
+    }
+    operations.push(("right_compose_h + MPS H", DeferredOp::H(id)));
+    operations
+}
+
+fn right_compose_primitive(tableau: &mut SparseStabY, operation: DeferredOp) {
+    match operation {
+        DeferredOp::Z(q) => crate::stab_mps::tableau_compose::right_compose_z(tableau, q),
+        DeferredOp::Cz(a, b) => crate::stab_mps::tableau_compose::right_compose_cz(tableau, a, b),
+        DeferredOp::SZ(q) => crate::stab_mps::tableau_compose::right_compose_sz(tableau, q),
+        DeferredOp::SZdg(q) => crate::stab_mps::tableau_compose::right_compose_szdg(tableau, q),
+        DeferredOp::H(q) => crate::stab_mps::tableau_compose::right_compose_h(tableau, q),
+        DeferredOp::Cnot(c, t) => {
+            crate::stab_mps::tableau_compose::right_compose_cx(tableau, c, t);
+        }
+    }
+}
+
+/// Replay one shipped forced-projection step at internal operation boundaries.
+/// Every reference vector comes from the same production dense reconstruction
+/// used for the outer walk.
+fn internal_step_diagnostics(
+    template: &StabMps,
+    input_tableau: &SparseStabY,
+    input_mps: &Mps,
+    qubit: usize,
+    outcome: bool,
+) -> Vec<(String, PhaseComparison)> {
+    let mut records = Vec::new();
+    let before = dense_pair(template, input_tableau, input_mps);
+    let Some(expected) = normalized_projected_dense(&before, qubit, outcome) else {
+        return records;
+    };
+    let mut tableau = input_tableau.clone();
+    let mut mps = input_mps.clone();
+    if is_mps_trivial(&mps) {
+        let previous = dense_pair(template, &tableau, &mps);
+        canonicalize_trivial_mps_basis(&mut tableau, &mut mps, None);
+        record_internal(
+            &mut records,
+            "canonicalize_trivial_mps_basis",
+            &dense_pair(template, &tableau, &mps),
+            &previous,
+        );
+        tableau.mz_forced(qubit, outcome);
+        mps.normalize();
+        record_internal(
+            &mut records,
+            "trivial mz_forced",
+            &dense_pair(template, &tableau, &mps),
+            &expected,
+        );
+        return records;
+    }
+
+    let norm_squared = mps.norm_squared();
+    let expectation =
+        (z_expectation_value(&tableau, &mps, qubit).re / norm_squared).clamp(-1.0, 1.0);
+    let probability = forced_outcome_probability(expectation, outcome);
+    diagnostic_pre_reduce(template, &mut tableau, &mut mps, qubit, &mut records);
+    let after_pre_reduce = dense_pair(template, &tableau, &mps);
+    record_internal(
+        &mut records,
+        "pre_reduce_for_measurement total",
+        &after_pre_reduce,
+        &before,
+    );
+    match decompose_z(tableau.stabs(), tableau.destabs(), qubit) {
+        ZDecomposition::Stabilizer { phase, sign_sites } => {
+            apply_pauli_projection(
+                &mut mps,
+                &[],
+                &sign_sites,
+                phase,
+                if outcome { -1.0 } else { 1.0 },
+                probability,
+            );
+            record_internal(
+                &mut records,
+                "apply_pauli_projection stabilizer",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+            if !sign_sites.is_empty() {
+                reduce_exact_projection_bonds(&mut mps).unwrap();
+            }
+            mps.normalize();
+            record_internal(
+                &mut records,
+                "reduce_exact_projection_bonds + normalize",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+        }
+        ZDecomposition::DestabilizerFlip {
+            flip_sites,
+            phase,
+            sign_sites,
+        } => {
+            let id = flip_sites[0];
+            let sign_f = if outcome { -1.0 } else { 1.0 };
+            let mut projected_mps = mps.clone();
+            apply_pauli_projection(
+                &mut projected_mps,
+                &flip_sites,
+                &sign_sites,
+                phase,
+                sign_f,
+                probability,
+            );
+            record_internal(
+                &mut records,
+                "apply_pauli_projection flip reference",
+                &dense_pair(template, &tableau, &projected_mps),
+                &expected,
+            );
+
+            let mut primitive_tableau = tableau.clone();
+            let mut primitive_mps = projected_mps;
+            for (label, operation) in rotation_operations(id, phase, &sign_sites, outcome) {
+                let previous = dense_pair(template, &primitive_tableau, &primitive_mps);
+                right_compose_primitive(&mut primitive_tableau, operation);
+                apply_inverse_virtual_primitive(&mut primitive_mps, operation);
+                record_internal(
+                    &mut records,
+                    label,
+                    &dense_pair(template, &primitive_tableau, &primitive_mps),
+                    &previous,
+                );
+            }
+
+            if sign_sites.is_empty() {
+                project_single_flip_without_sign(
+                    &mut mps,
+                    id,
+                    Complex64::new(sign_f, 0.0) * phase,
+                    probability,
+                );
+            } else {
+                apply_pauli_projection(
+                    &mut mps,
+                    &flip_sites,
+                    &sign_sites,
+                    phase,
+                    sign_f,
+                    probability,
+                );
+                collapse_projected_flip_site(&mut mps, id);
+            }
+            let collapse_label = if sign_sites.is_empty() {
+                "project_single_flip_without_sign vs explicit projector + W^-1"
+            } else {
+                "collapse_projected_flip_site vs explicit W^-1"
+            };
+            record_internal(
+                &mut records,
+                collapse_label,
+                &mps.state_vector(),
+                &primitive_mps.state_vector(),
+            );
+            let mut predicted = tableau.clone();
+            right_compose_measurement_basis_rotation(
+                &mut predicted,
+                id,
+                phase,
+                &sign_sites,
+                outcome,
+                None,
+            );
+            record_internal(
+                &mut records,
+                "projection collapse + predicted basis rotation",
+                &dense_pair(template, &predicted, &mps),
+                &expected,
+            );
+            let predicted_dense = dense_pair(template, &predicted, &mps);
+            tableau.mz_forced(qubit, outcome);
+            let gauge_sites = compensate_measurement_pauli_gauge(&mut mps, &predicted, &tableau);
+            let gauge_label = if gauge_sites.is_empty() {
+                "mz_forced + empty Pauli gauge"
+            } else {
+                "mz_forced + compensate_measurement_pauli_gauge"
+            };
+            record_internal(
+                &mut records,
+                gauge_label,
+                &dense_pair(template, &tableau, &mps),
+                &predicted_dense,
+            );
+            let before_reduction = dense_pair(template, &tableau, &mps);
+            if !sign_sites.is_empty() {
+                reduce_exact_projection_bonds(&mut mps).unwrap();
+            }
+            mps.normalize();
+            record_internal(
+                &mut records,
+                "forced projection final normalization",
+                &dense_pair(template, &tableau, &mps),
+                &before_reduction,
+            );
+        }
+    }
+    records
+}
+
+fn walk_all_bitstrings_with_internal(stn: &StabMps, collect_internal: bool) -> WalkSummary {
+    struct Walker<'a> {
+        template: &'a StabMps,
+        original: Vec<Complex64>,
+        summary: WalkSummary,
+        collect_internal: bool,
+        bits: Vec<bool>,
+    }
+
+    impl Walker<'_> {
+        fn descend(
+            &mut self,
+            tableau: &SparseStabY,
+            mps: &Mps,
+            before: &[Complex64],
+            qubit: usize,
+            projected_norm: f64,
+            accumulated_phase: Complex64,
+        ) {
+            let n = self.template.num_qubits;
+            if qubit == n {
+                let index = self
+                    .bits
+                    .iter()
+                    .enumerate()
+                    .fold(0usize, |index, (q, bit)| index | (usize::from(*bit) << q));
+                let expected = self.original[index];
+                if expected.norm() <= 1e-12 {
+                    return;
+                }
+                let mps_index = projected_mps_basis_index(tableau, &self.bits);
+                let coefficient = mps.amplitude(&mps_index);
+                let terminal_tableau_phase =
+                    crate::stab_mps::canonical_ket::terminal_tableau_basis_phase(
+                        tableau, &mps_index, &self.bits,
+                    );
+                let actual = self.template.global_phase
+                    * accumulated_phase
+                    * terminal_tableau_phase
+                    * coefficient
+                    / coefficient.norm()
+                    * projected_norm;
+                let comparison = compare_up_to_quarter_phase(&[actual], &[expected]);
+                assert!(comparison.phase_error <= PHASE_TOLERANCE);
+                assert!(comparison.vector_error <= VECTOR_TOLERANCE);
+                self.summary.max_phase_error =
+                    self.summary.max_phase_error.max(comparison.phase_error);
+                self.summary.max_vector_error =
+                    self.summary.max_vector_error.max(comparison.vector_error);
+                *self
+                    .summary
+                    .final_phases
+                    .entry(comparison.power)
+                    .or_default() += 1;
+                return;
+            }
+
+            for outcome in [false, true] {
+                let Some(expected_after) = normalized_projected_dense(before, qubit, outcome)
+                else {
+                    continue;
+                };
+                let mut next_tableau = tableau.clone();
+                let mut next_mps = mps.clone();
+                let mut next_phase = accumulated_phase;
+                let probability = project_forced_z_with_phase(
+                    &mut next_tableau,
+                    &mut next_mps,
+                    qubit,
+                    outcome,
+                    &mut next_phase,
+                )
+                .unwrap();
+                if probability <= 1e-20 {
+                    continue;
+                }
+                let mut actual_after = dense_pair(self.template, &next_tableau, &next_mps);
+                for amplitude in &mut actual_after {
+                    *amplitude *= next_phase;
+                }
+                let comparison = compare_up_to_quarter_phase(&actual_after, &expected_after);
+                assert!(
+                    comparison.phase_error <= PHASE_TOLERANCE
+                        && comparison.vector_error <= VECTOR_TOLERANCE,
+                    "q={qubit} outcome={outcome} phase={comparison:?}"
+                );
+                self.summary.max_phase_error =
+                    self.summary.max_phase_error.max(comparison.phase_error);
+                self.summary.max_vector_error =
+                    self.summary.max_vector_error.max(comparison.vector_error);
+                *self
+                    .summary
+                    .step_phases
+                    .entry(comparison.power)
+                    .or_default() += 1;
+                let features = step_features(tableau, mps, qubit, outcome);
+                *self
+                    .summary
+                    .step_features
+                    .entry(features)
+                    .or_default()
+                    .entry(comparison.power)
+                    .or_default() += 1;
+                self.bits.push(outcome);
+                if comparison.power != 0 && self.summary.first_leak.is_none() {
+                    self.summary.first_leak =
+                        Some((qubit, usize::from(outcome), self.bits.clone(), comparison));
+                }
+                if self.collect_internal {
+                    for (label, internal) in
+                        internal_step_diagnostics(self.template, tableau, mps, qubit, outcome)
+                    {
+                        if internal.vector_error <= VECTOR_TOLERANCE {
+                            *self
+                                .summary
+                                .internal_phases
+                                .entry(label)
+                                .or_default()
+                                .entry(internal.power)
+                                .or_default() += 1;
+                        } else {
+                            *self.summary.internal_non_scalar.entry(label).or_default() += 1;
+                        }
+                    }
+                }
+                self.descend(
+                    &next_tableau,
+                    &next_mps,
+                    &actual_after,
+                    qubit + 1,
+                    projected_norm * probability.sqrt(),
+                    next_phase,
+                );
+                self.bits.pop();
+            }
+        }
+    }
+
+    let original = stn.state_vector();
+    let mut walker = Walker {
+        template: stn,
+        original: original.clone(),
+        summary: WalkSummary::default(),
+        collect_internal,
+        bits: Vec::new(),
+    };
+    walker.descend(
+        &stn.tableau,
+        &stn.mps,
+        &original,
+        0,
+        1.0,
+        Complex64::new(1.0, 0.0),
+    );
+    for (index, &expected) in original.iter().enumerate() {
+        let bits = bits_from_index(index, stn.num_qubits);
+        let actual = stn.amplitude_iterative(&bits);
+        walker.summary.bitstrings_checked += 1;
+        if expected.norm() <= 1e-12 {
+            walker.summary.zero_bitstrings += 1;
+            assert!(
+                actual.norm() <= VECTOR_TOLERANCE,
+                "zero dense amplitude had nonzero iterative result: bits={bits:?} actual={actual}"
+            );
+        } else {
+            let comparison = compare_up_to_quarter_phase(&[actual], &[expected]);
+            assert!(
+                comparison.phase_error <= PHASE_TOLERANCE
+                    && comparison.vector_error <= VECTOR_TOLERANCE,
+                "end-to-end amplitude was not a fourth-root phase ratio: bits={bits:?} comparison={comparison:?}"
+            );
+        }
+    }
+    walker.summary
+}
+
+fn walk_all_bitstrings(stn: &StabMps) -> WalkSummary {
+    walk_all_bitstrings_with_internal(stn, false)
+}
+
+fn print_comparison(label: &str, actual: &[Complex64], expected: &[Complex64]) {
+    let comparison = compare_up_to_quarter_phase(actual, expected);
+    eprintln!(
+        "    {label:34} i^{} phase_err={:.2e} vector_err={:.2e}",
+        comparison.power, comparison.phase_error, comparison.vector_error
+    );
+}
+
+fn apply_inverse_virtual_primitive(mps: &mut Mps, operation: DeferredOp) {
+    let inverse = match operation {
+        DeferredOp::SZ(q) => DeferredOp::SZdg(q),
+        DeferredOp::SZdg(q) => DeferredOp::SZ(q),
+        other => other,
+    };
+    flush_deferred_ops(mps, &mut vec![inverse]).unwrap();
+}
+
+fn trace_forced_step(
+    template: &StabMps,
+    input_tableau: &SparseStabY,
+    input_mps: &Mps,
+    qubit: usize,
+    outcome: bool,
+) {
+    let before = dense_pair(template, input_tableau, input_mps);
+    let expected = normalized_projected_dense(&before, qubit, outcome).unwrap();
+    let mut tableau = input_tableau.clone();
+    let mut mps = input_mps.clone();
+    eprintln!("trace q={qubit} outcome={outcome}");
+
+    if is_mps_trivial(&mps) {
+        canonicalize_trivial_mps_basis(&mut tableau, &mut mps, None);
+        print_comparison(
+            "canonicalize_trivial_mps_basis",
+            &dense_pair(template, &tableau, &mps),
+            &before,
+        );
+        tableau.mz_forced(qubit, outcome);
+        mps.normalize();
+        print_comparison(
+            "trivial mz_forced",
+            &dense_pair(template, &tableau, &mps),
+            &expected,
+        );
+        return;
+    }
+
+    let norm_squared = mps.norm_squared();
+    let expectation =
+        (z_expectation_value(&tableau, &mps, qubit).re / norm_squared).clamp(-1.0, 1.0);
+    let probability = forced_outcome_probability(expectation, outcome);
+    pre_reduce_for_measurement(&mut tableau, &mut mps, qubit, true).unwrap();
+    let after_pre_reduce = dense_pair(template, &tableau, &mps);
+    print_comparison("pre_reduce_for_measurement", &after_pre_reduce, &before);
+    let decomposition = decompose_z(tableau.stabs(), tableau.destabs(), qubit);
+    eprintln!("    decomposition={decomposition:?} probability={probability:.16e}");
+
+    match decomposition {
+        ZDecomposition::Stabilizer { phase, sign_sites } => {
+            apply_pauli_projection(
+                &mut mps,
+                &[],
+                &sign_sites,
+                phase,
+                if outcome { -1.0 } else { 1.0 },
+                probability,
+            );
+            print_comparison(
+                "apply_pauli_projection(stab)",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+            if !sign_sites.is_empty() {
+                reduce_exact_projection_bonds(&mut mps).unwrap();
+            }
+            mps.normalize();
+            print_comparison(
+                "reduce + normalize",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+        }
+        ZDecomposition::DestabilizerFlip {
+            flip_sites,
+            phase,
+            sign_sites,
+        } => {
+            let id = flip_sites[0];
+            let sign_f = if outcome { -1.0 } else { 1.0 };
+            if sign_sites.is_empty() {
+                project_single_flip_without_sign(
+                    &mut mps,
+                    id,
+                    Complex64::new(sign_f, 0.0) * phase,
+                    probability,
+                );
+                // This specialized operation also absorbs the basis H, so it
+                // is only phase-comparable after the tableau basis rotation.
+            } else {
+                apply_pauli_projection(
+                    &mut mps,
+                    &flip_sites,
+                    &sign_sites,
+                    phase,
+                    sign_f,
+                    probability,
+                );
+                print_comparison(
+                    "apply_pauli_projection(flip)",
+                    &dense_pair(template, &tableau, &mps),
+                    &expected,
+                );
+                collapse_projected_flip_site(&mut mps, id);
+            }
+
+            let signed_phase = Complex64::new(sign_f, 0.0) * phase;
+            let mut primitive_tableau = tableau.clone();
+            let mut primitive_mps = if sign_sites.is_empty() {
+                // The local fast path already absorbed H. Reconstruct the
+                // pre-collapse projected eigenstate for primitive tests.
+                let mut projected = input_mps.clone();
+                pre_reduce_for_measurement(&mut input_tableau.clone(), &mut projected, qubit, true)
+                    .unwrap();
+                apply_pauli_projection(
+                    &mut projected,
+                    &flip_sites,
+                    &sign_sites,
+                    phase,
+                    sign_f,
+                    probability,
+                );
+                projected
+            } else {
+                // Undo the collapse solely for independent primitive tests by
+                // rebuilding the projected coefficient state.
+                let mut projected = input_mps.clone();
+                let mut projected_tableau = input_tableau.clone();
+                pre_reduce_for_measurement(&mut projected_tableau, &mut projected, qubit, true)
+                    .unwrap();
+                primitive_tableau = projected_tableau;
+                apply_pauli_projection(
+                    &mut projected,
+                    &flip_sites,
+                    &sign_sites,
+                    phase,
+                    sign_f,
+                    probability,
+                );
+                projected
+            };
+            let primitive_reference = dense_pair(template, &primitive_tableau, &primitive_mps);
+            let id_in_sign = sign_sites.contains(&id);
+            let mut operations = Vec::new();
+            if signed_phase.im.abs() < 1e-9 {
+                if signed_phase.re < 0.0 {
+                    operations.push(("right_compose_z", DeferredOp::Z(id)));
+                }
+                for &site in &sign_sites {
+                    if site != id {
+                        operations.push(("right_compose_cz", DeferredOp::Cz(id, site)));
+                    }
+                }
+            } else {
+                assert!(id_in_sign);
+                for &site in &sign_sites {
+                    if site != id {
+                        operations.push(("right_compose_cz", DeferredOp::Cz(id, site)));
+                    }
+                }
+                operations.push(if signed_phase.im > 0.0 {
+                    ("right_compose_sz", DeferredOp::SZ(id))
+                } else {
+                    ("right_compose_szdg", DeferredOp::SZdg(id))
+                });
+            }
+            operations.push(("right_compose_h", DeferredOp::H(id)));
+            for (label, operation) in operations {
+                match operation {
+                    DeferredOp::Z(q) => {
+                        crate::stab_mps::tableau_compose::right_compose_z(
+                            &mut primitive_tableau,
+                            q,
+                        );
+                    }
+                    DeferredOp::Cz(a, b) => crate::stab_mps::tableau_compose::right_compose_cz(
+                        &mut primitive_tableau,
+                        a,
+                        b,
+                    ),
+                    DeferredOp::SZ(q) => crate::stab_mps::tableau_compose::right_compose_sz(
+                        &mut primitive_tableau,
+                        q,
+                    ),
+                    DeferredOp::SZdg(q) => crate::stab_mps::tableau_compose::right_compose_szdg(
+                        &mut primitive_tableau,
+                        q,
+                    ),
+                    DeferredOp::H(q) => {
+                        crate::stab_mps::tableau_compose::right_compose_h(
+                            &mut primitive_tableau,
+                            q,
+                        );
+                    }
+                    DeferredOp::Cnot(_, _) => unreachable!(),
+                }
+                apply_inverse_virtual_primitive(&mut primitive_mps, operation);
+                print_comparison(
+                    label,
+                    &dense_pair(template, &primitive_tableau, &primitive_mps),
+                    &primitive_reference,
+                );
+            }
+
+            let mut predicted_tableau = tableau.clone();
+            right_compose_measurement_basis_rotation(
+                &mut predicted_tableau,
+                id,
+                phase,
+                &sign_sites,
+                outcome,
+                None,
+            );
+            print_comparison(
+                "collapse + predicted rotation",
+                &dense_pair(template, &predicted_tableau, &mps),
+                &expected,
+            );
+
+            tableau.mz_forced(qubit, outcome);
+            print_comparison(
+                "mz_forced before gauge",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+            let gauge_sites =
+                compensate_measurement_pauli_gauge(&mut mps, &predicted_tableau, &tableau);
+            eprintln!("    gauge_sites={gauge_sites:?}");
+            print_comparison(
+                "compensate_pauli_gauge",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+            if !sign_sites.is_empty() {
+                reduce_exact_projection_bonds(&mut mps).unwrap();
+            }
+            mps.normalize();
+            print_comparison(
+                "final reduce + normalize",
+                &dense_pair(template, &tableau, &mps),
+                &expected,
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "issue #562 diagnostic census"]
+fn phase_walk_exploration() {
+    for extended in [false, true] {
+        for n in 3..=6 {
+            for seed in 0..24 {
+                let stn = random_circuit(n, seed, extended);
+                let summary = walk_all_bitstrings(&stn);
+                if summary.step_phases.keys().any(|power| *power != 0)
+                    || summary.final_phases.keys().any(|power| *power != 0)
+                {
+                    eprintln!(
+                        "extended={extended} n={n} seed={seed} steps={:?} final={:?} first={:?}",
+                        summary.step_phases, summary.final_phases, summary.first_leak
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn merge_counts(target: &mut BTreeMap<u8, usize>, source: &BTreeMap<u8, usize>) {
+    for (&power, &count) in source {
+        *target.entry(power).or_default() += count;
+    }
+}
+
+fn merge_nested_counts(
+    target: &mut BTreeMap<String, BTreeMap<u8, usize>>,
+    source: &BTreeMap<String, BTreeMap<u8, usize>>,
+) {
+    for (label, counts) in source {
+        merge_counts(target.entry(label.clone()).or_default(), counts);
+    }
+}
+
+fn clean_validation_circuit(n: usize, seed: u64) -> StabMps {
+    let mut stn = StabMps::builder(n)
+        .seed(seed)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    stn.h(&(0..n).map(QubitId).collect::<Vec<_>>());
+    for q in 0..n {
+        let angle = Angle64::from_radians(
+            ((seed.wrapping_mul(137) + q as u64 * 251) % 1000) as f64
+                * 0.001
+                * std::f64::consts::TAU,
+        );
+        stn.rz(angle, &[QubitId(q)]);
+    }
+    for q in 0..n - 1 {
+        stn.cx(&[(QubitId(q), QubitId(q + 1))]);
+    }
+    stn.flush();
+    stn
+}
+
+/// Harness self-check: this real-Clifford-prefix H/RZ/CX family is known not
+/// to fire #562. Every outer forced-projection step and every final amplitude
+/// must retain phase exactly.
+#[test]
+fn clean_h_rz_cx_walk_is_phase_exact() {
+    let mut step_count = 0usize;
+    let mut final_count = 0usize;
+    let mut max_phase_error = 0.0f64;
+    let mut max_vector_error = 0.0f64;
+    let mut bitstrings_checked = 0usize;
+    let mut zero_bitstrings = 0usize;
+    for n in 3..=6 {
+        for seed in 0..4 {
+            let summary = walk_all_bitstrings(&clean_validation_circuit(n, seed));
+            assert_eq!(
+                summary.step_phases.keys().copied().collect::<Vec<_>>(),
+                vec![0]
+            );
+            assert_eq!(
+                summary.final_phases.keys().copied().collect::<Vec<_>>(),
+                vec![0]
+            );
+            step_count += summary.step_phases.values().sum::<usize>();
+            final_count += summary.final_phases.values().sum::<usize>();
+            max_phase_error = max_phase_error.max(summary.max_phase_error);
+            max_vector_error = max_vector_error.max(summary.max_vector_error);
+            bitstrings_checked += summary.bitstrings_checked;
+            zero_bitstrings += summary.zero_bitstrings;
+        }
+    }
+    eprintln!(
+        "clean self-check: steps={step_count} finals={final_count} bitstrings={bitstrings_checked} zeros={zero_bitstrings} max_phase_error={max_phase_error:.3e} max_vector_error={max_vector_error:.3e}"
+    );
+}
+
+/// Required n=3..=6, 24-seed, all-bitstring issue census. Kept ignored because
+/// dense reconstruction at every tree edge is intentionally expensive.
+#[test]
+#[ignore = "release-gated issue #562 full dense phase census"]
+fn extended_phase_census_report() {
+    let mut step_phases = BTreeMap::new();
+    let mut final_phases = BTreeMap::new();
+    let mut step_features = BTreeMap::new();
+    let mut internal_phases = BTreeMap::new();
+    let mut internal_non_scalar: BTreeMap<String, usize> = BTreeMap::new();
+    let mut circuit_feature_results: BTreeMap<String, [usize; 2]> = BTreeMap::new();
+    let mut leaking_circuits = 0usize;
+    let mut max_phase_error = 0.0f64;
+    let mut max_vector_error = 0.0f64;
+    let mut bitstrings_checked = 0usize;
+    let mut zero_bitstrings = 0usize;
+    for n in 3..=6 {
+        for seed in 0..24 {
+            let (stn, features) = random_circuit_with_features(n, seed, true);
+            let summary = walk_all_bitstrings_with_internal(&stn, true);
+            let leaks = summary.step_phases.keys().any(|power| *power != 0)
+                || summary.final_phases.keys().any(|power| *power != 0);
+            leaking_circuits += usize::from(leaks);
+            max_phase_error = max_phase_error.max(summary.max_phase_error);
+            max_vector_error = max_vector_error.max(summary.max_vector_error);
+            bitstrings_checked += summary.bitstrings_checked;
+            zero_bitstrings += summary.zero_bitstrings;
+            let feature_key = format!(
+                "sz_after={} x_after={} cz_after={} rx={}",
+                features.sz_after_nonclifford,
+                features.x_after_nonclifford,
+                features.cz_after_nonclifford,
+                features.rx
+            );
+            circuit_feature_results.entry(feature_key).or_default()[usize::from(leaks)] += 1;
+            merge_counts(&mut step_phases, &summary.step_phases);
+            merge_counts(&mut final_phases, &summary.final_phases);
+            merge_nested_counts(&mut step_features, &summary.step_features);
+            merge_nested_counts(&mut internal_phases, &summary.internal_phases);
+            for (label, count) in summary.internal_non_scalar {
+                *internal_non_scalar.entry(label).or_default() += count;
+            }
+        }
+    }
+    eprintln!("circuits=96 leaking_circuits={leaking_circuits}");
+    eprintln!("bitstrings_checked={bitstrings_checked} zero_bitstrings={zero_bitstrings}");
+    eprintln!("max_phase_error={max_phase_error:.3e} max_vector_error={max_vector_error:.3e}");
+    eprintln!("step_phases={step_phases:?}");
+    eprintln!("final_phases={final_phases:?}");
+    eprintln!("circuit_feature_results [clean, leak]={circuit_feature_results:#?}");
+    eprintln!("step_features={step_features:#?}");
+    eprintln!("internal_phases={internal_phases:#?}");
+    eprintln!("internal_non_scalar={internal_non_scalar:#?}");
+    assert_eq!(leaking_circuits, 0, "phase-tracked forced walk leaked");
+    assert_eq!(step_phases.keys().copied().collect::<Vec<_>>(), vec![0]);
+    assert_eq!(final_phases.keys().copied().collect::<Vec<_>>(), vec![0]);
+}
+
+#[test]
+#[ignore = "issue #562 targeted trace"]
+fn trace_first_exploratory_leak() {
+    let stn = random_circuit(3, 0, false);
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 0, true);
+}
+
+#[test]
+#[ignore = "issue #562 minimal trace search"]
+fn trace_one_qubit_h_rz() {
+    let mut stn = StabMps::builder(1)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    stn.h(&[QubitId(0)]);
+    stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
+    stn.flush();
+    eprintln!("state={:?}", stn.state_vector());
+    eprintln!(
+        "iter0={} iter1={}",
+        stn.amplitude_iterative(&[false]),
+        stn.amplitude_iterative(&[true])
+    );
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 0, false);
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 0, true);
+}
+
+#[test]
+#[ignore = "issue #562 candidate minimal trace"]
+fn trace_two_qubit_bell_rz() {
+    let mut stn = StabMps::builder(2)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    stn.h(&[QubitId(0)]);
+    stn.cx(&[(QubitId(0), QubitId(1))]);
+    stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(1)]);
+    stn.flush();
+    eprintln!("state={:?}", stn.state_vector());
+    for index in 0..4 {
+        let bits = bits_from_index(index, 2);
+        eprintln!(
+            "bits={bits:?} dense={} iter={}",
+            stn.amplitude(&bits),
+            stn.amplitude_iterative(&bits)
+        );
+    }
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 0, false);
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 0, true);
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 1, false);
+    trace_forced_step(&stn, &stn.tableau, &stn.mps, 1, true);
+}
+
+#[test]
+fn dense_pair_helper_reuses_state_vector_exactly() {
+    let stn = random_circuit(3, 7, true);
+    assert_eq!(dense_pair(&stn, &stn.tableau, &stn.mps), stn.state_vector());
+    for index in 0..(1usize << stn.num_qubits) {
+        let bits = bits_from_index(index, stn.num_qubits);
+        assert_eq!(stn.amplitude(&bits), stn.state_vector()[index]);
+    }
+}
+
+/// Exhaustively validate the polynomial canonical-ket amplitude against the
+/// dense projector convention used by `StabMps::state_vector`.
+#[test]
+fn canonical_ket_amplitude_matches_dense_projector_exhaustively() {
+    let mut tableaux_checked = 0usize;
+    let mut amplitudes_checked = 0usize;
+    let mut saw_y = false;
+    let mut saw_minus = false;
+    let mut saw_sign_i = false;
+
+    for n in 1..=6 {
+        for seed in 0..24_u64 {
+            let mut tableau = SparseStabY::with_seed(n, seed).with_destab_sign_tracking();
+            let mut random = seed.wrapping_add(1) ^ ((n as u64) << 48);
+            for gate_index in 0..48 {
+                let gate = xorshift(&mut random) % if n == 1 { 4 } else { 7 };
+                let q0 = (xorshift(&mut random) % n as u64) as usize;
+                let q1 = if n == 1 {
+                    0
+                } else {
+                    loop {
+                        let candidate = (xorshift(&mut random) % n as u64) as usize;
+                        if candidate != q0 {
+                            break candidate;
+                        }
+                    }
+                };
+                match gate {
+                    0 => {
+                        tableau.h(&[QubitId(q0)]);
+                    }
+                    1 => {
+                        tableau.sz(&[QubitId(q0)]);
+                    }
+                    2 => {
+                        tableau.x(&[QubitId(q0)]);
+                    }
+                    3 => {
+                        tableau.y(&[QubitId(q0)]);
+                    }
+                    4 => {
+                        tableau.cx(&[(QubitId(q0), QubitId(q1))]);
+                    }
+                    5 => {
+                        tableau.cz(&[(QubitId(q0), QubitId(q1))]);
+                    }
+                    _ => {
+                        tableau.sz(&[QubitId(q0)]).h(&[QubitId(q0)]);
+                    }
+                }
+
+                // Exercise the Y-convention measurement row-reduction path,
+                // including its signs_i bookkeeping, on reachable tableaux.
+                if gate_index % 7 == 6 {
+                    let outcome = xorshift(&mut random) & 1 != 0;
+                    tableau.mz_forced(q0, outcome);
+                }
+            }
+
+            for row in 0..n {
+                saw_y |= row_has_y(tableau.stabs(), row) || row_has_y(tableau.destabs(), row);
+            }
+            saw_minus |= !tableau.stabs().signs_minus.is_empty()
+                || !tableau.destabs().signs_minus.is_empty();
+            saw_sign_i |=
+                !tableau.stabs().signs_i.is_empty() || !tableau.destabs().signs_i.is_empty();
+
+            let mut dense_snapshot = StabMps::new(n);
+            dense_snapshot.tableau = tableau.clone();
+            let dense = dense_snapshot.state_vector();
+            for (index, expected) in dense.into_iter().enumerate() {
+                let bits = bits_from_index(index, n);
+                let actual =
+                    crate::stab_mps::canonical_ket::CanonicalKet::new(&tableau).amplitude(&bits);
+                assert!(
+                    (actual - expected).norm() <= 1e-12,
+                    "n={n} seed={seed} index={index}: canonical={actual:?}, dense={expected:?}"
+                );
+                amplitudes_checked += 1;
+            }
+            tableaux_checked += 1;
+        }
+    }
+
+    assert!(saw_y, "random validation never reached a Y-carrying row");
+    assert!(saw_minus, "random validation never reached a negative row");
+    // Valid Hermitian SparseStabY generators finish Clifford/measurement
+    // updates with real stored signs. The separate signed-Pauli action test
+    // exercises signs_i because it matters for destabilizer matrix action.
+    assert!(!saw_sign_i);
+    eprintln!(
+        "canonical ket validation: tableaux={tableaux_checked} amplitudes={amplitudes_checked} Y={saw_y} minus={saw_minus} reachable_signs_i={saw_sign_i}"
+    );
+}
+
+/// Smallest exhaustive-search reproducer over {H, T, SZ, X, CX, CZ}: one
+/// qubit and three gates. The shipped amplitude is now exact while the raw
+/// internal trace continues to bind the right-compose-H localization.
+#[test]
+fn smallest_reproducer_localizes_to_right_compose_h() {
+    let mut stn = StabMps::builder(1)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    stn.h(&[QubitId(0)]);
+    stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
+    stn.sz(&[QubitId(0)]);
+    stn.flush();
+
+    let dense = stn.amplitude(&[true]);
+    let iterative = stn.amplitude_iterative(&[true]);
+    let ratio = iterative / dense;
+    assert!((ratio - Complex64::new(1.0, 0.0)).norm() <= PHASE_TOLERANCE);
+
+    let summary = walk_all_bitstrings_with_internal(&stn, true);
+    assert_eq!(summary.step_phases, BTreeMap::from([(0, 2)]));
+    assert_eq!(summary.final_phases, BTreeMap::from([(0, 2)]));
+    assert_eq!(
+        summary.internal_phases["right_compose_h + MPS H"],
+        BTreeMap::from([(0, 1), (3, 1)])
+    );
+    for (label, phases) in &summary.internal_phases {
+        if label != "right_compose_h + MPS H"
+            && label != "projection collapse + predicted basis rotation"
+        {
+            assert_eq!(
+                phases.keys().copied().collect::<Vec<_>>(),
+                vec![0],
+                "unexpected scalar introduced by {label}: {phases:?}"
+            );
+        }
+    }
+}
+
+/// Fixed-workload timing/evidence lane for the original eight-qubit #562 census.
+/// Kept ignored because it exhausts every amplitude of six dense-reference states.
+#[test]
+#[ignore = "issue #562 eight-qubit amplitude evidence and timing"]
+fn issue_562_eight_qubit_amplitude_evidence() {
+    let mut cases = Vec::new();
+    for seed in 0..6 {
+        let mut stn = crate::stab_mps::tests::stability_census_random_circuit(seed);
+        stn.flush();
+        let expected = stn.state_vector();
+        cases.push((seed, stn, expected));
+    }
+
+    let started = std::time::Instant::now();
+    let mut max_delta = 0.0_f64;
+    let mut checksum = Complex64::new(0.0, 0.0);
+    for (seed, stn, expected) in &cases {
+        for (index, expected) in expected.iter().enumerate() {
+            let bits = bits_from_index(index, 8);
+            let actual = stn.amplitude_iterative(&bits);
+            max_delta = max_delta.max((actual - expected).norm());
+            checksum += actual * Complex64::new(1.0 + *seed as f64, index as f64 + 1.0);
+        }
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    eprintln!(
+        "issue #562 8q: circuits=6 amplitudes=1536 elapsed={elapsed:.6}s max_delta={max_delta:.3e} checksum={checksum:?}"
+    );
+    assert!(
+        max_delta <= 1e-12,
+        "eight-qubit #562 census max amplitude delta was {max_delta:.3e}"
+    );
+}

--- a/exp/pecos-stab-tn/src/stab_mps/tableau_compose.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/tableau_compose.rs
@@ -501,7 +501,7 @@ pub fn right_compose_cz<R: pecos_random::Rng + pecos_random::SeedableRng + std::
 }
 
 /// Multiply row `dst_row` by row `src_row` within the same generator set.
-fn multiply_row_within<S: IndexSet>(
+pub(super) fn multiply_row_within<S: IndexSet>(
     gens: &mut GensGeneric<S>,
     dst_row: usize,
     src_row: usize,


### PR DESCRIPTION
Closes #562

`StabMps::amplitude_iterative` returned amplitudes whose phases were wrong by a per-bitstring
fourth root of unity: the ratio against `state_vector` landed exactly on {+1, -1, +i, -i},
varying with the queried index, while magnitudes were exact. `state_vector` was verified correct
against an independent dense oracle; the defect predates the recent STN branches and reproduces
at older revisions.

## Root cause

A step-instrumented diagnostic harness (committed, release-gated) localized the leak: every
primitive in the forced-projection walk is phase-exact except the mandatory `right_compose_h` at
the end of the measurement-basis rotation. A stabilizer tableau describes `C P C^\dagger`, which
is identical for `C` and `iC`, so the row swap cannot record the global Clifford scalar the
rotation introduces (minimal example: `C W|0> = SHZH|0> = SX|0> = i|1>`, re-canonicalized by the
reconstruction convention as `+|1>`). The final read took its phase entirely from the projected
MPS coefficient, so the tableau-side scalar was silently dropped — differently for each
bitstring, since each triggers a different rotation sequence. A second, independent factor — the
phase of the terminal selected-destabilizer action `<z|D^x|phi>` — was also implicitly assumed
to be +1 and is not in general.

## The fix

- A new polynomial canonical-ket primitive computes `<z|phi>` for the tableau's canonical
  stabilizer ket, exactly reproducing `state_vector`'s phase convention (Gaussian elimination
  over the signed generators; exact quarter-turn phases; no dense vectors). Validated against
  dense reconstruction on 144 random tableaux at every one of their 3,024 amplitudes (n <= 6),
  including Y-carrying rows and sign combinations.
- The forced-projection path gains an optional phase accumulator (`Option<&mut Complex64>`).
  When requested, the scalar relating the tableau's canonical ket before and after each
  convention-changing operation (`right_compose_h`, trivial-basis `right_compose_x`,
  `mz_forced`) is accumulated. The Z/CZ/SZ branches were measured exact and compute nothing.
- `amplitude_iterative` requests the accumulator and multiplies in both the accumulated rotation
  scalar and the terminal selected-destabilizer phase. Measurements, `prob_bitstring`, and
  sampling pass `None` and are untouched.

## Verification

- 8-qubit census circuits, seeds 0-5, all 1,536 amplitudes vs `state_vector`: max delta
  1.280e-14 (was 4.271e-1).
- 96-circuit diagnostic sweep (n=3..6, 2,880 bitstrings): all 3,248 projection edges and all
  1,536 nonzero final amplitudes at ratio exactly +1; 0 leaking circuits. The uncorrected
  internal localization still observes the raw `right_compose_h` scalar distribution, confirming
  the accumulator corrects the diagnosed convention change rather than masking it elsewhere.
- Committed regressions, each verified to bind: the 1-qubit `H, T, SZ` reproducer (-i), the
  `H, T, CX, H` case (-1), and a terminal-factor case (n=4 census seed 0, index 0) that fails
  without the terminal phase.
- Randomized per-index equality families with SZ/CZ/X after non-Clifford gates at n=3..6 replace
  the previous vacuous coverage (H/RZ/CX-only circuits mostly cannot trigger the defect).
- Performance: probability-only #557 sweep A/B — 1.99s pre-fix vs 2.03s post-fix (+2%, within
  run noise), worst probability delta 3.296e-15 both sides. The combined #557 sweep rises 6.02%
  only because it calls `amplitude_iterative` per outcome; the amplitude workload itself pays
  4.27% for correct phases.
- Full suite 306 lib + 92 integration + 3 doc; release-ignored lane 8 + 8; 1,200-circuit
  stability census 0 panics; clippy --all-targets -D warnings and fmt clean.

Note on the performance of the phase-exact path: amplitude_iterative now scales roughly as n^3.4 on an adversarial dense-generator basis (about 1.9x improved by canonical-ket reuse across group-preserving steps, but still 6x-36x slower than the phase-blind parent at n=64-192). The cost model and methodology are documented on the API. prob_bitstring, sampling, and measurement paths are bit-identical to dev (verified by cross-build checksum).
