### PR TITLE
Remove the singular per-shot sampler

### DIFF
--- a/docs/user-guide/stabilizer-tensor-networks.md
+++ b/docs/user-guide/stabilizer-tensor-networks.md
@@ -10,7 +10,7 @@ All public bitstrings use qubit-index order: `bits[q]` is the bit for qubit `q`.
 
 ## `StabMps` quickstart
 
-Use `sample_bitstrings`, plural, for shot workloads. It shares each distinct measurement-prefix projection between shots and is always exact by construction, independent of the singular-measurement policy. `sample_bitstring` clones and collapses the entire simulator once per shot and follows that policy. The two methods do not share an RNG stream, so seeded outputs should not be compared shot for shot across methods.
+`sample_bitstrings` is the `StabMps` sampler. It shares each distinct measurement-prefix projection between shots and is always exact by construction, independent of the single-measurement policy. When each shot must follow the configured measurement mode, create a fresh simulator for that shot and explicitly loop over MZ.
 
 ```python
 import math
@@ -62,7 +62,7 @@ Python state reads automatically flush lazy operations and merged rotations. Whe
 
 `StabMps` defaults `merge_rz` to true for throughput. `Mast` defaults it to false so each RZ immediately exposes its injection and ancilla-capacity cost. Numerical flag redetection is opt-in. In `StabMps` it self-disables while lazy deferred operations are pending, because the stored tensors then differ from the effective MPS-frame state.
 
-`StabMps` measurement defaults to `"exact"`. Select `"pragmatic"` for the legacy uncompensated eager path or `"lazy"` for the deferred virtual-frame path. After the issue #555 and #572 frame and projection fixes, Lazy preserves exact conditional states subject to configured MPS truncation; Rust reads still require `flush()`, while Python reads auto-flush. Lazy and Exact consume distinct RNG streams, so equal seeds are not shot-for-shot comparable across those modes. The policy covers MZ, reset, PZ/PX, syndrome extraction, and singular `sample_bitstring`; plural `sample_bitstrings` remains exact.
+`StabMps` measurement defaults to `"exact"`. Select `"pragmatic"` for the legacy uncompensated eager path or `"lazy"` for the deferred virtual-frame path. After the issue #555 and #572 frame and projection fixes, Lazy preserves exact conditional states subject to configured MPS truncation; Rust reads still require `flush()`, while Python reads auto-flush. Lazy and Exact consume distinct RNG streams, so equal seeds are not shot-for-shot comparable across those modes. The policy covers MZ, reset, PZ/PX, and syndrome extraction; `sample_bitstrings` remains exact. Per-shot mode-following sampling is an explicit MZ loop on fresh simulators.
 
 ## `Mast` quickstart
 

--- a/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
+++ b/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
@@ -10,7 +10,7 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Frozen Stage-B benchmark for the singular-measurement policy.
+//! Frozen Stage-B benchmark for the single-qubit measurement policy.
 //!
 //! Run pinned to one CPU with:
 //! `taskset -c 2 cargo run --release -p pecos-stab-tn --example measurement_mode_bench`.

--- a/exp/pecos-stab-tn/examples/sampling_methods.rs
+++ b/exp/pecos-stab-tn/examples/sampling_methods.rs
@@ -10,13 +10,13 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Compare per-shot cloning with prefix-sharing perfect bitstring sampling.
+//! Compare a per-shot clone-and-MZ loop with prefix-sharing bitstring sampling.
 
 use std::collections::HashSet;
 use std::hint::black_box;
 use std::time::Instant;
 
-use pecos_core::{Angle64, QubitId};
+use pecos_core::{Angle64, QubitId, RngManageable};
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
 use pecos_stab_tn::stab_mps::StabMps;
 
@@ -67,9 +67,23 @@ fn distinct_internal_prefixes(shots: &[Vec<bool>]) -> usize {
     prefixes.len()
 }
 
+fn sample_with_fresh_clones(base: &StabMps, num_qubits: usize, num_shots: usize) -> Vec<Vec<bool>> {
+    (0..num_shots)
+        .map(|shot| {
+            let mut simulator = base.clone();
+            simulator.set_seed(0xF2E5_0000_u64.wrapping_add(shot as u64));
+            simulator
+                .mz(&(0..num_qubits).map(QubitId).collect::<Vec<_>>())
+                .into_iter()
+                .map(|result| result.outcome)
+                .collect()
+        })
+        .collect()
+}
+
 fn main() {
     println!(
-        "| n | T | shots | sample_bitstring | sample_bitstrings | speedup | distinct internal prefixes |"
+        "| n | T | shots | fresh clone + MZ loop | sample_bitstrings | speedup | distinct internal prefixes |"
     );
     println!("|---:|---:|---:|---:|---:|---:|---:|");
 
@@ -77,11 +91,10 @@ fn main() {
         let t_count = num_qubits / 2;
         let base = seeded_circuit(num_qubits, t_count, 0x5eed_u64 + num_qubits as u64);
         for num_shots in [100usize, 1_000, 10_000] {
-            let mut legacy = base.clone();
             let start = Instant::now();
-            let legacy_shots = legacy.sample_bitstring(num_shots);
-            let legacy_elapsed = start.elapsed();
-            black_box(&legacy_shots);
+            let per_shot = sample_with_fresh_clones(&base, num_qubits, num_shots);
+            let per_shot_elapsed = start.elapsed();
+            black_box(&per_shot);
 
             let mut prefix = base.clone();
             let start = Instant::now();
@@ -90,11 +103,11 @@ fn main() {
             let distinct_prefixes = distinct_internal_prefixes(&prefix_shots);
             black_box(&prefix_shots);
 
-            let legacy_ms = legacy_elapsed.as_secs_f64() * 1_000.0;
+            let per_shot_ms = per_shot_elapsed.as_secs_f64() * 1_000.0;
             let prefix_ms = prefix_elapsed.as_secs_f64() * 1_000.0;
-            let speedup = legacy_ms / prefix_ms;
+            let speedup = per_shot_ms / prefix_ms;
             println!(
-                "| {num_qubits} | {t_count} | {num_shots} | {legacy_ms:.3} ms | \
+                "| {num_qubits} | {t_count} | {num_shots} | {per_shot_ms:.3} ms | \
                  {prefix_ms:.3} ms | {speedup:.2}x | {distinct_prefixes} |"
             );
         }

--- a/exp/pecos-stab-tn/src/lib.rs
+++ b/exp/pecos-stab-tn/src/lib.rs
@@ -28,8 +28,7 @@
 //! and numerical flag redetection remain opt-in. `sample_bitstrings` is the
 //! bitstring sampler and is always exact by construction; per-shot sampling
 //! through the selected measurement mode is an explicit `mz` loop on fresh
-//! simulators. To
-//! recover the former behavior explicitly, use `max_bond_dim(64)`,
+//! simulators. To recover the former behavior explicitly, use `max_bond_dim(64)`,
 //! `max_truncation_error(0.0)`, and `merge_rz(false)` on the builder.
 //! `Mast` instead defaults `merge_rz` to false so every RZ immediately exposes
 //! its injection and ancilla-capacity cost; enable it explicitly when batching

--- a/exp/pecos-stab-tn/src/lib.rs
+++ b/exp/pecos-stab-tn/src/lib.rs
@@ -23,11 +23,12 @@
 //!
 //! `StabMps` defaults to a maximum bond dimension of 128, a maximum relative
 //! truncation error of `1e-8`, an SVD cutoff of `1e-12`, normalization after
-//! non-Clifford gates, merged same-qubit RZ rotations, and exact singular
+//! non-Clifford gates, merged same-qubit RZ rotations, and exact single-qubit
 //! measurement. Pragmatic and lazy measurement modes, Pauli-frame tracking,
-//! and numerical flag redetection remain opt-in. Singular `sample_bitstring`
-//! follows the selected mode; plural `sample_bitstrings` is always exact by
-//! construction. To
+//! and numerical flag redetection remain opt-in. `sample_bitstrings` is the
+//! bitstring sampler and is always exact by construction; per-shot sampling
+//! through the selected measurement mode is an explicit `mz` loop on fresh
+//! simulators. To
 //! recover the former behavior explicitly, use `max_bond_dim(64)`,
 //! `max_truncation_error(0.0)`, and `merge_rz(false)` on the builder.
 //! `Mast` instead defaults `merge_rz` to false so every RZ immediately exposes

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -363,8 +363,9 @@ pub enum PauliKind {
 /// This controls [`CliffordGateable::mz`], reset, `pz`/`px`, syndrome
 /// extraction. [`StabMps::sample_bitstrings`] is always exact by construction
 /// and does not dispatch through this policy. Per-shot sampling through the
-/// selected policy is expressed by cloning a prepared simulator for each shot
-/// and explicitly measuring its qubits with [`CliffordGateable::mz`].
+/// selected policy is expressed by cloning a prepared simulator for each
+/// shot, reseeding it with a distinct per-shot seed, and explicitly
+/// measuring its qubits with [`CliffordGateable::mz`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum MeasurementMode {
     /// Sample the normalized Born probability and transactionally force the
@@ -1755,8 +1756,8 @@ impl StabMps {
     /// This is the `StabMps` bitstring sampler. It is always exact by
     /// construction and does not use the configured [`MeasurementMode`].
     /// To sample each shot through that mode instead, clone a prepared
-    /// simulator per shot and explicitly measure all qubits with
-    /// [`CliffordGateable::mz`].
+    /// simulator per shot, reseed it with a distinct per-shot seed, and
+    /// explicitly measure all qubits with [`CliffordGateable::mz`].
     ///
     /// The original simulator state is preserved; only its RNG advances.
     /// A working clone first materializes any lazy-measurement frame and then
@@ -2586,11 +2587,12 @@ impl QuantumSimulator for StabMps {
 impl pecos_random::RngManageable for StabMps {
     type Rng = PecosRng;
 
+    /// Reseed BOTH of the simulator's independent random streams: the
+    /// tableau stream is derived from one draw of the supplied RNG, and the
+    /// advanced RNG becomes the main stream. Consequently `set_seed(seed)`
+    /// leaves the main stream one draw past `seed_from_u64(seed)` — a
+    /// deterministic, documented offset, not the raw seeded stream.
     fn set_rng(&mut self, mut rng: Self::Rng) {
-        // StabMps has two independent random streams. Derive the tableau
-        // stream from one draw of the supplied RNG, then retain the advanced
-        // RNG as the main stream. Thus `set_seed(seed)` deterministically
-        // leaves the main stream at a documented one-draw offset.
         let tableau_seed = rng.next_u64();
         self.tableau.set_rng(PecosRng::seed_from_u64(tableau_seed));
         self.rng = rng;

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -358,12 +358,13 @@ pub enum PauliKind {
     Z,
 }
 
-/// Policy for the family of operations implemented through singular Z measurement.
+/// Policy for the family of operations implemented through single-qubit Z measurement.
 ///
 /// This controls [`CliffordGateable::mz`], reset, `pz`/`px`, syndrome
-/// extraction, and singular [`StabMps::sample_bitstring`].
-/// [`StabMps::sample_bitstrings`] (plural) is always exact by construction and
-/// does not dispatch through this policy.
+/// extraction. [`StabMps::sample_bitstrings`] is always exact by construction
+/// and does not dispatch through this policy. Per-shot sampling through the
+/// selected policy is expressed by cloning a prepared simulator for each shot
+/// and explicitly measuring its qubits with [`CliffordGateable::mz`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum MeasurementMode {
     /// Sample the normalized Born probability and transactionally force the
@@ -1747,66 +1748,21 @@ impl StabMps {
 }
 
 impl StabMps {
-    /// Sample `num_shots` bitstrings from the Born distribution
-    /// `|⟨x|Ψ⟩|²` of the current state. Each shot clones the simulator,
-    /// measures all qubits in the Z basis (consuming the clone), and
-    /// returns the bitstring. The original simulator state is unchanged
-    /// (only the internal RNG advances, to ensure each shot uses a
-    /// distinct RNG seed).
-    /// Each clone follows this simulator's [`MeasurementMode`].
-    /// This method and [`Self::sample_bitstrings`] do not share an RNG stream,
-    /// so identically seeded runs are not shot-for-shot comparable across them.
-    ///
-    /// `bitstring[k]` corresponds to qubit `k`'s outcome. See the crate-level
-    /// **Bitstring convention** section.
-    ///
-    /// Useful for shot-based experiments (logical error rate estimation,
-    /// outcome distribution histograms, etc.).
-    ///
-    /// Prefer [`Self::sample_bitstrings`] for multiple shots: this method pays
-    /// for a full simulator clone and all-qubit collapse per shot, whereas the
-    /// plural method shares each distinct measurement prefix. The repository's
-    /// `sampling_methods` release example measures tens-to-hundreds-fold speedups
-    /// for its 1,000-shot workloads (hardware and circuit dependent).
-    pub fn sample_bitstring(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
-        use pecos_core::RngManageable;
-        let mut shots = Vec::with_capacity(num_shots);
-        for _shot in 0..num_shots {
-            let shot_seed = self.rng.next_u64();
-            let mut clone = self.clone();
-            // Re-seed both the StabMps-level RNG (used by random measurement
-            // probability sampling) and the tableau's internal RNG (used
-            // by the trivial-MPS measurement fast path). Otherwise clones
-            // would all share the parent's RNG state and produce identical
-            // outcomes.
-            clone.rng = PecosRng::seed_from_u64(shot_seed);
-            clone
-                .tableau
-                .set_rng(PecosRng::seed_from_u64(shot_seed.wrapping_add(1)));
-            let mut bitstring = Vec::with_capacity(self.num_qubits);
-            for q in 0..self.num_qubits {
-                bitstring.push(clone.measure_qubit(QubitId(q)).outcome);
-            }
-            shots.push(bitstring);
-        }
-        shots
-    }
-
     /// Sample `num_shots` bitstrings from the current Born distribution,
     /// sharing each distinct measurement-prefix projection across all shots
     /// that take that branch.
     ///
-    /// This plural sampler is always exact by construction and does not use
-    /// the configured [`MeasurementMode`].
+    /// This is the `StabMps` bitstring sampler. It is always exact by
+    /// construction and does not use the configured [`MeasurementMode`].
+    /// To sample each shot through that mode instead, clone a prepared
+    /// simulator per shot and explicitly measure all qubits with
+    /// [`CliffordGateable::mz`].
     ///
     /// The original simulator state is preserved; only its RNG advances.
-    /// This method and [`Self::sample_bitstring`] do not share an RNG stream,
-    /// so identically seeded runs are not shot-for-shot comparable across them.
     /// A working clone first materializes any lazy-measurement frame and then
     /// all pending merged RZ rotations. Tracked Pauli X bits remain classical:
-    /// as in [`Self::sample_bitstring`], they swap reported Z outcomes without
-    /// changing the stored-state collapse. Pauli Z bits and frame phase do not
-    /// affect computational-basis probabilities.
+    /// they swap reported Z outcomes without changing the stored-state collapse.
+    /// Pauli Z bits and frame phase do not affect computational-basis probabilities.
     ///
     /// At each prefix containing `k` shots, a candidate zero child is cloned and
     /// passed once through [`measure::project_forced_z`]. Its returned probability
@@ -1821,15 +1777,12 @@ impl StabMps {
     ///
     /// Children are visited depth-first, outcome 0 before outcome 1, measuring
     /// qubits `0..num_qubits`. Returned bitstrings therefore use the same
-    /// `bitstring[q] == qubit q` convention as [`Self::sample_bitstring`] and
-    /// are in lexicographic tree order, with copies of each leaf adjacent.
-    /// See the crate-level **Bitstring convention** section.
+    /// `bitstring[q] == qubit q` convention as the other bitstring APIs and are
+    /// in lexicographic tree order, with copies of each leaf adjacent. See the
+    /// crate-level **Bitstring convention** section.
     ///
-    /// Prefer this method over [`Self::sample_bitstring`] for multiple shots:
-    /// it shares projections for common prefixes instead of cloning and
-    /// collapsing the whole simulator once per shot. The repository's
-    /// `sampling_methods` release example measures tens-to-hundreds-fold speedups
-    /// for its 1,000-shot workloads (hardware and circuit dependent).
+    /// It shares projections for common prefixes instead of cloning and
+    /// collapsing the whole simulator once per shot.
     pub fn sample_bitstrings(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
         if num_shots == 0 {
             return Vec::new();
@@ -6418,55 +6371,6 @@ mod tests {
         stn.h(&[QubitId(0)]);
         let v = stn.pauli_expectation(&[(0, PauliKind::X)]);
         assert!((v - 1.0).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_sample_bitstring_plus_state() {
-        // |+⟩ on q0, |0⟩ on q1: shots should be 50/50 for q0, always 0 for q1.
-        let mut stn = StabMps::with_seed(2, 99);
-        stn.h(&[QubitId(0)]);
-        let shots = stn.sample_bitstring(200);
-        let q0_one_count = shots.iter().filter(|bs| bs[0]).count();
-        let q1_one_count = shots.iter().filter(|bs| bs[1]).count();
-        assert_eq!(q1_one_count, 0, "q1 must always measure 0");
-        assert!(
-            q0_one_count > 70 && q0_one_count < 130,
-            "q0 should be ~50/50, got {q0_one_count}/200"
-        );
-    }
-
-    #[test]
-    fn test_sample_bitstring_bell_correlation() {
-        // Bell state: each shot is either (0,0) or (1,1). Sample 200
-        // shots, verify all are correlated.
-        let mut stn = StabMps::with_seed(2, 99);
-        stn.h(&[QubitId(0)]);
-        stn.cx(&[(QubitId(0), QubitId(1))]);
-        let shots = stn.sample_bitstring(200);
-        for (i, bs) in shots.iter().enumerate() {
-            assert_eq!(bs[0], bs[1], "shot {i} not Bell-correlated: {bs:?}");
-        }
-        let zero_count = shots.iter().filter(|bs| !bs[0]).count();
-        assert!(
-            zero_count > 60 && zero_count < 140,
-            "zero_count {zero_count}/200 outside 60..140"
-        );
-    }
-
-    #[test]
-    fn test_sample_bitstring_does_not_mutate_state() {
-        // Verify the simulator state is unchanged after sampling.
-        let mut stn = StabMps::with_seed(3, 42);
-        stn.h(&[QubitId(0)]);
-        stn.cx(&[(QubitId(0), QubitId(1))]);
-        let bond_before = stn.max_bond_dim();
-        let _ = stn.sample_bitstring(10);
-        let bond_after = stn.max_bond_dim();
-        // Self-state untouched.
-        assert_eq!(
-            bond_before, bond_after,
-            "sample_bitstring mutated simulator state"
-        );
     }
 
     #[test]

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -570,7 +570,7 @@ impl StabMpsBuilder {
         self
     }
 
-    /// Select the singular-measurement policy. The default is
+    /// Select the single-qubit measurement policy. The default is
     /// [`MeasurementMode::Exact`]. See [`MeasurementMode`] for the affected
     /// operation family and the exact behavior of plural sampling.
     #[must_use]
@@ -829,7 +829,7 @@ pub struct StabMps {
     pauli_frame_z: Vec<bool>,
     /// Global scalar of the Pauli frame.
     pauli_frame_phase: Complex64,
-    /// Policy for singular measurement and the operations built on it.
+    /// Policy for single-qubit measurement and the operations built on it.
     measurement_mode: MeasurementMode,
     /// Runtime feature flags.
     flags: StabMpsFlags,
@@ -1520,7 +1520,7 @@ impl StabMps {
         self.mps.deferred_branch_lost_count()
     }
 
-    /// Return the configured singular-measurement policy.
+    /// Return the configured single-qubit measurement policy.
     #[must_use]
     pub fn measurement_mode(&self) -> MeasurementMode {
         self.measurement_mode
@@ -2586,7 +2586,13 @@ impl QuantumSimulator for StabMps {
 impl pecos_random::RngManageable for StabMps {
     type Rng = PecosRng;
 
-    fn set_rng(&mut self, rng: Self::Rng) {
+    fn set_rng(&mut self, mut rng: Self::Rng) {
+        // StabMps has two independent random streams. Derive the tableau
+        // stream from one draw of the supplied RNG, then retain the advanced
+        // RNG as the main stream. Thus `set_seed(seed)` deterministically
+        // leaves the main stream at a documented one-draw offset.
+        let tableau_seed = rng.next_u64();
+        self.tableau.set_rng(PecosRng::seed_from_u64(tableau_seed));
         self.rng = rng;
     }
 
@@ -8058,6 +8064,43 @@ mod tests {
             .measurement(MeasurementMode::Lazy)
             .build();
         assert_eq!(lazy.clone().measurement_mode(), MeasurementMode::Lazy);
+    }
+
+    fn assert_clone_set_seed_reseeds_trivial_tableau_measurements(mode: MeasurementMode) {
+        const NUM_SHOTS: usize = 400;
+
+        let mut prepared = StabMps::builder(2).seed(0x5EED).measurement(mode).build();
+        prepared.h(&[QubitId(0)]);
+        prepared.cx(&[(QubitId(0), QubitId(1))]);
+        assert_eq!(prepared.stats.total_nonclifford, 0);
+        assert_eq!(prepared.max_bond_dim(), 1);
+
+        let distinct = (0..NUM_SHOTS)
+            .map(|shot| {
+                let mut simulator = prepared.clone();
+                simulator.set_seed(0xC10E_0000_u64.wrapping_add(shot as u64));
+                simulator
+                    .mz(&[QubitId(0), QubitId(1)])
+                    .into_iter()
+                    .map(|result| result.outcome)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(
+            distinct.len() > 1,
+            "{mode:?} clone+set_seed shots collapsed to one tableau-RNG outcome: {distinct:?}"
+        );
+    }
+
+    #[test]
+    fn clone_set_seed_reseeds_trivial_tableau_measurements_in_lazy_mode() {
+        assert_clone_set_seed_reseeds_trivial_tableau_measurements(MeasurementMode::Lazy);
+    }
+
+    #[test]
+    fn clone_set_seed_reseeds_trivial_tableau_measurements_in_pragmatic_mode() {
+        assert_clone_set_seed_reseeds_trivial_tableau_measurements(MeasurementMode::Pragmatic);
     }
 
     #[test]

--- a/exp/pecos-stab-tn/tests/exact_default_measurement.rs
+++ b/exp/pecos-stab-tn/tests/exact_default_measurement.rs
@@ -19,7 +19,7 @@
 //! visible to the harness.
 
 use num_complex::Complex64;
-use pecos_core::{Angle64, QubitId};
+use pecos_core::{Angle64, QubitId, RngManageable};
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, DenseStateVec};
 use pecos_stab_tn::mps::MpsConfig;
 use pecos_stab_tn::stab_mps::mast::Mast;
@@ -56,7 +56,7 @@ enum Surface {
     Px,
     ExtractSyndromes,
     Continuation,
-    SampleBitstring,
+    PerShotMz,
     SampleBitstrings,
 }
 
@@ -70,7 +70,7 @@ impl Surface {
             Self::Px => "px",
             Self::ExtractSyndromes => "extract_syndromes",
             Self::Continuation => "continuation",
-            Self::SampleBitstring => "sample_bitstring",
+            Self::PerShotMz => "per_shot_mz_on_clone",
             Self::SampleBitstrings => "sample_bitstrings",
         }
     }
@@ -78,7 +78,7 @@ impl Surface {
     fn record_width(self, num_qubits: usize) -> usize {
         match self {
             Self::MzMid | Self::ExtractSyndromes => 1,
-            Self::MzEnd | Self::Pz | Self::Px | Self::SampleBitstring | Self::SampleBitstrings => {
+            Self::MzEnd | Self::Pz | Self::Px | Self::PerShotMz | Self::SampleBitstrings => {
                 num_qubits
             }
             Self::Reset | Self::Continuation => num_qubits + 1,
@@ -416,7 +416,7 @@ fn exact_probabilities(surface: Surface, num_qubits: usize) -> Vec<f64> {
             replay_dense_branches(&mut measured, &continuation_family(num_qubits));
             measured
         }
-        Surface::MzEnd | Surface::SampleBitstring | Surface::SampleBitstrings => {
+        Surface::MzEnd | Surface::PerShotMz | Surface::SampleBitstrings => {
             dense_measure_all(branches, num_qubits)
         }
         Surface::Reset => {
@@ -502,7 +502,7 @@ fn run_built_stn_shot(surface: Surface, num_qubits: usize, mut simulator: StabMp
             bits.extend(measure_all(&mut simulator, num_qubits));
             bits
         }
-        Surface::SampleBitstring | Surface::SampleBitstrings => {
+        Surface::PerShotMz | Surface::SampleBitstrings => {
             unreachable!("sampling surfaces use their public batch APIs")
         }
     };
@@ -556,7 +556,7 @@ fn run_mast_shot(surface: Surface, num_qubits: usize, seed: u64) -> usize {
             replay_gates(&mut simulator, &continuation);
             vec![outcome]
         }
-        Surface::MzEnd | Surface::SampleBitstring | Surface::SampleBitstrings => {
+        Surface::MzEnd | Surface::PerShotMz | Surface::SampleBitstrings => {
             measure_all(&mut simulator, num_qubits)
         }
         Surface::Reset => {
@@ -630,10 +630,7 @@ fn sampled_stn_counts_with_mode(
     merge_rz: bool,
 ) -> Vec<usize> {
     let num_outcomes = 1 << surface.record_width(num_qubits);
-    if matches!(
-        surface,
-        Surface::SampleBitstring | Surface::SampleBitstrings
-    ) {
+    if matches!(surface, Surface::PerShotMz | Surface::SampleBitstrings) {
         let mut simulator = build_stn_with_mode_and_merge(
             num_qubits,
             0x5A00_0000 + num_qubits as u64,
@@ -641,11 +638,20 @@ fn sampled_stn_counts_with_mode(
             merge_rz,
         );
         replay_gates(&mut simulator, &honest_family(num_qubits, num_qubits));
-        let samples = if surface == Surface::SampleBitstring {
-            simulator.sample_bitstring(num_shots)
-        } else {
-            simulator.sample_bitstrings(num_shots)
-        };
+        if surface == Surface::PerShotMz {
+            return parallel_counts(num_outcomes, num_shots, |shot| {
+                let mut shot_simulator = simulator.clone();
+                shot_simulator.set_seed(
+                    0x5A10_0000_u64
+                        .wrapping_add((num_qubits as u64) * 100_000)
+                        .wrapping_add(shot as u64),
+                );
+                let bits = measure_all(&mut shot_simulator, num_qubits);
+                assert_eq!(shot_simulator.bond_cap_hits(), 0);
+                encode_bits(&bits)
+            });
+        }
+        let samples = simulator.sample_bitstrings(num_shots);
         let mut counts = vec![0; num_outcomes];
         for bits in samples {
             counts[encode_bits(&bits)] += 1;
@@ -1554,9 +1560,9 @@ surface_gate_tests!(
     Surface::Continuation
 );
 surface_gate_tests!(
-    exact_default_sample_bitstring_fast,
-    exact_default_sample_bitstring_release,
-    Surface::SampleBitstring
+    exact_default_per_shot_mz_fast,
+    exact_default_per_shot_mz_release,
+    Surface::PerShotMz
 );
 surface_gate_tests!(
     exact_default_sample_bitstrings_fast,
@@ -1620,9 +1626,9 @@ lazy_surface_gate_tests!(
     Surface::Continuation
 );
 lazy_surface_gate_tests!(
-    lazy_sample_bitstring_fast,
-    lazy_sample_bitstring_release,
-    Surface::SampleBitstring
+    lazy_per_shot_mz_fast,
+    lazy_per_shot_mz_release,
+    Surface::PerShotMz
 );
 lazy_surface_gate_tests!(
     lazy_sample_bitstrings_fast,

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -2653,9 +2653,7 @@ fn test_prob_bitstring_nonzero_trivial_coefficient_basis_matches_dense_state_vec
 #[test]
 fn test_prefix_tree_sampler_random_clifford_t_distributions() {
     // Compare the exact forced-projection prefix sampler with the independent
-    // dense state vector. Do not use `sample_bitstring` as an oracle: that API
-    // deliberately retains the pre-existing pragmatic measurement path and
-    // its documented drift.
+    // dense state vector.
     let num_shots = 5000usize;
     for num_qubits in 3..=5 {
         for t_count in 2..=5 {

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -439,7 +439,7 @@ impl PyStabMpsBuilder {
         }
     }
 
-    /// Select "exact", "pragmatic", or "lazy" singular measurement.
+    /// Select "exact", "pragmatic", or "lazy" single-qubit measurement.
     ///
     /// Lazy preserves exact conditional states after issues #555 and #572,
     /// subject to configured MPS truncation. It consumes a distinct RNG stream

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -998,30 +998,16 @@ impl PyStabMps {
         Ok(self.inner.code_state_fidelity(&stabs))
     }
 
-    /// Sample `num_shots` computational-basis rows by cloning once per shot.
-    ///
-    /// Every returned row uses `row[q] == qubit q`; the original state is
-    /// preserved and its RNG advances. Prefer `sample_bitstrings`: this method
-    /// pays for a full clone and collapse per shot, while prefix sharing has
-    /// measured tens-to-hundreds-fold speedups on the repository's 1,000-shot
-    /// example workloads. The two sampler methods do not share an RNG stream,
-    /// so their seeded results are not shot-for-shot comparable. A negative or
-    /// oversized count raises `OverflowError`.
-    fn sample_bitstring(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
-        self.inner.sample_bitstring(num_shots)
-    }
-
     /// Sample `num_shots` computational-basis rows with shared prefixes.
     ///
     /// Every returned row uses `row[q] == qubit q`. The original state is
     /// preserved and its RNG advances. Distinct measurement-prefix projections
-    /// are shared across all shots taking that branch, avoiding the per-shot
-    /// cloning cost of `sample_bitstring`; the repository's 1,000-shot example
-    /// measures hardware-dependent tens-to-hundreds-fold speedups. Output is in
-    /// lexicographic tree order, not input shot order. Pending merged rotations
-    /// and lazy operations are handled internally. The two sampler methods do
-    /// not share an RNG stream, so their seeded results are not shot-for-shot
-    /// comparable. A negative or oversized count raises `OverflowError`.
+    /// are shared across all shots taking that branch. This is the `StabMps`
+    /// bitstring sampler and is always exact. For per-shot sampling through the
+    /// configured measurement mode, create a fresh simulator per shot and loop
+    /// over MZ explicitly. Output is in lexicographic tree order, not input shot
+    /// order. Pending merged rotations and lazy operations are handled
+    /// internally. A negative or oversized count raises `OverflowError`.
     fn sample_bitstrings(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
         self.inner.sample_bitstrings(num_shots)
     }

--- a/python/pecos-rslib-exp/src/stabmps_builder.rs
+++ b/python/pecos-rslib-exp/src/stabmps_builder.rs
@@ -26,7 +26,7 @@ use pecos_stab_tn::stab_mps::{MeasurementMode, StabMps};
 /// Implements `SimulatorFactory` so it can be used with `custom_backend()`.
 #[derive(Debug, Clone)]
 pub struct StabMpsBuilder {
-    /// Singular-measurement policy.
+    /// Single-qubit measurement policy.
     pub measurement: MeasurementMode,
     /// Maximum MPS bond dimension.
     pub max_bond_dim: usize,
@@ -55,7 +55,7 @@ impl StabMpsBuilder {
         Self::default()
     }
 
-    /// Select the singular-measurement policy.
+    /// Select the single-qubit measurement policy.
     #[must_use]
     pub fn with_measurement(mut self, measurement: MeasurementMode) -> Self {
         self.measurement = measurement;

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -124,6 +124,7 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     q0_one = exp.StabMps(2, seed=13)
     q0_one.run_1q_gate("X", 0)
     assert not hasattr(q0_one, "sample_bit" + "string")
+    assert hasattr(q0_one, "sample_bit" + "strings")
     assert q0_one.sample_bitstrings(4) == [[True, False]] * 4
     assert q0_one.state_vector() == [
         (0.0, 0.0),

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -123,6 +123,7 @@ def test_stab_mps_analysis_and_noise_exposure():
 def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     q0_one = exp.StabMps(2, seed=13)
     q0_one.run_1q_gate("X", 0)
+    assert not hasattr(q0_one, "sample_bit" + "string")
     assert q0_one.sample_bitstrings(4) == [[True, False]] * 4
     assert q0_one.state_vector() == [
         (0.0, 0.0),


### PR DESCRIPTION
Removes `StabMps::sample_bitstring(num_shots)` from the Rust API and Python binding, resolving a naming hazard: it shared an identical signature with `sample_bitstrings(num_shots)` while differing by one letter — but the singular cloned the full simulator per shot and followed the measurement mode, while the plural shares projection work via the prefix tree, is always exact, and is tens-to-hundreds-fold faster. A one-letter typo silently selected the slow path.

With exact measurement now the default (#567), the singular's only remaining distinction was being slower and mode-following. That intent is better expressed explicitly: code that requires each shot to follow the configured `MeasurementMode` should clone a fresh simulator per shot and measure with `mz` — which is exactly how the falsifier matrix's per-shot statistical surface is now implemented (`per_shot_mz_on_clone`), preserving all nine surfaces of measurement-statistics coverage in both Exact and Lazy matrices. The `sampling_methods` example keeps its performance comparison via the same explicit-loop leg.

Breaking change: `sample_bitstring` (singular) is removed; use `sample_bitstrings` for sampling, or an explicit per-shot `mz` loop for mode-following semantics.

Verification: whole-repo grep clean of the removed symbol; full suites debug (436) and release (454) green; the release-gated falsifier lane passes with all 20 matrices/stress tests; clippy -D warnings and fmt clean on both crates; the updated Python exposure test passes against a rebuilt extension.