### PR TITLE
Add apply_to_basis_state benchmarks and record the measured no to a sparse-Z skip

### DIFF
--- a/crates/benchmarks/benches/modules/pauli_ops.rs
+++ b/crates/benchmarks/benches/modules/pauli_ops.rs
@@ -72,12 +72,69 @@ macro_rules! bench_multiply {
     }};
 }
 
+macro_rules! bench_apply_to_basis_state {
+    ($group:expr, $id:expr, $pauli:expr, $state:expr) => {{
+        let pauli = $pauli;
+        let state = $state;
+        $group.bench_function($id, move |b| {
+            b.iter(|| black_box(black_box(&pauli).apply_to_basis_state(black_box(&state))));
+        });
+    }};
+}
+
 pub fn benchmarks<M: Measurement>(c: &mut Criterion<M>) {
     let mut group = c.benchmark_group("Pauli Operations");
     bench_u128(&mut group);
     bench_vec(&mut group);
     bench_small(&mut group);
+    bench_basis_state(&mut group);
     group.finish();
+}
+
+/// A Pauli whose Z plane holds exactly the given sites (built through the
+/// public constructors).
+fn z_only_small(sites: &[usize]) -> PauliBitmaskSmall {
+    let mut pauli = PauliBitmaskSmall::identity();
+    for &q in sites {
+        pauli = pauli.multiply(&PauliBitmaskSmall::z(q));
+    }
+    pauli
+}
+
+fn bench_basis_state<M: Measurement>(group: &mut BenchmarkGroup<M>) {
+    // States are the public X plane of a deterministically built Pauli:
+    // dense_small marks roughly two thirds of the register's qubits.
+    // Dense Pauli acting on a dense wide state: the full-walk shape.
+    bench_apply_to_basis_state!(
+        group,
+        "apply_to_basis_state/dense/smallvec_u64/1024q",
+        dense_small(1024, 0),
+        dense_small(1024, 1).x_bits
+    );
+    // A few Z sites at high indices on a dense state: the Z plane is stored
+    // out to word 15 but almost every word in the walk is all-identity. This
+    // is the shape an interior all-zero-Z skip would target.
+    bench_apply_to_basis_state!(
+        group,
+        "apply_to_basis_state/sparse_z_high/smallvec_u64/1024q",
+        z_only_small(&[1000, 1007, 1016, 1023]),
+        dense_small(1024, 1).x_bits
+    );
+    // A few low Z sites on a dense wide state: the walk bound is already
+    // small, so a skip has nothing to save.
+    bench_apply_to_basis_state!(
+        group,
+        "apply_to_basis_state/sparse_z_low/smallvec_u64/1024q",
+        z_only_small(&[0, 3, 9, 17]),
+        dense_small(1024, 1).x_bits
+    );
+    // Dense Pauli on the empty state: exercises padded state reads.
+    bench_apply_to_basis_state!(
+        group,
+        "apply_to_basis_state/dense_on_empty/smallvec_u64/1024q",
+        dense_small(1024, 0),
+        PauliBitmaskSmall::identity().x_bits
+    );
 }
 
 fn bench_u128<M: Measurement>(group: &mut BenchmarkGroup<M>) {


### PR DESCRIPTION
## What

Extends the `pauli_ops` benchmark module with four `apply_to_basis_state` shapes on the load-bearing `SmallVec` backend: dense Pauli on a dense 1024-qubit state, a few high-index Z sites on a dense state (the shape an interior all-zero-Z-word skip would target), a few low-index Z sites (walk bound already small), and dense on the empty state (padded reads). Operands are deterministic and built through public API only, so the module remains usable for cross-branch comparison.

## Why, and the measurement it already produced

When `apply_to_basis_state` landed, an optimization was deferred behind a measurement: skipping words whose Z plane is all identity, mirroring the exact skip that fixed the product-phase sparse regression. These benchmarks ran that experiment. The candidate one-liner was applied to the shared walk and measured against this baseline:

| shape | with skip |
|---|---|
| sparse Z-high | -56% |
| dense | **+27% regression** |
| sparse Z-low | +4.5% |
| dense on empty | ~0 |

Verdict: **not shipped.** The skip buys its win on a shape no current caller exhibits while charging 27% on the common dense walk — the opposite trade from the product-phase skip, whose dense cost was nil. If a sparse-Z-heavy consumer of `apply_to_basis_state` ever appears, these benchmarks are the ready-made harness for revisiting.

Only the benchmark module changes; no library code is touched.