### PR TITLE
Make exact sample-then-force the default StabMps measurement mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,6 +4871,7 @@ dependencies = [
  "pecos-quantum",
  "pecos-random",
  "pecos-simulators",
+ "rand_chacha 0.9.0",
  "rayon",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ approx = "0.5"
 assert_cmd = "2"
 criterion = "0.8"
 paste = "1"
+rand_chacha = "0.9"
 random_tester = "0.1"
 proptest = "1"
 

--- a/docs/user-guide/stabilizer-tensor-networks.md
+++ b/docs/user-guide/stabilizer-tensor-networks.md
@@ -10,14 +10,14 @@ All public bitstrings use qubit-index order: `bits[q]` is the bit for qubit `q`.
 
 ## `StabMps` quickstart
 
-Use `sample_bitstrings`, plural, for shot workloads. It shares each distinct measurement-prefix projection between shots; `sample_bitstring` clones and collapses the entire simulator once per shot. The two methods do not share an RNG stream, so seeded outputs should not be compared shot for shot across methods.
+Use `sample_bitstrings`, plural, for shot workloads. It shares each distinct measurement-prefix projection between shots and is always exact by construction, independent of the singular-measurement policy. `sample_bitstring` clones and collapses the entire simulator once per shot and follows that policy. The two methods do not share an RNG stream, so seeded outputs should not be compared shot for shot across methods.
 
 ```python
 import math
 
 import pecos_rslib_exp as exp
 
-sim = exp.StabMps(2, seed=7, lazy_measure=True)
+sim = exp.StabMps(2, seed=7)
 sim.run_gate("H", {0})
 sim.run_gate("CX", {(0, 1)})
 sim.run_gate("RZ", {1}, angle=math.pi / 4)
@@ -36,13 +36,15 @@ assert math.isclose(p11, 0.5, abs_tol=1e-12)
 # Python reads auto-flush lazy operations and merged RZ rotations.
 accuracy = {
     "state_exact": sim.is_state_exact(),
-    "pragmatic_drift_count": sim.pragmatic_drift_count,
+    "uncompensated_pre_reduction_count": sim.uncompensated_pre_reduction_count,
+    "summed_discarded_weight": sim.summed_discarded_weight,
     "truncation_error": sim.truncation_error,
     "bond_cap_hits": sim.bond_cap_hits,
 }
 assert accuracy == {
     "state_exact": True,
-    "pragmatic_drift_count": 0,
+    "uncompensated_pre_reduction_count": 0,
+    "summed_discarded_weight": 0.0,
     "truncation_error": 0.0,
     "bond_cap_hits": 0,
 }
@@ -50,14 +52,17 @@ assert accuracy == {
 
 The accuracy fields answer different questions:
 
-- `is_state_exact()` detects pending work, an unmaterialized Pauli frame, and stored-state drift from eager measurement. It does not include MPS truncation in its definition.
-- `pragmatic_drift_count` should remain zero when exact amplitudes are required after random measurements. Construct with `lazy_measure=True` to avoid that eager-measurement drift.
+- `is_state_exact()` is a conservative sufficient predicate covering pending work, an unmaterialized Pauli frame, measurement mode, pragmatic drift, discarded weight, and deferred MAST branch loss.
+- `uncompensated_pre_reduction_count` records pragmatic measurements whose tableau reduction was not applied to the coefficient MPS.
 - `truncation_error` estimates accumulated discarded singular-value weight.
+- `summed_discarded_weight` is the true sum of those per-SVD weights.
 - `bond_cap_hits` counts SVDs at which `max_bond_dim` was binding.
 
 Python state reads automatically flush lazy operations and merged rotations. When Pauli-frame tracking is enabled, call `flush_pauli_frame_to_state()` before a read that must include the physical frame.
 
 `StabMps` defaults `merge_rz` to true for throughput. `Mast` defaults it to false so each RZ immediately exposes its injection and ancilla-capacity cost. Numerical flag redetection is opt-in. In `StabMps` it self-disables while lazy deferred operations are pending, because the stored tensors then differ from the effective MPS-frame state.
+
+`StabMps` measurement defaults to `"exact"`. Select `"pragmatic"` for the legacy uncompensated eager path or `"lazy"` for the deferred virtual-frame path. The policy covers MZ, reset, PZ/PX, syndrome extraction, and singular `sample_bitstring`; plural `sample_bitstrings` remains exact.
 
 ## `Mast` quickstart
 
@@ -87,7 +92,7 @@ assert outcome in (0, 1)
 
 `flush()` is not the MAST completion operation: it materializes pending merged rotations, but leaves already deferred injections alone. Finish with `project_all()` or measure a data qubit with MZ.
 
-MAST predetermines each injection-gadget outcome from its exact half-probability distribution. That choice is exact for the untruncated state. If the coefficient MPS has been truncated, the predetermined branch can differ from the truncated representation's own outcome distribution; it still represents the exact, untruncated gadget protocol.
+MAST predetermines each injection-gadget outcome from its exact half-probability distribution. If truncation erases that deferred branch, MAST continues on the surviving complement. The normalized continuation is not a valid gadget trajectory for either outcome because its injection-time correction does not match the projected complement. This additional bias is absent from `truncation_error`; `deferred_branch_lost_count` is its only witness. Untruncated configurations never take this path.
 
 ## Analyze first with `StabMpsCompile`
 
@@ -136,10 +141,7 @@ use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
 use pecos_stab_tn::stab_mps::StabMps;
 
 fn main() {
-    let mut sim = StabMps::builder(2)
-        .seed(7)
-        .lazy_measure(true)
-        .build();
+    let mut sim = StabMps::builder(2).seed(7).build();
     sim.h(&[QubitId(0)]);
     sim.cx(&[(QubitId(0), QubitId(1))]);
     sim.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(1)]);

--- a/examples/surface/coherent_noise_sweep.py
+++ b/examples/surface/coherent_noise_sweep.py
@@ -102,7 +102,7 @@ def run_sweep(
             # New merge/truncation defaults change LERs; pin the legacy configuration for reproducibility.
             quantum_backend = (
                 stab_mps()
-                .lazy_measure(lazy_measure)
+                .measurement("lazy" if lazy_measure else "pragmatic")
                 .max_bond_dim(max_bond_dim)
                 .max_truncation_error(0.0)
                 .merge_rz(enabled=False)

--- a/examples/surface/coherent_noise_sweep.py
+++ b/examples/surface/coherent_noise_sweep.py
@@ -100,6 +100,7 @@ def run_sweep(
         builder = sim_neo(tc).noise(noise).shots(shots).seed(seed)
         if backend == "stabmps":
             # New merge/truncation defaults change LERs; pin the legacy configuration for reproducibility.
+            # Pragmatic preserves this script's historical sampler and is known-biased on honest families.
             quantum_backend = (
                 stab_mps()
                 .measurement("lazy" if lazy_measure else "pragmatic")

--- a/exp/pecos-stab-tn/Cargo.toml
+++ b/exp/pecos-stab-tn/Cargo.toml
@@ -28,7 +28,7 @@ thiserror.workspace = true
 [dev-dependencies]
 approx.workspace = true
 paste.workspace = true
-rand_chacha = "0.9"
+rand_chacha.workspace = true
 
 [lints.clippy]
 # Inherit workspace pedantic lint policy

--- a/exp/pecos-stab-tn/Cargo.toml
+++ b/exp/pecos-stab-tn/Cargo.toml
@@ -28,6 +28,7 @@ thiserror.workspace = true
 [dev-dependencies]
 approx.workspace = true
 paste.workspace = true
+rand_chacha = "0.9"
 
 [lints.clippy]
 # Inherit workspace pedantic lint policy

--- a/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
+++ b/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
@@ -1,0 +1,416 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Frozen Stage-B benchmark for the singular-measurement policy.
+//!
+//! Run pinned to one CPU with:
+//! `taskset -c 2 cargo run --release -p pecos-stab-tn --example measurement_mode_bench`.
+//!
+//! Each repetition-code syndrome circuit is expanded here rather than using
+//! `extract_syndromes`, so the independently sampled two-qubit Pauli noise has
+//! an explicit insertion point after every entangler.
+//! Bond telemetry is the maximum across a timed run's shots; discarded weight
+//! and event counters are summed across those shots. Each reported field is
+//! the median of the seven timed-run aggregates.
+
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
+use pecos_stab_tn::stab_mps::{MeasurementMode, StabMps};
+use rand_chacha::ChaCha12Rng;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use std::hint::black_box;
+use std::time::Instant;
+
+const ROUNDS: usize = 8;
+const COHERENT_RZ_RADIANS: f64 = 0.1;
+const TWO_QUBIT_DEPOLARIZING_PROBABILITY: f64 = 1e-3;
+// Largest multiple of 15 below 2^32; reject the one remaining u32 value.
+const DEPOLARIZING_CHOICE_ZONE: u32 = 4_294_967_295;
+const TIMED_RUN_SEEDS: std::ops::RangeInclusive<u64> = 7001..=7007;
+const WARMUP_SEED: u64 = 7000;
+
+#[derive(Clone, Copy, Debug)]
+enum CheckBasis {
+    Z,
+    X,
+}
+
+impl CheckBasis {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Z => "z",
+            Self::X => "x",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Workload {
+    distance: usize,
+    shots: usize,
+    basis: CheckBasis,
+}
+
+impl Workload {
+    fn label(self) -> String {
+        format!("d{}_{}", self.distance, self.basis.label())
+    }
+
+    const fn num_qubits(self) -> usize {
+        2 * self.distance - 1
+    }
+
+    const fn entanglers_per_shot(self) -> usize {
+        ROUNDS * (self.distance - 1) * 2
+    }
+}
+
+const WORKLOADS: [Workload; 4] = [
+    Workload {
+        distance: 3,
+        shots: 2_000,
+        basis: CheckBasis::Z,
+    },
+    Workload {
+        distance: 3,
+        shots: 2_000,
+        basis: CheckBasis::X,
+    },
+    Workload {
+        distance: 5,
+        shots: 500,
+        basis: CheckBasis::Z,
+    },
+    Workload {
+        distance: 5,
+        shots: 500,
+        basis: CheckBasis::X,
+    },
+];
+
+#[derive(Clone, Copy, Debug)]
+enum Pauli {
+    I,
+    X,
+    Y,
+    Z,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TwoQubitNoise {
+    first: Pauli,
+    second: Pauli,
+}
+
+#[derive(Clone)]
+struct ShotNoise {
+    after_entanglers: Vec<TwoQubitNoise>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct RunMetrics {
+    shots_per_second: f64,
+    lifetime_peak_bond: usize,
+    final_bond: usize,
+    summed_discarded_weight: f64,
+    cap_hit_count: u64,
+    branch_vanish_retry_count: u64,
+    uncompensated_pre_reduction_count: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MedianMetrics {
+    shots_per_second: f64,
+    lifetime_peak_bond: usize,
+    final_bond: usize,
+    summed_discarded_weight: f64,
+    cap_hit_count: u64,
+    branch_vanish_retry_count: u64,
+    uncompensated_pre_reduction_count: u64,
+}
+
+fn depolarizing_error(rng: &mut ChaCha12Rng) -> TwoQubitNoise {
+    let threshold = (TWO_QUBIT_DEPOLARIZING_PROBABILITY * (u64::MAX as f64)) as u64;
+    if rng.next_u64() > threshold {
+        return TwoQubitNoise {
+            first: Pauli::I,
+            second: Pauli::I,
+        };
+    }
+
+    // Rejection sampling makes the fifteen non-identity two-qubit Paulis
+    // equiprobable instead of introducing a modulo bias.
+    let index = loop {
+        let word = rng.next_u32();
+        if word < DEPOLARIZING_CHOICE_ZONE {
+            break word % 15 + 1;
+        }
+    };
+    let decode = |digit| match digit {
+        0 => Pauli::I,
+        1 => Pauli::X,
+        2 => Pauli::Y,
+        3 => Pauli::Z,
+        _ => unreachable!(),
+    };
+    TwoQubitNoise {
+        first: decode(index / 4),
+        second: decode(index % 4),
+    }
+}
+
+fn pregenerate_noise(workload: Workload, run_seed: u64) -> Vec<ShotNoise> {
+    let mut rng = ChaCha12Rng::seed_from_u64(run_seed);
+    (0..workload.shots)
+        .map(|_| ShotNoise {
+            after_entanglers: (0..workload.entanglers_per_shot())
+                .map(|_| depolarizing_error(&mut rng))
+                .collect(),
+        })
+        .collect()
+}
+
+fn apply_pauli(stn: &mut StabMps, qubit: QubitId, pauli: Pauli) {
+    match pauli {
+        Pauli::I => {}
+        Pauli::X => {
+            stn.x(&[qubit]);
+        }
+        Pauli::Y => {
+            stn.y(&[qubit]);
+        }
+        Pauli::Z => {
+            stn.z(&[qubit]);
+        }
+    }
+}
+
+fn apply_entangler(
+    stn: &mut StabMps,
+    basis: CheckBasis,
+    ancilla: QubitId,
+    data: QubitId,
+    noise: TwoQubitNoise,
+) {
+    match basis {
+        CheckBasis::Z => {
+            stn.cz(&[(ancilla, data)]);
+        }
+        CheckBasis::X => {
+            stn.cx(&[(ancilla, data)]);
+        }
+    }
+    apply_pauli(stn, ancilla, noise.first);
+    apply_pauli(stn, data, noise.second);
+}
+
+fn prepare_code_state(stn: &mut StabMps, workload: Workload) {
+    match workload.basis {
+        CheckBasis::Z => {
+            // The encoded logical |+> is a GHZ state stabilized by every
+            // adjacent ZZ check and is sensitive to the prescribed RZ noise.
+            stn.h(&[QubitId(0)]);
+            for q in 1..workload.distance {
+                stn.cx(&[(QubitId(0), QubitId(q))]);
+            }
+        }
+        CheckBasis::X => {
+            // The encoded logical |0> is |+>^d and satisfies every adjacent
+            // XX check while remaining sensitive to RZ noise.
+            for q in 0..workload.distance {
+                stn.h(&[QubitId(q)]);
+            }
+        }
+    }
+}
+
+fn run_shot(
+    workload: Workload,
+    mode: MeasurementMode,
+    simulator_seed: u64,
+    noise: &ShotNoise,
+) -> (StabMps, u64) {
+    let mut stn = StabMps::builder(workload.num_qubits())
+        .seed(simulator_seed)
+        .measurement(mode)
+        .merge_rz(false)
+        .build();
+    prepare_code_state(&mut stn, workload);
+
+    let rz = Angle64::from_radians(COHERENT_RZ_RADIANS);
+    let mut noise_cursor = 0;
+    let mut syndrome_checksum = 0_u64;
+    for round in 0..ROUNDS {
+        for data in 0..workload.distance {
+            stn.rz(rz, &[QubitId(data)]);
+        }
+
+        for check in 0..workload.distance - 1 {
+            let ancilla = QubitId(workload.distance + check);
+            stn.h(&[ancilla]);
+            for data in [check, check + 1] {
+                apply_entangler(
+                    &mut stn,
+                    workload.basis,
+                    ancilla,
+                    QubitId(data),
+                    noise.after_entanglers[noise_cursor],
+                );
+                noise_cursor += 1;
+            }
+            stn.h(&[ancilla]);
+            let outcome = stn.mz(&[ancilla])[0].outcome;
+            syndrome_checksum ^= u64::from(outcome) << ((round + check) % 64);
+            stn.reset_qubit(ancilla);
+        }
+    }
+    debug_assert_eq!(noise_cursor, noise.after_entanglers.len());
+    (stn, syndrome_checksum)
+}
+
+fn run_once(
+    workload: Workload,
+    mode: MeasurementMode,
+    run_seed: u64,
+    noise: &[ShotNoise],
+) -> RunMetrics {
+    assert_eq!(noise.len(), workload.shots);
+    let start = Instant::now();
+    let mut metrics = RunMetrics::default();
+    let mut checksum = 0_u64;
+    for (shot, shot_noise) in noise.iter().enumerate() {
+        let simulator_seed = 10_000 * run_seed + shot as u64;
+        let (stn, shot_checksum) = run_shot(workload, mode, simulator_seed, shot_noise);
+        checksum ^= shot_checksum;
+        metrics.lifetime_peak_bond = metrics.lifetime_peak_bond.max(stn.lifetime_peak_bond());
+        metrics.final_bond = metrics.final_bond.max(stn.max_bond_dim());
+        metrics.summed_discarded_weight += stn.summed_discarded_weight();
+        metrics.cap_hit_count += stn.bond_cap_hits();
+        metrics.branch_vanish_retry_count += stn.branch_vanish_retry_count();
+        metrics.uncompensated_pre_reduction_count += stn.uncompensated_pre_reduction_count();
+    }
+    metrics.shots_per_second = workload.shots as f64 / start.elapsed().as_secs_f64();
+    black_box(checksum);
+    metrics
+}
+
+fn median_f64(values: impl Iterator<Item = f64>) -> f64 {
+    let mut values = values.collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    values[values.len() / 2]
+}
+
+fn median_usize(values: impl Iterator<Item = usize>) -> usize {
+    let mut values = values.collect::<Vec<_>>();
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+fn median_u64(values: impl Iterator<Item = u64>) -> u64 {
+    let mut values = values.collect::<Vec<_>>();
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+fn medians(runs: &[RunMetrics]) -> MedianMetrics {
+    MedianMetrics {
+        shots_per_second: median_f64(runs.iter().map(|r| r.shots_per_second)),
+        lifetime_peak_bond: median_usize(runs.iter().map(|r| r.lifetime_peak_bond)),
+        final_bond: median_usize(runs.iter().map(|r| r.final_bond)),
+        summed_discarded_weight: median_f64(runs.iter().map(|r| r.summed_discarded_weight)),
+        cap_hit_count: median_u64(runs.iter().map(|r| r.cap_hit_count)),
+        branch_vanish_retry_count: median_u64(runs.iter().map(|r| r.branch_vanish_retry_count)),
+        uncompensated_pre_reduction_count: median_u64(
+            runs.iter().map(|r| r.uncompensated_pre_reduction_count),
+        ),
+    }
+}
+
+fn mode_label(mode: MeasurementMode) -> &'static str {
+    match mode {
+        MeasurementMode::Exact => "exact",
+        MeasurementMode::Pragmatic => "pragmatic",
+        MeasurementMode::Lazy => unreachable!("the frozen benchmark compares two modes"),
+    }
+}
+
+fn print_metrics(workload: Workload, mode: MeasurementMode, metrics: MedianMetrics) {
+    println!(
+        "MEASUREMENT_MODE_BENCH workload={} mode={} shots={} runs=7 shots_per_s={:.6} lifetime_peak_bond={} final_bond={} summed_discarded_weight={:.16e} cap_hit_count={} branch_vanish_retry_count={} uncompensated_pre_reduction_count={}",
+        workload.label(),
+        mode_label(mode),
+        workload.shots,
+        metrics.shots_per_second,
+        metrics.lifetime_peak_bond,
+        metrics.final_bond,
+        metrics.summed_discarded_weight,
+        metrics.cap_hit_count,
+        metrics.branch_vanish_retry_count,
+        metrics.uncompensated_pre_reduction_count,
+    );
+}
+
+fn main() {
+    let mut slowdowns = Vec::with_capacity(WORKLOADS.len());
+    for workload in WORKLOADS {
+        let warmup_noise = pregenerate_noise(workload, WARMUP_SEED);
+        for mode in [MeasurementMode::Exact, MeasurementMode::Pragmatic] {
+            black_box(run_once(workload, mode, WARMUP_SEED, &warmup_noise));
+        }
+
+        let mut exact_runs = Vec::with_capacity(TIMED_RUN_SEEDS.count());
+        let mut pragmatic_runs = Vec::with_capacity(TIMED_RUN_SEEDS.count());
+        for run_seed in TIMED_RUN_SEEDS {
+            let noise = pregenerate_noise(workload, run_seed);
+            // Alternate the execution order to balance any drift between the
+            // two modes without changing their shared workload.
+            if run_seed % 2 == 0 {
+                pragmatic_runs.push(run_once(
+                    workload,
+                    MeasurementMode::Pragmatic,
+                    run_seed,
+                    &noise,
+                ));
+                exact_runs.push(run_once(workload, MeasurementMode::Exact, run_seed, &noise));
+            } else {
+                exact_runs.push(run_once(workload, MeasurementMode::Exact, run_seed, &noise));
+                pragmatic_runs.push(run_once(
+                    workload,
+                    MeasurementMode::Pragmatic,
+                    run_seed,
+                    &noise,
+                ));
+            }
+        }
+
+        let exact = medians(&exact_runs);
+        let pragmatic = medians(&pragmatic_runs);
+        print_metrics(workload, MeasurementMode::Exact, exact);
+        print_metrics(workload, MeasurementMode::Pragmatic, pragmatic);
+        slowdowns.push(pragmatic.shots_per_second / exact.shots_per_second);
+    }
+
+    let geometric_mean =
+        (slowdowns.iter().map(|value| value.ln()).sum::<f64>() / slowdowns.len() as f64).exp();
+    let maximum = slowdowns.iter().copied().fold(0.0_f64, f64::max);
+    let decision = if geometric_mean > 10.0 {
+        "stop"
+    } else if geometric_mean <= 3.0 && maximum <= 5.0 {
+        "exact_everywhere"
+    } else {
+        "middle"
+    };
+    println!(
+        "MEASUREMENT_MODE_DECISION slowdowns={:.6},{:.6},{:.6},{:.6} geometric_mean_slowdown={geometric_mean:.6} max_slowdown={maximum:.6} decision={decision}",
+        slowdowns[0], slowdowns[1], slowdowns[2], slowdowns[3]
+    );
+}

--- a/exp/pecos-stab-tn/examples/qec_bench.rs
+++ b/exp/pecos-stab-tn/examples/qec_bench.rs
@@ -20,8 +20,8 @@
 //!   5. Ancilla resets (prep |0>).
 //!
 //! Compares wall time + max bond dim across builder knob combinations:
-//!   - default (eager measure, no adaptive truncation)
-//!   - `lazy_measure`
+//!   - pragmatic eager measurement (no adaptive truncation)
+//!   - lazy measurement
 //!   - `max_truncation_error`
 //!   - both
 //!
@@ -29,15 +29,15 @@
 
 use pecos_core::{Angle64, QubitId};
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
-use pecos_stab_tn::stab_mps::StabMps;
 use pecos_stab_tn::stab_mps::mast::Mast;
+use pecos_stab_tn::stab_mps::{MeasurementMode, StabMps};
 use std::time::Instant;
 
 struct BenchConfig {
     num_data: usize,
     num_rounds: usize,
     noise_angle: Angle64,
-    lazy: bool,
+    measurement: MeasurementMode,
     max_trunc: Option<f64>,
     merge_rz: bool,
     max_bond: usize,
@@ -49,7 +49,7 @@ fn build_and_run(cfg: &BenchConfig) -> (f64, usize, u64) {
         num_data,
         num_rounds,
         noise_angle,
-        lazy,
+        measurement,
         max_trunc,
         merge_rz,
         max_bond,
@@ -60,7 +60,7 @@ fn build_and_run(cfg: &BenchConfig) -> (f64, usize, u64) {
     let mut builder = StabMps::builder(n)
         .seed(seed)
         .max_bond_dim(max_bond)
-        .lazy_measure(lazy)
+        .measurement(measurement)
         .merge_rz(merge_rz);
     if let Some(e) = max_trunc {
         builder = builder.max_truncation_error(e);
@@ -205,27 +205,45 @@ fn main() {
     );
     println!("{:-<90}", "");
 
-    let configs: &[(&str, bool, Option<f64>, bool, usize)] = &[
-        ("legacy defaults", false, Some(0.0), false, 64),
-        ("legacy + lazy_measure", true, Some(0.0), false, 64),
-        ("max_truncation_error=1e-8", false, Some(1e-8), false, 64),
-        ("merge_rz", false, None, true, 64),
+    let configs: &[(&str, MeasurementMode, Option<f64>, bool, usize)] = &[
+        (
+            "legacy defaults",
+            MeasurementMode::Pragmatic,
+            Some(0.0),
+            false,
+            64,
+        ),
+        ("legacy + lazy", MeasurementMode::Lazy, Some(0.0), false, 64),
+        (
+            "max_truncation_error=1e-8",
+            MeasurementMode::Pragmatic,
+            Some(1e-8),
+            false,
+            64,
+        ),
+        ("merge_rz", MeasurementMode::Pragmatic, None, true, 64),
         (
             "merge_rz + max_truncation_error=1e-8",
-            false,
+            MeasurementMode::Pragmatic,
             Some(1e-8),
             true,
             64,
         ),
-        ("general defaults (cap pinned)", false, Some(1e-8), true, 64),
+        (
+            "general defaults (cap pinned)",
+            MeasurementMode::Pragmatic,
+            Some(1e-8),
+            true,
+            64,
+        ),
     ];
 
-    for &(name, lazy, trunc, merge, max_bond) in configs {
+    for &(name, measurement, trunc, merge, max_bond) in configs {
         let (t, bond, parity) = build_and_run(&BenchConfig {
             num_data,
             num_rounds,
             noise_angle: t_angle,
-            lazy,
+            measurement,
             max_trunc: trunc,
             merge_rz: merge,
             max_bond,
@@ -236,7 +254,7 @@ fn main() {
 
     println!("{:-<90}", "");
     println!(
-        "\nNote: outcome parities differ between lazy/eager because the RNG is consumed in\n      different sequences (not a correctness issue — both give the right distribution)."
+        "\nNote: outcome parities differ between lazy/pragmatic because the RNG is consumed in\n      different sequences (not a correctness issue — both give the intended distribution)."
     );
 
     // -------------------------------------------------------------------------

--- a/exp/pecos-stab-tn/examples/qec_bench.rs
+++ b/exp/pecos-stab-tn/examples/qec_bench.rs
@@ -230,7 +230,7 @@ fn main() {
             64,
         ),
         (
-            "general defaults (cap pinned)",
+            "pragmatic defaults (cap pinned)",
             MeasurementMode::Pragmatic,
             Some(1e-8),
             true,

--- a/exp/pecos-stab-tn/examples/qec_tutorial.rs
+++ b/exp/pecos-stab-tn/examples/qec_tutorial.rs
@@ -40,8 +40,9 @@ fn main() {
     // 1. Builder + preset
     // ------------------------------------------------------------------
     //
-    // `for_qec()` keeps the general numerical defaults but selects pragmatic
-    // measurement during Stage A, pending the Stage B QEC measurement:
+    // `for_qec()` keeps the general numerical defaults and selects exact
+    // measurement. The frozen Stage-B repetition-code benchmark measured a
+    // 1.497x geometric-mean slowdown (1.548x maximum) versus pragmatic.
     //   - max_bond_dim = 128 (enough for syndrome rounds without truncation)
     //   - max_truncation_error = 1e-8 (very tight)
     //   - merge_rz = true (batch same-qubit RZ noise)

--- a/exp/pecos-stab-tn/examples/qec_tutorial.rs
+++ b/exp/pecos-stab-tn/examples/qec_tutorial.rs
@@ -40,14 +40,14 @@ fn main() {
     // 1. Builder + preset
     // ------------------------------------------------------------------
     //
-    // `StabMps::builder(n).build()` and the source-compatible `for_qec()` set:
+    // `for_qec()` keeps the general numerical defaults but selects pragmatic
+    // measurement during Stage A, pending the Stage B QEC measurement:
     //   - max_bond_dim = 128 (enough for syndrome rounds without truncation)
     //   - max_truncation_error = 1e-8 (very tight)
     //   - merge_rz = true (batch same-qubit RZ noise)
     //
-    // For ion-trap-memory-noise or T-heavy workloads these are the general
-    // defaults. You can layer `pauli_frame_tracking(true)` on top for
-    // fast Pauli-noise injection.
+    // The general builder instead defaults to exact measurement. You can layer
+    // `pauli_frame_tracking(true)` on top for fast Pauli-noise injection.
     //
     // 3 data + 2 ancillas = 5 qubits total.
 

--- a/exp/pecos-stab-tn/examples/tier3_profile.rs
+++ b/exp/pecos-stab-tn/examples/tier3_profile.rs
@@ -69,8 +69,9 @@ fn main() {
     // ---- 2. Long-range CX/CZ cost (sub-MPO target) ----
     // For Clifford gates, tableau handles long-range in O(n) regardless.
     // Sub-MPO would help only for NON-CLIFFORD ops applied to an entangled
-    // MPS where the pre_reduce path needs long-range compensation — but
-    // we've already switched to the pragmatic-fix path that avoids this.
+    // MPS where the pre_reduce path needs long-range compensation. The exact
+    // measurement default takes that compensating path, so this cost is live
+    // on the mainline; only the opt-in pragmatic mode avoids it.
     println!();
     println!("2. Long-range 2-qubit Clifford cost (sub-MPO target):");
     println!("   Question: does long-range CX hurt STN, given the tableau-only path?");

--- a/exp/pecos-stab-tn/src/lib.rs
+++ b/exp/pecos-stab-tn/src/lib.rs
@@ -23,8 +23,11 @@
 //!
 //! `StabMps` defaults to a maximum bond dimension of 128, a maximum relative
 //! truncation error of `1e-8`, an SVD cutoff of `1e-12`, normalization after
-//! non-Clifford gates, and merged same-qubit RZ rotations. Lazy measurement,
-//! Pauli-frame tracking, and numerical flag redetection remain opt-in. To
+//! non-Clifford gates, merged same-qubit RZ rotations, and exact singular
+//! measurement. Pragmatic and lazy measurement modes, Pauli-frame tracking,
+//! and numerical flag redetection remain opt-in. Singular `sample_bitstring`
+//! follows the selected mode; plural `sample_bitstrings` is always exact by
+//! construction. To
 //! recover the former behavior explicitly, use `max_bond_dim(64)`,
 //! `max_truncation_error(0.0)`, and `merge_rz(false)` on the builder.
 //! `Mast` instead defaults `merge_rz` to false so every RZ immediately exposes

--- a/exp/pecos-stab-tn/src/mps.rs
+++ b/exp/pecos-stab-tn/src/mps.rs
@@ -99,6 +99,14 @@ pub struct Mps {
     /// Number of SVDs that were capped by `max_bond_dim` (rank-limited rather
     /// than cutoff-limited). If > 0 the caller may want to raise `max_bond_dim`.
     bond_cap_hits: u64,
+    /// True sum of every relative singular-value weight discarded by an SVD.
+    summed_discarded_weight: f64,
+    /// Largest bond dimension held by this MPS during its lifetime.
+    lifetime_peak_bond: usize,
+    /// Number of rolled-back sampled projections retried without truncation.
+    branch_vanish_retry_count: u64,
+    /// Number of deferred MAST branches replaced by their surviving complement.
+    deferred_branch_lost_count: u64,
 }
 
 /// Pass-scoped left and right identity environments for selected MPS sites.
@@ -210,6 +218,10 @@ impl Mps {
             config,
             truncation_error: 0.0,
             bond_cap_hits: 0,
+            summed_discarded_weight: 0.0,
+            lifetime_peak_bond: 1,
+            branch_vanish_retry_count: 0,
+            deferred_branch_lost_count: 0,
         }
     }
 
@@ -228,20 +240,64 @@ impl Mps {
         self.bond_cap_hits
     }
 
+    /// Sum of the relative discarded weights reported by every SVD.
+    ///
+    /// Unlike [`Self::truncation_error`], this is a true sum rather than the
+    /// product-form estimate `1 - product(1 - weight)`.
+    #[must_use]
+    pub fn summed_discarded_weight(&self) -> f64 {
+        self.summed_discarded_weight
+    }
+
+    /// Largest bond dimension held by this MPS since construction or reset.
+    #[must_use]
+    pub fn lifetime_peak_bond(&self) -> usize {
+        self.lifetime_peak_bond
+    }
+
+    /// Number of sampled branches whose first, rolled-back projection vanished.
+    #[must_use]
+    pub fn branch_vanish_retry_count(&self) -> u64 {
+        self.branch_vanish_retry_count
+    }
+
+    /// Number of lost deferred MAST branches continued on their complement.
+    #[must_use]
+    pub fn deferred_branch_lost_count(&self) -> u64 {
+        self.deferred_branch_lost_count
+    }
+
     /// Reset truncation diagnostics (keep state).
     pub fn reset_truncation_stats(&mut self) {
         self.truncation_error = 0.0;
         self.bond_cap_hits = 0;
+        self.summed_discarded_weight = 0.0;
+        self.branch_vanish_retry_count = 0;
+        self.deferred_branch_lost_count = 0;
+        self.lifetime_peak_bond = self.max_bond_dim();
     }
 
     /// Record the outcome of one truncated SVD for telemetry.
     pub(crate) fn record_truncation(&mut self, discarded_weight: f64, hit_cap: bool) {
         if discarded_weight > 0.0 {
             self.truncation_error += (1.0 - self.truncation_error) * discarded_weight;
+            self.summed_discarded_weight += discarded_weight;
         }
         if hit_cap {
             self.bond_cap_hits += 1;
         }
+    }
+
+    pub(crate) fn record_branch_vanish_retry(&mut self) {
+        self.branch_vanish_retry_count += 1;
+    }
+
+    pub(crate) fn record_deferred_branch_lost(&mut self) {
+        self.deferred_branch_lost_count += 1;
+    }
+
+    fn record_current_peak_bond(&mut self) {
+        self.lifetime_peak_bond = self.lifetime_peak_bond.max(self.max_bond_dim());
     }
 
     #[must_use]
@@ -280,6 +336,25 @@ impl Mps {
     /// subsequent SVD truncations.
     pub fn set_max_bond_dim(&mut self, new_cap: usize) {
         self.config.max_bond_dim = new_cap;
+    }
+
+    /// Replace the truncation configuration while preserving state telemetry.
+    pub(crate) fn set_config(&mut self, config: MpsConfig) {
+        self.config = config;
+    }
+
+    /// Exact Schmidt-rank ceiling over the physical bonds this operation may touch.
+    ///
+    /// Forced projection can route compensating long-range gates across the
+    /// whole chain, so every internal bond is affected in the general case.
+    /// The fallback stays below the arithmetic limit used by randomized-SVD
+    /// eligibility checks on platforms too narrow to represent `2^(n/2)`.
+    #[must_use]
+    pub(crate) fn physical_rank_ceiling(&self) -> usize {
+        let exponent = self.num_sites / 2;
+        1usize
+            .checked_shl(u32::try_from(exponent).unwrap_or(u32::MAX))
+            .unwrap_or(usize::MAX / 8)
     }
 
     /// Multiply the entire MPS by a scalar (absorbed into the first tensor).
@@ -538,6 +613,7 @@ impl Mps {
         // Update bond dimension
         self.bond_dims[q + 1] = new_chi;
         self.center = can_track_absorption.then_some(if absorb_right { q + 1 } else { q });
+        self.record_current_peak_bond();
 
         Ok(())
     }
@@ -793,6 +869,10 @@ impl Mps {
             return;
         }
         let norm_sq = self.norm_squared();
+        debug_assert!(
+            norm_sq > 0.0,
+            "cannot normalize a zero-norm MPS after projection"
+        );
         if norm_sq > 0.0 {
             let inv_norm = Complex64::new(1.0 / norm_sq.sqrt(), 0.0);
             self.tensors[0] *= inv_norm;
@@ -918,6 +998,7 @@ impl Mps {
             new_tensors.push(t);
         }
 
+        let current_peak = new_bond_dims.iter().copied().max().unwrap_or(1);
         Self {
             num_sites: n,
             phys_dim: d,
@@ -927,6 +1008,19 @@ impl Mps {
             config: self.config.clone(),
             truncation_error: self.truncation_error.max(other.truncation_error),
             bond_cap_hits: self.bond_cap_hits + other.bond_cap_hits,
+            summed_discarded_weight: self
+                .summed_discarded_weight
+                .max(other.summed_discarded_weight),
+            lifetime_peak_bond: self
+                .lifetime_peak_bond
+                .max(other.lifetime_peak_bond)
+                .max(current_peak),
+            branch_vanish_retry_count: self
+                .branch_vanish_retry_count
+                .max(other.branch_vanish_retry_count),
+            deferred_branch_lost_count: self
+                .deferred_branch_lost_count
+                .max(other.deferred_branch_lost_count),
         }
     }
 
@@ -978,12 +1072,14 @@ impl Mps {
     pub fn left_canonicalize(&mut self) {
         canon::left_canonicalize_all(&mut self.tensors, &mut self.bond_dims, self.phys_dim);
         self.center = self.num_sites.checked_sub(1);
+        self.record_current_peak_bond();
     }
 
     /// Right-canonicalize the entire MPS.
     pub fn right_canonicalize(&mut self) {
         canon::right_canonicalize_all(&mut self.tensors, &mut self.bond_dims, self.phys_dim);
         self.center = (self.num_sites > 0).then_some(0);
+        self.record_current_peak_bond();
     }
 
     /// Put the environments bordering `(q, q + 1)` in canonical form.
@@ -1043,6 +1139,7 @@ impl Mps {
             }
             self.center = Some(target);
         }
+        self.record_current_peak_bond();
     }
 
     /// Validate a tracked center to an absolute max-entry Gram tolerance of
@@ -1154,6 +1251,7 @@ impl Mps {
         // after every truncation has been evaluated in the right-to-left
         // mixed-canonical gauge above.
         self.left_canonicalize();
+        self.record_current_peak_bond();
         Ok(())
     }
 }
@@ -1169,6 +1267,10 @@ impl Clone for Mps {
             config: self.config.clone(),
             truncation_error: self.truncation_error,
             bond_cap_hits: self.bond_cap_hits,
+            summed_discarded_weight: self.summed_discarded_weight,
+            lifetime_peak_bond: self.lifetime_peak_bond,
+            branch_vanish_retry_count: self.branch_vanish_retry_count,
+            deferred_branch_lost_count: self.deferred_branch_lost_count,
         }
     }
 }
@@ -1187,6 +1289,23 @@ mod tests {
         let first_norm = first.iter().map(Complex64::norm_sqr).sum::<f64>();
         let second_norm = second.iter().map(Complex64::norm_sqr).sum::<f64>();
         overlap.norm_sqr() / (first_norm * second_norm)
+    }
+
+    #[test]
+    fn truncation_telemetry_separates_product_error_sum_and_lifetime_peak() {
+        let mut mps = Mps::new(3, MpsConfig::default());
+        mps.record_truncation(0.1, false);
+        mps.record_truncation(0.2, true);
+        assert!((mps.truncation_error() - 0.28).abs() < 1e-15);
+        assert!((mps.summed_discarded_weight() - 0.3).abs() < 1e-15);
+        assert_eq!(mps.bond_cap_hits(), 1);
+
+        let doubled = mps.add(&mps);
+        assert_eq!(doubled.max_bond_dim(), 2);
+        assert_eq!(doubled.lifetime_peak_bond(), 2);
+        let mut reduced = doubled;
+        reduced.compress().unwrap();
+        assert_eq!(reduced.lifetime_peak_bond(), 2);
     }
 
     #[cfg(not(debug_assertions))]

--- a/exp/pecos-stab-tn/src/mps.rs
+++ b/exp/pecos-stab-tn/src/mps.rs
@@ -347,14 +347,16 @@ impl Mps {
     ///
     /// Forced projection can route compensating long-range gates across the
     /// whole chain, so every internal bond is affected in the general case.
-    /// The fallback stays below the arithmetic limit used by randomized-SVD
-    /// eligibility checks on platforms too narrow to represent `2^(n/2)`.
+    /// The result is clamped below the arithmetic limit used by randomized-SVD
+    /// eligibility checks. This includes representable shifts near the top of
+    /// `usize`, not only chains whose `2^(n/2)` shift itself overflows.
     #[must_use]
     pub(crate) fn physical_rank_ceiling(&self) -> usize {
         let exponent = self.num_sites / 2;
         1usize
             .checked_shl(u32::try_from(exponent).unwrap_or(u32::MAX))
             .unwrap_or(usize::MAX / 8)
+            .min(usize::MAX / 8)
     }
 
     /// Multiply the entire MPS by a scalar (absorbed into the first tensor).
@@ -1254,6 +1256,46 @@ impl Mps {
         self.record_current_peak_bond();
         Ok(())
     }
+
+    /// Compress from an established right-canonical gauge.
+    ///
+    /// The orthogonality center starts at site zero and follows this
+    /// left-to-right SVD sweep. Thus every split sees physical Schmidt
+    /// weights while avoiding the cold left-canonical sweep used by
+    /// [`Self::compress`]. The configured cutoff, cap, and adaptive error
+    /// budget are applied unchanged.
+    pub(crate) fn compress_from_right_canonical(&mut self) -> Result<(), MpsError> {
+        if self.num_sites <= 1 {
+            self.center = (self.num_sites == 1).then_some(0);
+            return Ok(());
+        }
+        debug_assert_eq!(self.center, Some(0));
+        #[cfg(debug_assertions)]
+        debug_assert!(self.claimed_center_is_valid(0));
+
+        let d = self.phys_dim;
+        for q in 0..self.num_sites - 1 {
+            let chi_l = self.bond_dims[q];
+            let chi_r = self.bond_dims[q + 1];
+            let matrix = tensor::reshape_left_group(&self.tensors[q], chi_l, d, chi_r);
+            let scaled_cutoff = self.config.svd_cutoff * matrix.norm();
+            let (u, svt, disc, hit) = svd::truncated_svd_right_absorb_with_error(
+                &matrix,
+                self.config.max_bond_dim,
+                scaled_cutoff,
+                self.config.max_truncation_error,
+            )?;
+            self.record_truncation(disc, hit);
+            let new_chi = u.ncols();
+
+            self.tensors[q] = reshape_left_ungroup(&u, chi_l, d, new_chi);
+            self.tensors[q + 1] = &svt * &self.tensors[q + 1];
+            self.bond_dims[q + 1] = new_chi;
+            self.center = Some(q + 1);
+        }
+        self.record_current_peak_bond();
+        Ok(())
+    }
 }
 
 impl Clone for Mps {
@@ -1490,6 +1532,14 @@ mod tests {
         #[cfg(debug_assertions)]
         assert!(mps.claimed_center_is_valid(2));
         assert_eq!(mps.clone().center, Some(2));
+    }
+
+    #[test]
+    fn physical_rank_ceiling_is_safe_for_randomized_svd_arithmetic() {
+        for num_sites in 124..=127 {
+            let mps = Mps::new(num_sites, MpsConfig::default());
+            assert!(mps.physical_rank_ceiling() <= usize::MAX / 8);
+        }
     }
 
     #[test]

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -249,14 +249,7 @@ fn measure_qubit_exact_transactional(
     q_idx: usize,
     operation: &str,
 ) -> Result<measure::LiveMeasurementResult, MpsError> {
-    let norm_squared = mps.norm_squared();
-    assert!(
-        norm_squared.is_finite() && norm_squared > 0.0,
-        "{operation}: cannot measure an MPS with non-finite or zero norm"
-    );
-    let expectation =
-        (measure::z_expectation_value(tableau, mps, q_idx).re / norm_squared).clamp(-1.0, 1.0);
-    let probability_one = measure::forced_outcome_probability(expectation, true);
+    let probability_one = measure::z_outcome_probability(tableau, mps, q_idx, true, operation);
     let is_probability_zero = probability_one <= 0.0;
     let is_probability_one = probability_one >= 1.0;
     let outcome = if is_probability_zero {
@@ -267,10 +260,8 @@ fn measure_qubit_exact_transactional(
         rng.random_bool(probability_one)
     };
 
-    let original_tableau = tableau.clone();
-    let original_mps = mps.clone();
-    let mut candidate_tableau = original_tableau.clone();
-    let mut candidate_mps = original_mps.clone();
+    let mut candidate_tableau = tableau.clone();
+    let mut candidate_mps = mps.clone();
     let first = measure::project_forced_z_with_update(
         &mut candidate_tableau,
         &mut candidate_mps,
@@ -283,9 +274,9 @@ fn measure_qubit_exact_transactional(
     );
 
     let projection = if first.survival_ratio < measure::BRANCH_VANISH_SURVIVAL_THRESHOLD {
-        candidate_tableau = original_tableau;
-        candidate_mps = original_mps;
-        let original_config = candidate_mps.config().clone();
+        candidate_tableau = tableau.clone();
+        candidate_mps = mps.clone();
+        let original_config = mps.config().clone();
         let mut retry_config = original_config.clone();
         retry_config.max_bond_dim = candidate_mps.physical_rank_ceiling();
         retry_config.svd_cutoff = 0.0;
@@ -6635,7 +6626,40 @@ mod tests {
         let _ = stn.mz(&[QubitId(0)]);
 
         assert!(!stn.is_state_exact(), "lazy operations should be pending");
+        assert!(
+            !stn.deferred_ops.is_empty(),
+            "the fixture must exercise a nonempty lazy-operation queue"
+        );
+        let pre_flush_state = stn.state_vector();
+        let mut expected = stn.clone();
+        measure::flush_deferred_ops(&mut expected.mps, &mut expected.deferred_ops).unwrap();
+        let expected_state = expected.state_vector();
+        let stale_fidelity = pre_flush_state
+            .iter()
+            .zip(&expected_state)
+            .map(|(left, right)| left.conj() * right)
+            .sum::<Complex64>()
+            .norm_sqr();
+        assert!(
+            stale_fidelity < 1.0 - 1e-8,
+            "the fixture must make deferred materialization observable"
+        );
         stn.flush();
+        assert!(
+            stn.deferred_ops.is_empty(),
+            "flush must empty the lazy queue"
+        );
+        let materialized_fidelity = stn
+            .state_vector()
+            .iter()
+            .zip(&expected_state)
+            .map(|(left, right)| left.conj() * right)
+            .sum::<Complex64>()
+            .norm_sqr();
+        assert!(
+            materialized_fidelity > 1.0 - 1e-12,
+            "flush must materialize the queued state: fidelity={materialized_fidelity:.16}"
+        );
         assert!(
             !stn.is_state_exact(),
             "lazy mode itself is a conservative exactness guard"

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -659,10 +659,23 @@ impl StabMpsBuilder {
 
     /// QEC-style preset retained for source compatibility.
     ///
-    /// This keeps its existing pragmatic measurement behavior for Stage A,
-    /// pending the Stage B QEC measurement. Its other settings match the
-    /// general defaults: `max_bond_dim(128)`, `max_truncation_error(1e-8)`,
-    /// and `merge_rz(true)`.
+    /// This selects exact measurement. The frozen Stage-B recipe in
+    /// `examples/measurement_mode_bench.rs` measures manually expanded
+    /// distance-3 and distance-5 repetition-code syndrome circuits in both
+    /// check bases: eight rounds, coherent `RZ(0.1)` on every data qubit per
+    /// round, two-qubit depolarizing noise at `p=1e-3`, identical pre-generated
+    /// noise for both modes, `merge_rz(false)`, otherwise-default builders,
+    /// 2,000 shots at d3 and 500 at d5, one warmup, timed seeds 7001 through
+    /// 7007, and pinned release execution. Median Exact slowdowns relative to
+    /// Pragmatic were 1.496812 (d3/Z), 1.488242 (d3/X), 1.457758 (d5/Z), and
+    /// 1.548499 (d5/X): geometric mean 1.497474 and maximum 1.548499. Both are
+    /// inside the decided Exact-everywhere limits (geometric mean at most 3
+    /// and per-workload maximum at most 5).
+    ///
+    /// Run the recorded recipe with
+    /// `taskset -c 2 cargo run --release -p pecos-stab-tn --example measurement_mode_bench`.
+    /// The preset's other settings match the general defaults:
+    /// `max_bond_dim(128)`, `max_truncation_error(1e-8)`, and `merge_rz(true)`.
     ///
     /// Override any of these with subsequent builder calls:
     /// ```
@@ -684,7 +697,7 @@ impl StabMpsBuilder {
         self.max_truncation_error(1e-8)
             .max_bond_dim(bond_dim)
             .merge_rz(true)
-            .measurement(MeasurementMode::Pragmatic)
+            .measurement(MeasurementMode::Exact)
     }
 
     /// Build the simulator.
@@ -7985,7 +7998,7 @@ mod tests {
         // Smoke test: the preset should build a working StabMps and handle
         // a Clifford + T + measurement sequence.
         let mut stn = StabMps::builder(4).seed(99).for_qec().build();
-        assert_eq!(stn.measurement_mode(), MeasurementMode::Pragmatic);
+        assert_eq!(stn.measurement_mode(), MeasurementMode::Exact);
         stn.h(&[QubitId(0)]);
         stn.cx(&[(QubitId(0), QubitId(1))]);
         stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -670,7 +670,12 @@ impl StabMpsBuilder {
     /// Pragmatic were 1.496812 (d3/Z), 1.488242 (d3/X), 1.457758 (d5/Z), and
     /// 1.548499 (d5/X): geometric mean 1.497474 and maximum 1.548499. Both are
     /// inside the decided Exact-everywhere limits (geometric mean at most 3
-    /// and per-workload maximum at most 5).
+    /// and per-workload maximum at most 5). The ratios are specific to this
+    /// noisy workload family: on noiseless Clifford-dominated variants of the
+    /// same circuits, where pragmatic measurements are nearly free, the
+    /// relative gap is far larger even though absolute per-shot costs stay
+    /// small. Note also that this family never triggers pragmatic's biased
+    /// drift path, so pragmatic was timed at its unbiased best case.
     ///
     /// Run the recorded recipe with
     /// `taskset -c 2 cargo run --release -p pecos-stab-tn --example measurement_mode_bench`.

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -861,7 +861,7 @@ impl StabMps {
             parallel: false,
             auto_grow_bond_dim: None,
             auto_grow_max_bond_dim: 4096,
-            measurement_mode: MeasurementMode::Exact,
+            measurement_mode: MeasurementMode::default(),
             flags: StabMpsFlags::new(),
         }
     }

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -238,6 +238,92 @@ fn repair_disent_flags(
     }
 }
 
+/// Sample and transactionally force one exact Z-measurement branch.
+///
+/// `StabMps` exact measurement and MAST data measurement share this owning
+/// layer so neither can expose a partially mutated tableau/MPS pair.
+fn measure_qubit_exact_transactional(
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    rng: &mut PecosRng,
+    q_idx: usize,
+    operation: &str,
+) -> Result<measure::LiveMeasurementResult, MpsError> {
+    let norm_squared = mps.norm_squared();
+    assert!(
+        norm_squared.is_finite() && norm_squared > 0.0,
+        "{operation}: cannot measure an MPS with non-finite or zero norm"
+    );
+    let expectation =
+        (measure::z_expectation_value(tableau, mps, q_idx).re / norm_squared).clamp(-1.0, 1.0);
+    let probability_one = measure::forced_outcome_probability(expectation, true);
+    let is_probability_zero = probability_one <= 0.0;
+    let is_probability_one = probability_one >= 1.0;
+    let outcome = if is_probability_zero {
+        false
+    } else if is_probability_one {
+        true
+    } else {
+        rng.random_bool(probability_one)
+    };
+
+    let original_tableau = tableau.clone();
+    let original_mps = mps.clone();
+    let mut candidate_tableau = original_tableau.clone();
+    let mut candidate_mps = original_mps.clone();
+    let first = measure::project_forced_z_with_update(
+        &mut candidate_tableau,
+        &mut candidate_mps,
+        q_idx,
+        outcome,
+    )?;
+    assert!(
+        first.snapped_probability > 0.0,
+        "{operation}: sampled a projector-impossible outcome"
+    );
+
+    let projection = if first.survival_ratio < measure::BRANCH_VANISH_SURVIVAL_THRESHOLD {
+        candidate_tableau = original_tableau;
+        candidate_mps = original_mps;
+        let original_config = candidate_mps.config().clone();
+        let mut retry_config = original_config.clone();
+        retry_config.max_bond_dim = candidate_mps.physical_rank_ceiling();
+        retry_config.svd_cutoff = 0.0;
+        retry_config.max_truncation_error = Some(0.0);
+        candidate_mps.set_config(retry_config);
+        let retry = measure::project_forced_z_with_update(
+            &mut candidate_tableau,
+            &mut candidate_mps,
+            q_idx,
+            outcome,
+        )?;
+        let retry_vanished = retry.survival_ratio < measure::BRANCH_VANISH_SURVIVAL_THRESHOLD;
+        debug_assert!(
+            !retry_vanished,
+            "{operation}: sampled branch vanished on the untruncated retry"
+        );
+        assert!(
+            !retry_vanished,
+            "{operation}: sampled branch vanished on the untruncated retry"
+        );
+        candidate_mps.set_config(original_config);
+        candidate_mps.record_branch_vanish_retry();
+        retry
+    } else {
+        first
+    };
+
+    *tableau = candidate_tableau;
+    *mps = candidate_mps;
+    Ok(measure::LiveMeasurementResult {
+        measurement: MeasurementResult {
+            outcome,
+            is_deterministic: is_probability_zero || is_probability_one,
+        },
+        update: projection.update,
+    })
+}
+
 fn invalidate_disent_flags(
     disent_flags: &mut [Option<SiteEigenstate>],
     update: &measure::ProjectionUpdate,
@@ -281,6 +367,25 @@ pub enum PauliKind {
     Z,
 }
 
+/// Policy for the family of operations implemented through singular Z measurement.
+///
+/// This controls [`CliffordGateable::mz`], reset, `pz`/`px`, syndrome
+/// extraction, and singular [`StabMps::sample_bitstring`].
+/// [`StabMps::sample_bitstrings`] (plural) is always exact by construction and
+/// does not dispatch through this policy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MeasurementMode {
+    /// Sample the normalized Born probability and transactionally force the
+    /// sampled branch, retrying without truncation if that branch vanishes.
+    #[default]
+    Exact,
+    /// Preserve the legacy uncompensated eager pre-reduction path. This is
+    /// faster for some workloads but can bias the stored conditional state.
+    Pragmatic,
+    /// Keep exact measurement-basis Cliffords in a deferred virtual frame.
+    Lazy,
+}
+
 /// Single-qubit Clifford kind used internally for Pauli frame propagation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SingleQubitCliffordKind {
@@ -301,10 +406,9 @@ pub struct StabMpsFlags(u8);
 
 impl StabMpsFlags {
     const NORMALIZE_AFTER_GATE: u8 = 1 << 0;
-    const LAZY_MEASURE: u8 = 1 << 1;
-    const MERGE_RZ: u8 = 1 << 2;
-    const PAULI_FRAME_TRACKING: u8 = 1 << 3;
-    const NUMERICAL_FLAG_REDETECTION: u8 = 1 << 4;
+    const MERGE_RZ: u8 = 1 << 1;
+    const PAULI_FRAME_TRACKING: u8 = 1 << 2;
+    const NUMERICAL_FLAG_REDETECTION: u8 = 1 << 3;
 
     /// Default flags: normalization and RZ merging enabled, everything else off.
     #[must_use]
@@ -332,15 +436,6 @@ impl StabMpsFlags {
     /// Set whether non-Clifford gates are followed by MPS normalization.
     pub fn set_normalize_after_gate(&mut self, v: bool) {
         self.set(Self::NORMALIZE_AFTER_GATE, v);
-    }
-    #[must_use]
-    /// Return whether measurement uses the deferred virtual-frame path.
-    pub fn lazy_measure(self) -> bool {
-        self.get(Self::LAZY_MEASURE)
-    }
-    /// Set whether measurement uses the deferred virtual-frame path.
-    pub fn set_lazy_measure(&mut self, v: bool) {
-        self.set(Self::LAZY_MEASURE, v);
     }
     #[must_use]
     /// Return whether consecutive same-qubit RZ rotations are merged.
@@ -387,6 +482,7 @@ pub struct StabMpsBuilder {
     parallel: bool,
     auto_grow_bond_dim: Option<f64>,
     auto_grow_max_bond_dim: usize,
+    measurement_mode: MeasurementMode,
     flags: StabMpsFlags,
 }
 
@@ -476,27 +572,12 @@ impl StabMpsBuilder {
         self
     }
 
-    /// Use lazy virtual-frame measurement: accumulate `pre_reduce` CNOTs AND
-    /// post-projection basis-rotation Cliffords into a deferred `V` queue
-    /// instead of applying them eagerly to the MPS. Pauli strings from
-    /// `decompose_z` are conjugated by `V†` before application to the
-    /// stored MPS, so expectation/projection are exact.
-    ///
-    /// - Default: false (eager path)
-    /// - **Not a universal win.** Per `examples/qec_bench.rs`, eager is
-    ///   faster for both QEC-like (syndrome extraction + T noise) and
-    ///   MAST-style (T-injection + ancilla measurement) workloads. Lazy
-    ///   uses MPS addition for projection (bond grows ~2× per measurement)
-    ///   whereas eager uses an in-place single-site basis-swap trick that
-    ///   avoids bond growth. Lazy's only advantage is exact stored-MPS
-    ///   state for subsequent non-measurement operations; eager's stored
-    ///   MPS drifts slightly but measurement statistics and tableau stay
-    ///   correct. Enable only if you need exact MPS state after random
-    ///   measurements (e.g., computing `state_vector` or `amplitude` and
-    ///   requiring no drift across many measurements).
+    /// Select the singular-measurement policy. The default is
+    /// [`MeasurementMode::Exact`]. See [`MeasurementMode`] for the affected
+    /// operation family and the exact behavior of plural sampling.
     #[must_use]
-    pub fn lazy_measure(mut self, lazy: bool) -> Self {
-        self.flags.set_lazy_measure(lazy);
+    pub fn measurement(mut self, mode: MeasurementMode) -> Self {
+        self.measurement_mode = mode;
         self
     }
 
@@ -587,8 +668,10 @@ impl StabMpsBuilder {
 
     /// QEC-style preset retained for source compatibility.
     ///
-    /// This now matches the general defaults: `max_bond_dim(128)`,
-    /// `max_truncation_error(1e-8)`, `merge_rz(true)`, and eager measurement.
+    /// This keeps its existing pragmatic measurement behavior for Stage A,
+    /// pending the Stage B QEC measurement. Its other settings match the
+    /// general defaults: `max_bond_dim(128)`, `max_truncation_error(1e-8)`,
+    /// and `merge_rz(true)`.
     ///
     /// Override any of these with subsequent builder calls:
     /// ```
@@ -610,6 +693,7 @@ impl StabMpsBuilder {
         self.max_truncation_error(1e-8)
             .max_bond_dim(bond_dim)
             .merge_rz(true)
+            .measurement(MeasurementMode::Pragmatic)
     }
 
     /// Build the simulator.
@@ -634,7 +718,7 @@ impl StabMpsBuilder {
             rng,
             stats: StabMpsStats::default(),
             deferred_ops: Vec::new(),
-            pragmatic_drift_count: 0,
+            uncompensated_pre_reduction_count: 0,
             pending_rz: vec![None; self.num_qubits],
             auto_grow_bond_dim: self.auto_grow_bond_dim,
             auto_grow_max_bond_dim: self.auto_grow_max_bond_dim,
@@ -642,6 +726,7 @@ impl StabMpsBuilder {
             pauli_frame_x: vec![false; self.num_qubits],
             pauli_frame_z: vec![false; self.num_qubits],
             pauli_frame_phase: Complex64::new(1.0, 0.0),
+            measurement_mode: self.measurement_mode,
             flags: self.flags,
         }
     }
@@ -660,10 +745,7 @@ impl StabMpsBuilder {
 /// use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
 /// use pecos_stab_tn::stab_mps::StabMps;
 ///
-/// let mut sim = StabMps::builder(2)
-///     .seed(7)
-///     .lazy_measure(true)
-///     .build();
+/// let mut sim = StabMps::builder(2).seed(7).build();
 /// sim.h(&[QubitId(0)]);
 /// sim.cx(&[(QubitId(0), QubitId(1))]);
 /// sim.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(1)]);
@@ -685,17 +767,15 @@ impl StabMpsBuilder {
 /// call [`Self::flush_pauli_frame_to_state`] as well before reads that must include
 /// the physical Pauli frame. The Python bindings automatically perform
 /// `flush()` for state and MPS-diagnostic reads, but not for the pure
-/// `is_state_exact()` and `pragmatic_drift_count` diagnostics, and they do not
+/// `is_state_exact()` and `uncompensated_pre_reduction_count` diagnostics, and they do not
 /// implicitly materialize a Pauli frame.
 ///
-/// Before relying on a state read, check all four diagnostics:
+/// Before relying on a state read, check the diagnostics:
 ///
-/// 1. [`Self::is_state_exact`] is `true` after the required flushes. It excludes
-///    MPS truncation from its definition of exactness.
-/// 2. [`Self::pragmatic_drift_count`] is zero. Nonzero drift from eager random
-///    measurement is irreversible; use `lazy_measure(true)` when later exact
-///    amplitudes are required.
-/// 3. [`Self::truncation_error`] is acceptable for the application.
+/// 1. [`Self::is_state_exact`] is `true` after the required flushes.
+/// 2. [`Self::uncompensated_pre_reduction_count`] is zero.
+/// 3. [`Self::truncation_error`] and [`Self::summed_discarded_weight`] are
+///    acceptable for the application.
 /// 4. [`Self::bond_cap_hits`] is zero, or the configured bond cap is known to be
 ///    adequate despite having bound an SVD.
 #[derive(Clone)]
@@ -717,8 +797,8 @@ pub struct StabMps {
     pub stats: StabMpsStats,
     /// Deferred virtual-frame Clifford V (see `measure::DeferredOp`).
     deferred_ops: Vec<measure::DeferredOp>,
-    /// Count of pragmatic-path measurement drifts.
-    pragmatic_drift_count: u64,
+    /// Count of pragmatic measurements whose pre-reduction was uncompensated.
+    uncompensated_pre_reduction_count: u64,
     /// Pending non-Clifford RZ angle per qubit when `merge_rz` is on.
     pending_rz: Vec<Option<Angle64>>,
     /// Auto-grow bond-dim threshold; `None` disables.
@@ -733,6 +813,8 @@ pub struct StabMps {
     pauli_frame_z: Vec<bool>,
     /// Global scalar of the Pauli frame.
     pauli_frame_phase: Complex64,
+    /// Policy for singular measurement and the operations built on it.
+    measurement_mode: MeasurementMode,
     /// Runtime feature flags.
     flags: StabMpsFlags,
 }
@@ -788,6 +870,7 @@ impl StabMps {
             parallel: false,
             auto_grow_bond_dim: None,
             auto_grow_max_bond_dim: 4096,
+            measurement_mode: MeasurementMode::Exact,
             flags: StabMpsFlags::new(),
         }
     }
@@ -1394,6 +1477,36 @@ impl StabMps {
         self.mps.truncation_error()
     }
 
+    /// True sum of all relative discarded SVD weights over this run.
+    #[must_use]
+    pub fn summed_discarded_weight(&self) -> f64 {
+        self.mps.summed_discarded_weight()
+    }
+
+    /// Largest coefficient-MPS bond dimension observed over this run.
+    #[must_use]
+    pub fn lifetime_peak_bond(&self) -> usize {
+        self.mps.lifetime_peak_bond()
+    }
+
+    /// Number of sampled projections retried after a rolled-back branch vanish.
+    #[must_use]
+    pub fn branch_vanish_retry_count(&self) -> u64 {
+        self.mps.branch_vanish_retry_count()
+    }
+
+    /// Number of deferred MAST branches lost; always zero for `StabMps`.
+    #[must_use]
+    pub fn deferred_branch_lost_count(&self) -> u64 {
+        self.mps.deferred_branch_lost_count()
+    }
+
+    /// Return the configured singular-measurement policy.
+    #[must_use]
+    pub fn measurement_mode(&self) -> MeasurementMode {
+        self.measurement_mode
+    }
+
     /// Number of SVDs where `max_bond_dim` was the binding cap. If > 0 the
     /// state is under-resolved; consider raising `max_bond_dim` or loosening
     /// `max_truncation_error`.
@@ -1459,16 +1572,19 @@ impl StabMps {
     ///
     /// # Accuracy caveats (read if you have outstanding measurements)
     ///
-    /// - **Default (pragmatic-fix) measurement path**: `measure_qubit_stab_mps`
-    ///   skips MPS compensation for `pre_reduce` row-ops. The stored
+    /// - **Pragmatic measurement path**:
+    ///   [`measure::measure_qubit_stab_mps_pragmatic`] skips MPS compensation
+    ///   for `pre_reduce` row-ops. The stored
     ///   `(tableau, MPS)` pair may no longer represent the exact physical
     ///   state after a measurement that triggered multi-anticom
     ///   `pre_reduce`. Measurement outcome statistics stay correct, but
     ///   `state_vector`/`amplitude` reads can drift. If exact state is
-    ///   needed, use `StabMpsBuilder::lazy_measure(true)`.
+    ///   needed, keep the default [`MeasurementMode::Exact`] or select
+    ///   [`MeasurementMode::Lazy`].
     /// - **Merged-RZ pending buffer** (`merge_rz = true`): any pending
     ///   merged-RZ angle has not been applied yet.
-    /// - **Lazy-measurement deferred operations** (`lazy_measure = true`):
+    /// - **Lazy-measurement deferred operations**
+    ///   ([`MeasurementMode::Lazy`]):
     ///   queued virtual-frame operations have not been applied to the stored
     ///   MPS yet. Call `StabMps::flush()` before either kind of read.
     /// - **Pauli-frame tracking** (`pauli_frame_tracking = true`): the
@@ -1619,6 +1735,7 @@ impl StabMps {
     /// returns the bitstring. The original simulator state is unchanged
     /// (only the internal RNG advances, to ensure each shot uses a
     /// distinct RNG seed).
+    /// Each clone follows this simulator's [`MeasurementMode`].
     /// This method and [`Self::sample_bitstrings`] do not share an RNG stream,
     /// so identically seeded runs are not shot-for-shot comparable across them.
     ///
@@ -1661,6 +1778,9 @@ impl StabMps {
     /// sharing each distinct measurement-prefix projection across all shots
     /// that take that branch.
     ///
+    /// This plural sampler is always exact by construction and does not use
+    /// the configured [`MeasurementMode`].
+    ///
     /// The original simulator state is preserved; only its RNG advances.
     /// This method and [`Self::sample_bitstring`] do not share an RNG stream,
     /// so identically seeded runs are not shot-for-shot comparable across them.
@@ -1678,8 +1798,8 @@ impl StabMps {
     /// follows the same atomic projection sequence as [`Self::prob_bitstring`].
     /// The clamped `p0` is tested against `k` uniforms in branch-local shot order,
     /// with all node draws completed before visiting either child. Probabilities
-    /// below `1e-20`, the forced projector's tolerance, are zero; if either child
-    /// is zero-probability, the node consumes no RNG draws.
+    /// at the projector's shared endpoint snap become zero; if either child is
+    /// zero-probability, the node consumes no RNG draws.
     ///
     /// Children are visited depth-first, outcome 0 before outcome 1, measuring
     /// qubits `0..num_qubits`. Returned bitstrings therefore use the same
@@ -1737,8 +1857,6 @@ impl StabMps {
         prefix: &mut Vec<bool>,
         context: &mut PrefixSamplingContext<'_>,
     ) -> Result<(), MpsError> {
-        const ZERO_PROBABILITY_TOLERANCE: f64 = 1e-20;
-
         let q = prefix.len();
         if q == context.num_qubits {
             context
@@ -1758,9 +1876,9 @@ impl StabMps {
             measure::project_forced_z(&mut zero_tableau, &mut zero_mps, q, context.frame_x[q])?
                 .clamp(0.0, 1.0);
         let probability_one = 1.0 - probability_zero;
-        let num_zero = if probability_zero < ZERO_PROBABILITY_TOLERANCE {
+        let num_zero = if probability_zero == 0.0 {
             0
-        } else if probability_one < ZERO_PROBABILITY_TOLERANCE {
+        } else if probability_one == 0.0 {
             num_shots
         } else {
             (0..num_shots)
@@ -2145,18 +2263,14 @@ impl StabMps {
         }
     }
 
-    /// Returns `true` if the stored `(tableau, MPS)` pair exactly
-    /// represents the current physical state — no pending merged RZ,
-    /// no unflushed Pauli frame, no deferred CNOT queue from lazy
-    /// measurement. When `true`, `state_vector` / `amplitude` etc. return
-    /// exact results (modulo MPS truncation error reported by
-    /// `truncation_error`).
+    /// Conservative sufficient predicate for an exact stored physical state.
     ///
-    /// Also returns `false` if the pragmatic-fix path in
-    /// `measure_qubit_stab_mps` has fired at least once on this simulator
-    /// (tracked via `pragmatic_drift_count`). Use
-    /// `StabMpsBuilder::lazy_measure(true)` if you need exact state after
-    /// random measurements with multi-anticom stabilizer columns.
+    /// This is deliberately not an if-and-only-if classifier. It requires all
+    /// seven guards: no pending RZ, no unmaterialized Pauli frame, no lazy
+    /// deferred operations, no uncompensated pragmatic pre-reduction, exact
+    /// measurement mode, zero summed discarded weight, and no deferred MAST
+    /// branch loss. A branch-vanish retry is not a guard because its first
+    /// attempt was rolled back and its committed retry was untruncated.
     #[must_use]
     pub fn is_state_exact(&self) -> bool {
         let no_pending_rz = self.pending_rz.iter().all(std::option::Option::is_none);
@@ -2166,19 +2280,24 @@ impl StabMps {
                 && self.pauli_frame_z.iter().all(|&b| !b)
                 && phase_trivial);
         let no_deferred = self.deferred_ops.is_empty();
-        let no_drift = self.pragmatic_drift_count == 0;
-        no_pending_rz && no_frame && no_deferred && no_drift
+        let no_drift = self.uncompensated_pre_reduction_count == 0;
+        let exact_mode = self.measurement_mode == MeasurementMode::Exact;
+        let no_discarded_weight = self.mps.summed_discarded_weight() == 0.0;
+        let no_deferred_branch_loss = self.mps.deferred_branch_lost_count() == 0;
+        no_pending_rz
+            && no_frame
+            && no_deferred
+            && no_drift
+            && exact_mode
+            && no_discarded_weight
+            && no_deferred_branch_loss
     }
 
-    /// Number of measurements that took the pragmatic-fix path (`pre_reduce`
-    /// row-ops applied to the tableau without MPS compensation) on this
-    /// simulator. Non-zero means the stored `(tableau, MPS)` pair has
-    /// drifted from the exact physical state; read methods may return
-    /// approximate amplitudes. Enable `StabMpsBuilder::lazy_measure(true)` to
-    /// avoid drift entirely.
+    /// Number of pragmatic measurements whose generator pre-reduction changed
+    /// the tableau without matching coefficient-MPS compensation.
     #[must_use]
-    pub fn pragmatic_drift_count(&self) -> u64 {
-        self.pragmatic_drift_count
+    pub fn uncompensated_pre_reduction_count(&self) -> u64 {
+        self.uncompensated_pre_reduction_count
     }
 
     /// Materialize deferred lazy-measurement operations and any pending
@@ -2391,33 +2510,41 @@ impl StabMps {
     /// Measure qubit q in the Z basis using the shared STN measurement protocol.
     fn measure_qubit(&mut self, q: QubitId) -> MeasurementResult {
         self.flush_pending_rz(q.index());
-        let live_result = if self.flags.lazy_measure() {
-            measure::measure_qubit_stab_mps_lazy_with_update(
+        let live_result = match self.measurement_mode {
+            MeasurementMode::Lazy => measure::measure_qubit_stab_mps_lazy_with_update(
                 &mut self.tableau,
                 &mut self.mps,
                 &mut self.rng,
                 q.index(),
                 &mut self.deferred_ops,
-            )
-        } else {
-            // Detect pragmatic-fix drift: pre_reduce fires when col_x has
-            // multiple anticommuting stabilizers. It applies row-ops to the
-            // tableau (changing C) WITHOUT compensating MPS. Drift occurs
-            // regardless of whether decompose_z then takes the Stabilizer
-            // or DestabilizerFlip path — the uncompensated row-ops already
-            // changed the (C, MPS) pair.
-            if self.tableau.stabs().col_x[q.index()].len() > 1 {
-                self.pragmatic_drift_count += 1;
+            ),
+            MeasurementMode::Pragmatic => {
+                // Detect pragmatic-fix drift: pre_reduce fires when col_x has
+                // multiple anticommuting stabilizers. It applies row-ops to the
+                // tableau (changing C) WITHOUT compensating MPS. Drift occurs
+                // regardless of whether decompose_z then takes the Stabilizer
+                // or DestabilizerFlip path — the uncompensated row-ops already
+                // changed the (C, MPS) pair.
+                if self.tableau.stabs().col_x[q.index()].len() > 1 {
+                    self.uncompensated_pre_reduction_count += 1;
+                }
+                measure::measure_qubit_stab_mps_with_update(
+                    &mut self.tableau,
+                    &mut self.mps,
+                    &mut self.rng,
+                    q.index(),
+                )
             }
-            measure::measure_qubit_stab_mps_with_update(
+            MeasurementMode::Exact => measure_qubit_exact_transactional(
                 &mut self.tableau,
                 &mut self.mps,
                 &mut self.rng,
                 q.index(),
-            )
+                "StabMps::mz",
+            ),
         };
         let live_result = expect_mps_operation(live_result, "StabMps::mz projection");
-        if self.flags.lazy_measure() && !self.deferred_ops.is_empty() {
+        if self.measurement_mode == MeasurementMode::Lazy && !self.deferred_ops.is_empty() {
             // Deferred virtual Cliffords mean a stored |0> is not necessarily
             // an effective |0> (issue #555).  Invalidate touched sites, but do
             // not install any new proof until that frame has been materialized.
@@ -2461,7 +2588,7 @@ impl QuantumSimulator for StabMps {
         self.gf2_matrix.reset();
         self.stats = StabMpsStats::default();
         self.deferred_ops.clear();
-        self.pragmatic_drift_count = 0;
+        self.uncompensated_pre_reduction_count = 0;
         self.last_truncation_error = 0.0;
         for slot in &mut self.pending_rz {
             *slot = None;
@@ -6411,23 +6538,24 @@ mod tests {
     }
 
     #[test]
-    fn test_pauli_frame_with_lazy_measure() {
+    fn test_pauli_frame_with_measurement_modes() {
         // Lazy measure + Pauli frame should compose: frame applies AFTER
         // the measurement outcome, irrespective of lazy/eager internals.
         // Init |0⟩, inject X in frame, measure: expect outcome=1 regardless
-        // of lazy_measure setting.
+        // of the selected measurement mode.
         for lazy in [false, true] {
             let mut stn = StabMps::builder(1)
                 .seed(42)
-                .lazy_measure(lazy)
+                .measurement(if lazy {
+                    MeasurementMode::Lazy
+                } else {
+                    MeasurementMode::Pragmatic
+                })
                 .pauli_frame_tracking(true)
                 .build();
             stn.inject_x_in_frame(QubitId(0));
             let r = stn.mz(&[QubitId(0)])[0].outcome;
-            assert!(
-                r,
-                "lazy_measure={lazy}, frame X should give outcome=1, got {r}"
-            );
+            assert!(r, "lazy={lazy}, frame X should give outcome=1, got {r}");
         }
     }
 
@@ -6495,7 +6623,10 @@ mod tests {
 
     #[test]
     fn test_flush_materializes_lazy_deferred_operations() {
-        let mut stn = StabMps::builder(2).seed(19).lazy_measure(true).build();
+        let mut stn = StabMps::builder(2)
+            .seed(19)
+            .measurement(MeasurementMode::Lazy)
+            .build();
         stn.h(&[QubitId(1)]);
         stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(1)]);
         stn.sz(&[QubitId(0)]);
@@ -6506,24 +6637,31 @@ mod tests {
         assert!(!stn.is_state_exact(), "lazy operations should be pending");
         stn.flush();
         assert!(
-            stn.is_state_exact(),
-            "flush should materialize lazy operations"
+            !stn.is_state_exact(),
+            "lazy mode itself is a conservative exactness guard"
         );
     }
 
     #[test]
-    fn test_pragmatic_drift_count_tracks_non_lazy_pre_reduce() {
+    fn test_uncompensated_pre_reduction_count_tracks_pragmatic_path() {
         // Build a state where col_x for the measured qubit has multiple
         // anticommuting stabilizers so pre_reduce fires. H(0), H(1), CX(0,1)
         // gives stabs {X_0X_1, X_1}; measuring qubit 1 has col_x[1].len()=2.
-        let mut stn = StabMps::builder(2).seed(3).build();
+        let mut stn = StabMps::builder(2)
+            .seed(3)
+            .measurement(MeasurementMode::Pragmatic)
+            .build();
         stn.h(&[QubitId(0)]);
         stn.h(&[QubitId(1)]);
         stn.cx(&[(QubitId(0), QubitId(1))]);
-        assert_eq!(stn.pragmatic_drift_count(), 0, "no measurements yet");
+        assert_eq!(
+            stn.uncompensated_pre_reduction_count(),
+            0,
+            "no measurements yet"
+        );
         let _ = stn.mz(&[QubitId(1)]);
         assert_eq!(
-            stn.pragmatic_drift_count(),
+            stn.uncompensated_pre_reduction_count(),
             1,
             "non-lazy mz on multi-anticom col_x should bump drift counter"
         );
@@ -6533,26 +6671,36 @@ mod tests {
         );
 
         // Lazy path: same setup but no drift (pre_reduce CNOTs go into V).
-        let mut stn = StabMps::builder(2).seed(3).lazy_measure(true).build();
+        let mut stn = StabMps::builder(2)
+            .seed(3)
+            .measurement(MeasurementMode::Lazy)
+            .build();
         stn.h(&[QubitId(0)]);
         stn.h(&[QubitId(1)]);
         stn.cx(&[(QubitId(0), QubitId(1))]);
         let _ = stn.mz(&[QubitId(1)]);
         assert_eq!(
-            stn.pragmatic_drift_count(),
+            stn.uncompensated_pre_reduction_count(),
             0,
-            "lazy_measure path must not increment drift count"
+            "lazy path must not increment the uncompensated count"
         );
 
         // Reset clears the counter.
-        let mut stn = StabMps::builder(2).seed(3).build();
+        let mut stn = StabMps::builder(2)
+            .seed(3)
+            .measurement(MeasurementMode::Pragmatic)
+            .build();
         stn.h(&[QubitId(0)]);
         stn.h(&[QubitId(1)]);
         stn.cx(&[(QubitId(0), QubitId(1))]);
         let _ = stn.mz(&[QubitId(1)]);
-        assert!(stn.pragmatic_drift_count() > 0);
+        assert!(stn.uncompensated_pre_reduction_count() > 0);
         stn.reset();
-        assert_eq!(stn.pragmatic_drift_count(), 0, "reset clears drift counter");
+        assert_eq!(
+            stn.uncompensated_pre_reduction_count(),
+            0,
+            "reset clears drift counter"
+        );
     }
 
     #[test]
@@ -6570,7 +6718,10 @@ mod tests {
         let mut one_count = 0;
         let t = Angle64::QUARTER_TURN / 2u64;
         for shot in 0..num_shots {
-            let mut stn = StabMps::builder(2).seed(shot).lazy_measure(true).build();
+            let mut stn = StabMps::builder(2)
+                .seed(shot)
+                .measurement(MeasurementMode::Lazy)
+                .build();
             // Non-Clifford first to force MPS non-trivial (Cliffords alone
             // keep MPS in its initial product form via tableau routing).
             stn.h(&[QubitId(1)]);
@@ -7671,7 +7822,7 @@ mod tests {
         assert_eq!(stn.config.max_truncation_error, Some(1e-8));
         assert!(!stn.config.parallel);
         assert!(stn.flags.normalize_after_gate());
-        assert!(!stn.flags.lazy_measure());
+        assert_eq!(stn.measurement_mode, MeasurementMode::Exact);
         assert!(stn.flags.merge_rz());
         assert!(!stn.flags.pauli_frame_tracking());
         assert!(!stn.flags.numerical_flag_redetection());
@@ -7810,6 +7961,7 @@ mod tests {
         // Smoke test: the preset should build a working StabMps and handle
         // a Clifford + T + measurement sequence.
         let mut stn = StabMps::builder(4).seed(99).for_qec().build();
+        assert_eq!(stn.measurement_mode(), MeasurementMode::Pragmatic);
         stn.h(&[QubitId(0)]);
         stn.cx(&[(QubitId(0), QubitId(1))]);
         stn.rz(Angle64::QUARTER_TURN / 2u64, &[QubitId(0)]);
@@ -7820,12 +7972,32 @@ mod tests {
     }
 
     #[test]
+    fn measurement_mode_override_clone_and_reset_retention() {
+        let mut exact_override = StabMps::builder(2)
+            .for_qec()
+            .measurement(MeasurementMode::Exact)
+            .build();
+        assert_eq!(exact_override.measurement_mode(), MeasurementMode::Exact);
+        assert_eq!(
+            exact_override.clone().measurement_mode(),
+            MeasurementMode::Exact
+        );
+        exact_override.reset();
+        assert_eq!(exact_override.measurement_mode(), MeasurementMode::Exact);
+
+        let lazy = StabMps::builder(2)
+            .measurement(MeasurementMode::Lazy)
+            .build();
+        assert_eq!(lazy.clone().measurement_mode(), MeasurementMode::Lazy);
+    }
+
+    #[test]
     fn test_builder_lazy_measure_bell_correlation() {
         // Lazy-measure path must give same Bell-state correlation as eager.
         for trial in 0..20 {
             let mut stn = StabMps::builder(2)
                 .seed(3000 + trial)
-                .lazy_measure(true)
+                .measurement(MeasurementMode::Lazy)
                 .build();
             stn.h(&[QubitId(0)]);
             stn.cx(&[(QubitId(0), QubitId(1))]);
@@ -7845,7 +8017,7 @@ mod tests {
         for trial in 0..num_trials {
             let mut stn = StabMps::builder(1)
                 .seed(u64::from(4000 + trial))
-                .lazy_measure(true)
+                .measurement(MeasurementMode::Lazy)
                 .build();
             stn.rx(theta, &[QubitId(0)]);
             if !stn.mz(&[QubitId(0)])[0].outcome {
@@ -7896,7 +8068,11 @@ mod tests {
                             .svd_cutoff(svd_cutoff)
                             .max_truncation_error(max_truncation_error)
                             .merge_rz(false)
-                            .lazy_measure(lazy_measure)
+                            .measurement(if lazy_measure {
+                                MeasurementMode::Lazy
+                            } else {
+                                MeasurementMode::Pragmatic
+                            })
                             .numerical_flag_redetection(numerical_flag_redetection)
                             .build();
 
@@ -8090,7 +8266,11 @@ mod tests {
                         .svd_cutoff(0.0)
                         .max_truncation_error(0.0)
                         .merge_rz(false)
-                        .lazy_measure(lazy_measure)
+                        .measurement(if lazy_measure {
+                            MeasurementMode::Lazy
+                        } else {
+                            MeasurementMode::Pragmatic
+                        })
                         .numerical_flag_redetection(numerical_flag_redetection)
                         .build();
                     let mut dense = DenseStateVec::new(N);
@@ -8126,8 +8306,8 @@ mod tests {
                     let mut post_measurement = stn.clone();
                     post_measurement.flush();
                     if lazy_measure {
-                        assert_eq!(stn.pragmatic_drift_count(), 0);
-                    } else if stn.pragmatic_drift_count() > 0 {
+                        assert_eq!(stn.uncompensated_pre_reduction_count(), 0);
+                    } else if stn.uncompensated_pre_reduction_count() > 0 {
                         eager_pragmatic_drift_exercised = true;
                     }
                     let projected =
@@ -8141,7 +8321,7 @@ mod tests {
                             "measurement; lazy={lazy_measure} redetect={numerical_flag_redetection} seed={circuit_seed}"
                         ),
                     );
-                    if !lazy_measure && stn.pragmatic_drift_count() > 0 {
+                    if !lazy_measure && stn.uncompensated_pre_reduction_count() > 0 {
                         // Eager pre-reduction deliberately records that exact
                         // amplitude comparisons are no longer valid. The stored
                         // flag marginal above remains an exact local invariant.
@@ -8193,5 +8373,138 @@ mod tests {
             eager_pragmatic_drift_exercised,
             "eager seed sweep must exercise the pragmatic-drift branch"
         );
+    }
+
+    #[test]
+    fn exact_measurement_vanish_retry_matches_clean_projection_and_restores_config() {
+        let prepare = || {
+            let mut stn = StabMps::builder(3)
+                .seed(0xabc)
+                .max_bond_dim(1)
+                .svd_cutoff(1e-7)
+                .max_truncation_error(1e-4)
+                .merge_rz(false)
+                .build();
+            stn.h(&[QubitId(0)]);
+            stn.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+            stn
+        };
+
+        let mut clean = prepare();
+        let clean_outcome = clean.mz(&[QubitId(0)])[0].outcome;
+
+        let mut retried = prepare();
+        measure::inject_projection_vanishes(1);
+        let retried_outcome = retried.mz(&[QubitId(0)])[0].outcome;
+        assert_eq!(retried_outcome, clean_outcome);
+        assert_eq!(
+            format!("{:?}", retried.tableau.stabs()),
+            format!("{:?}", clean.tableau.stabs())
+        );
+        assert_eq!(
+            format!("{:?}", retried.tableau.destabs()),
+            format!("{:?}", clean.tableau.destabs())
+        );
+        assert_eq!(retried.mps.tensors(), clean.mps.tensors());
+        assert_eq!(retried.mps.bond_dims(), clean.mps.bond_dims());
+        assert_eq!(
+            retried.mps.tracked_center_for_test(),
+            clean.mps.tracked_center_for_test()
+        );
+        assert_eq!(
+            retried.mps.truncation_error().to_bits(),
+            clean.mps.truncation_error().to_bits()
+        );
+        assert_eq!(
+            retried.mps.summed_discarded_weight().to_bits(),
+            clean.mps.summed_discarded_weight().to_bits()
+        );
+        assert_eq!(retried.mps.bond_cap_hits(), clean.mps.bond_cap_hits());
+        assert_eq!(retried.branch_vanish_retry_count(), 1);
+        assert_eq!(retried.mps.config().max_bond_dim, 1);
+        assert_eq!(
+            retried.mps.config().svd_cutoff.to_bits(),
+            1e-7_f64.to_bits()
+        );
+        assert_eq!(retried.mps.config().max_truncation_error, Some(1e-4));
+
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let cnot = DMatrix::from_row_slice(
+            4,
+            4,
+            &[
+                one, zero, zero, zero, zero, one, zero, zero, zero, zero, zero, one, zero, zero,
+                one, zero,
+            ],
+        );
+        retried
+            .mps
+            .apply_long_range_two_site_gate(0, 2, &cnot)
+            .unwrap();
+        retried.mps.compress().unwrap();
+        assert!(retried.mps.norm_squared().is_finite());
+        assert!(retried.mps.max_bond_dim() <= 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "StabMps::mz: sampled branch vanished on the untruncated retry")]
+    fn exact_measurement_double_vanish_panics_with_operation_name() {
+        let mut stn = StabMps::builder(1).seed(9).merge_rz(false).build();
+        stn.h(&[QubitId(0)]);
+        stn.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        measure::inject_projection_vanishes(2);
+        let _ = stn.mz(&[QubitId(0)]);
+    }
+
+    #[test]
+    fn pragmatic_mode_without_pre_reduction_is_not_state_exact() {
+        let mut stn = StabMps::builder(1)
+            .measurement(MeasurementMode::Pragmatic)
+            .build();
+        stn.h(&[QubitId(0)]);
+        let _ = stn.mz(&[QubitId(0)]);
+        assert_eq!(stn.uncompensated_pre_reduction_count(), 0);
+        assert!(!stn.is_state_exact());
+    }
+
+    #[test]
+    fn state_exactness_has_all_seven_guards_but_not_retry_count() {
+        let exact = || StabMps::builder(2).merge_rz(false).build();
+        assert!(exact().is_state_exact());
+
+        let mut pending_rz = StabMps::builder(2).merge_rz(true).build();
+        pending_rz.rz(Angle64::from_radians(0.37), &[QubitId(0)]);
+        assert!(!pending_rz.is_state_exact());
+
+        let mut frame = StabMps::builder(2).pauli_frame_tracking(true).build();
+        frame.inject_x_in_frame(QubitId(0));
+        assert!(!frame.is_state_exact());
+
+        let mut deferred = exact();
+        deferred.deferred_ops.push(measure::DeferredOp::H(0));
+        assert!(!deferred.is_state_exact());
+
+        let mut uncompensated = exact();
+        uncompensated.uncompensated_pre_reduction_count = 1;
+        assert!(!uncompensated.is_state_exact());
+
+        let pragmatic = StabMps::builder(2)
+            .merge_rz(false)
+            .measurement(MeasurementMode::Pragmatic)
+            .build();
+        assert!(!pragmatic.is_state_exact());
+
+        let mut truncated = exact();
+        truncated.mps.record_truncation(1e-9, false);
+        assert!(!truncated.is_state_exact());
+
+        let mut deferred_loss = exact();
+        deferred_loss.mps.record_deferred_branch_lost();
+        assert!(!deferred_loss.is_state_exact());
+
+        let mut retried = exact();
+        retried.mps.record_branch_vanish_retry();
+        assert!(retried.is_state_exact());
     }
 }

--- a/exp/pecos-stab-tn/src/stab_mps/mast.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/mast.rs
@@ -606,10 +606,8 @@ impl Mast {
         // The branch correction was applied at injection time. Try the
         // predetermined branch transactionally so a vanished attempt cannot
         // mutate the live tableau/MPS pair.
-        let original_tableau = self.tableau.clone();
-        let original_mps = self.mps.clone();
-        let mut candidate_tableau = original_tableau.clone();
-        let mut candidate_mps = original_mps.clone();
+        let mut candidate_tableau = self.tableau.clone();
+        let mut candidate_mps = self.mps.clone();
         let mut projection = super::measure::project_forced_z_with_update(
             &mut candidate_tableau,
             &mut candidate_mps,
@@ -623,9 +621,9 @@ impl Mast {
             "Mast::project_all predetermined deferred branch was lost"
         );
         if branch_lost {
-            candidate_tableau = original_tableau;
-            candidate_mps = original_mps;
-            let original_config = candidate_mps.config().clone();
+            candidate_tableau = self.tableau.clone();
+            candidate_mps = self.mps.clone();
+            let original_config = self.mps.config().clone();
             let mut retry_config = original_config.clone();
             retry_config.max_bond_dim = candidate_mps.physical_rank_ceiling();
             retry_config.svd_cutoff = 0.0;
@@ -1887,6 +1885,19 @@ mod tests {
     }
 
     #[cfg(not(debug_assertions))]
+    fn assert_deferred_ancilla_outcome(mast: &Mast, ancilla: usize, outcome: bool) {
+        let norm_squared = mast.mps.norm_squared();
+        let expectation =
+            crate::stab_mps::measure::z_expectation_value(&mast.tableau, &mast.mps, ancilla).re
+                / norm_squared;
+        let expected = if outcome { -1.0 } else { 1.0 };
+        assert!(
+            (expectation - expected).abs() < 1e-10,
+            "deferred ancilla {ancilla} projected outcome mismatch: expected {outcome}, Z={expectation:.16e}"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
     #[test]
     fn mast_deferred_branch_loss_uses_untruncated_complement_in_release() {
         let configured = MpsConfig {
@@ -1898,9 +1909,11 @@ mod tests {
         let mut mast = Mast::with_seed(1, 1, 17).with_mps_config(configured.clone());
         mast.h(&[QubitId(0)]);
         mast.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        let deferred = mast.deferred[0];
         crate::stab_mps::measure::inject_projection_vanishes(1);
         mast.project_all();
         assert_eq!(mast.deferred_branch_lost_count(), 1);
+        assert_deferred_ancilla_outcome(&mast, deferred.ancilla, !deferred.predetermined_outcome);
         assert!((mast.mps.norm_squared() - 1.0).abs() < 1e-12);
         assert_eq!(mast.mps.config().max_bond_dim, configured.max_bond_dim);
         assert_eq!(
@@ -1911,6 +1924,27 @@ mod tests {
             mast.mps.config().max_truncation_error,
             configured.max_truncation_error
         );
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn mast_zero_probability_deferred_loss_projects_complement_in_release() {
+        let configured = MpsConfig {
+            max_bond_dim: 1,
+            svd_cutoff: 1e-7,
+            max_truncation_error: Some(1e-4),
+            parallel: false,
+        };
+        let mut mast = Mast::with_seed(1, 1, 23).with_mps_config(configured);
+        mast.h(&[QubitId(0)]);
+        mast.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        let deferred = mast.deferred[0];
+        // Preserve a healthy survival ratio while emulating the probability
+        // zero returned when prior configured truncation erased this branch.
+        crate::stab_mps::measure::inject_zero_projection_probabilities(1);
+        mast.project_all();
+        assert_eq!(mast.deferred_branch_lost_count(), 1);
+        assert_deferred_ancilla_outcome(&mast, deferred.ancilla, !deferred.predetermined_outcome);
     }
 
     #[cfg(not(debug_assertions))]

--- a/exp/pecos-stab-tn/src/stab_mps/mast.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/mast.rs
@@ -101,13 +101,17 @@ struct DeferredMeasurement {
 /// RZ rotations; it does not project already deferred injections.
 ///
 /// The injection gadget's predetermined outcomes have exact probability 1/2
-/// for the untruncated state. If MPS truncation has occurred, that predetermined
-/// branch can deviate from the truncated representation's own distribution;
-/// it remains the branch required by the exact, untruncated gadget protocol.
+/// for the untruncated state. If truncation erases that deferred branch,
+/// `project_all` continues on the surviving complement. That continuation is a
+/// normalized approximate state whose injection-time correction does not match
+/// the projected outcome: it is not a valid gadget trajectory for either
+/// outcome. This additional bias is not represented by `truncation_error`;
+/// `deferred_branch_lost_count` is its only witness. An untruncated
+/// configuration never reaches this policy.
 ///
 /// Data-qubit measurements use an exact sample-then-force route: evaluate the
 /// physical Z expectation, sample that probability, then apply the normalized
-/// forced projector for the drawn outcome. This deliberately avoids the default
+/// forced projector for the drawn outcome. This deliberately avoids the
 /// `StabMps` pragmatic measurement path, whose uncompensated tableau
 /// pre-reduction is not composable with MAST's exact forced ancilla projections.
 /// Exact compensation can apply long-range CNOTs to the MPS and therefore cost
@@ -364,6 +368,30 @@ impl Mast {
         self.mps.truncation_error()
     }
 
+    /// True sum of all relative discarded SVD weights over this run.
+    #[must_use]
+    pub fn summed_discarded_weight(&self) -> f64 {
+        self.mps.summed_discarded_weight()
+    }
+
+    /// Largest coefficient-MPS bond dimension observed over this run.
+    #[must_use]
+    pub fn lifetime_peak_bond(&self) -> usize {
+        self.mps.lifetime_peak_bond()
+    }
+
+    /// Number of sampled data projections retried after branch vanish.
+    #[must_use]
+    pub fn branch_vanish_retry_count(&self) -> u64 {
+        self.mps.branch_vanish_retry_count()
+    }
+
+    /// Number of deferred gadget branches replaced by their complement.
+    #[must_use]
+    pub fn deferred_branch_lost_count(&self) -> u64 {
+        self.mps.deferred_branch_lost_count()
+    }
+
     /// Number of SVDs where `max_bond_dim` was the binding cap.
     /// Pending operations are not materialized by this diagnostic.
     #[must_use]
@@ -575,19 +603,56 @@ impl Mast {
         let bond_before = self.mps.max_bond_dim();
         self.projection_peak_bond = self.projection_peak_bond.max(bond_before);
 
-        // The branch correction was applied at injection time. Project only
-        // the ancilla, deterministically and with normalized output.
-        let projection = super::measure::project_forced_z_with_update(
-            &mut self.tableau,
-            &mut self.mps,
+        // The branch correction was applied at injection time. Try the
+        // predetermined branch transactionally so a vanished attempt cannot
+        // mutate the live tableau/MPS pair.
+        let original_tableau = self.tableau.clone();
+        let original_mps = self.mps.clone();
+        let mut candidate_tableau = original_tableau.clone();
+        let mut candidate_mps = original_mps.clone();
+        let mut projection = super::measure::project_forced_z_with_update(
+            &mut candidate_tableau,
+            &mut candidate_mps,
             dm.ancilla,
             dm.predetermined_outcome,
         )?;
-        super::repair_disent_flags(&self.mps, &mut self.disent_flags, &projection.update);
-        assert!(
-            projection.probability > 1e-20,
-            "predetermined magic-state gadget branch has zero represented weight"
+        let branch_lost = projection.snapped_probability == 0.0
+            || projection.survival_ratio < super::measure::BRANCH_VANISH_SURVIVAL_THRESHOLD;
+        debug_assert!(
+            !branch_lost,
+            "Mast::project_all predetermined deferred branch was lost"
         );
+        if branch_lost {
+            candidate_tableau = original_tableau;
+            candidate_mps = original_mps;
+            let original_config = candidate_mps.config().clone();
+            let mut retry_config = original_config.clone();
+            retry_config.max_bond_dim = candidate_mps.physical_rank_ceiling();
+            retry_config.svd_cutoff = 0.0;
+            retry_config.max_truncation_error = Some(0.0);
+            candidate_mps.set_config(retry_config);
+            projection = super::measure::project_forced_z_with_update(
+                &mut candidate_tableau,
+                &mut candidate_mps,
+                dm.ancilla,
+                !dm.predetermined_outcome,
+            )?;
+            let complement_lost = projection.snapped_probability == 0.0
+                || projection.survival_ratio < super::measure::BRANCH_VANISH_SURVIVAL_THRESHOLD;
+            debug_assert!(
+                !complement_lost,
+                "Mast::project_all complement deferred branch was also lost"
+            );
+            assert!(
+                !complement_lost,
+                "Mast::project_all complement deferred branch was also lost"
+            );
+            candidate_mps.set_config(original_config);
+            candidate_mps.record_deferred_branch_lost();
+        }
+        self.tableau = candidate_tableau;
+        self.mps = candidate_mps;
+        super::repair_disent_flags(&self.mps, &mut self.disent_flags, &projection.update);
 
         let bond_after = self.mps.max_bond_dim();
         self.projection_peak_bond = self.projection_peak_bond.max(bond_after);
@@ -604,40 +669,15 @@ impl Mast {
     /// Evaluate a physical data-qubit Z probability, then apply the normalized
     /// forced projector to the live state for the sampled outcome.
     fn measure_data_qubit_exact(&mut self, q_idx: usize) -> Result<MeasurementResult, MpsError> {
-        // Sample the exact physical observable before the forced projector's
-        // compensated tableau pre-reduction changes its internal basis.
-        let norm_squared = self.mps.norm_squared();
-        assert!(norm_squared > 1e-20, "cannot measure a zero-norm MPS");
-        let expectation = (super::measure::z_expectation_value(&self.tableau, &self.mps, q_idx).re
-            / norm_squared)
-            .clamp(-1.0, 1.0);
-        let probability_zero = f64::midpoint(1.0, expectation);
-        let probability_one = 1.0 - probability_zero;
-        // Match the forced projector's numerical zero threshold; unlike the
-        // pragmatic StabMps route, do not round merely near-deterministic
-        // probabilities to 0 or 1.
-        let is_deterministic = probability_zero.min(probability_one) < 1e-20;
-        let outcome = if is_deterministic {
-            probability_zero < probability_one
-        } else {
-            self.rng.random_bool(probability_one)
-        };
-
-        let projection = super::measure::project_forced_z_with_update(
+        let live = super::measure_qubit_exact_transactional(
             &mut self.tableau,
             &mut self.mps,
+            &mut self.rng,
             q_idx,
-            outcome,
+            "Mast::mz data-qubit projection",
         )?;
-        super::repair_disent_flags(&self.mps, &mut self.disent_flags, &projection.update);
-        assert!(
-            projection.probability > 1e-20,
-            "sampled data-measurement branch has zero represented weight"
-        );
-        Ok(MeasurementResult {
-            outcome,
-            is_deterministic,
-        })
+        super::repair_disent_flags(&self.mps, &mut self.disent_flags, &live.update);
+        Ok(live.measurement)
     }
 }
 
@@ -1833,5 +1873,54 @@ mod tests {
             0,
             "CZ should not flush pending_rz, merge persists"
         );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Mast::project_all predetermined deferred branch was lost")]
+    fn mast_deferred_branch_loss_keeps_debug_assertion() {
+        let mut mast = Mast::with_seed(1, 1, 17);
+        mast.h(&[QubitId(0)]);
+        mast.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        crate::stab_mps::measure::inject_projection_vanishes(1);
+        mast.project_all();
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn mast_deferred_branch_loss_uses_untruncated_complement_in_release() {
+        let configured = MpsConfig {
+            max_bond_dim: 1,
+            svd_cutoff: 1e-7,
+            max_truncation_error: Some(1e-4),
+            parallel: false,
+        };
+        let mut mast = Mast::with_seed(1, 1, 17).with_mps_config(configured.clone());
+        mast.h(&[QubitId(0)]);
+        mast.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        crate::stab_mps::measure::inject_projection_vanishes(1);
+        mast.project_all();
+        assert_eq!(mast.deferred_branch_lost_count(), 1);
+        assert!((mast.mps.norm_squared() - 1.0).abs() < 1e-12);
+        assert_eq!(mast.mps.config().max_bond_dim, configured.max_bond_dim);
+        assert_eq!(
+            mast.mps.config().svd_cutoff.to_bits(),
+            configured.svd_cutoff.to_bits()
+        );
+        assert_eq!(
+            mast.mps.config().max_truncation_error,
+            configured.max_truncation_error
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    #[should_panic(expected = "Mast::project_all complement deferred branch was also lost")]
+    fn mast_deferred_double_loss_panics_in_release() {
+        let mut mast = Mast::with_seed(1, 1, 29);
+        mast.h(&[QubitId(0)]);
+        mast.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(0)]);
+        crate::stab_mps::measure::inject_projection_vanishes(2);
+        mast.project_all();
     }
 }

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -36,9 +36,22 @@ std::thread_local! {
     static INJECTED_PROJECTION_VANISHES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+#[cfg(all(test, not(debug_assertions)))]
+std::thread_local! {
+    static INJECTED_ZERO_PROBABILITIES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 #[cfg(test)]
 pub(super) fn inject_projection_vanishes(count: usize) {
     INJECTED_PROJECTION_VANISHES.with(|remaining| remaining.set(count));
+}
+
+#[cfg(all(test, not(debug_assertions)))]
+pub(super) fn inject_zero_projection_probabilities(count: usize) {
+    // Model a branch whose amplitude was erased by earlier configured
+    // truncation: projection itself leaves a healthy normalized candidate,
+    // but reports an exactly zero Born probability to the MAST owner.
+    INJECTED_ZERO_PROBABILITIES.with(|remaining| remaining.set(count));
 }
 
 #[cfg(test)]
@@ -52,8 +65,26 @@ fn inject_projection_vanish_if_requested(mps: &mut Mps) {
     });
 }
 
+#[cfg(all(test, not(debug_assertions)))]
+fn inject_zero_projection_probability_if_requested(probability: f64) -> f64 {
+    INJECTED_ZERO_PROBABILITIES.with(|remaining| {
+        let count = remaining.get();
+        if count > 0 {
+            remaining.set(count - 1);
+            0.0
+        } else {
+            probability
+        }
+    })
+}
+
 #[cfg(not(test))]
 fn inject_projection_vanish_if_requested(_mps: &mut Mps) {}
+
+#[cfg(any(not(test), debug_assertions))]
+fn inject_zero_projection_probability_if_requested(probability: f64) -> f64 {
+    probability
+}
 
 /// Virtual coefficient-MPS sites whose disentangling proofs must be rechecked
 /// after a physical measurement projection.
@@ -78,6 +109,15 @@ pub(super) struct LiveMeasurementResult {
     pub(super) update: ProjectionUpdate,
 }
 
+/// Block-norm tolerance for the coefficient-MPS computational-basis fast path.
+///
+/// A bond-one site with either physical block below this threshold is treated
+/// as a basis state. Its physical measurement probability is consequently
+/// quantized to the stabilizer values `{0, 1/2, 1}` before both sampling and
+/// projection; this tolerance is intentionally distinct from the Pauli
+/// endpoint snap below.
+pub(super) const TRIVIAL_MPS_BLOCK_NORM_TOLERANCE: f64 = 1e-12;
+
 /// Check if the MPS is trivial (all sites in a computational basis state).
 fn is_mps_trivial(mps: &Mps) -> bool {
     mps.max_bond_dim() == 1
@@ -89,7 +129,7 @@ fn is_mps_trivial(mps: &Mps) -> bool {
             let b1_norm: f64 = (0..t.nrows())
                 .flat_map(|i| (0..chi_r).map(move |j| t[(i, chi_r + j)].norm_sqr()))
                 .sum();
-            b0_norm < 1e-12 || b1_norm < 1e-12
+            b0_norm < TRIVIAL_MPS_BLOCK_NORM_TOLERANCE || b1_norm < TRIVIAL_MPS_BLOCK_NORM_TOLERANCE
         })
 }
 
@@ -128,7 +168,7 @@ fn canonicalize_trivial_mps_basis(
         // Every project_forced_z entry path normalizes before this helper can
         // be reached again, so the block weight has unit-state scale and this
         // absolute zero threshold is intentional.
-        if block_0_norm < 1e-12 {
+        if block_0_norm < TRIVIAL_MPS_BLOCK_NORM_TOLERANCE {
             // C|...1...> = (C X_site)(X_site|...1...>).
             let before = phase_accumulator.as_ref().map(|_| tableau.clone());
             crate::stab_mps::tableau_compose::right_compose_x(tableau, site);
@@ -242,6 +282,44 @@ pub(super) fn forced_outcome_probability(expectation: f64, outcome: bool) -> f64
         1.0 - probability_zero
     } else {
         probability_zero
+    }
+}
+
+fn quantize_trivial_probability(probability: f64) -> f64 {
+    [0.0_f64, 0.5, 1.0]
+        .into_iter()
+        .min_by(|left, right| {
+            (probability - *left)
+                .abs()
+                .total_cmp(&(probability - *right).abs())
+        })
+        .expect("three trivial probabilities")
+}
+
+/// Return the probability used by both exact sampling and forced projection.
+///
+/// The trivial coefficient-MPS path is a pure stabilizer state even when
+/// contraction roundoff reports a nearby non-stabilizer value, so its result
+/// is quantized to `{0, 1/2, 1}` under the same predicate used by the
+/// projector's tableau fast path.
+pub(super) fn z_outcome_probability(
+    tableau: &SparseStabY,
+    mps: &Mps,
+    q_idx: usize,
+    outcome: bool,
+    operation: &str,
+) -> f64 {
+    let norm_squared = mps.norm_squared();
+    assert!(
+        norm_squared.is_finite() && norm_squared > 0.0,
+        "{operation}: cannot measure an MPS with non-finite or zero norm"
+    );
+    let expectation = (z_expectation_value(tableau, mps, q_idx).re / norm_squared).clamp(-1.0, 1.0);
+    let probability = forced_outcome_probability(expectation, outcome);
+    if is_mps_trivial(mps) {
+        quantize_trivial_probability(probability)
+    } else {
+        probability
     }
 }
 
@@ -977,20 +1055,16 @@ fn project_single_flip_without_sign(
     mps.set_physical_block(id, 1, &zero);
 }
 
-/// Remove the direct-sum projector's structurally oversized virtual bonds
-/// without discarding any component of the state.
+/// Remove the direct-sum projector's structurally oversized virtual bonds.
 ///
 /// A right-canonical QR sweep is an exact factorization and bounds every bond
-/// by the Hilbert-space dimension to its right. This avoids applying the
-/// cutoff-based SVD compressor to the cancellation-heavy projected sum. Only
-/// a bond that still exceeds the caller's explicit approximation cap is sent
-/// through the configured compressor.
+/// by the Hilbert-space dimension to its right. The following configured SVD
+/// sweep reuses that gauge and runs unconditionally: it removes exact rank
+/// redundancy and numerical dust, while any nonzero truncation remains the
+/// caller-approved cutoff/cap behavior and is recorded by MPS telemetry.
 fn reduce_exact_projection_bonds(mps: &mut Mps) -> Result<(), MpsError> {
     mps.right_canonicalize();
-    if mps.max_bond_dim() > mps.config().max_bond_dim {
-        mps.compress()?;
-    }
-    Ok(())
+    mps.compress_from_right_canonical()
 }
 
 /// Shared implementation for tracked and phase-insensitive forced projection.
@@ -1010,6 +1084,7 @@ fn project_forced_z_with_update_impl(
         pre_projection_norm_squared > 0.0,
         "cannot project a zero-norm MPS"
     );
+    let probability = z_outcome_probability(tableau, mps, q_idx, outcome, "forced Z projection");
     if is_mps_trivial(mps) {
         // A trivial coefficient MPS represents a pure stabilizer state. First
         // absorb a possible nonzero virtual basis word into the tableau; only
@@ -1017,7 +1092,7 @@ fn project_forced_z_with_update_impl(
         let modified_sites =
             canonicalize_trivial_mps_basis(tableau, mps, phase_accumulator.as_deref_mut());
         let decomp = decompose_z(tableau.stabs(), tableau.destabs(), q_idx);
-        let probability = match decomp {
+        let tableau_probability: f64 = match decomp {
             ZDecomposition::Stabilizer { phase, .. } => {
                 if (phase.re < 0.0) == outcome {
                     1.0
@@ -1027,6 +1102,7 @@ fn project_forced_z_with_update_impl(
             }
             ZDecomposition::DestabilizerFlip { .. } => 0.5,
         };
+        debug_assert_eq!(probability.to_bits(), tableau_probability.to_bits());
         if probability > 0.0 {
             let before_measurement = phase_accumulator.as_ref().map(|_| tableau.clone());
             tableau.mz_forced(q_idx, outcome);
@@ -1049,7 +1125,7 @@ fn project_forced_z_with_update_impl(
             mps.normalize();
         }
         return Ok(ForcedProjectionResult {
-            snapped_probability: probability,
+            snapped_probability: inject_zero_projection_probability_if_requested(probability),
             survival_ratio,
             update: ProjectionUpdate {
                 collapsed_site: None,
@@ -1058,11 +1134,6 @@ fn project_forced_z_with_update_impl(
         });
     }
 
-    // Evaluate the Born probability in the incoming representation before
-    // generator pre-reduction changes the tableau/MPS factorization.
-    let expectation = (z_expectation_value(tableau, mps, q_idx).re / pre_projection_norm_squared)
-        .clamp(-1.0, 1.0);
-
     // Reduce to one virtual X site while compensating every generator-basis
     // CNOT on the MPS. This preserves C·MPS exactly.
     let mut modified_sites = pre_reduce_for_measurement(tableau, mps, q_idx, true)?;
@@ -1070,7 +1141,6 @@ fn project_forced_z_with_update_impl(
 
     match decomposition {
         ZDecomposition::Stabilizer { phase, sign_sites } => {
-            let probability = forced_outcome_probability(expectation, outcome);
             if probability == 0.0 {
                 let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
                 return Ok(ForcedProjectionResult {
@@ -1093,9 +1163,7 @@ fn project_forced_z_with_update_impl(
             // The physical observable was already in the stabilizer span, so
             // mz_forced performs no Clifford-basis change. The projected
             // stabilizer-sign superposition remains encoded in the MPS.
-            if !sign_sites.is_empty() {
-                reduce_exact_projection_bonds(mps)?;
-            }
+            reduce_exact_projection_bonds(mps)?;
             inject_projection_vanish_if_requested(mps);
             let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
             if survival_ratio >= BRANCH_VANISH_SURVIVAL_THRESHOLD {
@@ -1105,7 +1173,7 @@ fn project_forced_z_with_update_impl(
             modified_sites.sort_unstable();
             modified_sites.dedup();
             Ok(ForcedProjectionResult {
-                snapped_probability: probability,
+                snapped_probability: inject_zero_projection_probability_if_requested(probability),
                 survival_ratio,
                 update: ProjectionUpdate {
                     collapsed_site: None,
@@ -1123,7 +1191,6 @@ fn project_forced_z_with_update_impl(
                 1,
                 "forced projection must have one flip after pre-reduction"
             );
-            let probability = forced_outcome_probability(expectation, outcome);
             if probability == 0.0 {
                 let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
                 return Ok(ForcedProjectionResult {
@@ -1173,9 +1240,7 @@ fn project_forced_z_with_update_impl(
             // destabilizer gauge. Therefore the post-H canonical ket cached
             // by the phase tracker remains valid for the measured tableau and
             // can be the before-ket of the next scalar site.
-            if !is_local_projection {
-                reduce_exact_projection_bonds(mps)?;
-            }
+            reduce_exact_projection_bonds(mps)?;
             inject_projection_vanish_if_requested(mps);
             let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
             if survival_ratio >= BRANCH_VANISH_SURVIVAL_THRESHOLD {
@@ -1187,7 +1252,7 @@ fn project_forced_z_with_update_impl(
             modified_sites.sort_unstable();
             modified_sites.dedup();
             Ok(ForcedProjectionResult {
-                snapped_probability: probability,
+                snapped_probability: inject_zero_projection_probability_if_requested(probability),
                 survival_ratio,
                 update: ProjectionUpdate {
                     collapsed_site: Some(flip_sites[0]),
@@ -1833,6 +1898,54 @@ mod tests {
         let vanished = project_forced_z_with_update(&mut tableau, &mut mps, 0, false).unwrap();
         assert!((vanished.snapped_probability - 0.5).abs() < 1e-14);
         assert!(vanished.survival_ratio < BRANCH_VANISH_SURVIVAL_THRESHOLD);
+    }
+
+    #[test]
+    fn trivial_probability_quantization_is_shared_by_sampling_and_projection() {
+        assert_eq!(
+            quantize_trivial_probability(0.499_999_68).to_bits(),
+            0.5_f64.to_bits()
+        );
+
+        let probability_one: f64 = 1.0e-13;
+        let mut mps = Mps::new(1, MpsConfig::default());
+        let preparation = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new((1.0 - probability_one).sqrt(), 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(probability_one.sqrt(), 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+        );
+        mps.apply_one_site_gate(0, &preparation).unwrap();
+        let mut tableau = SparseStabY::new(1).with_destab_sign_tracking();
+        let sampled_probability =
+            z_outcome_probability(&tableau, &mps, 0, true, "trivial probability test");
+        let projected = project_forced_z_with_update(&mut tableau, &mut mps, 0, true).unwrap();
+        assert_eq!(sampled_probability.to_bits(), 0.0_f64.to_bits());
+        assert_eq!(
+            projected.snapped_probability.to_bits(),
+            sampled_probability.to_bits()
+        );
+    }
+
+    #[test]
+    fn exact_projection_compresses_clean_rank_redundancy_without_discarded_weight() {
+        let product = Mps::new(4, MpsConfig::default());
+        let mut mps = product.add(&product);
+        mps.normalize();
+        mps.reset_truncation_stats();
+        assert_eq!(mps.max_bond_dim(), 2);
+        let mut tableau = SparseStabY::new(4).with_destab_sign_tracking();
+
+        let projection = project_forced_z_with_update(&mut tableau, &mut mps, 0, false).unwrap();
+
+        assert_eq!(projection.snapped_probability.to_bits(), 1.0_f64.to_bits());
+        assert_eq!(mps.max_bond_dim(), 1);
+        assert_eq!(mps.summed_discarded_weight().to_bits(), 0.0_f64.to_bits());
+        assert_eq!(mps.truncation_error().to_bits(), 0.0_f64.to_bits());
     }
 
     #[test]

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -31,6 +31,30 @@ use pecos_core::BitSet;
 use pecos_random::PecosRng;
 use pecos_simulators::{CliffordGateable, MeasurementResult, SparseStabY};
 
+#[cfg(test)]
+std::thread_local! {
+    static INJECTED_PROJECTION_VANISHES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(super) fn inject_projection_vanishes(count: usize) {
+    INJECTED_PROJECTION_VANISHES.with(|remaining| remaining.set(count));
+}
+
+#[cfg(test)]
+fn inject_projection_vanish_if_requested(mps: &mut Mps) {
+    INJECTED_PROJECTION_VANISHES.with(|remaining| {
+        let count = remaining.get();
+        if count > 0 {
+            remaining.set(count - 1);
+            mps.scale(Complex64::new(0.0, 0.0));
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn inject_projection_vanish_if_requested(_mps: &mut Mps) {}
+
 /// Virtual coefficient-MPS sites whose disentangling proofs must be rechecked
 /// after a physical measurement projection.
 #[derive(Debug, Default)]
@@ -43,7 +67,8 @@ pub(super) struct ProjectionUpdate {
 
 /// Probability and virtual-site metadata returned by a forced projection.
 pub(super) struct ForcedProjectionResult {
-    pub(super) probability: f64,
+    pub(super) snapped_probability: f64,
+    pub(super) survival_ratio: f64,
     pub(super) update: ProjectionUpdate,
 }
 
@@ -184,7 +209,20 @@ pub fn z_expectation_value(tableau: &SparseStabY, mps: &Mps, q: usize) -> Comple
     }
 }
 
-fn forced_outcome_probability(expectation: f64, outcome: bool) -> f64 {
+/// Endpoint tolerance shared by sampling and forced projection.
+///
+/// A cancellation residue this close to a Pauli endpoint would be amplified
+/// by the projector's division by `sqrt(probability)`, so it is classified as
+/// the indistinguishable exact endpoint before any RNG draw.
+pub(super) const EXPECTATION_ENDPOINT_TOLERANCE: f64 = 1e-14;
+
+/// A normalized forced projector divides by `sqrt(probability)`, so a valid
+/// post-projection state has a survival ratio near one regardless of its Born
+/// probability. `1e-12` is therefore twelve orders below a healthy branch; it
+/// is not a lower bound on the smallest admissible probability.
+pub(super) const BRANCH_VANISH_SURVIVAL_THRESHOLD: f64 = 1e-12;
+
+pub(super) fn forced_outcome_probability(expectation: f64, outcome: bool) -> f64 {
     // This endpoint guard is deliberately looser than the 1e-15 product-site
     // installer and its 5e-16 proof assertion. Those tolerances classify a
     // normalized physical marginal after environment contraction. Here the
@@ -194,7 +232,6 @@ fn forced_outcome_probability(expectation: f64, outcome: bool) -> f64 {
     // normalize() turns it into a spurious state. Values within 1e-14 of a
     // Pauli endpoint are therefore treated as the exact eigenvalue they are
     // indistinguishable from at this contraction's accuracy.
-    const EXPECTATION_ENDPOINT_TOLERANCE: f64 = 1e-14;
     let expectation = if 1.0 - expectation.abs() <= EXPECTATION_ENDPOINT_TOLERANCE {
         expectation.signum()
     } else {
@@ -206,6 +243,24 @@ fn forced_outcome_probability(expectation: f64, outcome: bool) -> f64 {
     } else {
         probability_zero
     }
+}
+
+fn projection_survival_ratio(mps: &Mps, pre_projection_norm_squared: f64) -> f64 {
+    let post_projection_norm_squared = mps.norm_squared();
+    assert!(
+        pre_projection_norm_squared.is_finite() && post_projection_norm_squared.is_finite(),
+        "forced Z projection produced a non-finite pre/post norm"
+    );
+    assert!(
+        pre_projection_norm_squared > 0.0,
+        "cannot project a zero-norm MPS"
+    );
+    let ratio = post_projection_norm_squared / pre_projection_norm_squared;
+    assert!(
+        ratio.is_finite(),
+        "forced Z projection produced a non-finite survival ratio"
+    );
+    ratio
 }
 
 /// Compute the inner product <`mps_a|mps_b`> by contracting from left to right.
@@ -282,7 +337,7 @@ pub fn pre_reduce_for_measurement_pub(
 ///
 /// `apply_mps_compensation` is `true` for the exact-state caller
 /// `project_forced_z`, used by `prob_bitstring` / `amplitude_iterative`. It is `false` for random
-/// measurement (`measure_qubit_stab_mps`): the state representation becomes
+/// measurement (`measure_qubit_stab_mps_pragmatic`): the state representation becomes
 /// inconsistent with the tableau after row ops, but measurement
 /// statistics stay correct and subsequent measurements remain
 /// self-consistent. Skipping compensation avoids SWAP-chain bond growth
@@ -946,6 +1001,15 @@ fn project_forced_z_with_update_impl(
     outcome: bool,
     mut phase_accumulator: Option<&mut crate::stab_mps::canonical_ket::CanonicalPhaseTracker>,
 ) -> Result<ForcedProjectionResult, MpsError> {
+    let pre_projection_norm_squared = mps.norm_squared();
+    assert!(
+        pre_projection_norm_squared.is_finite(),
+        "forced Z projection received a non-finite pre-projection norm"
+    );
+    assert!(
+        pre_projection_norm_squared > 0.0,
+        "cannot project a zero-norm MPS"
+    );
     if is_mps_trivial(mps) {
         // A trivial coefficient MPS represents a pure stabilizer state. First
         // absorb a possible nonzero virtual basis word into the tableau; only
@@ -978,10 +1042,15 @@ fn project_forced_z_with_update_impl(
                     probability,
                 );
             }
+        }
+        inject_projection_vanish_if_requested(mps);
+        let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
+        if probability > 0.0 && survival_ratio >= BRANCH_VANISH_SURVIVAL_THRESHOLD {
             mps.normalize();
         }
         return Ok(ForcedProjectionResult {
-            probability,
+            snapped_probability: probability,
+            survival_ratio,
             update: ProjectionUpdate {
                 collapsed_site: None,
                 modified_sites,
@@ -991,9 +1060,8 @@ fn project_forced_z_with_update_impl(
 
     // Evaluate the Born probability in the incoming representation before
     // generator pre-reduction changes the tableau/MPS factorization.
-    let norm_squared = mps.norm_squared();
-    assert!(norm_squared > 1e-20, "cannot project a zero-norm MPS");
-    let expectation = (z_expectation_value(tableau, mps, q_idx).re / norm_squared).clamp(-1.0, 1.0);
+    let expectation = (z_expectation_value(tableau, mps, q_idx).re / pre_projection_norm_squared)
+        .clamp(-1.0, 1.0);
 
     // Reduce to one virtual X site while compensating every generator-basis
     // CNOT on the MPS. This preserves C·MPS exactly.
@@ -1003,9 +1071,11 @@ fn project_forced_z_with_update_impl(
     match decomposition {
         ZDecomposition::Stabilizer { phase, sign_sites } => {
             let probability = forced_outcome_probability(expectation, outcome);
-            if probability < 1e-20 {
+            if probability == 0.0 {
+                let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
                 return Ok(ForcedProjectionResult {
-                    probability: 0.0,
+                    snapped_probability: 0.0,
+                    survival_ratio,
                     update: ProjectionUpdate {
                         collapsed_site: None,
                         modified_sites,
@@ -1026,12 +1096,17 @@ fn project_forced_z_with_update_impl(
             if !sign_sites.is_empty() {
                 reduce_exact_projection_bonds(mps)?;
             }
-            mps.normalize();
+            inject_projection_vanish_if_requested(mps);
+            let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
+            if survival_ratio >= BRANCH_VANISH_SURVIVAL_THRESHOLD {
+                mps.normalize();
+            }
             modified_sites.extend(sign_sites);
             modified_sites.sort_unstable();
             modified_sites.dedup();
             Ok(ForcedProjectionResult {
-                probability,
+                snapped_probability: probability,
+                survival_ratio,
                 update: ProjectionUpdate {
                     collapsed_site: None,
                     modified_sites,
@@ -1049,9 +1124,11 @@ fn project_forced_z_with_update_impl(
                 "forced projection must have one flip after pre-reduction"
             );
             let probability = forced_outcome_probability(expectation, outcome);
-            if probability < 1e-20 {
+            if probability == 0.0 {
+                let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
                 return Ok(ForcedProjectionResult {
-                    probability: 0.0,
+                    snapped_probability: 0.0,
+                    survival_ratio,
                     update: ProjectionUpdate {
                         collapsed_site: None,
                         modified_sites,
@@ -1099,14 +1176,19 @@ fn project_forced_z_with_update_impl(
             if !is_local_projection {
                 reduce_exact_projection_bonds(mps)?;
             }
-            mps.normalize();
+            inject_projection_vanish_if_requested(mps);
+            let survival_ratio = projection_survival_ratio(mps, pre_projection_norm_squared);
+            if survival_ratio >= BRANCH_VANISH_SURVIVAL_THRESHOLD {
+                mps.normalize();
+            }
             modified_sites.extend(flip_sites.iter().copied());
             modified_sites.extend(sign_sites);
             modified_sites.extend(gauge_sites);
             modified_sites.sort_unstable();
             modified_sites.dedup();
             Ok(ForcedProjectionResult {
-                probability,
+                snapped_probability: probability,
+                survival_ratio,
                 update: ProjectionUpdate {
                     collapsed_site: Some(flip_sites[0]),
                     modified_sites,
@@ -1119,7 +1201,7 @@ fn project_forced_z_with_update_impl(
 /// Project qubit `q_idx` onto a forced Z-basis outcome and return its
 /// probability together with the affected virtual coefficient-MPS sites.
 ///
-/// Mirrors `measure_qubit_stab_mps` but is deterministic: the caller supplies
+/// Mirrors `measure_qubit_stab_mps_pragmatic` but is deterministic: the caller supplies
 /// the outcome. This is the phase-insensitive Liu-Clark 2412.17209 Algorithm 3
 /// / VI.A path used by probability and measurement callers.
 ///
@@ -1147,7 +1229,7 @@ pub(super) fn project_forced_z_with_phase(
 ) -> Result<f64, MpsError> {
     Ok(
         project_forced_z_with_update_impl(tableau, mps, q_idx, outcome, Some(phase_accumulator))?
-            .probability,
+            .snapped_probability,
     )
 }
 
@@ -1163,7 +1245,7 @@ pub fn project_forced_z(
     q_idx: usize,
     outcome: bool,
 ) -> Result<f64, MpsError> {
-    Ok(project_forced_z_with_update(tableau, mps, q_idx, outcome)?.probability)
+    Ok(project_forced_z_with_update(tableau, mps, q_idx, outcome)?.snapped_probability)
 }
 
 /// Measure qubit `q_idx` in the Z basis using the STN protocol.
@@ -1685,12 +1767,17 @@ pub(super) fn measure_qubit_stab_mps_with_update(
     }
 }
 
-/// Measure qubit `q_idx` in the Z basis using the eager STN protocol.
+/// Measure qubit `q_idx` with the pragmatic eager STN protocol.
+///
+/// This path deliberately skips coefficient-MPS compensation when tableau
+/// generator pre-reduction is needed. Its outcome stream remains internally
+/// useful for throughput-oriented workloads, but the stored conditional state
+/// is biased and cannot support exact continuation or amplitude reads.
 ///
 /// # Errors
 ///
 /// Returns an [`MpsError`] if an MPS operation fails.
-pub fn measure_qubit_stab_mps(
+pub fn measure_qubit_stab_mps_pragmatic(
     tableau: &mut SparseStabY,
     mps: &mut Mps,
     rng: &mut PecosRng,
@@ -1707,6 +1794,54 @@ mod tests {
     fn sort_dedup(v: &mut Vec<usize>) {
         v.sort_unstable();
         v.dedup();
+    }
+
+    #[test]
+    fn endpoint_probability_and_survival_loss_are_distinct_classifications() {
+        let probability_one: f64 = 4.0e-15;
+        let mut mps = Mps::new(1, MpsConfig::default());
+        let preparation = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new((1.0 - probability_one).sqrt(), 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(probability_one.sqrt(), 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+        );
+        mps.apply_one_site_gate(0, &preparation).unwrap();
+        let mut tableau = SparseStabY::new(1).with_destab_sign_tracking();
+        let endpoint = project_forced_z_with_update(&mut tableau, &mut mps, 0, true).unwrap();
+        assert_eq!(endpoint.snapped_probability.to_bits(), 0.0_f64.to_bits());
+        assert!(endpoint.survival_ratio > 1.0 - 1e-12);
+
+        let mut mps = Mps::new(1, MpsConfig::default());
+        let hadamard = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0),
+                Complex64::new(-std::f64::consts::FRAC_1_SQRT_2, 0.0),
+            ],
+        );
+        mps.apply_one_site_gate(0, &hadamard).unwrap();
+        let mut tableau = SparseStabY::new(1).with_destab_sign_tracking();
+        inject_projection_vanishes(1);
+        let vanished = project_forced_z_with_update(&mut tableau, &mut mps, 0, false).unwrap();
+        assert!((vanished.snapped_probability - 0.5).abs() < 1e-14);
+        assert!(vanished.survival_ratio < BRANCH_VANISH_SURVIVAL_THRESHOLD);
+    }
+
+    #[test]
+    fn renamed_pragmatic_low_level_entry_is_callable() {
+        let mut tableau = SparseStabY::new(1).with_destab_sign_tracking();
+        let mut mps = Mps::new(1, MpsConfig::default());
+        let mut rng = PecosRng::seed_from_u64(11);
+        let result = measure_qubit_stab_mps_pragmatic(&mut tableau, &mut mps, &mut rng, 0).unwrap();
+        assert!(!result.outcome);
     }
 
     #[test]

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -12,8 +12,9 @@
 
 //! Statistical falsifier for the default `StabMps` random-measurement route.
 //!
-//! The default route is exact sample-then-force. Fast surfaces run normally;
-//! larger release matrices remain in the explicit ignored lane. The liveness
+//! The default route is exact sample-then-force. Debug builds run a tiny smoke
+//! subset; optimized builds run the full fast surface matrix, while larger
+//! matrices remain in the explicit ignored release lane. The liveness
 //! meta-test selects `Pragmatic` explicitly and proves the known bias remains
 //! visible to the harness.
 
@@ -25,8 +26,14 @@ use pecos_stab_tn::stab_mps::mast::Mast;
 use pecos_stab_tn::stab_mps::{MeasurementMode, PauliKind, StabMps};
 use rayon::prelude::*;
 
+#[cfg(debug_assertions)]
+const DEBUG_SHOTS: usize = 16;
+#[cfg(not(debug_assertions))]
 const FAST_SHOTS: usize = 2_048;
 const RELEASE_SHOTS: usize = 1_024;
+#[cfg(debug_assertions)]
+const META_SHOTS: usize = 32;
+#[cfg(not(debug_assertions))]
 const META_SHOTS: usize = 256;
 const PROBABILITY_EPSILON: f64 = 1e-14;
 
@@ -442,18 +449,12 @@ fn exact_probabilities(surface: Surface, num_qubits: usize) -> Vec<f64> {
     probabilities
 }
 
-fn run_stn_shot_with_mode(
-    surface: Surface,
-    num_qubits: usize,
-    seed: u64,
-    mode: MeasurementMode,
-) -> usize {
+fn run_built_stn_shot(surface: Surface, num_qubits: usize, mut simulator: StabMps) -> usize {
     let preparation_qubits = if surface == Surface::ExtractSyndromes {
         num_qubits - 1
     } else {
         num_qubits
     };
-    let mut simulator = build_stn_with_mode(num_qubits, seed, mode);
     replay_gates(
         &mut simulator,
         &honest_family(preparation_qubits, num_qubits),
@@ -505,8 +506,21 @@ fn run_stn_shot_with_mode(
     encode_bits(&bits)
 }
 
+fn run_stn_shot_with_mode(
+    surface: Surface,
+    num_qubits: usize,
+    seed: u64,
+    mode: MeasurementMode,
+) -> usize {
+    run_built_stn_shot(
+        surface,
+        num_qubits,
+        build_stn_with_mode(num_qubits, seed, mode),
+    )
+}
+
 fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
-    run_stn_shot_with_mode(surface, num_qubits, seed, MeasurementMode::Exact)
+    run_built_stn_shot(surface, num_qubits, build_stn(num_qubits, seed))
 }
 
 fn run_mast_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
@@ -955,6 +969,7 @@ fn exact_default_measurement_falsifier_is_live() {
 
 macro_rules! surface_gate_tests {
     ($fast_name:ident, $release_name:ident, $surface:expr) => {
+        #[cfg(not(debug_assertions))]
         #[test]
         fn $fast_name() {
             assert_surface_matrix($surface, &[3, 4], FAST_SHOTS);
@@ -966,6 +981,18 @@ macro_rules! surface_gate_tests {
             assert_surface_matrix($surface, &[5, 6], RELEASE_SHOTS);
         }
     };
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn exact_default_debug_smoke_subset() {
+    for surface in [
+        Surface::MzMid,
+        Surface::ExtractSyndromes,
+        Surface::Continuation,
+    ] {
+        assert_surface_matrix(surface, &[3], DEBUG_SHOTS);
+    }
 }
 
 surface_gate_tests!(

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -12,17 +12,17 @@
 
 //! Statistical falsifier for the default `StabMps` random-measurement route.
 //!
-//! The gate tests are intentionally ignored until the default route changes from
-//! pragmatic measurement to exact sample-then-force. The non-ignored meta-test
-//! proves that the harness can see the current bias and will fail when the default
-//! changes, forcing the gate tests to be un-ignored at that point.
+//! The default route is exact sample-then-force. Fast surfaces run normally;
+//! larger release matrices remain in the explicit ignored lane. The liveness
+//! meta-test selects `Pragmatic` explicitly and proves the known bias remains
+//! visible to the harness.
 
 use num_complex::Complex64;
 use pecos_core::{Angle64, QubitId};
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, DenseStateVec};
 use pecos_stab_tn::mps::MpsConfig;
 use pecos_stab_tn::stab_mps::mast::Mast;
-use pecos_stab_tn::stab_mps::{PauliKind, StabMps};
+use pecos_stab_tn::stab_mps::{MeasurementMode, PauliKind, StabMps};
 use rayon::prelude::*;
 
 const FAST_SHOTS: usize = 2_048;
@@ -159,6 +159,17 @@ fn exact_mps_config() -> MpsConfig {
         max_truncation_error: Some(0.0),
         parallel: false,
     }
+}
+
+fn build_stn_with_mode(num_qubits: usize, seed: u64, mode: MeasurementMode) -> StabMps {
+    StabMps::builder(num_qubits)
+        .seed(seed)
+        .measurement(mode)
+        .merge_rz(false)
+        .max_bond_dim(64)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build()
 }
 
 fn build_stn(num_qubits: usize, seed: u64) -> StabMps {
@@ -431,13 +442,18 @@ fn exact_probabilities(surface: Surface, num_qubits: usize) -> Vec<f64> {
     probabilities
 }
 
-fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
+fn run_stn_shot_with_mode(
+    surface: Surface,
+    num_qubits: usize,
+    seed: u64,
+    mode: MeasurementMode,
+) -> usize {
     let preparation_qubits = if surface == Surface::ExtractSyndromes {
         num_qubits - 1
     } else {
         num_qubits
     };
-    let mut simulator = build_stn(num_qubits, seed);
+    let mut simulator = build_stn_with_mode(num_qubits, seed, mode);
     replay_gates(
         &mut simulator,
         &honest_family(preparation_qubits, num_qubits),
@@ -487,6 +503,10 @@ fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
         surface.name()
     );
     encode_bits(&bits)
+}
+
+fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
+    run_stn_shot_with_mode(surface, num_qubits, seed, MeasurementMode::Exact)
 }
 
 fn run_mast_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
@@ -758,9 +778,147 @@ fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
     );
 }
 
+fn state_fidelity(first: &[Complex64], second: &[Complex64]) -> f64 {
+    first
+        .iter()
+        .zip(second)
+        .map(|(left, right)| left.conj() * right)
+        .sum::<Complex64>()
+        .norm_sqr()
+}
+
+fn assert_default_state_matches(
+    simulator: &mut StabMps,
+    expected: &mut DenseStateVec,
+    context: &str,
+) {
+    simulator.flush();
+    let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+    assert!(
+        fidelity >= 1.0 - 1e-10,
+        "{context}: conditional-state fidelity={fidelity:.16}"
+    );
+}
+
+#[test]
+fn exact_default_conditional_state_fidelity_matrix() {
+    for num_qubits in 3..=4 {
+        let measured = num_qubits / 2;
+        let preparation = honest_family(num_qubits, 0x41 + num_qubits);
+
+        let prepare = |seed| {
+            let mut stn = build_stn(num_qubits, seed);
+            let mut dense = DenseStateVec::new(num_qubits);
+            replay_gates(&mut stn, &preparation);
+            replay_gates(&mut dense, &preparation);
+            (stn, dense)
+        };
+
+        let (mut stn, dense) = prepare(0x7100 + num_qubits as u64);
+        let outcome = stn.mz(&[QubitId(measured)])[0].outcome;
+        let (_, mut expected) = projected_dense_state(dense, measured, outcome).unwrap();
+        assert_default_state_matches(
+            &mut stn,
+            &mut expected,
+            &format!("default mz n={num_qubits}"),
+        );
+
+        let (mut stn, dense) = prepare(0x7200 + num_qubits as u64);
+        let outcome = stn.reset_qubit(QubitId(measured));
+        let (_, mut expected) = projected_dense_state(dense, measured, outcome).unwrap();
+        if outcome {
+            expected.x(&[QubitId(measured)]);
+        }
+        assert_default_state_matches(
+            &mut stn,
+            &mut expected,
+            &format!("default reset n={num_qubits}"),
+        );
+
+        for px in [false, true] {
+            let (mut stn, dense) = prepare(0x7300 + num_qubits as u64 + u64::from(px));
+            if px {
+                stn.px(QubitId(measured));
+            } else {
+                stn.pz(QubitId(measured));
+            }
+            let branch = DenseBranch {
+                state: dense,
+                probability: 1.0,
+                record: Vec::new(),
+            };
+            let mut branches = if px {
+                dense_px(vec![branch], measured)
+            } else {
+                dense_pz(vec![branch], measured)
+            };
+            stn.flush();
+            let actual = stn.state_vector();
+            let fidelity = branches
+                .iter_mut()
+                .map(|branch| state_fidelity(&actual, &branch.state.state()))
+                .fold(0.0_f64, f64::max);
+            assert!(
+                fidelity >= 1.0 - 1e-10,
+                "default {} n={num_qubits}: conditional-state fidelity={fidelity:.16}",
+                if px { "px" } else { "pz" }
+            );
+        }
+
+        let (mut stn, dense) = prepare(0x7400 + num_qubits as u64);
+        let outcome = stn.mz(&[QubitId(measured)])[0].outcome;
+        let (_, mut expected) = projected_dense_state(dense, measured, outcome).unwrap();
+        let continuation = continuation_family(num_qubits);
+        replay_gates(&mut stn, &continuation);
+        replay_gates(&mut expected, &continuation);
+        assert_default_state_matches(
+            &mut stn,
+            &mut expected,
+            &format!("default continuation n={num_qubits}"),
+        );
+
+        let data_qubits = num_qubits - 1;
+        let preparation = honest_family(data_qubits, 0x51 + num_qubits);
+        let mut stn = build_stn(num_qubits, 0x7500 + num_qubits as u64);
+        let mut dense = DenseStateVec::new(num_qubits);
+        replay_gates(&mut stn, &preparation);
+        replay_gates(&mut dense, &preparation);
+        let generator = syndrome_generator(num_qubits);
+        let syndrome =
+            stn.extract_syndromes(std::slice::from_ref(&generator), &[QubitId(data_qubits)])[0];
+        dense.h(&[QubitId(data_qubits)]);
+        for (data, kind) in generator {
+            let pair = [(QubitId(data_qubits), QubitId(data))];
+            match kind {
+                PauliKind::X => dense.cx(&pair),
+                PauliKind::Y => dense.cy(&pair),
+                PauliKind::Z => dense.cz(&pair),
+            };
+        }
+        dense.h(&[QubitId(data_qubits)]);
+        let (_, mut expected) = projected_dense_state(dense, data_qubits, syndrome).unwrap();
+        if syndrome {
+            expected.x(&[QubitId(data_qubits)]);
+        }
+        assert_default_state_matches(
+            &mut stn,
+            &mut expected,
+            &format!("default syndrome extraction n={num_qubits}"),
+        );
+    }
+}
+
 #[test]
 fn exact_default_measurement_falsifier_is_live() {
-    let comparison = compare_surface(Surface::Continuation, 3, META_SHOTS);
+    let mut comparison = compare_surface(Surface::Continuation, 3, META_SHOTS);
+    comparison.default_counts = parallel_counts(comparison.exact.len(), META_SHOTS, |shot| {
+        run_stn_shot_with_mode(
+            Surface::Continuation,
+            3,
+            0x5100_0000 + 300_000 + shot as u64,
+            MeasurementMode::Pragmatic,
+        )
+    });
     let num_binomial_checks = comparison.exact.len() * 2;
     let limit = corrected_five_sigma_limit(num_binomial_checks);
     let default = worst_deviation(
@@ -774,7 +932,7 @@ fn exact_default_measurement_falsifier_is_live() {
         comparison.num_shots,
     );
     eprintln!(
-        "exact-default-falsifier meta surface={} n={} shots={} default={:.2}sigma \
+        "exact-default-falsifier meta surface={} n={} shots={} pragmatic={:.2}sigma \
          control={:.2}sigma corrected_limit={limit:.2}sigma",
         comparison.surface.name(),
         comparison.num_qubits,
@@ -789,8 +947,8 @@ fn exact_default_measurement_falsifier_is_live() {
     );
     assert!(
         default.sigma > 5.0,
-        "default measurement no longer shows the expected bias: worst deviation={:.2}sigma; \
-         un-ignore the exact-default gate matrix and retire this meta-test",
+        "explicit pragmatic measurement no longer shows the expected bias: \
+         worst deviation={:.2}sigma",
         default.sigma
     );
 }
@@ -798,13 +956,12 @@ fn exact_default_measurement_falsifier_is_live() {
 macro_rules! surface_gate_tests {
     ($fast_name:ident, $release_name:ident, $surface:expr) => {
         #[test]
-        #[ignore = "gates the exact measurement default; pragmatic default is known-biased (see design/stab-tn/exact-default-measurement-v2.md); un-ignore when the default flips"]
         fn $fast_name() {
             assert_surface_matrix($surface, &[3, 4], FAST_SHOTS);
         }
 
         #[test]
-        #[ignore = "gates the exact measurement default; pragmatic default is known-biased (see design/stab-tn/exact-default-measurement-v2.md); un-ignore when the default flips"]
+        #[ignore = "larger exact-default statistical release lane"]
         fn $release_name() {
             assert_surface_matrix($surface, &[5, 6], RELEASE_SHOTS);
         }

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -1,0 +1,850 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Statistical falsifier for the default `StabMps` random-measurement route.
+//!
+//! The gate tests are intentionally ignored until the default route changes from
+//! pragmatic measurement to exact sample-then-force. The non-ignored meta-test
+//! proves that the harness can see the current bias and will fail when the default
+//! changes, forcing the gate tests to be un-ignored at that point.
+
+use num_complex::Complex64;
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, DenseStateVec};
+use pecos_stab_tn::mps::MpsConfig;
+use pecos_stab_tn::stab_mps::mast::Mast;
+use pecos_stab_tn::stab_mps::{PauliKind, StabMps};
+use rayon::prelude::*;
+
+const FAST_SHOTS: usize = 2_048;
+const RELEASE_SHOTS: usize = 1_024;
+const META_SHOTS: usize = 256;
+const PROBABILITY_EPSILON: f64 = 1e-14;
+
+#[derive(Clone, Copy, Debug)]
+enum Gate {
+    H(usize),
+    Sz(usize),
+    X(usize),
+    Cx(usize, usize),
+    Cz(usize, usize),
+    Rz(usize, Angle64),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Surface {
+    MzMid,
+    MzEnd,
+    Reset,
+    Pz,
+    Px,
+    ExtractSyndromes,
+    Continuation,
+    SampleBitstring,
+    SampleBitstrings,
+}
+
+impl Surface {
+    fn name(self) -> &'static str {
+        match self {
+            Self::MzMid => "mz_mid",
+            Self::MzEnd => "mz_end",
+            Self::Reset => "reset_qubit",
+            Self::Pz => "pz",
+            Self::Px => "px",
+            Self::ExtractSyndromes => "extract_syndromes",
+            Self::Continuation => "continuation",
+            Self::SampleBitstring => "sample_bitstring",
+            Self::SampleBitstrings => "sample_bitstrings",
+        }
+    }
+
+    fn record_width(self, num_qubits: usize) -> usize {
+        match self {
+            Self::MzMid | Self::ExtractSyndromes => 1,
+            Self::MzEnd | Self::Pz | Self::Px | Self::SampleBitstring | Self::SampleBitstrings => {
+                num_qubits
+            }
+            Self::Reset | Self::Continuation => num_qubits + 1,
+        }
+    }
+}
+
+/// Deterministic Clifford+rotation family with non-diagonal continuation.
+///
+/// Every non-Clifford RZ/T is followed by SZ, CZ, X, H, and CX operations.
+/// In particular, this is not a diagonal-tail toy: the H after every rotation
+/// changes basis, while CZ/CX spread the resulting frame across the circuit.
+fn honest_family(num_qubits: usize, phase: usize) -> Vec<Gate> {
+    assert!(num_qubits >= 2);
+    let mut gates = vec![Gate::H(phase % num_qubits)];
+    if num_qubits > 2 {
+        gates.push(Gate::H((phase + 2) % num_qubits));
+    }
+    for q in 0..num_qubits - 1 {
+        gates.push(Gate::Cx(q, q + 1));
+    }
+
+    for layer in 0..num_qubits + 2 {
+        let target = (layer + phase) % num_qubits;
+        let neighbor = (target + 1) % num_qubits;
+        let other = (target + 2) % num_qubits;
+        let angle = if layer % 2 == 0 {
+            Angle64::QUARTER_TURN / 2_u64
+        } else {
+            Angle64::from_radians(0.37 + 0.11 * layer as f64)
+        };
+        gates.extend([
+            Gate::Rz(target, angle),
+            Gate::Sz(neighbor),
+            Gate::Cz(target, neighbor),
+            Gate::X(other),
+            Gate::H(target),
+            Gate::Cx(neighbor, other),
+        ]);
+    }
+    gates
+}
+
+fn continuation_family(num_qubits: usize) -> Vec<Gate> {
+    vec![
+        Gate::Rz(0, Angle64::from_radians(0.731)),
+        Gate::Sz(1 % num_qubits),
+        Gate::Cz(0, 1 % num_qubits),
+        Gate::X(2 % num_qubits),
+        Gate::H(0),
+        Gate::Cx(1 % num_qubits, 2 % num_qubits),
+    ]
+}
+
+fn replay_gates<S>(simulator: &mut S, gates: &[Gate])
+where
+    S: CliffordGateable + ArbitraryRotationGateable,
+{
+    for &gate in gates {
+        match gate {
+            Gate::H(q) => simulator.h(&[QubitId(q)]),
+            Gate::Sz(q) => simulator.sz(&[QubitId(q)]),
+            Gate::X(q) => simulator.x(&[QubitId(q)]),
+            Gate::Cx(control, target) => simulator.cx(&[(QubitId(control), QubitId(target))]),
+            Gate::Cz(first, second) => simulator.cz(&[(QubitId(first), QubitId(second))]),
+            Gate::Rz(q, angle) => simulator.rz(angle, &[QubitId(q)]),
+        };
+    }
+}
+
+fn non_clifford_count(gates: &[Gate]) -> usize {
+    gates
+        .iter()
+        .filter(|gate| matches!(gate, Gate::Rz(_, _)))
+        .count()
+}
+
+fn exact_mps_config() -> MpsConfig {
+    MpsConfig {
+        // The release matrix has at most 15 MAST sites (six data, eight
+        // preparation injections, and one continuation injection), whose
+        // exact Schmidt-rank ceiling is 2^floor(15/2) = 128.
+        max_bond_dim: 128,
+        svd_cutoff: 0.0,
+        max_truncation_error: Some(0.0),
+        parallel: false,
+    }
+}
+
+fn build_stn(num_qubits: usize, seed: u64) -> StabMps {
+    StabMps::builder(num_qubits)
+        .seed(seed)
+        .merge_rz(false)
+        .max_bond_dim(64)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build()
+}
+
+fn build_mast(num_qubits: usize, capacity: usize, seed: u64) -> Mast {
+    Mast::with_seed(num_qubits, capacity, seed).with_mps_config(exact_mps_config())
+}
+
+fn measure_all<S: CliffordGateable>(simulator: &mut S, num_qubits: usize) -> Vec<bool> {
+    simulator
+        .mz(&(0..num_qubits).map(QubitId).collect::<Vec<_>>())
+        .into_iter()
+        .map(|result| result.outcome)
+        .collect()
+}
+
+fn reset_through_measurement<S: CliffordGateable>(simulator: &mut S, q: usize) -> bool {
+    let outcome = simulator.mz(&[QubitId(q)])[0].outcome;
+    if outcome {
+        simulator.x(&[QubitId(q)]);
+    }
+    outcome
+}
+
+fn pz_through_measurement<S: CliffordGateable>(simulator: &mut S, q: usize) {
+    reset_through_measurement(simulator, q);
+}
+
+fn px_through_measurement<S: CliffordGateable>(simulator: &mut S, q: usize) {
+    reset_through_measurement(simulator, q);
+    simulator.h(&[QubitId(q)]);
+}
+
+fn syndrome_generator(num_qubits: usize) -> Vec<(usize, PauliKind)> {
+    let num_data = num_qubits - 1;
+    (0..num_data)
+        .map(|q| {
+            let kind = match q % 3 {
+                0 => PauliKind::X,
+                1 => PauliKind::Z,
+                _ => PauliKind::Y,
+            };
+            (q, kind)
+        })
+        .collect()
+}
+
+fn extract_one_syndrome_through_measurement<S: CliffordGateable>(
+    simulator: &mut S,
+    num_qubits: usize,
+) -> bool {
+    let ancilla = num_qubits - 1;
+    px_through_measurement(simulator, ancilla);
+    for (data, kind) in syndrome_generator(num_qubits) {
+        let pair = [(QubitId(ancilla), QubitId(data))];
+        match kind {
+            PauliKind::X => simulator.cx(&pair),
+            PauliKind::Y => simulator.cy(&pair),
+            PauliKind::Z => simulator.cz(&pair),
+        };
+    }
+    simulator.h(&[QubitId(ancilla)]);
+    let syndrome = simulator.mz(&[QubitId(ancilla)])[0].outcome;
+    reset_through_measurement(simulator, ancilla);
+    syndrome
+}
+
+fn encode_bits(bits: &[bool]) -> usize {
+    bits.iter()
+        .enumerate()
+        .fold(0, |value, (bit, &set)| value | (usize::from(set) << bit))
+}
+
+#[derive(Clone)]
+struct DenseBranch {
+    state: DenseStateVec,
+    probability: f64,
+    record: Vec<bool>,
+}
+
+fn projected_dense_state(
+    mut state: DenseStateVec,
+    qubit: usize,
+    outcome: bool,
+) -> Option<(f64, DenseStateVec)> {
+    let amplitudes = state.state();
+    let probability = amplitudes
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| ((*index >> qubit) & 1 != 0) == outcome)
+        .map(|(_, amplitude)| amplitude.norm_sqr())
+        .sum::<f64>();
+    if probability <= PROBABILITY_EPSILON {
+        return None;
+    }
+
+    let normalization = probability.sqrt();
+    for (index, amplitude) in amplitudes.into_iter().enumerate() {
+        let projected = if ((index >> qubit) & 1 != 0) == outcome {
+            amplitude / normalization
+        } else {
+            Complex64::new(0.0, 0.0)
+        };
+        state.set_amplitude(index, projected);
+    }
+    Some((probability, state))
+}
+
+fn dense_measure(branches: Vec<DenseBranch>, qubit: usize, record: bool) -> Vec<DenseBranch> {
+    let mut measured = Vec::with_capacity(branches.len() * 2);
+    for branch in branches {
+        for outcome in [false, true] {
+            if let Some((conditional_probability, state)) =
+                projected_dense_state(branch.state.clone(), qubit, outcome)
+            {
+                let mut next = DenseBranch {
+                    state,
+                    probability: branch.probability * conditional_probability,
+                    record: branch.record.clone(),
+                };
+                if record {
+                    next.record.push(outcome);
+                }
+                measured.push(next);
+            }
+        }
+    }
+    measured
+}
+
+fn dense_reset(branches: Vec<DenseBranch>, qubit: usize, record: bool) -> Vec<DenseBranch> {
+    let mut reset = Vec::with_capacity(branches.len() * 2);
+    for branch in branches {
+        for outcome in [false, true] {
+            if let Some((conditional_probability, mut state)) =
+                projected_dense_state(branch.state.clone(), qubit, outcome)
+            {
+                if outcome {
+                    state.x(&[QubitId(qubit)]);
+                }
+                let mut next = DenseBranch {
+                    state,
+                    probability: branch.probability * conditional_probability,
+                    record: branch.record.clone(),
+                };
+                if record {
+                    next.record.push(outcome);
+                }
+                reset.push(next);
+            }
+        }
+    }
+    reset
+}
+
+fn dense_pz(branches: Vec<DenseBranch>, qubit: usize) -> Vec<DenseBranch> {
+    dense_reset(branches, qubit, false)
+}
+
+fn dense_px(branches: Vec<DenseBranch>, qubit: usize) -> Vec<DenseBranch> {
+    let mut branches = dense_pz(branches, qubit);
+    for branch in &mut branches {
+        branch.state.h(&[QubitId(qubit)]);
+    }
+    branches
+}
+
+fn replay_dense_branches(branches: &mut [DenseBranch], gates: &[Gate]) {
+    for branch in branches {
+        replay_gates(&mut branch.state, gates);
+    }
+}
+
+fn dense_measure_all(mut branches: Vec<DenseBranch>, num_qubits: usize) -> Vec<DenseBranch> {
+    for q in 0..num_qubits {
+        branches = dense_measure(branches, q, true);
+    }
+    branches
+}
+
+fn dense_extract_syndrome(mut branches: Vec<DenseBranch>, num_qubits: usize) -> Vec<DenseBranch> {
+    let ancilla = num_qubits - 1;
+    branches = dense_px(branches, ancilla);
+    for (data, kind) in syndrome_generator(num_qubits) {
+        let pair = [(QubitId(ancilla), QubitId(data))];
+        for branch in &mut branches {
+            match kind {
+                PauliKind::X => branch.state.cx(&pair),
+                PauliKind::Y => branch.state.cy(&pair),
+                PauliKind::Z => branch.state.cz(&pair),
+            };
+        }
+    }
+    for branch in &mut branches {
+        branch.state.h(&[QubitId(ancilla)]);
+    }
+    branches = dense_measure(branches, ancilla, true);
+    dense_reset(branches, ancilla, false)
+}
+
+fn exact_probabilities(surface: Surface, num_qubits: usize) -> Vec<f64> {
+    let preparation_qubits = if surface == Surface::ExtractSyndromes {
+        num_qubits - 1
+    } else {
+        num_qubits
+    };
+    let preparation = honest_family(preparation_qubits, num_qubits);
+    let mut dense = DenseStateVec::with_seed(num_qubits, 0xD3E5_E000 + num_qubits as u64);
+    replay_gates(&mut dense, &preparation);
+    let mut branches = vec![DenseBranch {
+        state: dense,
+        probability: 1.0,
+        record: Vec::new(),
+    }];
+    let measured = num_qubits / 2;
+
+    branches = match surface {
+        Surface::MzMid => {
+            let mut measured = dense_measure(branches, measured, true);
+            replay_dense_branches(&mut measured, &continuation_family(num_qubits));
+            measured
+        }
+        Surface::MzEnd | Surface::SampleBitstring | Surface::SampleBitstrings => {
+            dense_measure_all(branches, num_qubits)
+        }
+        Surface::Reset => {
+            let mut reset = dense_reset(branches, measured, true);
+            replay_dense_branches(&mut reset, &continuation_family(num_qubits));
+            dense_measure_all(reset, num_qubits)
+        }
+        Surface::Pz => {
+            let mut prepared = dense_pz(branches, measured);
+            replay_dense_branches(&mut prepared, &continuation_family(num_qubits));
+            dense_measure_all(prepared, num_qubits)
+        }
+        Surface::Px => {
+            let mut prepared = dense_px(branches, measured);
+            replay_dense_branches(&mut prepared, &continuation_family(num_qubits));
+            dense_measure_all(prepared, num_qubits)
+        }
+        Surface::ExtractSyndromes => dense_extract_syndrome(branches, num_qubits),
+        Surface::Continuation => {
+            let mut continued = dense_measure(branches, measured, true);
+            replay_dense_branches(&mut continued, &continuation_family(num_qubits));
+            dense_measure_all(continued, num_qubits)
+        }
+    };
+
+    let mut probabilities = vec![0.0; 1 << surface.record_width(num_qubits)];
+    for branch in branches {
+        probabilities[encode_bits(&branch.record)] += branch.probability;
+    }
+    let total = probabilities.iter().sum::<f64>();
+    assert!(
+        (total - 1.0).abs() <= 1e-10,
+        "surface={} n={num_qubits}: dense probabilities sum to {total:.16}",
+        surface.name()
+    );
+    for probability in &mut probabilities {
+        *probability /= total;
+    }
+    probabilities
+}
+
+fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
+    let preparation_qubits = if surface == Surface::ExtractSyndromes {
+        num_qubits - 1
+    } else {
+        num_qubits
+    };
+    let mut simulator = build_stn(num_qubits, seed);
+    replay_gates(
+        &mut simulator,
+        &honest_family(preparation_qubits, num_qubits),
+    );
+    let measured = num_qubits / 2;
+    let bits = match surface {
+        Surface::MzMid => {
+            let outcome = simulator.mz(&[QubitId(measured)])[0].outcome;
+            replay_gates(&mut simulator, &continuation_family(num_qubits));
+            vec![outcome]
+        }
+        Surface::MzEnd => measure_all(&mut simulator, num_qubits),
+        Surface::Reset => {
+            let mut bits = vec![simulator.reset_qubit(QubitId(measured))];
+            replay_gates(&mut simulator, &continuation_family(num_qubits));
+            bits.extend(measure_all(&mut simulator, num_qubits));
+            bits
+        }
+        Surface::Pz => {
+            simulator.pz(QubitId(measured));
+            replay_gates(&mut simulator, &continuation_family(num_qubits));
+            measure_all(&mut simulator, num_qubits)
+        }
+        Surface::Px => {
+            simulator.px(QubitId(measured));
+            replay_gates(&mut simulator, &continuation_family(num_qubits));
+            measure_all(&mut simulator, num_qubits)
+        }
+        Surface::ExtractSyndromes => simulator.extract_syndromes(
+            &[syndrome_generator(num_qubits)],
+            &[QubitId(num_qubits - 1)],
+        ),
+        Surface::Continuation => {
+            let mut bits = vec![simulator.mz(&[QubitId(measured)])[0].outcome];
+            replay_gates(&mut simulator, &continuation_family(num_qubits));
+            bits.extend(measure_all(&mut simulator, num_qubits));
+            bits
+        }
+        Surface::SampleBitstring | Surface::SampleBitstrings => {
+            unreachable!("sampling surfaces use their public batch APIs")
+        }
+    };
+    assert_eq!(
+        simulator.bond_cap_hits(),
+        0,
+        "surface={} n={num_qubits}: StabMps exact-test cap was binding",
+        surface.name()
+    );
+    encode_bits(&bits)
+}
+
+fn run_mast_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
+    let preparation_qubits = if surface == Surface::ExtractSyndromes {
+        num_qubits - 1
+    } else {
+        num_qubits
+    };
+    let preparation = honest_family(preparation_qubits, num_qubits);
+    let continuation = continuation_family(num_qubits);
+    let capacity = non_clifford_count(&preparation) + non_clifford_count(&continuation);
+    let mut simulator = build_mast(num_qubits, capacity, seed);
+    replay_gates(&mut simulator, &preparation);
+    let measured = num_qubits / 2;
+    let bits = match surface {
+        Surface::MzMid => {
+            let outcome = simulator.mz(&[QubitId(measured)])[0].outcome;
+            replay_gates(&mut simulator, &continuation);
+            vec![outcome]
+        }
+        Surface::MzEnd | Surface::SampleBitstring | Surface::SampleBitstrings => {
+            measure_all(&mut simulator, num_qubits)
+        }
+        Surface::Reset => {
+            let mut bits = vec![reset_through_measurement(&mut simulator, measured)];
+            replay_gates(&mut simulator, &continuation);
+            bits.extend(measure_all(&mut simulator, num_qubits));
+            bits
+        }
+        Surface::Pz => {
+            pz_through_measurement(&mut simulator, measured);
+            replay_gates(&mut simulator, &continuation);
+            measure_all(&mut simulator, num_qubits)
+        }
+        Surface::Px => {
+            px_through_measurement(&mut simulator, measured);
+            replay_gates(&mut simulator, &continuation);
+            measure_all(&mut simulator, num_qubits)
+        }
+        Surface::ExtractSyndromes => {
+            vec![extract_one_syndrome_through_measurement(
+                &mut simulator,
+                num_qubits,
+            )]
+        }
+        Surface::Continuation => {
+            let mut bits = vec![simulator.mz(&[QubitId(measured)])[0].outcome];
+            replay_gates(&mut simulator, &continuation);
+            bits.extend(measure_all(&mut simulator, num_qubits));
+            bits
+        }
+    };
+    assert_eq!(
+        simulator.bond_cap_hits(),
+        0,
+        "surface={} n={num_qubits}: Mast exact-test cap was binding",
+        surface.name()
+    );
+    encode_bits(&bits)
+}
+
+fn parallel_counts(
+    num_outcomes: usize,
+    num_shots: usize,
+    sample: impl Fn(usize) -> usize + Sync,
+) -> Vec<usize> {
+    (0..num_shots)
+        .into_par_iter()
+        .fold(
+            || vec![0; num_outcomes],
+            |mut counts, shot| {
+                counts[sample(shot)] += 1;
+                counts
+            },
+        )
+        .reduce(
+            || vec![0; num_outcomes],
+            |mut counts, local| {
+                for (count, increment) in counts.iter_mut().zip(local) {
+                    *count += increment;
+                }
+                counts
+            },
+        )
+}
+
+fn sampled_stn_counts(surface: Surface, num_qubits: usize, num_shots: usize) -> Vec<usize> {
+    let num_outcomes = 1 << surface.record_width(num_qubits);
+    if matches!(
+        surface,
+        Surface::SampleBitstring | Surface::SampleBitstrings
+    ) {
+        let mut simulator = build_stn(num_qubits, 0x5A00_0000 + num_qubits as u64);
+        replay_gates(&mut simulator, &honest_family(num_qubits, num_qubits));
+        let samples = if surface == Surface::SampleBitstring {
+            simulator.sample_bitstring(num_shots)
+        } else {
+            simulator.sample_bitstrings(num_shots)
+        };
+        let mut counts = vec![0; num_outcomes];
+        for bits in samples {
+            counts[encode_bits(&bits)] += 1;
+        }
+        assert_eq!(simulator.bond_cap_hits(), 0);
+        counts
+    } else {
+        parallel_counts(num_outcomes, num_shots, |shot| {
+            run_stn_shot(
+                surface,
+                num_qubits,
+                0x5100_0000 + (num_qubits as u64) * 100_000 + shot as u64,
+            )
+        })
+    }
+}
+
+fn sampled_mast_counts(surface: Surface, num_qubits: usize, num_shots: usize) -> Vec<usize> {
+    let num_outcomes = 1 << surface.record_width(num_qubits);
+    parallel_counts(num_outcomes, num_shots, |shot| {
+        run_mast_shot(
+            surface,
+            num_qubits,
+            0x6A00_0000 + (num_qubits as u64) * 100_000 + shot as u64,
+        )
+    })
+}
+
+#[derive(Debug)]
+struct Comparison {
+    surface: Surface,
+    num_qubits: usize,
+    num_shots: usize,
+    exact: Vec<f64>,
+    default_counts: Vec<usize>,
+    control_counts: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WorstDeviation {
+    outcome: usize,
+    sigma: f64,
+    exact: f64,
+    sampled: f64,
+}
+
+fn binomial_sigma(count: usize, probability: f64, num_shots: usize) -> f64 {
+    let sampled = count as f64 / num_shots as f64;
+    if probability <= PROBABILITY_EPSILON || 1.0 - probability <= PROBABILITY_EPSILON {
+        return if (sampled - probability).abs() <= PROBABILITY_EPSILON {
+            0.0
+        } else {
+            f64::INFINITY
+        };
+    }
+    let standard_error = (probability * (1.0 - probability) / num_shots as f64).sqrt();
+    (sampled - probability).abs() / standard_error
+}
+
+fn worst_deviation(counts: &[usize], exact: &[f64], num_shots: usize) -> WorstDeviation {
+    exact
+        .iter()
+        .enumerate()
+        .map(|(outcome, &probability)| WorstDeviation {
+            outcome,
+            sigma: binomial_sigma(counts[outcome], probability, num_shots),
+            exact: probability,
+            sampled: counts[outcome] as f64 / num_shots as f64,
+        })
+        .max_by(|left, right| left.sigma.total_cmp(&right.sigma))
+        .expect("every surface has at least one outcome")
+}
+
+/// Bonferroni-style family allowance for a matrix of binomial checks.
+///
+/// Each bin starts with a two-sided five-sigma guard. For `m` simultaneous
+/// default/control bin checks, `sqrt(5^2 + 2 ln(m))` keeps the union-bound
+/// Gaussian tail envelope no larger than the single-bin five-sigma envelope.
+/// This is deliberately an allowance for multiple comparisons, not a relaxed
+/// per-surface empirical tolerance.
+fn corrected_five_sigma_limit(num_comparisons: usize) -> f64 {
+    (25.0 + 2.0 * (num_comparisons.max(1) as f64).ln()).sqrt()
+}
+
+fn compare_surface(surface: Surface, num_qubits: usize, num_shots: usize) -> Comparison {
+    let exact = exact_probabilities(surface, num_qubits);
+    let default_counts = sampled_stn_counts(surface, num_qubits, num_shots);
+    let control_counts = sampled_mast_counts(surface, num_qubits, num_shots);
+    assert_eq!(default_counts.iter().sum::<usize>(), num_shots);
+    assert_eq!(control_counts.iter().sum::<usize>(), num_shots);
+    Comparison {
+        surface,
+        num_qubits,
+        num_shots,
+        exact,
+        default_counts,
+        control_counts,
+    }
+}
+
+fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
+    let comparisons = qubits
+        .iter()
+        .map(|&num_qubits| compare_surface(surface, num_qubits, num_shots))
+        .collect::<Vec<_>>();
+    let num_binomial_checks = comparisons
+        .iter()
+        .map(|comparison| comparison.exact.len() * 2)
+        .sum();
+    let limit = corrected_five_sigma_limit(num_binomial_checks);
+
+    let mut worst_default = None::<(WorstDeviation, usize)>;
+    let mut worst_control = None::<(WorstDeviation, usize)>;
+    for comparison in &comparisons {
+        let default = worst_deviation(
+            &comparison.default_counts,
+            &comparison.exact,
+            comparison.num_shots,
+        );
+        let control = worst_deviation(
+            &comparison.control_counts,
+            &comparison.exact,
+            comparison.num_shots,
+        );
+        eprintln!(
+            "exact-default-falsifier surface={} n={} shots={} default={:.2}sigma \
+             (outcome={}, exact={:.6}, sampled={:.6}) control={:.2}sigma \
+             (outcome={}, exact={:.6}, sampled={:.6}) corrected_limit={limit:.2}sigma",
+            comparison.surface.name(),
+            comparison.num_qubits,
+            comparison.num_shots,
+            default.sigma,
+            default.outcome,
+            default.exact,
+            default.sampled,
+            control.sigma,
+            control.outcome,
+            control.exact,
+            control.sampled,
+        );
+        if worst_default.is_none_or(|(worst, _)| default.sigma > worst.sigma) {
+            worst_default = Some((default, comparison.num_qubits));
+        }
+        if worst_control.is_none_or(|(worst, _)| control.sigma > worst.sigma) {
+            worst_control = Some((control, comparison.num_qubits));
+        }
+    }
+
+    let (control, control_n) = worst_control.expect("nonempty surface matrix");
+    assert!(
+        control.sigma <= limit,
+        "Mast exact-route control failed: surface={} n={control_n} outcome={} \
+         exact={:.8} sampled={:.8}, deviation={:.2}sigma > corrected {limit:.2}sigma",
+        surface.name(),
+        control.outcome,
+        control.exact,
+        control.sampled,
+        control.sigma,
+    );
+    let (default, default_n) = worst_default.expect("nonempty surface matrix");
+    assert!(
+        default.sigma <= limit,
+        "default StabMps measurement is biased: surface={} n={default_n} outcome={} \
+         exact={:.8} sampled={:.8}, deviation={:.2}sigma > corrected {limit:.2}sigma",
+        surface.name(),
+        default.outcome,
+        default.exact,
+        default.sampled,
+        default.sigma,
+    );
+}
+
+#[test]
+fn exact_default_measurement_falsifier_is_live() {
+    let comparison = compare_surface(Surface::Continuation, 3, META_SHOTS);
+    let num_binomial_checks = comparison.exact.len() * 2;
+    let limit = corrected_five_sigma_limit(num_binomial_checks);
+    let default = worst_deviation(
+        &comparison.default_counts,
+        &comparison.exact,
+        comparison.num_shots,
+    );
+    let control = worst_deviation(
+        &comparison.control_counts,
+        &comparison.exact,
+        comparison.num_shots,
+    );
+    eprintln!(
+        "exact-default-falsifier meta surface={} n={} shots={} default={:.2}sigma \
+         control={:.2}sigma corrected_limit={limit:.2}sigma",
+        comparison.surface.name(),
+        comparison.num_qubits,
+        comparison.num_shots,
+        default.sigma,
+        control.sigma,
+    );
+    assert!(
+        control.sigma <= limit,
+        "live-harness Mast control deviated by {:.2}sigma (limit {limit:.2}sigma)",
+        control.sigma
+    );
+    assert!(
+        default.sigma > 5.0,
+        "default measurement no longer shows the expected bias: worst deviation={:.2}sigma; \
+         un-ignore the exact-default gate matrix and retire this meta-test",
+        default.sigma
+    );
+}
+
+macro_rules! surface_gate_tests {
+    ($fast_name:ident, $release_name:ident, $surface:expr) => {
+        #[test]
+        #[ignore = "gates the exact measurement default; pragmatic default is known-biased (see design/stab-tn/exact-default-measurement-v2.md); un-ignore when the default flips"]
+        fn $fast_name() {
+            assert_surface_matrix($surface, &[3, 4], FAST_SHOTS);
+        }
+
+        #[test]
+        #[ignore = "gates the exact measurement default; pragmatic default is known-biased (see design/stab-tn/exact-default-measurement-v2.md); un-ignore when the default flips"]
+        fn $release_name() {
+            assert_surface_matrix($surface, &[5, 6], RELEASE_SHOTS);
+        }
+    };
+}
+
+surface_gate_tests!(
+    exact_default_mz_mid_fast,
+    exact_default_mz_mid_release,
+    Surface::MzMid
+);
+surface_gate_tests!(
+    exact_default_mz_end_fast,
+    exact_default_mz_end_release,
+    Surface::MzEnd
+);
+surface_gate_tests!(
+    exact_default_reset_qubit_fast,
+    exact_default_reset_qubit_release,
+    Surface::Reset
+);
+surface_gate_tests!(exact_default_pz_fast, exact_default_pz_release, Surface::Pz);
+surface_gate_tests!(exact_default_px_fast, exact_default_px_release, Surface::Px);
+surface_gate_tests!(
+    exact_default_extract_syndromes_fast,
+    exact_default_extract_syndromes_release,
+    Surface::ExtractSyndromes
+);
+surface_gate_tests!(
+    exact_default_continuation_fast,
+    exact_default_continuation_release,
+    Surface::Continuation
+);
+surface_gate_tests!(
+    exact_default_sample_bitstring_fast,
+    exact_default_sample_bitstring_release,
+    Surface::SampleBitstring
+);
+surface_gate_tests!(
+    exact_default_sample_bitstrings_fast,
+    exact_default_sample_bitstrings_release,
+    Surface::SampleBitstrings
+);

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -2534,12 +2534,11 @@ fn test_prob_bitstring_honest_clifford_t_wide_seed_sweep_matches_dense_state_vec
         0.0,
         "wide issue #557 exact sweep",
     );
-    assert_honest_clifford_t_readouts_match_dense(
-        3..=6,
-        &seed_families,
-        1e-8,
-        "wide issue #557 adaptive sweep",
-    );
+    // The 1e-8 adaptive budget never binds on this Clifford+T family at
+    // n <= 6 (zero recorded weight over all 640 circuits), so a second sweep
+    // arm here would duplicate the exact arm byte for byte. Nonzero-budget
+    // read coverage lives in the weak-branch fixture below, whose branch is
+    // engineered to sit under the budget.
 }
 
 fn apply_weak_branch_readout_fixture(stn: &mut StabMps) {

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -4120,6 +4120,12 @@ fn test_large_scale_50_qubits() {
         mast_bond <= configured_cap,
         "MAST exceeded its configured bond cap: {mast_bond} > {configured_cap}"
     );
+    // A cap-only bound is near-vacuous because compression enforces the cap
+    // by construction; this seeded workload deterministically ends at bond 2.
+    assert_eq!(
+        mast_bond, 2,
+        "seeded 50-qubit MAST workload no longer compresses to its known bond"
+    );
 }
 
 #[test]

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -2423,15 +2423,20 @@ fn test_sampled_bitstring_round_trips_through_probability_and_amplitude() {
 fn assert_honest_clifford_t_readouts_match_dense(
     qubit_counts: std::ops::RangeInclusive<usize>,
     seed_families: &[u64],
+    max_truncation_error: f64,
     label: &str,
 ) {
     // This family deliberately puts H, S, and CX between non-Clifford gates,
     // plus a target H after roughly half of them. That exposes sequential
     // forced-projection frame errors hidden by diagonal-only circuit tails.
-    const TOLERANCE: f64 = 1e-12;
+    const NUMERICAL_FLOOR: f64 = 1e-12;
+    let adaptive = max_truncation_error > 0.0;
     let mut circuits = 0;
+    let mut circuits_with_discarded_weight = 0;
     let mut worst_probability_delta = 0.0_f64;
     let mut worst_iterative_delta = 0.0_f64;
+    let mut largest_recorded_weight = 0.0_f64;
+    let mut largest_allowed_delta = NUMERICAL_FLOOR;
     for num_qubits in qubit_counts {
         for t_count in 3..=6 {
             for &seed_family in seed_families {
@@ -2440,12 +2445,37 @@ fn assert_honest_clifford_t_readouts_match_dense(
                 let mut stn = StabMps::builder(num_qubits)
                     .seed(circuit_seed)
                     .merge_rz(false)
-                    .max_truncation_error(0.0)
+                    .max_truncation_error(max_truncation_error)
                     .build();
                 apply_seeded_clifford_t_to_stn(&mut stn, &gates);
                 stn.flush();
 
-                let dense_probabilities = dense_state_vector_probabilities(&stn);
+                let recorded_weight = stn.summed_discarded_weight();
+                if recorded_weight > 0.0 {
+                    circuits_with_discarded_weight += 1;
+                }
+                largest_recorded_weight = largest_recorded_weight.max(recorded_weight);
+                // The non-commutative union bound turns summed discarded
+                // weight into at most 2*sqrt(weight) distinguishability.
+                // Keep the exact configuration's original numerical ceiling.
+                let allowed_delta = if adaptive {
+                    2.0 * recorded_weight.sqrt() + NUMERICAL_FLOOR
+                } else {
+                    NUMERICAL_FLOOR
+                };
+                largest_allowed_delta = largest_allowed_delta.max(allowed_delta);
+                let dense_probabilities = if adaptive {
+                    let mut oracle = StabMps::builder(num_qubits)
+                        .seed(circuit_seed)
+                        .merge_rz(false)
+                        .max_truncation_error(0.0)
+                        .build();
+                    apply_seeded_clifford_t_to_stn(&mut oracle, &gates);
+                    oracle.flush();
+                    dense_state_vector_probabilities(&oracle)
+                } else {
+                    dense_state_vector_probabilities(&stn)
+                };
                 for (outcome, &expected) in dense_probabilities.iter().enumerate() {
                     let bits = (0..num_qubits)
                         .map(|q| ((outcome >> q) & 1) != 0)
@@ -2454,10 +2484,12 @@ fn assert_honest_clifford_t_readouts_match_dense(
                     let probability_delta = (actual - expected).abs();
                     worst_probability_delta = worst_probability_delta.max(probability_delta);
                     assert!(
-                        probability_delta <= TOLERANCE,
+                        probability_delta <= allowed_delta,
                         "{label}: n={num_qubits} t={t_count} seed={circuit_seed} \
                          outcome={outcome}: prob_bitstring={actual:.16}, \
-                         dense={expected:.16}, delta={probability_delta:.3e}, gates={gates:?}"
+                         dense={expected:.16}, delta={probability_delta:.3e}, \
+                         recorded_weight={recorded_weight:.3e}, \
+                         allowed_delta={allowed_delta:.3e}, gates={gates:?}"
                     );
 
                     // The unnormalized sibling projector must preserve the
@@ -2468,10 +2500,12 @@ fn assert_honest_clifford_t_readouts_match_dense(
                     let iterative_delta = (iterative_probability - expected).abs();
                     worst_iterative_delta = worst_iterative_delta.max(iterative_delta);
                     assert!(
-                        iterative_delta <= TOLERANCE,
+                        iterative_delta <= allowed_delta,
                         "{label}: n={num_qubits} t={t_count} seed={circuit_seed} \
                          outcome={outcome}: |amplitude_iterative|^2={iterative_probability:.16}, \
-                         dense={expected:.16}, delta={iterative_delta:.3e}, gates={gates:?}"
+                         dense={expected:.16}, delta={iterative_delta:.3e}, \
+                         recorded_weight={recorded_weight:.3e}, \
+                         allowed_delta={allowed_delta:.3e}, gates={gates:?}"
                     );
                 }
                 circuits += 1;
@@ -2479,7 +2513,7 @@ fn assert_honest_clifford_t_readouts_match_dense(
         }
     }
     eprintln!(
-        "{label}: circuits={circuits}, worst prob_bitstring delta={worst_probability_delta:.3e}, worst |amplitude_iterative|^2 delta={worst_iterative_delta:.3e}"
+        "{label}: circuits={circuits}, circuits with discarded weight={circuits_with_discarded_weight}, largest recorded weight={largest_recorded_weight:.3e}, largest allowed delta={largest_allowed_delta:.3e}, worst prob_bitstring delta={worst_probability_delta:.3e}, worst |amplitude_iterative|^2 delta={worst_iterative_delta:.3e}"
     );
 }
 
@@ -2487,14 +2521,100 @@ fn assert_honest_clifford_t_readouts_match_dense(
 fn test_prob_bitstring_honest_clifford_t_family_matches_dense_state_vector() {
     // Keep a known formerly failing small-n family (n=4, t=6, seed=21406)
     // in the default lane while bounding debug-suite runtime.
-    assert_honest_clifford_t_readouts_match_dense(3..=4, &[10, 21], "fast issue #557 sweep");
+    assert_honest_clifford_t_readouts_match_dense(3..=4, &[10, 21], 0.0, "fast issue #557 sweep");
 }
 
 #[test]
 #[ignore = "wide issue #557 sweep; run in release mode"]
 fn test_prob_bitstring_honest_clifford_t_wide_seed_sweep_matches_dense_state_vector() {
     let seed_families = (10..50_u64).collect::<Vec<_>>();
-    assert_honest_clifford_t_readouts_match_dense(3..=6, &seed_families, "wide issue #557 sweep");
+    assert_honest_clifford_t_readouts_match_dense(
+        3..=6,
+        &seed_families,
+        0.0,
+        "wide issue #557 exact sweep",
+    );
+    assert_honest_clifford_t_readouts_match_dense(
+        3..=6,
+        &seed_families,
+        1e-8,
+        "wide issue #557 adaptive sweep",
+    );
+}
+
+fn apply_weak_branch_readout_fixture(stn: &mut StabMps) {
+    let t = Angle64::QUARTER_TURN / 2u64;
+    for q in 0..4 {
+        stn.h(&[QubitId(q)]);
+        stn.rz(t, &[QubitId(q)]);
+    }
+    stn.cx(&[(QubitId(0), QubitId(1))]);
+    stn.cx(&[(QubitId(1), QubitId(2))]);
+    stn.cx(&[(QubitId(2), QubitId(3))]);
+    // This creates a 2.5e-9-weight coefficient branch: below the configured
+    // 1e-8 adaptive budget, but above numerical zero.
+    stn.rz(Angle64::from_radians(1e-4), &[QubitId(3)]);
+    // Uncompute the entangler and rotate every affected axis so the weak
+    // branch changes computational-basis probabilities, then retain a
+    // nonlocal tableau frame for the sequential forced-projection readers.
+    stn.cx(&[(QubitId(2), QubitId(3))]);
+    stn.cx(&[(QubitId(1), QubitId(2))]);
+    stn.cx(&[(QubitId(0), QubitId(1))]);
+    for q in 0..4 {
+        stn.h(&[QubitId(q)]);
+    }
+    stn.cx(&[(QubitId(3), QubitId(1))]);
+    stn.h(&[QubitId(2)]);
+    stn.flush();
+}
+
+#[test]
+#[ignore = "adaptive issue #557 readout bound; run in release mode"]
+fn test_prob_bitstring_adaptive_truncation_respects_recorded_weight_bound() {
+    const NUM_QUBITS: usize = 4;
+    const NUMERICAL_FLOOR: f64 = 1e-12;
+    let mut oracle = StabMps::builder(NUM_QUBITS)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(0.0)
+        .build();
+    let mut adaptive = StabMps::builder(NUM_QUBITS)
+        .merge_rz(false)
+        .svd_cutoff(0.0)
+        .max_truncation_error(1e-8)
+        .build();
+    apply_weak_branch_readout_fixture(&mut oracle);
+    apply_weak_branch_readout_fixture(&mut adaptive);
+
+    let recorded_weight = adaptive.summed_discarded_weight();
+    assert!(
+        recorded_weight > 0.0 && recorded_weight <= 1e-8,
+        "adaptive fixture recorded weight {recorded_weight:.16e}"
+    );
+    let allowed_delta = 2.0 * recorded_weight.sqrt() + NUMERICAL_FLOOR;
+    let exact_probabilities = dense_state_vector_probabilities(&oracle);
+    let mut worst_probability_delta = 0.0_f64;
+    let mut worst_iterative_delta = 0.0_f64;
+    for (outcome, &expected) in exact_probabilities.iter().enumerate() {
+        let bits = (0..NUM_QUBITS)
+            .map(|q| ((outcome >> q) & 1) != 0)
+            .collect::<Vec<_>>();
+        let probability_delta = (adaptive.prob_bitstring(&bits) - expected).abs();
+        let iterative_delta = (adaptive.amplitude_iterative(&bits).norm_sqr() - expected).abs();
+        worst_probability_delta = worst_probability_delta.max(probability_delta);
+        worst_iterative_delta = worst_iterative_delta.max(iterative_delta);
+        assert!(
+            probability_delta <= allowed_delta,
+            "outcome={outcome}: prob_bitstring delta={probability_delta:.3e}, recorded_weight={recorded_weight:.3e}, bound={allowed_delta:.3e}"
+        );
+        assert!(
+            iterative_delta <= allowed_delta,
+            "outcome={outcome}: amplitude_iterative probability delta={iterative_delta:.3e}, recorded_weight={recorded_weight:.3e}, bound={allowed_delta:.3e}"
+        );
+    }
+    eprintln!(
+        "adaptive issue #557 fixture: recorded weight={recorded_weight:.3e}, bound={allowed_delta:.3e}, worst prob_bitstring delta={worst_probability_delta:.3e}, worst |amplitude_iterative|^2 delta={worst_iterative_delta:.3e}"
+    );
 }
 
 #[test]

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -17,7 +17,7 @@ use pecos_core::{Angle64, QubitId};
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, QuantumSimulator, StabVec};
 use pecos_stab_tn::mps::MpsConfig;
 use pecos_stab_tn::stab_mps::mast::{Mast, ProjectionOrder};
-use pecos_stab_tn::stab_mps::{PauliKind, StabMps};
+use pecos_stab_tn::stab_mps::{MeasurementMode, PauliKind, StabMps};
 use rayon::prelude::*;
 
 /// Check that two state vectors match up to global phase.
@@ -1791,7 +1791,7 @@ fn test_accepted_heuristic_disentangler_keeps_all_reads_in_one_frame() {
 fn test_disentangle_flushes_lazy_measurement_and_merged_rz() {
     let mut stn = StabMps::builder(2)
         .seed(19)
-        .lazy_measure(true)
+        .measurement(MeasurementMode::Lazy)
         .merge_rz(true)
         .svd_cutoff(0.0)
         .max_truncation_error(0.0)
@@ -1832,8 +1832,8 @@ fn test_disentangle_flushes_lazy_measurement_and_merged_rz() {
 
     let _ = stn.disentangle(1);
     assert!(
-        stn.is_state_exact(),
-        "disentangle should flush deferred operations and merged RZs"
+        !stn.is_state_exact(),
+        "Lazy mode remains a conservative exactness guard after flushing"
     );
     assert_states_close(
         &stn.state_vector(),
@@ -2638,7 +2638,10 @@ fn test_prefix_tree_sampler_flushes_supported_modes_on_working_clone() {
     let q0_ones = merged_shots.iter().filter(|shot| shot[0]).count();
     assert!((70..=130).contains(&q0_ones));
 
-    let mut lazy = StabMps::builder(3).seed(503).lazy_measure(true).build();
+    let mut lazy = StabMps::builder(3)
+        .seed(503)
+        .measurement(MeasurementMode::Lazy)
+        .build();
     lazy.h(&[QubitId(0), QubitId(1)]);
     lazy.cx(&[(QubitId(0), QubitId(2))]);
     let _ = lazy.mz(&[QubitId(1)]);

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -4113,11 +4113,12 @@ fn test_large_scale_50_qubits() {
     let (stn_bond, mast_bond) =
         large_scale_bond_dim_check(num_qubits, num_t, 3, configured_cap, 42);
     eprintln!("{num_qubits}q {num_t}T: STN bond={stn_bond}, MAST bond={mast_bond}");
-    // Exact-route data measurement saturates the configured cap at scale, so
-    // accuracy is truncation-limited here rather than merely bounded by it.
-    assert_eq!(
-        mast_bond, configured_cap,
-        "MAST did not saturate its configured bond cap"
+    // Exact projection now removes direct-sum rank redundancy even when the
+    // stored bond is below the cap. This regression only requires the
+    // cross-word BitSet path to finish within the configured bound.
+    assert!(
+        mast_bond <= configured_cap,
+        "MAST exceeded its configured bond cap: {mast_bond} > {configured_cap}"
     );
 }
 

--- a/python/pecos-rslib-exp/src/lib.rs
+++ b/python/pecos-rslib-exp/src/lib.rs
@@ -42,7 +42,7 @@ mod stab_mps_bindings;
 pub mod stabmps_builder;
 
 use pecos_core::Angle64;
-use pecos_stab_tn::stab_mps::StabMpsStats;
+use pecos_stab_tn::stab_mps::{MeasurementMode, StabMpsStats};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -60,6 +60,17 @@ pub(crate) fn stab_mps_stats_to_dict(py: Python<'_>, stats: &StabMpsStats) -> Py
     result.set_item("ofd_in_span_single", stats.ofd_in_span_single)?;
     result.set_item("ofd_in_span_disent", stats.ofd_in_span_disent)?;
     Ok(result.unbind())
+}
+
+pub(crate) fn parse_measurement_mode(value: &str) -> PyResult<MeasurementMode> {
+    match value {
+        "exact" => Ok(MeasurementMode::Exact),
+        "pragmatic" => Ok(MeasurementMode::Pragmatic),
+        "lazy" => Ok(MeasurementMode::Lazy),
+        _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "measurement must be one of: 'exact', 'pragmatic', 'lazy'",
+        )),
+    }
 }
 
 pub(crate) fn extract_angle(

--- a/python/pecos-rslib-exp/src/mast_bindings.rs
+++ b/python/pecos-rslib-exp/src/mast_bindings.rs
@@ -222,6 +222,26 @@ impl PyMast {
     }
 
     #[getter]
+    fn summed_discarded_weight(&self) -> f64 {
+        self.inner.summed_discarded_weight()
+    }
+
+    #[getter]
+    fn lifetime_peak_bond(&self) -> usize {
+        self.inner.lifetime_peak_bond()
+    }
+
+    #[getter]
+    fn branch_vanish_retry_count(&self) -> u64 {
+        self.inner.branch_vanish_retry_count()
+    }
+
+    #[getter]
+    fn deferred_branch_lost_count(&self) -> u64 {
+        self.inner.deferred_branch_lost_count()
+    }
+
+    #[getter]
     /// Number of SVDs where `max_bond_dim` was the binding cap.
     ///
     /// This is a pure stored-state diagnostic: pending merged rotations are not

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -15,7 +15,7 @@
 //! Mirrors the Rust-side API:
 //! ```python
 //! results = (sim_neo(tc)
-//!     .quantum(stab_mps().lazy_measure().max_bond_dim(128))
+//!     .quantum(stab_mps().measurement("lazy").max_bond_dim(128))
 //!     .noise(depolarizing().p1(0.003).p2(0.003).p_meas(0.003).p_prep(0.003).idle_rz(0.05))
 //!     .sampling(monte_carlo(5000))
 //!     .seed(42)
@@ -419,7 +419,7 @@ pub fn stabilizer() -> PyStabilizerBuilder {
 /// Builder for StabMps backend configuration.
 ///
 /// Example:
-///     stab_mps().lazy_measure().max_bond_dim(128)
+///     stab_mps().measurement("lazy").max_bond_dim(128)
 #[pyclass(
     name = "StabMpsBuilder",
     skip_from_py_object,
@@ -439,14 +439,10 @@ impl PyStabMpsBuilder {
         }
     }
 
-    /// Set whether measurements are deferred for non-Clifford states.
-    ///
-    /// Calling without an argument enables lazy measurement; an explicit bool
-    /// sets the option exactly.
-    #[pyo3(signature = (enabled=true))]
-    fn lazy_measure(mut slf: PyRefMut<'_, Self>, enabled: bool) -> PyRefMut<'_, Self> {
-        slf.inner.lazy_measure = enabled;
-        slf
+    /// Select "exact", "pragmatic", or "lazy" singular measurement.
+    fn measurement<'py>(mut slf: PyRefMut<'py, Self>, mode: &str) -> PyResult<PyRefMut<'py, Self>> {
+        slf.inner.measurement = crate::parse_measurement_mode(mode)?;
+        Ok(slf)
     }
 
     fn max_bond_dim(mut slf: PyRefMut<'_, Self>, bd: usize) -> PyRefMut<'_, Self> {
@@ -806,7 +802,7 @@ impl PySimNeoBuilder {
     /// Example:
     ///     sim_neo(tc).quantum(state_vec()).noise(...).run()
     ///     sim_neo(tc).quantum(stabilizer()).noise(...).run()
-    ///     sim_neo(tc).quantum(stab_mps().lazy_measure()).noise(...).run()
+    ///     sim_neo(tc).quantum(stab_mps().measurement("lazy")).noise(...).run()
     fn quantum(&self, builder: &Bound<'_, PyAny>) -> PyResult<Self> {
         let mut c = self.clone();
         if builder.is_instance_of::<PyMeasSamplingBuilder>() {
@@ -1514,7 +1510,7 @@ fn commands_to_gates(commands: &pecos_neo::command::CommandQueue) -> Vec<pecos_c
 ///
 /// Example:
 ///     results = (sim_neo(tc)
-///         .quantum(stab_mps().lazy_measure().max_bond_dim(128))
+///         .quantum(stab_mps().measurement("lazy").max_bond_dim(128))
 ///         .noise(depolarizing().p1(0.003).p2(0.003).p_meas(0.003).idle_rz(0.05))
 ///         .sampling(monte_carlo(5000))
 ///         .seed(42)

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -380,7 +380,7 @@ impl PyStabMps {
     /// preset, while `False` and `None` are identical no-ops.
     /// `measurement` accepts `"exact"`, `"pragmatic"`, or `"lazy"`; when
     /// omitted, the normal default is exact. An explicit value is applied
-    /// after `for_qec` and therefore overrides that preset's Stage-A policy.
+    /// after `for_qec` and therefore overrides that preset's exact policy.
     /// `max_truncation_error=None` preserves the builder default of
     /// `1e-8`; a float overrides it, and `0.0` disables adaptive truncation
     /// while retaining the SVD cutoff and bond cap. Negative and non-finite

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -23,7 +23,7 @@ use pyo3::types::{PyBool, PyDict, PyList, PySet, PyTuple};
 ///
 /// Read methods materialize pending lazy-measurement operations and merged RZ
 /// rotations before returning, except the pure diagnostics `is_state_exact()`
-/// and `pragmatic_drift_count`. Bitstrings use qubit-index order: `bits[q]` is
+/// and `uncompensated_pre_reduction_count`. Bitstrings use qubit-index order: `bits[q]` is
 /// the bit for qubit `q`, and input items must be actual Python `bool` values.
 /// A tracked Pauli frame remains separate until
 /// `flush_pauli_frame_to_state()` is called. The `for_qec` constructor keyword is an enable-only
@@ -378,6 +378,9 @@ impl PyStabMps {
     /// the Rust builder default, while `True` or `False` explicitly enables or
     /// disables the option. `for_qec` is enable-only: `True` applies the
     /// preset, while `False` and `None` are identical no-ops.
+    /// `measurement` accepts `"exact"`, `"pragmatic"`, or `"lazy"`; when
+    /// omitted, the normal default is exact. An explicit value is applied
+    /// after `for_qec` and therefore overrides that preset's Stage-A policy.
     /// `max_truncation_error=None` preserves the builder default of
     /// `1e-8`; a float overrides it, and `0.0` disables adaptive truncation
     /// while retaining the SVD cutoff and bond cap. Negative and non-finite
@@ -398,7 +401,7 @@ impl PyStabMps {
         max_bond_dim=None,
         merge_rz=None,
         pauli_frame_tracking=None,
-        lazy_measure=None,
+        measurement=None,
         for_qec=None,
         auto_grow_bond_dim=None,
         auto_grow_max_bond_dim=None,
@@ -413,7 +416,7 @@ impl PyStabMps {
         max_bond_dim: Option<usize>,
         merge_rz: Option<bool>,
         pauli_frame_tracking: Option<bool>,
-        lazy_measure: Option<bool>,
+        measurement: Option<&str>,
         for_qec: Option<bool>,
         auto_grow_bond_dim: Option<f64>,
         auto_grow_max_bond_dim: Option<usize>,
@@ -442,8 +445,8 @@ impl PyStabMps {
         if let Some(v) = pauli_frame_tracking {
             b = b.pauli_frame_tracking(v);
         }
-        if let Some(v) = lazy_measure {
-            b = b.lazy_measure(v);
+        if let Some(value) = measurement {
+            b = b.measurement(crate::parse_measurement_mode(value)?);
         }
         if let Some(t) = auto_grow_bond_dim {
             b = b.auto_grow_bond_dim(t);
@@ -501,19 +504,45 @@ impl PyStabMps {
     }
 
     #[getter]
-    /// Number of eager measurements that introduced pragmatic stored-state drift.
-    ///
-    /// A nonzero value means amplitude-like reads can be approximate even after
-    /// flushing. Use `lazy_measure=True` when later exact state reads are needed.
-    fn pragmatic_drift_count(&self) -> u64 {
-        self.inner.pragmatic_drift_count()
+    /// Number of pragmatic measurements with uncompensated pre-reduction.
+    fn uncompensated_pre_reduction_count(&self) -> u64 {
+        self.inner.uncompensated_pre_reduction_count()
+    }
+
+    #[getter]
+    fn summed_discarded_weight(&self) -> f64 {
+        self.inner.summed_discarded_weight()
+    }
+
+    #[getter]
+    fn lifetime_peak_bond(&self) -> usize {
+        self.inner.lifetime_peak_bond()
+    }
+
+    #[getter]
+    fn branch_vanish_retry_count(&self) -> u64 {
+        self.inner.branch_vanish_retry_count()
+    }
+
+    #[getter]
+    fn deferred_branch_lost_count(&self) -> u64 {
+        self.inner.deferred_branch_lost_count()
+    }
+
+    #[getter]
+    fn measurement(&self) -> &'static str {
+        match self.inner.measurement_mode() {
+            pecos_stab_tn::stab_mps::MeasurementMode::Exact => "exact",
+            pecos_stab_tn::stab_mps::MeasurementMode::Pragmatic => "pragmatic",
+            pecos_stab_tn::stab_mps::MeasurementMode::Lazy => "lazy",
+        }
     }
 
     /// Whether the stored tableau/MPS exactly represents the physical state.
     ///
-    /// This is false for pending merged rotations, lazy operations, an
-    /// unmaterialized Pauli frame, or pragmatic measurement drift. MPS
-    /// truncation is reported separately by `truncation_error`.
+    /// This conservative sufficient predicate covers all pending-state,
+    /// policy, uncompensated-reduction, truncation-weight, and deferred-loss
+    /// guards.
     fn is_state_exact(&self) -> bool {
         self.inner.is_state_exact()
     }

--- a/python/pecos-rslib-exp/src/stabmps_builder.rs
+++ b/python/pecos-rslib-exp/src/stabmps_builder.rs
@@ -13,12 +13,12 @@
 //! `StabMps` backend for `sim_neo`.
 //!
 //! Provides a `SimulatorFactory` implementation that creates `StabMps` simulators
-//! with configurable parameters (`lazy_measure`, `max_bond_dim`, etc.).
+//! with configurable parameters (`measurement`, `max_bond_dim`, etc.).
 
 use pecos_neo::noise::ComposableNoiseModel;
 use pecos_neo::program::{DynProgramRunner, ProgramRunner};
 use pecos_neo::tool::SimulatorFactory;
-use pecos_stab_tn::stab_mps::StabMps;
+use pecos_stab_tn::stab_mps::{MeasurementMode, StabMps};
 
 /// Configuration for the `StabMps` backend.
 ///
@@ -26,8 +26,8 @@ use pecos_stab_tn::stab_mps::StabMps;
 /// Implements `SimulatorFactory` so it can be used with `custom_backend()`.
 #[derive(Debug, Clone)]
 pub struct StabMpsBuilder {
-    /// Use lazy measurement (correct for non-Clifford, slower).
-    pub lazy_measure: bool,
+    /// Singular-measurement policy.
+    pub measurement: MeasurementMode,
     /// Maximum MPS bond dimension.
     pub max_bond_dim: usize,
     /// Maximum truncation error for MPS compression.
@@ -40,7 +40,7 @@ pub struct StabMpsBuilder {
 impl Default for StabMpsBuilder {
     fn default() -> Self {
         Self {
-            lazy_measure: false,
+            measurement: MeasurementMode::Exact,
             max_bond_dim: 128,
             max_truncation_error: Some(1e-8),
             merge_rz: true,
@@ -55,10 +55,10 @@ impl StabMpsBuilder {
         Self::default()
     }
 
-    /// Enable lazy measurement (correct for non-Clifford states).
+    /// Select the singular-measurement policy.
     #[must_use]
-    pub fn with_lazy_measure(mut self, lazy: bool) -> Self {
-        self.lazy_measure = lazy;
+    pub fn with_measurement(mut self, measurement: MeasurementMode) -> Self {
+        self.measurement = measurement;
         self
     }
 
@@ -100,7 +100,7 @@ impl SimulatorFactory for StabMpsBuilder {
         seed: Option<u64>,
     ) -> Box<dyn DynProgramRunner> {
         let mut builder = StabMps::builder(num_qubits);
-        builder = builder.lazy_measure(self.lazy_measure);
+        builder = builder.measurement(self.measurement);
         builder = builder.max_bond_dim(self.max_bond_dim);
         if let Some(err) = self.max_truncation_error {
             builder = builder.max_truncation_error(err);
@@ -119,5 +119,20 @@ impl SimulatorFactory for StabMpsBuilder {
             runner = runner.with_seed(s);
         }
         Box::new(runner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sim_neo_measurement_mode_defaults_and_selection() {
+        let default = StabMpsBuilder::default();
+        assert_eq!(default.measurement, MeasurementMode::Exact);
+        let pragmatic = default.with_measurement(MeasurementMode::Pragmatic);
+        assert_eq!(pragmatic.measurement, MeasurementMode::Pragmatic);
+        let lazy = pragmatic.with_measurement(MeasurementMode::Lazy);
+        assert_eq!(lazy.measurement, MeasurementMode::Lazy);
     }
 }

--- a/python/pecos-rslib-exp/src/stabmps_builder.rs
+++ b/python/pecos-rslib-exp/src/stabmps_builder.rs
@@ -40,7 +40,7 @@ pub struct StabMpsBuilder {
 impl Default for StabMpsBuilder {
     fn default() -> Self {
         Self {
-            measurement: MeasurementMode::Exact,
+            measurement: MeasurementMode::default(),
             max_bond_dim: 128,
             max_truncation_error: Some(1e-8),
             merge_rz: true,

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -31,19 +31,36 @@ def assert_complex_tuple(value):
     assert all(isinstance(component, float) for component in value)
 
 
-def test_sim_neo_stab_mps_boolean_builder_options():
+def test_sim_neo_stab_mps_measurement_and_boolean_builder_options():
     circuit = TickCircuit()
     circuit.tick().x([0])
     circuit.tick().mz([0])
 
     backends = [
-        exp.stab_mps().lazy_measure().merge_rz(),
-        exp.stab_mps().lazy_measure(True).merge_rz(True),
-        exp.stab_mps().lazy_measure(False).merge_rz(False),
+        exp.stab_mps().measurement("exact").merge_rz(),
+        exp.stab_mps().measurement("lazy").merge_rz(True),
+        exp.stab_mps().measurement("pragmatic").merge_rz(False),
     ]
     for backend in backends:
         result = exp.sim_neo(circuit).quantum(backend).sampling(exp.monte_carlo(1)).seed(7).run()
         assert [list(row) for row in result] == [[1]]
+
+    with pytest.raises(ValueError, match="measurement must be one of"):
+        exp.stab_mps().measurement("eager")
+
+
+def test_stab_mps_measurement_selection_precedence_and_reset_retention():
+    assert exp.StabMps(1).measurement == "exact"
+    assert exp.StabMps(1, measurement="pragmatic").measurement == "pragmatic"
+    assert exp.StabMps(1, measurement="lazy").measurement == "lazy"
+    assert exp.StabMps(1, for_qec=True).measurement == "pragmatic"
+    assert exp.StabMps(1, for_qec=True, measurement="exact").measurement == "exact"
+    lazy = exp.StabMps(1, for_qec=True, measurement="lazy")
+    assert lazy.measurement == "lazy"
+    assert lazy.reset().measurement == "lazy"
+
+    with pytest.raises(ValueError, match="measurement must be one of"):
+        exp.StabMps(1, measurement="eager")
 
 
 def test_stab_mps_analysis_and_noise_exposure():
@@ -123,7 +140,7 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     assert_complex_tuple(merged_amplitude)
     assert merged.is_state_exact() is True
 
-    lazy = exp.StabMps(2, seed=19, lazy_measure=True)
+    lazy = exp.StabMps(2, seed=19, measurement="lazy")
     lazy.run_1q_gate("H", 1)
     lazy.run_1q_gate("T", 1)
     lazy.run_1q_gate("S", 0)
@@ -132,7 +149,12 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     lazy.run_1q_gate("MZ", 0)
     assert lazy.is_state_exact() is False
     assert len(lazy.state_vector()) == 4
-    assert lazy.is_state_exact() is True
+    assert lazy.is_state_exact() is False
+    assert lazy.uncompensated_pre_reduction_count == 0
+    assert lazy.summed_discarded_weight == 0.0
+    assert lazy.branch_vanish_retry_count == 0
+    assert lazy.deferred_branch_lost_count == 0
+    assert isinstance(lazy.lifetime_peak_bond, int)
 
     with pytest.raises(ValueError, match="bitstring length 1, expected 2"):
         q0_one.amplitude([True])

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -53,8 +53,9 @@ def test_stab_mps_measurement_selection_precedence_and_reset_retention():
     assert exp.StabMps(1).measurement == "exact"
     assert exp.StabMps(1, measurement="pragmatic").measurement == "pragmatic"
     assert exp.StabMps(1, measurement="lazy").measurement == "lazy"
-    assert exp.StabMps(1, for_qec=True).measurement == "pragmatic"
+    assert exp.StabMps(1, for_qec=True).measurement == "exact"
     assert exp.StabMps(1, for_qec=True, measurement="exact").measurement == "exact"
+    assert exp.StabMps(1, for_qec=True, measurement="pragmatic").measurement == "pragmatic"
     lazy = exp.StabMps(1, for_qec=True, measurement="lazy")
     assert lazy.measurement == "lazy"
     assert lazy.reset().measurement == "lazy"

--- a/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_stabilizer_tensor_networks.rs
+++ b/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_stabilizer_tensor_networks.rs
@@ -8,10 +8,7 @@ fn test_user_guide_stabilizer_tensor_networks_rust_1() {
     use pecos_core::{Angle64, QubitId};
     use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
     use pecos_stab_tn::stab_mps::StabMps;
-    let mut sim = StabMps::builder(2)
-        .seed(7)
-        .lazy_measure(true)
-        .build();
+    let mut sim = StabMps::builder(2).seed(7).build();
     sim.h(&[QubitId(0)]);
     sim.cx(&[(QubitId(0), QubitId(1))]);
     sim.rz(Angle64::QUARTER_TURN / 2_u64, &[QubitId(1)]);

--- a/python/selene-plugins/pecos-selene-stab-mps/README.md
+++ b/python/selene-plugins/pecos-selene-stab-mps/README.md
@@ -12,8 +12,9 @@ from pecos_selene_stab_mps import StabMpsPlugin
 sim = StabMpsPlugin()
 ```
 
-The plugin inherits `StabMps::for_qec()`'s Pragmatic measurement mode pending
-the Stage B performance measurement. That mode preserves the current QEC
-throughput behavior, but its conditional states are known to be biased on
-honest non-Clifford circuit families; use the general `StabMps` interface with
-Exact measurement when exact continuation or state reads are required.
+The plugin inherits `StabMps::for_qec()`'s Exact measurement mode. The frozen
+Stage-B repetition-code benchmark in
+`exp/pecos-stab-tn/examples/measurement_mode_bench.rs` measured a 1.497x
+geometric-mean slowdown and a 1.548x per-workload maximum versus Pragmatic,
+inside the decided Exact-everywhere limits. Exact avoids Pragmatic mode's
+known conditional-state bias on honest non-Clifford circuit families.

--- a/python/selene-plugins/pecos-selene-stab-mps/README.md
+++ b/python/selene-plugins/pecos-selene-stab-mps/README.md
@@ -15,6 +15,7 @@ sim = StabMpsPlugin()
 The plugin inherits `StabMps::for_qec()`'s Exact measurement mode. The frozen
 Stage-B repetition-code benchmark in
 `exp/pecos-stab-tn/examples/measurement_mode_bench.rs` measured a 1.497x
-geometric-mean slowdown and a 1.548x per-workload maximum versus Pragmatic,
+geometric-mean slowdown and a 1.548x per-workload maximum versus Pragmatic on
+that noisy repetition-code family,
 inside the decided Exact-everywhere limits. Exact avoids Pragmatic mode's
 known conditional-state bias on honest non-Clifford circuit families.

--- a/python/selene-plugins/pecos-selene-stab-mps/README.md
+++ b/python/selene-plugins/pecos-selene-stab-mps/README.md
@@ -11,3 +11,9 @@ from pecos_selene_stab_mps import StabMpsPlugin
 
 sim = StabMpsPlugin()
 ```
+
+The plugin inherits `StabMps::for_qec()`'s Pragmatic measurement mode pending
+the Stage B performance measurement. That mode preserves the current QEC
+throughput behavior, but its conditional states are known to be biased on
+honest non-Clifford circuit families; use the general `StabMps` interface with
+Exact measurement when exact continuation or state reads are required.

--- a/python/selene-plugins/pecos-selene-stab-mps/src/lib.rs
+++ b/python/selene-plugins/pecos-selene-stab-mps/src/lib.rs
@@ -147,8 +147,8 @@ impl StabMpsSimulator {
                 MetricValue::U64(self.simulator.max_bond_dim() as u64),
             ))),
             1 => Ok(Some((
-                "pragmatic_drift_count".to_string(),
-                MetricValue::U64(self.simulator.pragmatic_drift_count()),
+                "uncompensated_pre_reduction_count".to_string(),
+                MetricValue::U64(self.simulator.uncompensated_pre_reduction_count()),
             ))),
             _ => Ok(None),
         }
@@ -261,7 +261,8 @@ export_simulator_plugin!(crate::StabMpsSimulatorFactory);
 
 #[cfg(test)]
 mod tests {
-    use super::StabMpsSimulatorFactory;
+    use super::{StabMpsSimulator, StabMpsSimulatorFactory};
+    use pecos_stab_tn::stab_mps::{MeasurementMode, StabMps};
     use selene_core::simulator::conformance_testing::run_basic_tests;
     use std::sync::Arc;
 
@@ -270,5 +271,22 @@ mod tests {
         let interface = Arc::new(StabMpsSimulatorFactory);
         let args: Vec<String> = vec![String::new()];
         run_basic_tests(interface, args);
+    }
+
+    #[test]
+    fn selene_keeps_for_qec_measurement_policy() {
+        let mut interface = StabMpsSimulator {
+            simulator: StabMps::builder(2).for_qec().build(),
+            n_qubits: 2,
+        };
+        assert_eq!(
+            interface.simulator.measurement_mode(),
+            MeasurementMode::Pragmatic
+        );
+        interface.shot_start(0, 7).unwrap();
+        assert_eq!(
+            interface.simulator.measurement_mode(),
+            MeasurementMode::Pragmatic
+        );
     }
 }

--- a/python/selene-plugins/pecos-selene-stab-mps/src/lib.rs
+++ b/python/selene-plugins/pecos-selene-stab-mps/src/lib.rs
@@ -281,12 +281,12 @@ mod tests {
         };
         assert_eq!(
             interface.simulator.measurement_mode(),
-            MeasurementMode::Pragmatic
+            MeasurementMode::Exact
         );
         interface.shot_start(0, 7).unwrap();
         assert_eq!(
             interface.simulator.measurement_mode(),
-            MeasurementMode::Pragmatic
+            MeasurementMode::Exact
         );
     }
 }


### PR DESCRIPTION
Retires the pragmatic measurement bias: StabMps's default measurement becomes exact
sample-then-force, with the pragmatic path opt-in and lazy quarantined behind its known bias
(issue #555).

## The problem

StabMps's default random-measurement path skipped MPS frame compensation. Long documented as
"statistics correct, state drifts", the second half was falsified during the #523 fix round and
the first half is falsified here, per surface, by a committed falsifier harness: on honest
circuit families (basis-changing Cliffords after non-Clifford gates), against an independent
dense oracle at 5-sigma guards, the old default measured 25-69 sigma biased on end-of-circuit
mz, up to 104 sigma on reset/continuation, 85 sigma on pz, 30 on px, 19 on extract_syndromes,
and 24-63 sigma on per-shot sampling. A liveness meta-test pins an explicitly-pragmatic
simulator at 37.6 sigma so the harness can never pass vacuously; a Mast control validates the
harness itself.

## The change

- `MeasurementMode { Exact, Pragmatic, Lazy }` on the builder (default Exact) replaces
  `lazy_measure(bool)` across Rust, Python, sim_neo, and Selene, with an explicit migration:
  `lazy_measure(false)` mapped to Pragmatic where the call site's intent was the legacy
  comparison semantics, and to the new Exact default where sites simply used the default.
  Python: `measurement="exact"|"pragmatic"|"lazy"`, explicit kwarg overriding presets (tested).
  The low-level uncompensated entry point is renamed `measure_qubit_stab_mps_pragmatic`.
- The Exact path samples from the projector's own endpoint-snapped probability (one shared
  trivial-aware probability function guarantees the draw and the projection agree bit-for-bit
  on every path) and projects transactionally on a candidate clone. If configured truncation
  erases the sampled branch (pre-normalization survival ratio below 1e-12), the same outcome is
  retried once untruncated with the original config restored on commit; a second vanish panics.
  Deferred MAST projections, whose outcomes were drawn at injection, get a separate documented
  policy: a branch erased by prior truncation projects the surviving branch and increments
  `deferred_branch_lost_count`.
- Exact projections now compress redundant rank in the projection's own gauge. This was the
  decisive performance fix: before it, the exact path accumulated direct-sum rank up to the
  bond cap (measured 10x to 1768x slowdowns at n=5..9 syndrome extraction); after it, exact
  matches pragmatic's bond profile exactly and the measured cost is 1.5x-1.8x.
- `is_state_exact()` now requires seven conjuncts (the four existing plus Exact mode, zero
  summed discarded weight, zero deferred branch losses) and is documented as
  conservative-sufficient. New telemetry: summed discarded weight, lifetime peak bond,
  branch-vanish retries, and the renamed `uncompensated_pre_reduction_count`.

## The decision function, measured

`for_qec()` selects Exact based on the committed frozen benchmark
(`examples/measurement_mode_bench.rs`: manually expanded d=3/d=5 repetition-code syndrome
circuits in both check bases, 8 rounds, coherent RZ(0.1) per data qubit per round, pre-generated
per-CX two-qubit depolarizing at 1e-3 identical across modes, 7 pinned seeds, medians):

| Workload | Exact vs Pragmatic |
|---|---:|
| d3/Z | 1.50x |
| d3/X | 1.49x |
| d5/Z | 1.46x |
| d5/X | 1.55x |

Geometric mean 1.497, maximum 1.548 — inside the pre-registered Exact-everywhere limits
(geomean <= 3, per-workload max <= 5). Telemetry: identical peak/final bonds across modes, zero
cap hits, zero vanish retries.

## Verification

- Falsifier matrix on the actual default: worst 3.96 sigma across all nine surfaces
  (limits 5.4-6.1); explicit-Pragmatic liveness still 37.6 sigma.
- Non-ignored conditional-state fidelity tests (distributions alone cannot see the phase
  corruption class #547 fixed).
- 1,200-circuit stability census: 0 panics. 640-circuit issue #557 sweep: worst deltas
  1.5e-15 (ceiling 3.3e-15), plus a new adaptive-budget variant asserting reads within the
  recorded-weight bound.
- Every guard proven binding by mutation or fault injection: all seven exactness conjuncts,
  rollback identity (tableau, MPS, telemetry, tracked center), config restoration, the MAST
  complement choice and its probability-zero detection arm, double-vanish panics, and the
  rank-compression fix itself.
- Two full adversarial review rounds on the implementation (verdict MERGEABLE after fixes) on
  top of five design review rounds; the design record lives in pecos-docs
  (design/stab-tn/exact-default-measurement-v5.md and its history).
- clippy -D warnings and fmt clean on pecos-stab-tn and pecos-rslib-exp; Selene plugin tests
  pass; debug-lane falsifier cost held to seconds via a cheap debug subset with the full
  matrix release-gated.

## Breaking changes

- `lazy_measure(bool)` is removed (builder and every binding); use `measurement`/
  `MeasurementMode`. `pragmatic_drift_count` is renamed `uncompensated_pre_reduction_count`.
- Seeded RNG streams change for measurement-bearing circuits (deterministic endpoints consume
  no draw; the exact path draws from snapped probabilities; noise draws share the stream).
  Consistent with the crate's per-revision trajectory policy recorded in #563.
- Default results change wherever the old biased default was in use - that is the point.
