### PR TITLE
Conjugate lazy-frame rotations through the pending deferred queue and fix the CZ conjugation phase

### DIFF
--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -6690,6 +6690,116 @@ mod tests {
     }
 
     #[test]
+    fn lazy_multi_measurement_cnot_cz_frame_rz_matches_dense() {
+        use pecos_simulators::DenseStateVec;
+
+        fn project_z(state: &[Complex64], qubit: usize, outcome: bool) -> Vec<Complex64> {
+            let probability = state
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| ((*index >> qubit) & 1 != 0) == outcome)
+                .map(|(_, amplitude)| amplitude.norm_sqr())
+                .sum::<f64>();
+            assert!(probability > 1e-14, "sampled branch must have support");
+            let scale = probability.sqrt().recip();
+            state
+                .iter()
+                .enumerate()
+                .map(|(index, &amplitude)| {
+                    if ((index >> qubit) & 1 != 0) == outcome {
+                        amplitude * scale
+                    } else {
+                        Complex64::new(0.0, 0.0)
+                    }
+                })
+                .collect()
+        }
+
+        let mut stn = StabMps::builder(4)
+            .seed(0x5550)
+            .measurement(MeasurementMode::Lazy)
+            .merge_rz(false)
+            .build();
+        let mut dense = DenseStateVec::new(4);
+        for q in 0..4 {
+            let angle = Angle64::from_radians(0.23 + 0.07 * q as f64);
+            stn.h(&[QubitId(q)]);
+            dense.h(&[QubitId(q)]);
+            stn.rz(angle, &[QubitId(q)]);
+            dense.rz(angle, &[QubitId(q)]);
+        }
+        for &(control, target) in &[(0, 1), (2, 3)] {
+            stn.cx(&[(QubitId(control), QubitId(target))]);
+            dense.cx(&[(QubitId(control), QubitId(target))]);
+        }
+        for &(first, second) in &[(1, 2), (3, 0)] {
+            stn.cz(&[(QubitId(first), QubitId(second))]);
+            dense.cz(&[(QubitId(first), QubitId(second))]);
+        }
+
+        for (measurement, measured) in [0, 3, 1].into_iter().enumerate() {
+            let outcome = stn.mz(&[QubitId(measured)])[0].outcome;
+            let projected = project_z(&dense.state(), measured, outcome);
+            dense = DenseStateVec::from_state(
+                &projected,
+                PecosRng::seed_from_u64(0x5550 + measurement as u64 + 1),
+            );
+        }
+        assert!(
+            stn.deferred_ops
+                .iter()
+                .any(|op| matches!(op, measure::DeferredOp::Cnot(_, _))),
+            "fixture must retain a lazy pre-reduction CNOT: {:?}",
+            stn.deferred_ops
+        );
+        assert!(
+            stn.deferred_ops
+                .iter()
+                .any(|op| matches!(op, measure::DeferredOp::Cz(_, _))),
+            "fixture must retain a lazy basis-rotation CZ: {:?}",
+            stn.deferred_ops
+        );
+        assert!(
+            stn.deferred_ops.len() > 2,
+            "fixture must exercise a nontrivial deferred queue: {:?}",
+            stn.deferred_ops
+        );
+
+        for q in [0, 0, 3] {
+            stn.sz(&[QubitId(q)]);
+            dense.sz(&[QubitId(q)]);
+        }
+        for &(control, target) in &[(3, 1), (3, 0)] {
+            stn.cx(&[(QubitId(control), QubitId(target))]);
+            dense.cx(&[(QubitId(control), QubitId(target))]);
+        }
+        stn.sz(&[QubitId(3)]);
+        dense.sz(&[QubitId(3)]);
+        stn.h(&[QubitId(0)]);
+        dense.h(&[QubitId(0)]);
+        stn.cx(&[(QubitId(1), QubitId(0))]);
+        dense.cx(&[(QubitId(1), QubitId(0))]);
+        let angle = Angle64::from_radians(0.67);
+        stn.rz(angle, &[QubitId(0)]);
+        dense.rz(angle, &[QubitId(0)]);
+
+        stn.flush();
+        let actual = stn.state_vector();
+        let expected = dense.state();
+        let fidelity = actual
+            .iter()
+            .zip(expected)
+            .map(|(left, right)| left.conj() * right)
+            .sum::<Complex64>()
+            .norm_sqr();
+        eprintln!("lazy-multi-measurement-frame-rz fidelity={fidelity:.16}");
+        assert!(
+            fidelity >= 1.0 - 1e-10,
+            "issue #555 multi-measurement lazy frame must match dense; fidelity={fidelity:.16}"
+        );
+    }
+
+    #[test]
     fn test_uncompensated_pre_reduction_count_tracks_pragmatic_path() {
         // Build a state where col_x for the measured qubit has multiple
         // anticommuting stabilizers so pre_reduce fires. H(0), H(1), CX(0,1)

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -837,6 +837,9 @@ pub struct StabMpsStats {
     pub single_site: u64,
     /// Non-Cliffords that fired multi-site disent (tableau right-compose).
     pub multi_disent: u64,
+    /// Multi-site rotations that could use a stored |0> proof but bypassed
+    /// tableau-right-composing disentangling because a Lazy frame was pending.
+    pub deferred_disent_bypass: u64,
     /// Missing |0> flags recovered numerically at product sites.
     pub numerical_redetect: u64,
     /// Non-Cliffords that fell through to the std multi-site CNOT cascade path.
@@ -2502,9 +2505,11 @@ impl StabMps {
                 self.flags.normalize_after_gate(),
                 &mut non_clifford::RzContext {
                     disent_flags: &mut self.disent_flags,
-                    // Redetection reads stored tensors; with pending lazy deferred
-                    // ops the effective state is V * stored MPS, so stored |0> does
-                    // not imply effective |0>.
+                    deferred_ops: &self.deferred_ops,
+                    // Redetection only feeds exact disentangling. That fast path
+                    // is disabled while V is pending because its tableau
+                    // right-composition cannot be moved across V, so avoid the
+                    // otherwise unused stored-tensor contractions too.
                     numerical_flag_redetection: self.flags.numerical_flag_redetection()
                         && self.deferred_ops.is_empty(),
                     gf2_matrix: &mut self.gf2_matrix,

--- a/exp/pecos-stab-tn/src/stab_mps/mast.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/mast.rs
@@ -474,6 +474,7 @@ impl Mast {
                 true,
                 &mut non_clifford::RzContext {
                     disent_flags: &mut self.disent_flags,
+                    deferred_ops: &[],
                     numerical_flag_redetection: self.numerical_flag_redetection,
                     gf2_matrix: &mut self.gf2_matrix,
                     stats: &mut self.stats,
@@ -533,6 +534,7 @@ impl Mast {
                     true,
                     &mut non_clifford::RzContext {
                         disent_flags: &mut self.disent_flags,
+                        deferred_ops: &[],
                         numerical_flag_redetection: self.numerical_flag_redetection,
                         gf2_matrix: &mut self.gf2_matrix,
                         stats: &mut self.stats,

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -577,7 +577,8 @@ fn toggle(v: &mut Vec<usize>, x: usize) {
 /// Conjugate a Pauli `P = X_flip · Z_sign` by `V†` where
 /// `V = ops[last] · ops[last-1] · ... · ops[0]`. Updates `flip_sites` and
 /// `sign_sites` in place to represent `V† · P · V`. The scalar phase is
-/// unchanged (CNOT/H/CZ conjugation preserves phase of the product).
+/// updated whenever the X-block-before-Z-block representation picks up a
+/// sign or a factor of i.
 ///
 /// Heisenberg rules:
 /// - CNOT(c, t): `X_c -> X_c · X_t`; `Z_t -> Z_c · Z_t`.
@@ -625,6 +626,11 @@ pub fn conjugate_pauli_by_deferred_ops(
             DeferredOp::Cz(a, b) => {
                 let has_x_a = flip_sites.contains(&a);
                 let has_x_b = flip_sites.contains(&b);
+                // CZ·(X_a X_b)·CZ = Y_a Y_b = -(XZ)_a (XZ)_b in the
+                // X-block-before-Z-block convention.
+                if has_x_a && has_x_b {
+                    *phase = -*phase;
+                }
                 if has_x_a {
                     toggle(sign_sites, b);
                 }
@@ -1859,6 +1865,191 @@ mod tests {
     fn sort_dedup(v: &mut Vec<usize>) {
         v.sort_unstable();
         v.dedup();
+    }
+
+    fn dense_pauli(flip_mask: usize, sign_mask: usize, phase: Complex64) -> DMatrix<Complex64> {
+        let identity = DMatrix::identity(2, 2);
+        let x = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(0.0, 0.0),
+            ],
+        );
+        let z = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+        ]));
+        let factors: Vec<_> = (0..2)
+            .map(
+                |q| match (flip_mask & (1 << q) != 0, sign_mask & (1 << q) != 0) {
+                    (false, false) => identity.clone(),
+                    (true, false) => x.clone(),
+                    (false, true) => z.clone(),
+                    (true, true) => &x * &z,
+                },
+            )
+            .collect();
+        factors[0].kronecker(&factors[1]).map(|entry| phase * entry)
+    }
+
+    fn dense_single_qubit_gate(gate: &DMatrix<Complex64>, q: usize) -> DMatrix<Complex64> {
+        let identity = DMatrix::identity(2, 2);
+        if q == 0 {
+            gate.kronecker(&identity)
+        } else {
+            identity.kronecker(gate)
+        }
+    }
+
+    fn identify_dense_pauli(matrix: &DMatrix<Complex64>) -> (usize, usize, Complex64) {
+        let phases = [
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(0.0, -1.0),
+        ];
+        let mut matches = Vec::new();
+        for flip_mask in 0..4 {
+            for sign_mask in 0..4 {
+                for phase in phases {
+                    if (dense_pauli(flip_mask, sign_mask, phase) - matrix).norm() < 1e-12 {
+                        matches.push((flip_mask, sign_mask, phase));
+                    }
+                }
+            }
+        }
+        assert_eq!(matches.len(), 1, "dense oracle must identify one Pauli");
+        matches[0]
+    }
+
+    #[test]
+    fn conjugate_pauli_by_deferred_ops_matches_dense_oracle_for_every_op_kind() {
+        let r = std::f64::consts::FRAC_1_SQRT_2;
+        let h = DMatrix::from_row_slice(
+            2,
+            2,
+            &[
+                Complex64::new(r, 0.0),
+                Complex64::new(r, 0.0),
+                Complex64::new(r, 0.0),
+                Complex64::new(-r, 0.0),
+            ],
+        );
+        let z = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+        ]));
+        let s = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 1.0),
+        ]));
+        let sdg = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, -1.0),
+        ]));
+        let cnot_01 = DMatrix::from_row_slice(
+            4,
+            4,
+            &[
+                1.0, 0.0, 0.0, 0.0, // |00> -> |00>
+                0.0, 1.0, 0.0, 0.0, // |01> -> |01>
+                0.0, 0.0, 0.0, 1.0, // |11> -> |10>
+                0.0, 0.0, 1.0, 0.0, // |10> -> |11>
+            ],
+        )
+        .map(|entry| Complex64::new(entry, 0.0));
+        let cnot_10 = DMatrix::from_row_slice(
+            4,
+            4,
+            &[
+                1.0, 0.0, 0.0, 0.0, // |00> -> |00>
+                0.0, 0.0, 0.0, 1.0, // |11> -> |01>
+                0.0, 0.0, 1.0, 0.0, // |10> -> |10>
+                0.0, 1.0, 0.0, 0.0, // |01> -> |11>
+            ],
+        )
+        .map(|entry| Complex64::new(entry, 0.0));
+        let cz = DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+        ]));
+        let cases = vec![
+            ("Cnot(0,1)", DeferredOp::Cnot(0, 1), cnot_01),
+            ("Cnot(1,0)", DeferredOp::Cnot(1, 0), cnot_10),
+            ("H(0)", DeferredOp::H(0), dense_single_qubit_gate(&h, 0)),
+            ("H(1)", DeferredOp::H(1), dense_single_qubit_gate(&h, 1)),
+            ("Z(0)", DeferredOp::Z(0), dense_single_qubit_gate(&z, 0)),
+            ("Z(1)", DeferredOp::Z(1), dense_single_qubit_gate(&z, 1)),
+            (
+                "SZdg(0)",
+                DeferredOp::SZdg(0),
+                dense_single_qubit_gate(&sdg, 0),
+            ),
+            (
+                "SZdg(1)",
+                DeferredOp::SZdg(1),
+                dense_single_qubit_gate(&sdg, 1),
+            ),
+            ("SZ(0)", DeferredOp::SZ(0), dense_single_qubit_gate(&s, 0)),
+            ("SZ(1)", DeferredOp::SZ(1), dense_single_qubit_gate(&s, 1)),
+            ("Cz(0,1)", DeferredOp::Cz(0, 1), cz),
+        ];
+        let input_phases = [
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(0.0, -1.0),
+        ];
+
+        for (name, op, gate) in cases {
+            let mut mismatches = Vec::new();
+            for input_flip_mask in 0..4 {
+                for input_sign_mask in 0..4 {
+                    for input_phase in input_phases {
+                        let input = dense_pauli(input_flip_mask, input_sign_mask, input_phase);
+                        let oracle = gate.adjoint() * input * &gate;
+                        let expected = identify_dense_pauli(&oracle);
+                        let mut flip_sites = (0..2)
+                            .filter(|q| input_flip_mask & (1 << q) != 0)
+                            .collect::<Vec<_>>();
+                        let mut sign_sites = (0..2)
+                            .filter(|q| input_sign_mask & (1 << q) != 0)
+                            .collect::<Vec<_>>();
+                        let mut actual_phase = input_phase;
+                        conjugate_pauli_by_deferred_ops(
+                            &mut flip_sites,
+                            &mut sign_sites,
+                            &mut actual_phase,
+                            std::slice::from_ref(&op),
+                        );
+                        sort_dedup(&mut flip_sites);
+                        sort_dedup(&mut sign_sites);
+                        let actual = (
+                            flip_sites.iter().fold(0, |mask, q| mask | (1 << q)),
+                            sign_sites.iter().fold(0, |mask, q| mask | (1 << q)),
+                            actual_phase,
+                        );
+                        if actual != expected {
+                            mismatches.push(format!(
+                                "input=(X={input_flip_mask:02b}, Z={input_sign_mask:02b}, phase={input_phase}); expected={expected:?}, actual={actual:?}"
+                            ));
+                        }
+                    }
+                }
+            }
+            assert!(
+                mismatches.is_empty(),
+                "{name} had {} dense-oracle mismatches; first: {}",
+                mismatches.len(),
+                mismatches.first().map_or("none", String::as_str)
+            );
+        }
     }
 
     #[test]

