### PR TITLE
Queue the lazy measurement gauge, guard tableau-only reads, and lift the lazy quarantine

### DIFF
--- a/docs/user-guide/stabilizer-tensor-networks.md
+++ b/docs/user-guide/stabilizer-tensor-networks.md
@@ -62,7 +62,7 @@ Python state reads automatically flush lazy operations and merged rotations. Whe
 
 `StabMps` defaults `merge_rz` to true for throughput. `Mast` defaults it to false so each RZ immediately exposes its injection and ancilla-capacity cost. Numerical flag redetection is opt-in. In `StabMps` it self-disables while lazy deferred operations are pending, because the stored tensors then differ from the effective MPS-frame state.
 
-`StabMps` measurement defaults to `"exact"`. Select `"pragmatic"` for the legacy uncompensated eager path or `"lazy"` for the deferred virtual-frame path. The policy covers MZ, reset, PZ/PX, syndrome extraction, and singular `sample_bitstring`; plural `sample_bitstrings` remains exact.
+`StabMps` measurement defaults to `"exact"`. Select `"pragmatic"` for the legacy uncompensated eager path or `"lazy"` for the deferred virtual-frame path. After the issue #555 and #572 frame and projection fixes, Lazy preserves exact conditional states subject to configured MPS truncation; Rust reads still require `flush()`, while Python reads auto-flush. Lazy and Exact consume distinct RNG streams, so equal seeds are not shot-for-shot comparable across those modes. The policy covers MZ, reset, PZ/PX, syndrome extraction, and singular `sample_bitstring`; plural `sample_bitstrings` remains exact.
 
 ## `Mast` quickstart
 

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -373,7 +373,13 @@ pub enum MeasurementMode {
     /// Preserve the legacy uncompensated eager pre-reduction path. This is
     /// faster for some workloads but can bias the stored conditional state.
     Pragmatic,
-    /// Keep exact measurement-basis Cliffords in a deferred virtual frame.
+    /// Keep measurement-basis Cliffords in a deferred virtual frame.
+    ///
+    /// Conditional states are exact after the issue #555 and #572 frame and
+    /// projection fixes, subject to the configured MPS truncation. Call
+    /// [`StabMps::flush`] before Rust state reads. This path consumes a distinct
+    /// RNG stream from [`Self::Exact`], so equal seeds are not shot-for-shot
+    /// comparable across the two modes.
     Lazy,
 }
 

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -2289,6 +2289,8 @@ impl StabMps {
     /// measurement mode, zero summed discarded weight, and no deferred MAST
     /// branch loss. A branch-vanish retry is not a guard because its first
     /// attempt was rolled back and its committed retry was untruncated.
+    /// Lazy conditional states are exact after issues #555 and #572, but this
+    /// conservative diagnostic deliberately remains gated to exact mode.
     #[must_use]
     pub fn is_state_exact(&self) -> bool {
         let no_pending_rz = self.pending_rz.iter().all(std::option::Option::is_none);

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -185,6 +185,31 @@ fn canonicalize_trivial_mps_basis(
     modified_sites
 }
 
+/// Measure a computational-basis product coefficient state through the tableau.
+///
+/// The tableau-only read is valid only after the coefficient basis word has
+/// been absorbed into the tableau, leaving the stored MPS in `|0...0>`.
+fn measure_trivial_mps_with_update(
+    tableau: &mut SparseStabY,
+    mps: &mut Mps,
+    q_idx: usize,
+) -> LiveMeasurementResult {
+    debug_assert!(is_mps_trivial(mps));
+    let modified_sites = canonicalize_trivial_mps_basis(tableau, mps, None);
+    let measurement = tableau
+        .mz(&[pecos_core::QubitId(q_idx)])
+        .into_iter()
+        .next()
+        .expect("MPS op on valid site");
+    LiveMeasurementResult {
+        measurement,
+        update: ProjectionUpdate {
+            collapsed_site: None,
+            modified_sites,
+        },
+    }
+}
+
 /// Compute `<mps| phase · X_flip · Z_sign |mps>` via clone + inner product.
 ///
 /// Returns the expectation value of the Pauli string. Z applied first, then
@@ -1002,7 +1027,7 @@ fn measurement_pauli_gauge_sites(predicted: &SparseStabY, measured: &SparseStabY
     // `mz_forced` path, forces the replacement stabilizer row's sign to the
     // requested outcome. The predicted basis rotation encodes that same sign,
     // so an X-gauge difference is structurally unreachable here.
-    debug_assert!(
+    assert!(
         predicted
             .stabs()
             .signs_minus
@@ -1431,15 +1456,16 @@ pub(super) fn measure_qubit_stab_mps_lazy_with_update(
     deferred: &mut Vec<DeferredOp>,
 ) -> Result<LiveMeasurementResult, MpsError> {
     if is_mps_trivial(mps) {
-        let measurement = tableau
-            .mz(&[pecos_core::QubitId(q_idx)])
-            .into_iter()
-            .next()
-            .expect("MPS op on valid site");
-        return Ok(LiveMeasurementResult {
-            measurement,
-            update: ProjectionUpdate::default(),
-        });
+        // A tableau-only read requires both a zero coefficient-basis word and
+        // an identity virtual frame. Materialize a pending frame first: it can
+        // turn a computational product MPS into a nontrivial coefficient
+        // state, in which case the general Lazy projection must handle it.
+        if !deferred.is_empty() {
+            flush_deferred_ops(mps, deferred)?;
+        }
+        if is_mps_trivial(mps) {
+            return Ok(measure_trivial_mps_with_update(tableau, mps, q_idx));
+        }
     }
 
     // Push pre_reduce CNOTs to deferred instead of applying eagerly.
@@ -1687,17 +1713,8 @@ pub(super) fn measure_qubit_stab_mps_with_update(
     rng: &mut PecosRng,
     q_idx: usize,
 ) -> Result<LiveMeasurementResult, MpsError> {
-    // Trivial MPS: delegate to tableau
     if is_mps_trivial(mps) {
-        let measurement = tableau
-            .mz(&[pecos_core::QubitId(q_idx)])
-            .into_iter()
-            .next()
-            .expect("MPS op on valid site");
-        return Ok(LiveMeasurementResult {
-            measurement,
-            update: ProjectionUpdate::default(),
-        });
+        return Ok(measure_trivial_mps_with_update(tableau, mps, q_idx));
     }
 
     // Pre-reduce the tableau so that Z_q has at most one anticommuting stabilizer.

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -949,17 +949,14 @@ fn right_compose_measurement_basis_rotation(
     }
 }
 
-/// Apply the inverse of the virtual Pauli gauge between two structurally
-/// identical Clifford tableaux.
+/// Return the virtual Z gauge between two structurally identical tableaux.
 ///
-/// The forced measurement outcome fixes the stabilizer-row signs, leaving only
-/// destabilizer-row sign differences. Each such difference is a right-composed
-/// Z on that virtual site, so applying Z to the MPS realizes the inverse gauge.
-fn compensate_measurement_pauli_gauge(
-    mps: &mut Mps,
-    predicted: &SparseStabY,
-    measured: &SparseStabY,
-) -> Vec<usize> {
+/// `SparseStabY::nondeterministic_meas` structurally XORs destabilizer rows
+/// without propagating their phases. The forced outcome fixes stabilizer-row
+/// signs, so the only possible difference from a phase-complete predicted
+/// tableau is a right-composed Z on each returned virtual site:
+/// `measured * Z_gauge = predicted`.
+fn measurement_pauli_gauge_sites(predicted: &SparseStabY, measured: &SparseStabY) -> Vec<usize> {
     assert_eq!(predicted.num_qubits(), measured.num_qubits());
     let rows_match = |predicted_rows: &[BitSet], measured_rows: &[BitSet]| {
         predicted_rows
@@ -1001,8 +998,6 @@ fn compensate_measurement_pauli_gauge(
             .eq(measured.destabs().signs_i.iter())
     );
 
-    let z_diag = [Complex64::new(1.0, 0.0), Complex64::new(-1.0, 0.0)];
-
     // `SparseStabY::apply_outcome`, called by the nondeterministic
     // `mz_forced` path, forces the replacement stabilizer row's sign to the
     // requested outcome. The predicted basis rotation encodes that same sign,
@@ -1015,17 +1010,102 @@ fn compensate_measurement_pauli_gauge(
             .eq(measured.stabs().signs_minus.iter()),
         "apply_outcome must leave no stabilizer-sign (X-gauge) difference"
     );
-    let mut modified_sites = Vec::new();
-    for site in 0..predicted.num_qubits() {
-        let differs = predicted.destabs().signs_minus.contains(site)
-            != measured.destabs().signs_minus.contains(site);
-        if differs {
-            mps.apply_diagonal_one_site(site, &z_diag)
-                .expect("MPS op on valid site");
-            modified_sites.push(site);
+    (0..predicted.num_qubits())
+        .filter(|&site| {
+            predicted.destabs().signs_minus.contains(site)
+                != measured.destabs().signs_minus.contains(site)
+        })
+        .collect()
+}
+
+/// Apply the inverse of the virtual Pauli gauge between two structurally
+/// identical Clifford tableaux.
+fn compensate_measurement_pauli_gauge(
+    mps: &mut Mps,
+    predicted: &SparseStabY,
+    measured: &SparseStabY,
+) -> Vec<usize> {
+    let gauge_sites = measurement_pauli_gauge_sites(predicted, measured);
+    let z_diag = [Complex64::new(1.0, 0.0), Complex64::new(-1.0, 0.0)];
+    for &site in &gauge_sites {
+        mps.apply_diagonal_one_site(site, &z_diag)
+            .expect("MPS op on valid site");
+    }
+    gauge_sites
+}
+
+/// Apply the forced tableau update and enqueue its phase-complete inverse.
+///
+/// If the phase-complete basis rotation predicts `C_predicted = C_before * W`,
+/// the structural forced-measurement implementation can return a tableau with
+/// a virtual Pauli gauge, `C_measured * G = C_predicted`. The deferred frame
+/// must therefore be left-multiplied by both factors: `G * W^-1`.
+fn enqueue_lazy_measurement_basis_update(
+    tableau: &mut SparseStabY,
+    deferred: &mut Vec<DeferredOp>,
+    q_idx: usize,
+    id: usize,
+    phase: Complex64,
+    sign_sites: &[usize],
+    outcome: bool,
+) -> Vec<usize> {
+    assert!(
+        tableau.tracks_destab_signs(),
+        "lazy measurement requires destabilizer-sign tracking"
+    );
+    let mut predicted_tableau = tableau.clone();
+    right_compose_measurement_basis_rotation(
+        &mut predicted_tableau,
+        id,
+        phase,
+        sign_sites,
+        outcome,
+        None,
+    );
+
+    let signed_phase = Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase;
+    let id_in_sign = sign_sites.contains(&id);
+    if signed_phase.im.abs() < 1e-9 {
+        debug_assert!(
+            !id_in_sign,
+            "lazy measure: real signed phase={signed_phase:?} but id in sign"
+        );
+        if signed_phase.re < 0.0 {
+            deferred.push(DeferredOp::Z(id));
+        }
+        for &site in sign_sites {
+            if site != id {
+                deferred.push(DeferredOp::Cz(id, site));
+            }
+        }
+    } else {
+        debug_assert!(
+            id_in_sign,
+            "lazy measure: imaginary signed phase={signed_phase:?} but id not in sign"
+        );
+        debug_assert!(
+            signed_phase.re.abs() < 1e-9,
+            "lazy measure: signed phase={signed_phase:?} not pure imaginary"
+        );
+        for &site in sign_sites {
+            if site != id {
+                deferred.push(DeferredOp::Cz(id, site));
+            }
+        }
+        // W contains SZ for +i and SZdg for -i, so W^-1 contains the adjoint.
+        if signed_phase.im > 0.0 {
+            deferred.push(DeferredOp::SZdg(id));
+        } else {
+            deferred.push(DeferredOp::SZ(id));
         }
     }
-    modified_sites
+    deferred.push(DeferredOp::H(id));
+
+    let result = tableau.mz_forced(q_idx, outcome);
+    debug_assert_eq!(result.outcome, outcome);
+    let gauge_sites = measurement_pauli_gauge_sites(&predicted_tableau, tableau);
+    deferred.extend(gauge_sites.iter().copied().map(DeferredOp::Z));
+    gauge_sites
 }
 
 /// Convert a normalized single-flip Pauli eigenstate into the coefficient
@@ -1497,76 +1577,23 @@ pub(super) fn measure_qubit_stab_mps_lazy_with_update(
             // Project stored MPS via conjugated Pauli.
             apply_pauli_projection(mps, &flip_conj, &sign_conj, phase_conj, sign_f, prob);
             mps.compress()?;
-            // Absorb W⁻¹ into V. W satisfies:
-            //   W · Z_id · W† = sp · X_flip · Z_sign  (MPS-frame post-measurement Pauli)
-            // where `sp = sign_f · phase_conj` (sign_f = -1 if outcome else +1).
-            // sp is one of {+1, -1, +i, -i}. Hermiticity of Z_id forces a
-            // dichotomy on `X_flip · Z_sign` (single flip = {id}):
-            //   - id ∉ sign: X_id · Z_sign is Hermitian, sp must be real.
-            //   - id ∈ sign: X_id · Z_id · Z_rest = -i·Y_id·Z_rest is
-            //     anti-Hermitian, sp must be imaginary.
-            //
-            // Basis-rotation constructions (each giving W·Z_id·W† = target):
-            //   Real sp, id ∉ sign:
-            //     sp = +1: W = [CZ(id, s) for s∈sign] · H_id
-            //     sp = -1: W = Z_id · [CZ(id, s) for s∈sign] · H_id
-            //   Imaginary sp, id ∈ sign:
-            //     sp = +i: W = [CZ(id, s) for s∈sign\id] · SZ_id · H_id
-            //     sp = -i: W = [CZ(id, s) for s∈sign\id] · SZdg_id · H_id
-            //
-            // W⁻¹ reverses the product and adjoints each primitive. Deferred
-            // queue push order is application order (first-pushed applied
-            // first), which corresponds to rightmost-in-product. So push
-            // W⁻¹'s primitives right-to-left:
-            //
-            // W is determined by mz_forced's action on the CURRENT tableau
-            // (post-pre_reduce). Use the original decomposition `phase`, not
-            // the V-conjugated `phase_conj` — V-conjugation is for MPS
-            // operations only; the tableau sees the original decomposition.
-            let sp = Complex64::new(sign_f, 0.0) * phase;
-            let id_in_sign = sign_sites.contains(&id);
-            if sp.im.abs() < 1e-9 {
-                // Real sp branch. id must not be in sign.
-                debug_assert!(
-                    !id_in_sign,
-                    "lazy measure: real sp={sp:?} but id in sign (expected imaginary)"
-                );
-                if sp.re < 0.0 {
-                    deferred.push(DeferredOp::Z(id));
-                }
-                for &s in &sign_sites {
-                    if s != id {
-                        deferred.push(DeferredOp::Cz(id, s));
-                    }
-                }
-            } else {
-                // Imaginary sp branch. id must be in sign.
-                debug_assert!(
-                    id_in_sign,
-                    "lazy measure: imaginary sp={sp:?} but id not in sign (expected real)"
-                );
-                debug_assert!(
-                    sp.re.abs() < 1e-9,
-                    "lazy measure: sp={sp:?} not pure imaginary"
-                );
-                for &s in &sign_sites {
-                    if s != id {
-                        deferred.push(DeferredOp::Cz(id, s));
-                    }
-                }
-                // W inner rotation: SZ for sp=+i, SZdg for sp=-i.
-                // W⁻¹'s corresponding primitive: SZdg for sp=+i, SZ for sp=-i.
-                if sp.im > 0.0 {
-                    deferred.push(DeferredOp::SZdg(id));
-                } else {
-                    deferred.push(DeferredOp::SZ(id));
-                }
-            }
-            deferred.push(DeferredOp::H(id));
-
-            tableau.mz_forced(q_idx, outcome);
+            // Use the original decomposition phase here: deferred conjugation
+            // changes the stored-MPS projector, but the tableau update acts in
+            // the current post-pre-reduction generator basis. The helper also
+            // queues the virtual Z gauge omitted by `mz_forced`'s structural
+            // destabilizer-row XORs.
+            let gauge_sites = enqueue_lazy_measurement_basis_update(
+                tableau,
+                deferred,
+                q_idx,
+                id,
+                phase,
+                &sign_sites,
+                outcome,
+            );
             modified_sites.extend(flip_conj);
             modified_sites.extend(sign_conj);
+            modified_sites.extend(gauge_sites);
             modified_sites.push(id);
             modified_sites.sort_unstable();
             modified_sites.dedup();
@@ -2050,6 +2077,168 @@ mod tests {
                 mismatches.first().map_or("none", String::as_str)
             );
         }
+    }
+
+    #[test]
+    fn lazy_measurement_basis_update_matches_dense_oracle_for_all_two_qubit_cliffords() {
+        use crate::stab_mps::StabMps;
+        use pecos_core::QubitId;
+        use std::collections::{HashSet, VecDeque};
+
+        fn tableau_key(tableau: &SparseStabY) -> Vec<u8> {
+            let mut key = Vec::new();
+            for generators in [tableau.stabs(), tableau.destabs()] {
+                for row in 0..tableau.num_qubits() {
+                    for qubit in 0..tableau.num_qubits() {
+                        key.push(u8::from(generators.row_x[row].contains(qubit)));
+                        key.push(u8::from(generators.row_z[row].contains(qubit)));
+                    }
+                    key.push(u8::from(generators.signs_minus.contains(row)));
+                    key.push(u8::from(generators.signs_i.contains(row)));
+                }
+            }
+            key
+        }
+
+        fn phase_bucket(phase: Complex64) -> usize {
+            if phase.re > 0.5 {
+                0
+            } else if phase.im > 0.5 {
+                1
+            } else if phase.re < -0.5 {
+                2
+            } else if phase.im < -0.5 {
+                3
+            } else {
+                panic!("phase is not a fourth root of unity: {phase}");
+            }
+        }
+
+        fn generic_coefficient_mps() -> Mps {
+            let mut mps = Mps::new(2, MpsConfig::default());
+            for (qubit, probability_one, argument) in [(0, 0.37_f64, 0.29_f64), (1, 0.61, -0.47)] {
+                let zero = (1.0 - probability_one).sqrt();
+                let one = Complex64::from_polar(probability_one.sqrt(), argument);
+                let gate = DMatrix::from_row_slice(
+                    2,
+                    2,
+                    &[
+                        Complex64::new(zero, 0.0),
+                        -one.conj(),
+                        one,
+                        Complex64::new(zero, 0.0),
+                    ],
+                );
+                mps.apply_one_site_gate(qubit, &gate).unwrap();
+            }
+            mps
+        }
+
+        fn represented_state(
+            template: &StabMps,
+            tableau: &SparseStabY,
+            mps: &Mps,
+        ) -> Vec<Complex64> {
+            let mut snapshot = template.clone();
+            snapshot.tableau = tableau.clone();
+            snapshot.mps = mps.clone();
+            snapshot.deferred_ops.clear();
+            snapshot.state_vector()
+        }
+
+        let coefficient_mps = generic_coefficient_mps();
+        let template = StabMps::new(2);
+        let initial = SparseStabY::with_seed(2, 0).with_destab_sign_tracking();
+        let mut seen = HashSet::from([tableau_key(&initial)]);
+        let mut pending = VecDeque::from([initial]);
+        let mut cliffords = 0_usize;
+        let mut cases = 0_usize;
+        let mut signed_phase_counts = [0_usize; 4];
+
+        while let Some(tableau) = pending.pop_front() {
+            cliffords += 1;
+            let before = represented_state(&template, &tableau, &coefficient_mps);
+            for measured_qubit in 0..2 {
+                // This is exactly the input domain of the post-pre-reduction
+                // lazy basis update: one virtual X site remains.
+                if tableau.stabs().col_x[measured_qubit].len() != 1 {
+                    continue;
+                }
+                let ZDecomposition::DestabilizerFlip {
+                    flip_sites,
+                    phase,
+                    sign_sites,
+                } = decompose_z(tableau.stabs(), tableau.destabs(), measured_qubit)
+                else {
+                    continue;
+                };
+                if flip_sites.len() != 1 {
+                    continue;
+                }
+
+                for outcome in [false, true] {
+                    signed_phase_counts[phase_bucket(
+                        Complex64::new(if outcome { -1.0 } else { 1.0 }, 0.0) * phase,
+                    )] += 1;
+                    let mut measured = tableau.clone();
+                    let mut deferred = Vec::new();
+                    enqueue_lazy_measurement_basis_update(
+                        &mut measured,
+                        &mut deferred,
+                        measured_qubit,
+                        flip_sites[0],
+                        phase,
+                        &sign_sites,
+                        outcome,
+                    );
+                    let queued = deferred.clone();
+                    let mut transformed_mps = coefficient_mps.clone();
+                    flush_deferred_ops(&mut transformed_mps, &mut deferred).unwrap();
+                    let after = represented_state(&template, &measured, &transformed_mps);
+                    let overlap = before
+                        .iter()
+                        .zip(&after)
+                        .map(|(left, right)| left.conj() * right)
+                        .sum::<Complex64>();
+                    let fidelity = overlap.norm_sqr();
+                    assert!(
+                        fidelity >= 1.0 - 2e-12,
+                        "dense lazy-basis oracle failed: measured={measured_qubit} outcome={outcome} \
+                         flip={flip_sites:?} sign={sign_sites:?} phase={phase} \
+                         queue={queued:?} fidelity={fidelity:.16}"
+                    );
+                    cases += 1;
+                }
+            }
+
+            for gate in 0..6 {
+                let mut next = tableau.clone();
+                match gate {
+                    0 => next.h(&[QubitId(0)]),
+                    1 => next.h(&[QubitId(1)]),
+                    2 => next.sz(&[QubitId(0)]),
+                    3 => next.sz(&[QubitId(1)]),
+                    4 => next.cx(&[(QubitId(0), QubitId(1))]),
+                    _ => next.cx(&[(QubitId(1), QubitId(0))]),
+                };
+                if seen.insert(tableau_key(&next)) {
+                    pending.push_back(next);
+                }
+            }
+        }
+
+        assert_eq!(
+            cliffords, 11_520,
+            "must enumerate the full two-qubit Clifford group"
+        );
+        assert!(cases > 0);
+        assert!(
+            signed_phase_counts.iter().all(|&count| count > 0),
+            "the exhaustive oracle must cover signed phases +1,+i,-1,-i: {signed_phase_counts:?}"
+        );
+        eprintln!(
+            "lazy measurement basis dense oracle: cliffords={cliffords} cases={cases} signed_phase_counts={signed_phase_counts:?}"
+        );
     }
 
     #[test]

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -519,10 +519,6 @@ fn run_stn_shot_with_mode(
     )
 }
 
-fn run_stn_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
-    run_built_stn_shot(surface, num_qubits, build_stn(num_qubits, seed))
-}
-
 fn run_mast_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
     let preparation_qubits = if surface == Surface::ExtractSyndromes {
         num_qubits - 1
@@ -607,13 +603,18 @@ fn parallel_counts(
         )
 }
 
-fn sampled_stn_counts(surface: Surface, num_qubits: usize, num_shots: usize) -> Vec<usize> {
+fn sampled_stn_counts_with_mode(
+    surface: Surface,
+    num_qubits: usize,
+    num_shots: usize,
+    mode: MeasurementMode,
+) -> Vec<usize> {
     let num_outcomes = 1 << surface.record_width(num_qubits);
     if matches!(
         surface,
         Surface::SampleBitstring | Surface::SampleBitstrings
     ) {
-        let mut simulator = build_stn(num_qubits, 0x5A00_0000 + num_qubits as u64);
+        let mut simulator = build_stn_with_mode(num_qubits, 0x5A00_0000 + num_qubits as u64, mode);
         replay_gates(&mut simulator, &honest_family(num_qubits, num_qubits));
         let samples = if surface == Surface::SampleBitstring {
             simulator.sample_bitstring(num_shots)
@@ -628,10 +629,11 @@ fn sampled_stn_counts(surface: Surface, num_qubits: usize, num_shots: usize) -> 
         counts
     } else {
         parallel_counts(num_outcomes, num_shots, |shot| {
-            run_stn_shot(
+            run_stn_shot_with_mode(
                 surface,
                 num_qubits,
                 0x5100_0000 + (num_qubits as u64) * 100_000 + shot as u64,
+                mode,
             )
         })
     }
@@ -705,8 +707,17 @@ fn corrected_five_sigma_limit(num_comparisons: usize) -> f64 {
 }
 
 fn compare_surface(surface: Surface, num_qubits: usize, num_shots: usize) -> Comparison {
+    compare_surface_with_mode(surface, num_qubits, num_shots, MeasurementMode::Exact)
+}
+
+fn compare_surface_with_mode(
+    surface: Surface,
+    num_qubits: usize,
+    num_shots: usize,
+    mode: MeasurementMode,
+) -> Comparison {
     let exact = exact_probabilities(surface, num_qubits);
-    let default_counts = sampled_stn_counts(surface, num_qubits, num_shots);
+    let default_counts = sampled_stn_counts_with_mode(surface, num_qubits, num_shots, mode);
     let control_counts = sampled_mast_counts(surface, num_qubits, num_shots);
     assert_eq!(default_counts.iter().sum::<usize>(), num_shots);
     assert_eq!(control_counts.iter().sum::<usize>(), num_shots);
@@ -721,9 +732,25 @@ fn compare_surface(surface: Surface, num_qubits: usize, num_shots: usize) -> Com
 }
 
 fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
+    assert_surface_matrix_with_mode(
+        "exact-default",
+        MeasurementMode::Exact,
+        surface,
+        qubits,
+        num_shots,
+    );
+}
+
+fn assert_surface_matrix_with_mode(
+    lane: &str,
+    mode: MeasurementMode,
+    surface: Surface,
+    qubits: &[usize],
+    num_shots: usize,
+) {
     let comparisons = qubits
         .iter()
-        .map(|&num_qubits| compare_surface(surface, num_qubits, num_shots))
+        .map(|&num_qubits| compare_surface_with_mode(surface, num_qubits, num_shots, mode))
         .collect::<Vec<_>>();
     let num_binomial_checks = comparisons
         .iter()
@@ -745,7 +772,7 @@ fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
             comparison.num_shots,
         );
         eprintln!(
-            "exact-default-falsifier surface={} n={} shots={} default={:.2}sigma \
+            "{lane}-falsifier surface={} n={} shots={} sampled={:.2}sigma \
              (outcome={}, exact={:.6}, sampled={:.6}) control={:.2}sigma \
              (outcome={}, exact={:.6}, sampled={:.6}) corrected_limit={limit:.2}sigma",
             comparison.surface.name(),
@@ -782,7 +809,7 @@ fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
     let (default, default_n) = worst_default.expect("nonempty surface matrix");
     assert!(
         default.sigma <= limit,
-        "default StabMps measurement is biased: surface={} n={default_n} outcome={} \
+        "{lane} StabMps measurement is biased: surface={} n={default_n} outcome={} \
          exact={:.8} sampled={:.8}, deviation={:.2}sigma > corrected {limit:.2}sigma",
         surface.name(),
         default.outcome,
@@ -888,6 +915,98 @@ fn lazy_measure_clifford_rz_conditional_state_fidelity() {
     assert_eq!(
         failed, 0,
         "issue #555: {failed}/{NUM_SEEDS} Lazy mz -> Clifford -> RZ conditional states failed; worst fidelity={worst:.16}"
+    );
+}
+
+#[test]
+fn lazy_single_measurement_preserves_pre_measurement_rz_branch_phase() {
+    let preparation = [
+        Gate::H(0),
+        Gate::Rz(0, Angle64::from_radians(0.41)),
+        Gate::Cx(3, 2),
+        Gate::X(3),
+        Gate::Cx(2, 0),
+        Gate::H(2),
+    ];
+    let mut simulator = build_stn_with_mode(4, 2, MeasurementMode::Lazy);
+    let mut dense = DenseStateVec::new(4);
+    replay_gates(&mut simulator, &preparation);
+    replay_gates(&mut dense, &preparation);
+
+    let outcome = simulator.mz(&[QubitId(2)])[0].outcome;
+    assert!(
+        outcome,
+        "seed 2 must select the issue #572 outcome-one branch"
+    );
+    let (_, mut expected) = projected_dense_state(dense, 2, outcome).unwrap();
+    simulator.flush();
+    let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+    assert!(
+        fidelity >= 1.0 - 1e-12,
+        "issue #572 lazy projection changed the pre-measurement RZ branch phase: \
+         fidelity={fidelity:.16}, legacy_signature={:.16}",
+        0.41_f64.cos().powi(2)
+    );
+}
+
+#[test]
+#[ignore = "issue #572 4000-circuit conditional-state hunt; run in release mode"]
+fn lazy_randomized_4000_conditional_state_hunt() {
+    const NUM_CIRCUITS: u64 = 4_000;
+    const NUM_QUBITS: usize = 4;
+    let mut mismatches = 0_usize;
+    let mut worst_fidelity = 1.0_f64;
+
+    for seed in 0..NUM_CIRCUITS {
+        let mut word = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut next = || {
+            word ^= word << 13;
+            word ^= word >> 7;
+            word ^= word << 17;
+            word
+        };
+        let rotated = next() as usize % NUM_QUBITS;
+        let mut gates = vec![
+            Gate::H(rotated),
+            Gate::Rz(
+                rotated,
+                Angle64::from_radians(0.11 + (next() % 700) as f64 / 1_000.0),
+            ),
+        ];
+        for _ in 0..12 {
+            let first = next() as usize % NUM_QUBITS;
+            let mut second = next() as usize % NUM_QUBITS;
+            if second == first {
+                second = (second + 1) % NUM_QUBITS;
+            }
+            gates.push(match next() % 5 {
+                0 => Gate::H(first),
+                1 => Gate::Sz(first),
+                2 => Gate::X(first),
+                3 => Gate::Cx(first, second),
+                _ => Gate::Cz(first, second),
+            });
+        }
+        let measured = next() as usize % NUM_QUBITS;
+        let mut simulator =
+            build_stn_with_mode(NUM_QUBITS, 0x5720_0000 + seed, MeasurementMode::Lazy);
+        let mut dense = DenseStateVec::new(NUM_QUBITS);
+        replay_gates(&mut simulator, &gates);
+        replay_gates(&mut dense, &gates);
+        let outcome = simulator.mz(&[QubitId(measured)])[0].outcome;
+        let (_, mut expected) = projected_dense_state(dense, measured, outcome).unwrap();
+        simulator.flush();
+        let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+        worst_fidelity = worst_fidelity.min(fidelity);
+        mismatches += usize::from(fidelity < 1.0 - 1e-10);
+    }
+
+    eprintln!(
+        "issue #572 randomized hunt: mismatches={mismatches}/{NUM_CIRCUITS} worst_fidelity={worst_fidelity:.16}"
+    );
+    assert_eq!(
+        mismatches, 0,
+        "issue #572 randomized Lazy conditional-state hunt found {mismatches}/{NUM_CIRCUITS} mismatches; worst_fidelity={worst_fidelity:.16}"
     );
 }
 
@@ -1162,5 +1281,63 @@ surface_gate_tests!(
 surface_gate_tests!(
     exact_default_sample_bitstrings_fast,
     exact_default_sample_bitstrings_release,
+    Surface::SampleBitstrings
+);
+
+macro_rules! lazy_surface_gate_tests {
+    ($fast_name:ident, $release_name:ident, $surface:expr) => {
+        #[cfg(not(debug_assertions))]
+        #[test]
+        fn $fast_name() {
+            assert_surface_matrix_with_mode(
+                "lazy",
+                MeasurementMode::Lazy,
+                $surface,
+                &[3, 4],
+                FAST_SHOTS,
+            );
+        }
+
+        #[test]
+        #[ignore = "larger Lazy statistical release lane"]
+        fn $release_name() {
+            assert_surface_matrix_with_mode(
+                "lazy",
+                MeasurementMode::Lazy,
+                $surface,
+                &[5, 6],
+                RELEASE_SHOTS,
+            );
+        }
+    };
+}
+
+lazy_surface_gate_tests!(lazy_mz_mid_fast, lazy_mz_mid_release, Surface::MzMid);
+lazy_surface_gate_tests!(lazy_mz_end_fast, lazy_mz_end_release, Surface::MzEnd);
+lazy_surface_gate_tests!(
+    lazy_reset_qubit_fast,
+    lazy_reset_qubit_release,
+    Surface::Reset
+);
+lazy_surface_gate_tests!(lazy_pz_fast, lazy_pz_release, Surface::Pz);
+lazy_surface_gate_tests!(lazy_px_fast, lazy_px_release, Surface::Px);
+lazy_surface_gate_tests!(
+    lazy_extract_syndromes_fast,
+    lazy_extract_syndromes_release,
+    Surface::ExtractSyndromes
+);
+lazy_surface_gate_tests!(
+    lazy_continuation_fast,
+    lazy_continuation_release,
+    Surface::Continuation
+);
+lazy_surface_gate_tests!(
+    lazy_sample_bitstring_fast,
+    lazy_sample_bitstring_release,
+    Surface::SampleBitstring
+);
+lazy_surface_gate_tests!(
+    lazy_sample_bitstrings_fast,
+    lazy_sample_bitstrings_release,
     Surface::SampleBitstrings
 );

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -169,10 +169,19 @@ fn exact_mps_config() -> MpsConfig {
 }
 
 fn build_stn_with_mode(num_qubits: usize, seed: u64, mode: MeasurementMode) -> StabMps {
+    build_stn_with_mode_and_merge(num_qubits, seed, mode, false)
+}
+
+fn build_stn_with_mode_and_merge(
+    num_qubits: usize,
+    seed: u64,
+    mode: MeasurementMode,
+    merge_rz: bool,
+) -> StabMps {
     StabMps::builder(num_qubits)
         .seed(seed)
         .measurement(mode)
-        .merge_rz(false)
+        .merge_rz(merge_rz)
         .max_bond_dim(64)
         .svd_cutoff(0.0)
         .max_truncation_error(0.0)
@@ -512,10 +521,20 @@ fn run_stn_shot_with_mode(
     seed: u64,
     mode: MeasurementMode,
 ) -> usize {
+    run_stn_shot_with_mode_and_merge(surface, num_qubits, seed, mode, false)
+}
+
+fn run_stn_shot_with_mode_and_merge(
+    surface: Surface,
+    num_qubits: usize,
+    seed: u64,
+    mode: MeasurementMode,
+    merge_rz: bool,
+) -> usize {
     run_built_stn_shot(
         surface,
         num_qubits,
-        build_stn_with_mode(num_qubits, seed, mode),
+        build_stn_with_mode_and_merge(num_qubits, seed, mode, merge_rz),
     )
 }
 
@@ -608,13 +627,19 @@ fn sampled_stn_counts_with_mode(
     num_qubits: usize,
     num_shots: usize,
     mode: MeasurementMode,
+    merge_rz: bool,
 ) -> Vec<usize> {
     let num_outcomes = 1 << surface.record_width(num_qubits);
     if matches!(
         surface,
         Surface::SampleBitstring | Surface::SampleBitstrings
     ) {
-        let mut simulator = build_stn_with_mode(num_qubits, 0x5A00_0000 + num_qubits as u64, mode);
+        let mut simulator = build_stn_with_mode_and_merge(
+            num_qubits,
+            0x5A00_0000 + num_qubits as u64,
+            mode,
+            merge_rz,
+        );
         replay_gates(&mut simulator, &honest_family(num_qubits, num_qubits));
         let samples = if surface == Surface::SampleBitstring {
             simulator.sample_bitstring(num_shots)
@@ -629,11 +654,12 @@ fn sampled_stn_counts_with_mode(
         counts
     } else {
         parallel_counts(num_outcomes, num_shots, |shot| {
-            run_stn_shot_with_mode(
+            run_stn_shot_with_mode_and_merge(
                 surface,
                 num_qubits,
                 0x5100_0000 + (num_qubits as u64) * 100_000 + shot as u64,
                 mode,
+                merge_rz,
             )
         })
     }
@@ -707,7 +733,13 @@ fn corrected_five_sigma_limit(num_comparisons: usize) -> f64 {
 }
 
 fn compare_surface(surface: Surface, num_qubits: usize, num_shots: usize) -> Comparison {
-    compare_surface_with_mode(surface, num_qubits, num_shots, MeasurementMode::Exact)
+    compare_surface_with_mode(
+        surface,
+        num_qubits,
+        num_shots,
+        MeasurementMode::Exact,
+        false,
+    )
 }
 
 fn compare_surface_with_mode(
@@ -715,12 +747,21 @@ fn compare_surface_with_mode(
     num_qubits: usize,
     num_shots: usize,
     mode: MeasurementMode,
+    merge_rz: bool,
 ) -> Comparison {
     let exact = exact_probabilities(surface, num_qubits);
-    let default_counts = sampled_stn_counts_with_mode(surface, num_qubits, num_shots, mode);
+    let default_counts =
+        sampled_stn_counts_with_mode(surface, num_qubits, num_shots, mode, merge_rz);
     let control_counts = sampled_mast_counts(surface, num_qubits, num_shots);
     assert_eq!(default_counts.iter().sum::<usize>(), num_shots);
     assert_eq!(control_counts.iter().sum::<usize>(), num_shots);
+    for (outcome, (&count, &probability)) in default_counts.iter().zip(&exact).enumerate() {
+        assert!(
+            count == 0 || probability > PROBABILITY_EPSILON,
+            "surface={} n={num_qubits} mode={mode:?} merge_rz={merge_rz}: reported impossible dense-oracle record {outcome:#b} {count} times; probability={probability:.16e}",
+            surface.name(),
+        );
+    }
     Comparison {
         surface,
         num_qubits,
@@ -735,6 +776,7 @@ fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
     assert_surface_matrix_with_mode(
         "exact-default",
         MeasurementMode::Exact,
+        false,
         surface,
         qubits,
         num_shots,
@@ -744,13 +786,16 @@ fn assert_surface_matrix(surface: Surface, qubits: &[usize], num_shots: usize) {
 fn assert_surface_matrix_with_mode(
     lane: &str,
     mode: MeasurementMode,
+    merge_rz: bool,
     surface: Surface,
     qubits: &[usize],
     num_shots: usize,
 ) {
     let comparisons = qubits
         .iter()
-        .map(|&num_qubits| compare_surface_with_mode(surface, num_qubits, num_shots, mode))
+        .map(|&num_qubits| {
+            compare_surface_with_mode(surface, num_qubits, num_shots, mode, merge_rz)
+        })
         .collect::<Vec<_>>();
     let num_binomial_checks = comparisons
         .iter()
@@ -826,6 +871,48 @@ fn state_fidelity(first: &[Complex64], second: &[Complex64]) -> f64 {
         .map(|(left, right)| left.conj() * right)
         .sum::<Complex64>()
         .norm_sqr()
+}
+
+fn assert_trivial_product_repeat_outcome_is_valid(mode: MeasurementMode) {
+    let preparation = [
+        Gate::H(0),
+        Gate::Rz(0, Angle64::from_radians(0.9)),
+        Gate::H(0),
+    ];
+    let mut simulator = build_stn_with_mode_and_merge(1, 0, mode, false);
+    let mut dense = DenseStateVec::new(1);
+    replay_gates(&mut simulator, &preparation);
+    replay_gates(&mut dense, &preparation);
+
+    let first = simulator.mz(&[QubitId(0)]).into_iter().next().unwrap();
+    assert!(first.outcome, "mode={mode:?}: seed 0 must select |1>");
+    let (first_probability, expected) = projected_dense_state(dense, 0, first.outcome)
+        .expect("the first reported outcome must have nonzero dense probability");
+    assert!(first_probability > PROBABILITY_EPSILON);
+
+    let second = simulator.mz(&[QubitId(0)]).into_iter().next().unwrap();
+    let (second_probability, mut expected) = projected_dense_state(expected, 0, second.outcome)
+        .expect("the repeated reported outcome must have nonzero dense probability");
+    assert_eq!(second.outcome, first.outcome, "mode={mode:?}");
+    assert!(second.is_deterministic, "mode={mode:?}");
+    assert_eq!(second_probability.to_bits(), 1.0_f64.to_bits());
+
+    simulator.flush();
+    let fidelity = state_fidelity(&simulator.state_vector(), &expected.state());
+    assert!(
+        fidelity >= 1.0 - 1e-12,
+        "mode={mode:?}: repeated trivial-product measurement fidelity={fidelity:.16}"
+    );
+}
+
+#[test]
+fn lazy_trivial_product_measurement_never_reports_an_impossible_repeat_outcome() {
+    assert_trivial_product_repeat_outcome_is_valid(MeasurementMode::Lazy);
+}
+
+#[test]
+fn pragmatic_trivial_product_measurement_never_reports_an_impossible_repeat_outcome() {
+    assert_trivial_product_repeat_outcome_is_valid(MeasurementMode::Pragmatic);
 }
 
 fn lazy_frame_clifford_family(seed: u64, num_qubits: usize) -> Vec<Gate> {
@@ -1008,6 +1095,148 @@ fn lazy_randomized_4000_conditional_state_hunt() {
         mismatches, 0,
         "issue #572 randomized Lazy conditional-state hunt found {mismatches}/{NUM_CIRCUITS} mismatches; worst_fidelity={worst_fidelity:.16}"
     );
+}
+
+#[test]
+#[ignore = "reviewer-style interleaved Lazy adversarial family; run in release mode"]
+fn lazy_interleaved_multi_measurement_adversarial_family() {
+    const SEEDS_PER_CONFIGURATION: u64 = 500;
+    const MEASUREMENTS_PER_CIRCUIT: usize = 3;
+
+    fn next(word: &mut u64) -> u64 {
+        *word ^= *word << 13;
+        *word ^= *word >> 7;
+        *word ^= *word << 17;
+        *word
+    }
+
+    fn distinct_pair(word: &mut u64, num_qubits: usize) -> (usize, usize) {
+        let first = next(word) as usize % num_qubits;
+        let mut second = next(word) as usize % (num_qubits - 1);
+        if second >= first {
+            second += 1;
+        }
+        (first, second)
+    }
+
+    fn random_clifford(word: &mut u64, num_qubits: usize) -> Gate {
+        let first = next(word) as usize % num_qubits;
+        match next(word) % 5 {
+            0 => Gate::H(first),
+            1 => Gate::Sz(first),
+            2 => Gate::X(first),
+            3 => {
+                let (control, target) = distinct_pair(word, num_qubits);
+                Gate::Cx(control, target)
+            }
+            _ => {
+                let (left, right) = distinct_pair(word, num_qubits);
+                Gate::Cz(left, right)
+            }
+        }
+    }
+
+    let mut circuits = 0_usize;
+    let mut measurements = 0_usize;
+    let mut invalid_outcomes = Vec::new();
+    let mut fidelity_mismatches = 0_usize;
+    let mut worst_fidelity = 1.0_f64;
+    let mut minimum_reported_probability = 1.0_f64;
+
+    for num_qubits in 3..=5 {
+        for merge_rz in [false, true] {
+            for seed in 0..SEEDS_PER_CONFIGURATION {
+                circuits += 1;
+                let mut word = seed
+                    ^ (num_qubits as u64).wrapping_mul(0x9E37_79B9)
+                    ^ u64::from(merge_rz).wrapping_mul(0xD1B5_4A32_D192_ED03);
+                let mut simulator = build_stn_with_mode_and_merge(
+                    num_qubits,
+                    0x572A_0000 + seed + 10_000 * num_qubits as u64,
+                    MeasurementMode::Lazy,
+                    merge_rz,
+                );
+                let mut dense = DenseStateVec::new(num_qubits);
+
+                for _ in 0..10 {
+                    let gate = if next(&mut word).is_multiple_of(4) {
+                        let qubit = next(&mut word) as usize % num_qubits;
+                        Gate::Rz(
+                            qubit,
+                            Angle64::from_radians(
+                                0.09 + (next(&mut word) % 1_100) as f64 / 1_000.0,
+                            ),
+                        )
+                    } else {
+                        random_clifford(&mut word, num_qubits)
+                    };
+                    replay_gates(&mut simulator, &[gate]);
+                    replay_gates(&mut dense, &[gate]);
+                }
+
+                for measurement_index in 0..MEASUREMENTS_PER_CIRCUIT {
+                    let measured = next(&mut word) as usize % num_qubits;
+                    let outcome = simulator.mz(&[QubitId(measured)])[0].outcome;
+                    measurements += 1;
+                    let dense_state = dense.state();
+                    let reported_probability = dense_state
+                        .iter()
+                        .enumerate()
+                        .filter(|(index, _)| ((*index >> measured) & 1 != 0) == outcome)
+                        .map(|(_, amplitude)| amplitude.norm_sqr())
+                        .sum::<f64>();
+                    let Some((probability, projected)) =
+                        projected_dense_state(dense.clone(), measured, outcome)
+                    else {
+                        invalid_outcomes.push((
+                            num_qubits,
+                            merge_rz,
+                            seed,
+                            measurement_index,
+                            measured,
+                            outcome,
+                            reported_probability,
+                        ));
+                        break;
+                    };
+                    minimum_reported_probability = minimum_reported_probability.min(probability);
+                    dense = projected;
+
+                    let mut snapshot = simulator.clone();
+                    snapshot.flush();
+                    let fidelity = state_fidelity(&snapshot.state_vector(), &dense.state());
+                    worst_fidelity = worst_fidelity.min(fidelity);
+                    fidelity_mismatches += usize::from(fidelity < 1.0 - 1e-10);
+
+                    if measurement_index + 1 < MEASUREMENTS_PER_CIRCUIT {
+                        let rotated = next(&mut word) as usize % num_qubits;
+                        let rotation = Gate::Rz(
+                            rotated,
+                            Angle64::from_radians(
+                                -0.83 + (next(&mut word) % 1_700) as f64 / 1_000.0,
+                            ),
+                        );
+                        replay_gates(&mut simulator, &[rotation]);
+                        replay_gates(&mut dense, &[rotation]);
+                        for _ in 0..4 {
+                            let gate = random_clifford(&mut word, num_qubits);
+                            replay_gates(&mut simulator, &[gate]);
+                            replay_gates(&mut dense, &[gate]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "reviewer-style Lazy adversarial family: circuits={circuits} measurements={measurements} invalid_outcomes={} fidelity_mismatches={fidelity_mismatches} worst_fidelity={worst_fidelity:.16} minimum_reported_probability={minimum_reported_probability:.3e} invalid_examples={:?}",
+        invalid_outcomes.len(),
+        invalid_outcomes.iter().take(8).collect::<Vec<_>>(),
+    );
+    assert!(invalid_outcomes.is_empty());
+    assert_eq!(measurements, circuits * MEASUREMENTS_PER_CIRCUIT);
+    assert_eq!(fidelity_mismatches, 0);
 }
 
 #[test]
@@ -1289,25 +1518,33 @@ macro_rules! lazy_surface_gate_tests {
         #[cfg(not(debug_assertions))]
         #[test]
         fn $fast_name() {
-            assert_surface_matrix_with_mode(
-                "lazy",
-                MeasurementMode::Lazy,
-                $surface,
-                &[3, 4],
-                FAST_SHOTS,
-            );
+            for merge_rz in [false, true] {
+                let lane = format!("lazy-merge-rz-{merge_rz}");
+                assert_surface_matrix_with_mode(
+                    &lane,
+                    MeasurementMode::Lazy,
+                    merge_rz,
+                    $surface,
+                    &[3, 4],
+                    FAST_SHOTS,
+                );
+            }
         }
 
         #[test]
         #[ignore = "larger Lazy statistical release lane"]
         fn $release_name() {
-            assert_surface_matrix_with_mode(
-                "lazy",
-                MeasurementMode::Lazy,
-                $surface,
-                &[5, 6],
-                RELEASE_SHOTS,
-            );
+            for merge_rz in [false, true] {
+                let lane = format!("lazy-merge-rz-{merge_rz}");
+                assert_surface_matrix_with_mode(
+                    &lane,
+                    MeasurementMode::Lazy,
+                    merge_rz,
+                    $surface,
+                    &[5, 6],
+                    RELEASE_SHOTS,
+                );
+            }
         }
     };
 }

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -915,6 +915,57 @@ fn pragmatic_trivial_product_measurement_never_reports_an_impossible_repeat_outc
     assert_trivial_product_repeat_outcome_is_valid(MeasurementMode::Pragmatic);
 }
 
+#[test]
+fn lazy_trivial_stored_mps_materializes_pending_frame_before_tableau_read() {
+    fn measure_and_check(
+        simulator: &mut StabMps,
+        dense: &mut DenseStateVec,
+        expected_outcome: bool,
+        measurement_index: usize,
+    ) {
+        let outcome = simulator.mz(&[QubitId(1)])[0].outcome;
+        assert_eq!(outcome, expected_outcome, "measurement {measurement_index}");
+        let (probability, projected) = projected_dense_state(dense.clone(), 1, outcome)
+            .expect("the reported Lazy outcome must have nonzero dense probability");
+        assert!(probability > PROBABILITY_EPSILON);
+        *dense = projected;
+
+        let mut snapshot = simulator.clone();
+        snapshot.flush();
+        let fidelity = state_fidelity(&snapshot.state_vector(), &dense.state());
+        assert!(
+            fidelity >= 1.0 - 1e-12,
+            "measurement {measurement_index}: conditional-state fidelity={fidelity:.16}"
+        );
+    }
+
+    let mut simulator = build_stn_with_mode_and_merge(3, 0x572A_75E5, MeasurementMode::Lazy, true);
+    let mut dense = DenseStateVec::new(3);
+
+    let preparation = [
+        Gate::H(1),
+        Gate::Rz(1, Angle64::from_radians(0.808)),
+        Gate::Rz(1, Angle64::from_radians(1.033)),
+    ];
+    replay_gates(&mut simulator, &preparation);
+    replay_gates(&mut dense, &preparation);
+    measure_and_check(&mut simulator, &mut dense, true, 0);
+
+    let first_continuation = [
+        Gate::Rz(1, Angle64::from_radians(0.430)),
+        Gate::H(1),
+        Gate::X(1),
+    ];
+    replay_gates(&mut simulator, &first_continuation);
+    replay_gates(&mut dense, &first_continuation);
+    measure_and_check(&mut simulator, &mut dense, false, 1);
+
+    let second_continuation = [Gate::Rz(1, Angle64::from_radians(0.837)), Gate::Sz(1)];
+    replay_gates(&mut simulator, &second_continuation);
+    replay_gates(&mut dense, &second_continuation);
+    measure_and_check(&mut simulator, &mut dense, false, 2);
+}
+
 fn lazy_frame_clifford_family(seed: u64, num_qubits: usize) -> Vec<Gate> {
     let mut word = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
     let mut next = || {

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -440,6 +440,10 @@ impl PyStabMpsBuilder {
     }
 
     /// Select "exact", "pragmatic", or "lazy" singular measurement.
+    ///
+    /// Lazy preserves exact conditional states after issues #555 and #572,
+    /// subject to configured MPS truncation. It consumes a distinct RNG stream
+    /// from exact, so equal seeds are not shot-for-shot comparable across modes.
     fn measurement<'py>(mut slf: PyRefMut<'py, Self>, mode: &str) -> PyResult<PyRefMut<'py, Self>> {
         slf.inner.measurement = crate::parse_measurement_mode(mode)?;
         Ok(slf)

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -381,6 +381,10 @@ impl PyStabMps {
     /// `measurement` accepts `"exact"`, `"pragmatic"`, or `"lazy"`; when
     /// omitted, the normal default is exact. An explicit value is applied
     /// after `for_qec` and therefore overrides that preset's exact policy.
+    /// Lazy has exact conditional states after issues #555 and #572, subject
+    /// to configured MPS truncation, and Python state reads auto-flush its
+    /// virtual frame. Lazy and exact consume distinct RNG streams, so equal
+    /// seeds are not shot-for-shot comparable between those modes.
     /// `max_truncation_error=None` preserves the builder default of
     /// `1e-8`; a float overrides it, and `0.0` disables adaptive truncation
     /// while retaining the SVD cutoff and bond cap. Negative and non-finite


### PR DESCRIPTION
Closes #572

Fixes the two remaining lazy-measurement defects and lifts the lazy quarantine, with the lift
standing on two independent 18,000-circuit adversarial harnesses at zero failures.

## Defect 1: the dropped measurement gauge

`SparseStabY::nondeterministic_meas` updates its destabilizer block structurally, without
propagating row phases, so the post-measurement tableau differs from the phase-complete
prediction by a virtual Z-type Pauli gauge G. Exact measurement's eager path compensated for G;
the lazy path queued only the measurement-basis rotation W^-1 and dropped G, reversing the
relative sign between branches of already-applied non-Clifford rotations (issue #572's
deterministic reproducer: conditional-state fidelity exactly cos^2 of the pre-measurement
rotation angle).

Fix: the gauge derivation is centralized in one owning helper reused by the exact path's eager
compensation, and the lazy path now derives G against the phase-complete prediction and
enqueues it after W^-1 (queue order proven load-bearing by mutation). Bound by an exhaustive
dense oracle over all 11,520 two-qubit Cliffords x both outcomes x four signed phases (24,576
cases), and by the review's independent algebra derivation from the tableau row operations
(the gauge is provably pure-Z; the X-gauge guard is a hard assertion).

## Defect 2: unguarded tableau-only reads on trivial basis products

The lazy and pragmatic measurement entries took a tableau-only fast path whenever the stored
MPS was trivial — but that read is valid only for C|0...0>, not a general basis product C|b>
(the exact path already guarded this via canonicalization). Result: measurements could report
outcomes with zero probability, then project onto the impossible branch (one-qubit reproducer:
h; rz(0.9); h; mz -> true; mz -> deterministic false, where the true branch is the only one
that exists). A shared boundary now canonicalizes before every tableau-only read on all three
entries; the lazy entry additionally materializes a pending deferred frame and rechecks
triviality first (a fourth edge the new outcome-validity coverage itself exposed, with a
non-ignored regression).

## Evidence for the quarantine lift

- All nine falsifier surfaces statistically clean under lazy in BOTH merge_rz configurations
  (worst 3.70 sigma against 5.4-6.1 corrected limits), with per-record outcome-validity checks
  against the dense oracle: 0 impossible outcomes in 110,592 records. Committed as release
  tests.
- The review's independent 18,000-circuit adversarial harness (whole-register entanglement,
  interleaved measurements/resets with rotations between, both merge configs): dev exhibits
  6,610 conditional-state mismatches and 27 zero-probability outcomes; this branch: 0 and 0.
- A committed interleaved adversarial family (3,000 circuits, 9,000 measurements): 0 impossible
  outcomes, 0 mismatches, worst fidelity 0.9999999999999996.
- 4,000-circuit randomized hunt: 0 mismatches. The #555 regressions stay green.
- Exact mode verified bit-identical to the branch base by a 400-seed trajectory-digest A/B in
  both merge configurations.
- Every fix mutation-verified: deleting the gauge enqueue, flipping its queue side, deleting
  the canonicalization, and deleting the frame materialization each fail their named guards
  (the last reproducing dev's 27 impossible outcomes at identical seeds).

Lazy's documentation now states conditional states are exact as of #555 and #572, subject to
configured MPS truncation, retaining the distinct-RNG-stream caveat. is_state_exact remains
deliberately mode-gated (documented).

## Verification

Full suites green in debug and release (336 lib + 26 integration + 92 verification + 3 doc in
release); all release-ignored lanes; 1,200-circuit census 0 panics; #557 sweeps (exact worst
1.5e-15; adaptive fixture within its recorded-weight bound); clippy -D warnings both crates;
fmt. Two adversarial review rounds ending MERGEABLE, all findings resolved.