--- a/exp/pecos-stab-tn/src/stab_mps/non_clifford.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/non_clifford.rs
@@ -22,6 +22,7 @@
 //! - Masot-Llima, Garcia-Saez. arXiv:2403.08724 (STN protocol).
 //! - Reference code: stabilizer-TN `update_xvec` and `apply_xvec_rot`.
 
+use super::measure::{DeferredOp, conjugate_pauli_by_deferred_ops};
 use super::pauli_decomp::{ZDecomposition, decompose_z};
 use crate::errors::MpsError;
 use crate::mps::Mps;
@@ -105,6 +106,8 @@ enum PauliType {
 pub struct RzContext<'a> {
     /// Per-site disentangling eigenstate flags.
     pub disent_flags: &'a mut [Option<super::SiteEigenstate>],
+    /// Pending Lazy frame separating the tableau from the stored MPS.
+    pub deferred_ops: &'a [DeferredOp],
     /// Whether missing |0> flags may be recovered from product-site tensors.
     pub numerical_flag_redetection: bool,
     /// GF(2) flip matrix for OFD diagnostics.
@@ -138,12 +141,39 @@ pub fn apply_rz_stab_mps(
 ) -> Result<(), MpsError> {
     let RzContext {
         disent_flags,
+        deferred_ops,
         numerical_flag_redetection,
         gf2_matrix,
         stats,
     } = ctx;
     stats.total_nonclifford += 1;
-    let decomp = decompose_z(tableau.stabs(), tableau.destabs(), q);
+    let tableau_decomp = decompose_z(tableau.stabs(), tableau.destabs(), q);
+    // The Lazy representation is C V |stored>, while `decompose_z` returns
+    // P = C† Z_q C in the tableau frame. Apply V† P V to the stored MPS.
+    // Measurement owns and tests the deferred-frame Heisenberg rules, so the
+    // non-Clifford path deliberately reuses that implementation.
+    let decomp = if deferred_ops.is_empty() {
+        tableau_decomp
+    } else {
+        let (mut flip_sites, mut sign_sites, mut phase) = match tableau_decomp {
+            ZDecomposition::Stabilizer { phase, sign_sites } => (Vec::new(), sign_sites, phase),
+            ZDecomposition::DestabilizerFlip {
+                flip_sites,
+                phase,
+                sign_sites,
+            } => (flip_sites, sign_sites, phase),
+        };
+        conjugate_pauli_by_deferred_ops(&mut flip_sites, &mut sign_sites, &mut phase, deferred_ops);
+        if flip_sites.is_empty() {
+            ZDecomposition::Stabilizer { phase, sign_sites }
+        } else {
+            ZDecomposition::DestabilizerFlip {
+                flip_sites,
+                phase,
+                sign_sites,
+            }
+        }
+    };
 
     // OFD diagnostic: check whether this gate's flip pattern is in the span
     // of previously-recorded patterns. OFD says such gates can be implemented
@@ -229,7 +259,7 @@ pub fn apply_rz_stab_mps(
             // Z(false) or None after this session's semantic cleanup -- hence
             // the simple check below.
             let mut disent_site = None;
-            if affected_sites.len() > 1 {
+            if affected_sites.len() > 1 && deferred_ops.is_empty() {
                 for &(site, pt) in &pauli_map {
                     if matches!(pt, PauliType::X | PauliType::Y)
                         && matches!(disent_flags[site], Some(super::SiteEigenstate::Z(false)))
@@ -265,6 +295,18 @@ pub fn apply_rz_stab_mps(
                         }
                     }
                 }
+            } else if affected_sites.len() > 1
+                && pauli_map.iter().any(|&(site, pt)| {
+                    matches!(pt, PauliType::X | PauliType::Y)
+                        && matches!(disent_flags[site], Some(super::SiteEigenstate::Z(false)))
+                })
+            {
+                // A stored-frame |0> proof is sound for V† P V, but the fast
+                // path also right-composes its absorbing Clifford into C. With
+                // a pending V that would produce C B V instead of the required
+                // C V B. Fall through to the general stored-MPS path and make
+                // that narrowly avoided optimization cost observable.
+                stats.deferred_disent_bypass += 1;
             }
 
             if let Some(rot_site) = disent_site {

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -918,7 +918,7 @@ fn lazy_frame_rz_does_not_consume_stored_disentangling_proof() {
     assert_eq!(
         simulator.stats.deferred_disent_bypass,
         bypass_before + 1,
-        "the fixture must expose a stored |0> proof that is unsafe to absorb across V"
+        "the fixture must expose a stored |0> proof that must not be absorbed across V"
     );
     assert_eq!(
         simulator.stats.multi_disent, disent_before,

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -846,7 +846,7 @@ fn lazy_measure_clifford_rz_conditional_state_fidelity() {
             Gate::H(2),
             Gate::Cx(1, 2),
         ];
-        let cliffords = lazy_frame_clifford_family(0, NUM_QUBITS);
+        let cliffords = lazy_frame_clifford_family(seed, NUM_QUBITS);
         let measured = 0;
         let rotated = 1;
         let angle = Angle64::from_radians(0.65 + 0.01 * seed as f64);
@@ -893,13 +893,14 @@ fn lazy_measure_clifford_rz_conditional_state_fidelity() {
 
 #[test]
 fn lazy_frame_rz_does_not_consume_stored_disentangling_proof() {
+    const FRAME_SEED: u64 = 4;
     let preparation = vec![
         Gate::H(1),
         Gate::Rz(1, Angle64::QUARTER_TURN / 2_u64),
         Gate::H(0),
         Gate::Cx(0, 1),
     ];
-    let cliffords = lazy_frame_clifford_family(0, 4);
+    let cliffords = lazy_frame_clifford_family(FRAME_SEED, 4);
     let angle = Angle64::from_radians(0.71);
     let mut simulator = build_stn_with_mode(4, 0x5555, MeasurementMode::Lazy);
     let mut dense = DenseStateVec::new(4);

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -801,6 +801,137 @@ fn state_fidelity(first: &[Complex64], second: &[Complex64]) -> f64 {
         .norm_sqr()
 }
 
+fn lazy_frame_clifford_family(seed: u64, num_qubits: usize) -> Vec<Gate> {
+    let mut word = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut next = || {
+        word ^= word << 13;
+        word ^= word >> 7;
+        word ^= word << 17;
+        word
+    };
+    let mut gates = Vec::new();
+    for layer in 0..2 {
+        let target = next() as usize % num_qubits;
+        let mut neighbor = next() as usize % num_qubits;
+        if neighbor == target {
+            neighbor = (neighbor + 1) % num_qubits;
+        }
+        // Every layer changes basis before spreading it, so this is an
+        // honest Clifford family rather than a diagonal tail.
+        gates.push(Gate::H(target));
+        if layer % 2 == 0 {
+            gates.push(Gate::Sz(neighbor));
+            gates.push(Gate::Cx(target, neighbor));
+        } else {
+            gates.push(Gate::Cz(target, neighbor));
+            gates.push(Gate::Cx(neighbor, target));
+        }
+    }
+    gates
+}
+
+#[test]
+fn lazy_measure_clifford_rz_conditional_state_fidelity() {
+    const NUM_SEEDS: u64 = 24;
+    const NUM_QUBITS: usize = 3;
+    let mut fidelities = Vec::with_capacity(NUM_SEEDS as usize);
+
+    for seed in 0..NUM_SEEDS {
+        let preparation = vec![
+            Gate::H(1),
+            Gate::Rz(1, Angle64::QUARTER_TURN / 2_u64),
+            Gate::Sz(0),
+            Gate::H(0),
+            Gate::Cx(0, 1),
+            Gate::H(2),
+            Gate::Cx(1, 2),
+        ];
+        let cliffords = lazy_frame_clifford_family(0, NUM_QUBITS);
+        let measured = 0;
+        let rotated = 1;
+        let angle = Angle64::from_radians(0.65 + 0.01 * seed as f64);
+
+        let mut simulator =
+            build_stn_with_mode(NUM_QUBITS, 0x5550_0000 + seed, MeasurementMode::Lazy);
+        let mut dense = DenseStateVec::new(NUM_QUBITS);
+        replay_gates(&mut simulator, &preparation);
+        replay_gates(&mut dense, &preparation);
+
+        let outcome = simulator.mz(&[QubitId(measured)])[0].outcome;
+        let (_, mut expected) = projected_dense_state(dense, measured, outcome)
+            .expect("the sampled Lazy branch must be present in the dense oracle");
+        replay_gates(&mut simulator, &cliffords);
+        replay_gates(&mut expected, &cliffords);
+        let mut before_rotation = simulator.clone();
+        before_rotation.flush();
+        let before_fidelity = state_fidelity(&before_rotation.state_vector(), &expected.state());
+        assert!(
+            before_fidelity >= 1.0 - 1e-10,
+            "seed={seed}: the Lazy conditional state must be correct before RZ; fidelity={before_fidelity:.16}"
+        );
+        simulator.rz(angle, &[QubitId(rotated)]);
+        expected.rz(angle, &[QubitId(rotated)]);
+
+        simulator.flush();
+        let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+        eprintln!(
+            "lazy-frame-rz-fidelity seed={seed} measured={measured} rotated={rotated} before={before_fidelity:.16} fidelity={fidelity:.16}"
+        );
+        fidelities.push(fidelity);
+    }
+
+    let worst = fidelities.iter().copied().fold(1.0_f64, f64::min);
+    let failed = fidelities
+        .iter()
+        .filter(|&&fidelity| fidelity < 1.0 - 1e-10)
+        .count();
+    assert_eq!(
+        failed, 0,
+        "issue #555: {failed}/{NUM_SEEDS} Lazy mz -> Clifford -> RZ conditional states failed; worst fidelity={worst:.16}"
+    );
+}
+
+#[test]
+fn lazy_frame_rz_does_not_consume_stored_disentangling_proof() {
+    let preparation = vec![
+        Gate::H(1),
+        Gate::Rz(1, Angle64::QUARTER_TURN / 2_u64),
+        Gate::H(0),
+        Gate::Cx(0, 1),
+    ];
+    let cliffords = lazy_frame_clifford_family(0, 4);
+    let angle = Angle64::from_radians(0.71);
+    let mut simulator = build_stn_with_mode(4, 0x5555, MeasurementMode::Lazy);
+    let mut dense = DenseStateVec::new(4);
+    replay_gates(&mut simulator, &preparation);
+    replay_gates(&mut dense, &preparation);
+    let outcome = simulator.mz(&[QubitId(0)])[0].outcome;
+    let (_, mut expected) = projected_dense_state(dense, 0, outcome).unwrap();
+    replay_gates(&mut simulator, &cliffords);
+    replay_gates(&mut expected, &cliffords);
+
+    let bypass_before = simulator.stats.deferred_disent_bypass;
+    let disent_before = simulator.stats.multi_disent;
+    simulator.rz(angle, &[QubitId(2)]);
+    expected.rz(angle, &[QubitId(2)]);
+    assert_eq!(
+        simulator.stats.deferred_disent_bypass,
+        bypass_before + 1,
+        "the fixture must expose a stored |0> proof that is unsafe to absorb across V"
+    );
+    assert_eq!(
+        simulator.stats.multi_disent, disent_before,
+        "a pending Lazy frame must prevent tableau-right-composing exact disentangling"
+    );
+
+    simulator.flush();
+    let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+    assert!(
+        fidelity >= 1.0 - 1e-10,
+        "bypassed stored-proof path must remain state-correct; fidelity={fidelity:.16}"
+    );
+}
+
 fn assert_default_state_matches(
     simulator: &mut StabMps,
     expected: &mut DenseStateVec,

--- a/python/pecos-rslib-exp/src/lib.rs
+++ b/python/pecos-rslib-exp/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) fn stab_mps_stats_to_dict(py: Python<'_>, stats: &StabMpsStats) -> Py
     result.set_item("total_nonclifford", stats.total_nonclifford)?;
     result.set_item("single_site", stats.single_site)?;
     result.set_item("multi_disent", stats.multi_disent)?;
+    result.set_item("deferred_disent_bypass", stats.deferred_disent_bypass)?;
     result.set_item("numerical_redetect", stats.numerical_redetect)?;
     result.set_item("multi_std", stats.multi_std)?;
     result.set_item("stabilizer", stats.stabilizer)?;

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -14,6 +14,7 @@ STATS_KEYS = {
     "total_nonclifford",
     "single_site",
     "multi_disent",
+    "deferred_disent_bypass",
     "numerical_redetect",
     "multi_std",
     "stabilizer",


### PR DESCRIPTION
Closes #555

With `MeasurementMode::Lazy`, applying a non-Clifford rotation while the deferred measurement
queue's frame V was pending evolved the wrong state: `rz_apply_direct` applied the tableau-frame
Pauli decomposition `P = C^dagger Z C` to the stored MPS without conjugating it by V. Measured
(from the issue): 24/24 seeds of the shape lazy `mz` -> Clifford -> `rz` failed against a dense
oracle at fidelity 0.71-0.87.

## The fix

The stored/effective relationship is `effective = C V |stored>`, so the rotation must apply
`V^dagger P V` to the stored MPS. The decomposition is now conjugated through the pending queue
via the shared `conjugate_pauli_by_deferred_ops` before application. The exact-disentangling
fast path is disabled while V is pending (its tableau right-composition would misorder the
state as `C B V` instead of `C V B` — proven a real 0.77-fidelity error, not a conservatism),
counted by new `deferred_disent_bypass` telemetry exposed to Python.

Review of the fix surfaced a second, pre-existing defect in the shared conjugation routine
itself, fixed here at the layer that owns it: the CZ rule omitted the phase flip required when
the Pauli carries X on both CZ qubits (`CZ (X x X) CZ = Y x Y = -(XZ)(XZ)`). This affected the
lazy measurement path on dev independently of rz. An exhaustive dense-matrix oracle test over
all six deferred operation kinds (704 comparisons, phases included) now binds the routine;
reverting the one-line fix fails exactly the 16 double-X CZ inputs, each by -1.

Every arbitrary-rotation entry point funnels through the fixed site (rx/ry/u/r1xy/rzz/rxx/ryy
lower to rz; merged-RZ flushing included), verified by audit and by an independent review's
4000-circuit randomized hunt: rz-path mismatches fell from 84/4000 to the measurement-only
baseline, with zero remaining CZ-class or rz-specific failures.

## Tests

- The issue's falsifier as a genuinely seeded 24-case conditional-state fidelity regression
  (fails 19/24 at worst 0.676 without the conjugation; passes 24/24 at worst
  0.9999999999999998 with it).
- A three-measurement fixture whose deferred queue provably contains both `Cnot` and `Cz`
  (asserted in the test; each assertion mutation-verified to fire on exactly its own kind):
  fidelity 0.614 without the CZ phase fix, 0.796 without any conjugation, 1.0 fixed.
- The dense conjugation oracle over all six deferred operation kinds.
- A seam regression proving a stored-frame `|0>` proof is inspected but never consumed while V
  is pending, the bypass counter advances, and the general path stays dense-correct.

## What this does not fix

Lazy mode remains statistically biased on six of nine falsifier surfaces (issue #572, updated
with the post-fix per-surface table: the CZ repair improved continuation 127.6 sigma -> 59.5
and reset 67.6 -> 44.8, but a distinct defect remains, now isolated to a deterministic minimal
reproducer failing at exactly cos^2 of the pre-measurement rotation angle with no
post-measurement rotation at all). All known-biased quarantine labels on Lazy are retained
unchanged.

## Verification

Full suites green in debug and release (335 lib + 13 harness + 92 integration + 3 doc in
release); all release-ignored lanes; 1,200-circuit stability census 0 panics; 640-circuit
issue #557 sweep worst deltas 1.5e-15 (ceiling 3.3e-15); clippy -D warnings and fmt clean on
pecos-stab-tn and pecos-rslib-exp. Independent adversarial review (two rounds; the first found
the CZ defect) with every fix mutation-verified.
