### PR TITLE
Preserve the tracked orthogonality center through normalization and center-local operations

### DIFF
--- a/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
+++ b/exp/pecos-stab-tn/examples/measurement_mode_bench.rs
@@ -125,6 +125,8 @@ struct RunMetrics {
     cap_hit_count: u64,
     branch_vanish_retry_count: u64,
     uncompensated_pre_reduction_count: u64,
+    full_canonical_sweep_count: u64,
+    center_reuse_count: u64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -136,6 +138,8 @@ struct MedianMetrics {
     cap_hit_count: u64,
     branch_vanish_retry_count: u64,
     uncompensated_pre_reduction_count: u64,
+    full_canonical_sweep_count: u64,
+    center_reuse_count: u64,
 }
 
 fn depolarizing_error(rng: &mut ChaCha12Rng) -> TwoQubitNoise {
@@ -297,6 +301,8 @@ fn run_once(
         metrics.cap_hit_count += stn.bond_cap_hits();
         metrics.branch_vanish_retry_count += stn.branch_vanish_retry_count();
         metrics.uncompensated_pre_reduction_count += stn.uncompensated_pre_reduction_count();
+        metrics.full_canonical_sweep_count += stn.full_canonical_sweep_count();
+        metrics.center_reuse_count += stn.center_reuse_count();
     }
     metrics.shots_per_second = workload.shots as f64 / start.elapsed().as_secs_f64();
     black_box(checksum);
@@ -332,6 +338,8 @@ fn medians(runs: &[RunMetrics]) -> MedianMetrics {
         uncompensated_pre_reduction_count: median_u64(
             runs.iter().map(|r| r.uncompensated_pre_reduction_count),
         ),
+        full_canonical_sweep_count: median_u64(runs.iter().map(|r| r.full_canonical_sweep_count)),
+        center_reuse_count: median_u64(runs.iter().map(|r| r.center_reuse_count)),
     }
 }
 
@@ -345,7 +353,7 @@ fn mode_label(mode: MeasurementMode) -> &'static str {
 
 fn print_metrics(workload: Workload, mode: MeasurementMode, metrics: MedianMetrics) {
     println!(
-        "MEASUREMENT_MODE_BENCH workload={} mode={} shots={} runs=7 shots_per_s={:.6} lifetime_peak_bond={} final_bond={} summed_discarded_weight={:.16e} cap_hit_count={} branch_vanish_retry_count={} uncompensated_pre_reduction_count={}",
+        "MEASUREMENT_MODE_BENCH workload={} mode={} shots={} runs=7 shots_per_s={:.6} lifetime_peak_bond={} final_bond={} summed_discarded_weight={:.16e} cap_hit_count={} branch_vanish_retry_count={} uncompensated_pre_reduction_count={} full_canonical_sweep_count={} center_reuse_count={}",
         workload.label(),
         mode_label(mode),
         workload.shots,
@@ -356,6 +364,8 @@ fn print_metrics(workload: Workload, mode: MeasurementMode, metrics: MedianMetri
         metrics.cap_hit_count,
         metrics.branch_vanish_retry_count,
         metrics.uncompensated_pre_reduction_count,
+        metrics.full_canonical_sweep_count,
+        metrics.center_reuse_count,
     );
 }
 

--- a/exp/pecos-stab-tn/src/mps.rs
+++ b/exp/pecos-stab-tn/src/mps.rs
@@ -107,6 +107,12 @@ pub struct Mps {
     branch_vanish_retry_count: u64,
     /// Number of deferred MAST branches replaced by their surviving complement.
     deferred_branch_lost_count: u64,
+    /// Number of cold full-chain canonicalization routes taken because no
+    /// orthogonality center was available at the canonicalization consult.
+    full_canonical_sweep_count: u64,
+    /// Number of canonicalization routes that reused a tracked orthogonality
+    /// center instead of starting from a cold full-chain sweep.
+    center_reuse_count: u64,
 }
 
 /// Pass-scoped left and right identity environments for selected MPS sites.
@@ -222,6 +228,8 @@ impl Mps {
             lifetime_peak_bond: 1,
             branch_vanish_retry_count: 0,
             deferred_branch_lost_count: 0,
+            full_canonical_sweep_count: 0,
+            center_reuse_count: 0,
         }
     }
 
@@ -267,13 +275,27 @@ impl Mps {
         self.deferred_branch_lost_count
     }
 
-    /// Reset truncation diagnostics (keep state).
+    /// Number of canonicalization consults that required a cold full-chain sweep.
+    #[must_use]
+    pub fn full_canonical_sweep_count(&self) -> u64 {
+        self.full_canonical_sweep_count
+    }
+
+    /// Number of canonicalization consults that reused a tracked center.
+    #[must_use]
+    pub fn center_reuse_count(&self) -> u64 {
+        self.center_reuse_count
+    }
+
+    /// Reset truncation and canonical-routing diagnostics (keep state).
     pub fn reset_truncation_stats(&mut self) {
         self.truncation_error = 0.0;
         self.bond_cap_hits = 0;
         self.summed_discarded_weight = 0.0;
         self.branch_vanish_retry_count = 0;
         self.deferred_branch_lost_count = 0;
+        self.full_canonical_sweep_count = 0;
+        self.center_reuse_count = 0;
         self.lifetime_peak_bond = self.max_bond_dim();
     }
 
@@ -359,13 +381,26 @@ impl Mps {
             .min(usize::MAX / 8)
     }
 
-    /// Multiply the entire MPS by a scalar (absorbed into the first tensor).
+    /// Multiply the entire MPS by a scalar absorbed into site zero.
+    ///
+    /// The mixed-canonical claim is retained only when site zero is the
+    /// orthogonality center. [`Self::normalize`] may instead choose a tracked
+    /// nonzero center to avoid invalidating an established canonical gauge.
     pub fn scale(&mut self, scalar: Complex64) {
         if self.tensors.is_empty() {
             return;
         }
-        self.tensors[0] *= scalar;
-        self.center = None;
+        self.scale_tensor(0, scalar);
+    }
+
+    /// Scale one tensor and retain the mixed-canonical claim exactly when that
+    /// tensor is the orthogonality center. Scaling any other tensor changes an
+    /// isometry's Gram matrix and therefore invalidates the claim.
+    fn scale_tensor(&mut self, site: usize, scalar: Complex64) {
+        self.tensors[site] *= scalar;
+        if self.center != Some(site) {
+            self.center = None;
+        }
     }
 
     /// Apply a single-site gate (d x d unitary matrix) to site `q`.
@@ -870,15 +905,22 @@ impl Mps {
         if self.tensors.is_empty() {
             return;
         }
-        let norm_sq = self.norm_squared();
+        // In a mixed-canonical gauge every environment contraction outside
+        // the center is the identity, so the center tensor's Frobenius norm
+        // is the global state norm. Besides avoiding a redundant contraction,
+        // this keeps normalization at the invariant-owning site.
+        let norm_sq = self.center.map_or_else(
+            || self.norm_squared(),
+            |center| self.tensors[center].iter().map(Complex64::norm_sqr).sum(),
+        );
         debug_assert!(
             norm_sq > 0.0,
             "cannot normalize a zero-norm MPS after projection"
         );
         if norm_sq > 0.0 {
             let inv_norm = Complex64::new(1.0 / norm_sq.sqrt(), 0.0);
-            self.tensors[0] *= inv_norm;
-            self.center = None;
+            let site = self.center.unwrap_or(0);
+            self.scale_tensor(site, inv_norm);
         }
     }
 
@@ -1023,6 +1065,10 @@ impl Mps {
             deferred_branch_lost_count: self
                 .deferred_branch_lost_count
                 .max(other.deferred_branch_lost_count),
+            full_canonical_sweep_count: self
+                .full_canonical_sweep_count
+                .max(other.full_canonical_sweep_count),
+            center_reuse_count: self.center_reuse_count.max(other.center_reuse_count),
         }
     }
 
@@ -1051,17 +1097,20 @@ impl Mps {
     /// Replace one physical block of a site tensor.
     ///
     /// This is the owner-mediated path for projection code that must mutate a
-    /// tensor without canonicalizing first. An arbitrary block replacement
-    /// invalidates any mixed-canonical claim.
+    /// tensor without canonicalizing first. Any replacement at the center
+    /// preserves the outer left and right isometries; a replacement away from
+    /// the center changes an isometry and invalidates the claim.
     pub(crate) fn set_physical_block(
         &mut self,
         site: usize,
         physical_index: usize,
         block: &DMatrix<Complex64>,
     ) {
-        self.center = None;
         let chi_r = self.bond_dims[site + 1];
         set_phys_block(&mut self.tensors[site], physical_index, chi_r, block);
+        if self.center != Some(site) {
+            self.center = None;
+        }
     }
 
     /// Access the bond dimensions (for testing).
@@ -1079,9 +1128,9 @@ impl Mps {
 
     /// Right-canonicalize the entire MPS.
     pub fn right_canonicalize(&mut self) {
-        canon::right_canonicalize_all(&mut self.tensors, &mut self.bond_dims, self.phys_dim);
-        self.center = (self.num_sites > 0).then_some(0);
-        self.record_current_peak_bond();
+        if self.num_sites > 0 {
+            self.canonicalize_at(0);
+        }
     }
 
     /// Put the environments bordering `(q, q + 1)` in canonical form.
@@ -1093,8 +1142,15 @@ impl Mps {
     /// even when the input MPS had an arbitrary or rank-redundant gauge.
     pub(crate) fn canonicalize_around_bond(&mut self, q: usize) {
         assert!(q + 1 < self.num_sites, "bond must join two valid sites");
-        let target = q + 1;
+        self.canonicalize_at(q + 1);
+    }
+
+    /// Move an established center with exact one-site QR factorizations, or
+    /// establish one from a cold gauge by canonicalizing both environments.
+    fn canonicalize_at(&mut self, target: usize) {
+        assert!(target < self.num_sites, "center must be a valid site");
         if let Some(center) = self.center {
+            self.center_reuse_count += 1;
             #[cfg(debug_assertions)]
             debug_assert!(
                 self.claimed_center_is_valid(center),
@@ -1123,7 +1179,8 @@ impl Mps {
                 }
             }
         } else {
-            for site in 0..=q {
+            self.full_canonical_sweep_count += 1;
+            for site in 0..target {
                 canon::left_canonicalize_site(
                     &mut self.tensors,
                     &mut self.bond_dims,
@@ -1131,7 +1188,7 @@ impl Mps {
                     self.phys_dim,
                 );
             }
-            for site in (q + 2..self.num_sites).rev() {
+            for site in (target + 1..self.num_sites).rev() {
                 canon::right_canonicalize_site(
                     &mut self.tensors,
                     &mut self.bond_dims,
@@ -1313,6 +1370,8 @@ impl Clone for Mps {
             lifetime_peak_bond: self.lifetime_peak_bond,
             branch_vanish_retry_count: self.branch_vanish_retry_count,
             deferred_branch_lost_count: self.deferred_branch_lost_count,
+            full_canonical_sweep_count: self.full_canonical_sweep_count,
+            center_reuse_count: self.center_reuse_count,
         }
     }
 }
@@ -1588,13 +1647,54 @@ mod tests {
     }
 
     #[test]
-    fn test_scale_invalidates_center() {
+    fn test_scale_preserves_only_when_site_zero_is_the_center() {
+        let mut mps = Mps::new(4, MpsConfig::default());
+        assert_eq!(mps.tracked_center_for_test(), Some(0));
+
+        mps.scale(Complex64::new(2.0, 0.0));
+        assert_eq!(mps.tracked_center_for_test(), Some(0));
+        mps.canonicalize_around_bond(1);
+        assert_eq!(mps.tracked_center_for_test(), Some(2));
+        assert_eq!(mps.full_canonical_sweep_count(), 0);
+        assert_eq!(mps.center_reuse_count(), 1);
+    }
+
+    #[test]
+    fn test_normalize_preserves_a_nonzero_center() {
+        let config = MpsConfig {
+            max_bond_dim: 64,
+            svd_cutoff: 0.0,
+            max_truncation_error: Some(0.0),
+            parallel: false,
+        };
+        let mut mps = seeded_random_mps(5, 4, 0x5ca1_e000_0000_0001, config);
+        mps.canonicalize_around_bond(2);
+        assert_eq!(mps.tracked_center_for_test(), Some(3));
+
+        mps.normalize();
+        assert_eq!(mps.tracked_center_for_test(), Some(3));
+        assert_relative_eq!(mps.norm_squared(), 1.0, epsilon = 1e-12);
+
+        // This is the production consult point: in debug builds it runs the
+        // claimed-center validator before trusting the preserved center.
+        mps.canonicalize_around_bond(1);
+        assert_eq!(mps.tracked_center_for_test(), Some(2));
+        assert_eq!(mps.full_canonical_sweep_count(), 1);
+        assert_eq!(mps.center_reuse_count(), 1);
+    }
+
+    #[test]
+    fn test_off_center_scaling_invalidates_before_canonical_routing() {
         let mut mps = Mps::new(4, MpsConfig::default());
         mps.left_canonicalize();
+        assert_eq!(mps.tracked_center_for_test(), Some(3));
 
         mps.scale(Complex64::new(2.0, 0.0));
 
-        assert_eq!(mps.tracked_center_for_test(), None);
+        mps.canonicalize_around_bond(1);
+        assert_eq!(mps.tracked_center_for_test(), Some(2));
+        assert_eq!(mps.full_canonical_sweep_count(), 1);
+        assert_eq!(mps.center_reuse_count(), 0);
     }
 
     #[cfg(debug_assertions)]

--- a/exp/pecos-stab-tn/src/mps.rs
+++ b/exp/pecos-stab-tn/src/mps.rs
@@ -276,6 +276,12 @@ impl Mps {
     }
 
     /// Number of canonicalization consults that required a cold full-chain sweep.
+    ///
+    /// Counts only the shared `canonicalize_at` route; the sweeps inside
+    /// `compress` and `left_canonicalize` are not routed through it, so this
+    /// undercounts total sweep work. The reuse counter likewise counts route
+    /// selection, not factorizations saved (a warm walk across the whole
+    /// chain does as many local factorizations as a cold sweep).
     #[must_use]
     pub fn full_canonical_sweep_count(&self) -> u64 {
         self.full_canonical_sweep_count
@@ -911,7 +917,17 @@ impl Mps {
         // this keeps normalization at the invariant-owning site.
         let norm_sq = self.center.map_or_else(
             || self.norm_squared(),
-            |center| self.tensors[center].iter().map(Complex64::norm_sqr).sum(),
+            |center| {
+                // This consult consumes the center claim for a VALUE, not
+                // just to skip work: a stale claim would silently
+                // mis-normalize. Guard it like every other trusting consult.
+                #[cfg(debug_assertions)]
+                debug_assert!(
+                    self.claimed_center_is_valid(center),
+                    "tracked MPS orthogonality center {center} is stale"
+                );
+                self.tensors[center].iter().map(Complex64::norm_sqr).sum()
+            },
         );
         debug_assert!(
             norm_sq > 0.0,
@@ -1126,7 +1142,11 @@ impl Mps {
         self.record_current_peak_bond();
     }
 
-    /// Right-canonicalize the entire MPS.
+    /// Right-canonicalize the MPS by moving the orthogonality center to
+    /// site 0. With a tracked center this is a local walk, and a no-op when
+    /// the center is already at site 0 — safe because the sites a valid
+    /// center claim skips are exact isometries, so the omitted factorizations
+    /// are pure unitary gauge moves that cannot change any bond dimension.
     pub fn right_canonicalize(&mut self) {
         if self.num_sites > 0 {
             self.canonicalize_at(0);

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -1519,6 +1519,18 @@ impl StabMps {
         self.mps.deferred_branch_lost_count()
     }
 
+    /// Number of MPS bond-canonicalization consults that required a cold full sweep.
+    #[must_use]
+    pub fn full_canonical_sweep_count(&self) -> u64 {
+        self.mps.full_canonical_sweep_count()
+    }
+
+    /// Number of MPS bond-canonicalization consults that reused a tracked center.
+    #[must_use]
+    pub fn center_reuse_count(&self) -> u64 {
+        self.mps.center_reuse_count()
+    }
+
     /// Return the configured singular-measurement policy.
     #[must_use]
     pub fn measurement_mode(&self) -> MeasurementMode {

--- a/exp/pecos-stab-tn/src/stab_mps/measure.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/measure.rs
@@ -2362,7 +2362,28 @@ mod tests {
 
         project_single_flip_without_sign(&mut mps, 0, Complex64::new(1.0, 0.0), 0.5);
 
-        assert_eq!(mps.tracked_center_for_test(), None);
+        mps.right_canonicalize();
+        assert_eq!(mps.tracked_center_for_test(), Some(0));
+        assert_eq!(mps.full_canonical_sweep_count(), 1);
+        assert_eq!(mps.center_reuse_count(), 0);
+    }
+
+    #[test]
+    fn projection_block_replacement_at_center_reuses_canonical_routing() {
+        let product = Mps::new(4, MpsConfig::default());
+        let mut mps = product.add(&product);
+        mps.left_canonicalize();
+        assert_eq!(mps.tracked_center_for_test(), Some(3));
+
+        project_single_flip_without_sign(&mut mps, 3, Complex64::new(1.0, 0.0), 0.5);
+
+        assert_eq!(mps.tracked_center_for_test(), Some(3));
+        // The production exact-projection compression route invokes the debug
+        // center validator here before reusing the preserved center.
+        mps.right_canonicalize();
+        assert_eq!(mps.tracked_center_for_test(), Some(0));
+        assert_eq!(mps.full_canonical_sweep_count(), 0);
+        assert_eq!(mps.center_reuse_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Extends #563's center tracking with four preserve/reuse decisions, each holding by the mixed-canonical invariant (independently re-derived in review): normalization reads the global norm from the center tensor and scales it in place; center-block replacement preserves; scale preserves only at a site-0 center; a shared canonicalize-at route walks a valid center locally instead of cold-sweeping. Sweep/reuse telemetry added.

## Measured effect (7-run pinned medians; reviewer-reproduced interleaved A/B)

measurement_mode_bench: +4.3% to +13.1% shots/s across all eight (workload, mode) rows.
canonical_cost_workloads: -2% to -10% wall time across the comparable workloads. Exact-vs-pragmatic geomean improved 1.475 -> 1.461.

ATTRIBUTION, corrected by review: the dominant contribution is the cheap center-tensor norm read in normalize (the review's isolation arm shows routing reuse alone is worth -1.4% to +4.6%). The sweep-counter story holds only on Z-check workloads; X-check workloads gain ~9% with zero routing reuse. The counters count route selection, not factorizations saved, and undercount sweeps not routed through the shared path — documented on the getters.

ACCURACY, corrected by review: the center-tensor Frobenius read is 3-5x LESS accurate than the full contraction it replaces (~1e-14 relative worst case on ill-conditioned states) — far below every tolerance in the crate (validator 1e-9, trivial-basis 1e-8), but the direction is worth recording. An unclaimed benefit found in review: the new gauge leaves off-center sites at per-site norm exactly one, strictly improving the conditioning of the absolute thresholds in is_mps_trivial and the trivial-basis canonicalization.

## Guarding the new consult

normalize's center branch consumes the claim for a VALUE, so it now carries the same debug validator as every other trusting consult point (review-verified non-vacuous: 140 tests reach the branch). Falsifiers proven binding by mutation: off-center scalar preservation and off-center block replacement each trip the stale-center assert.

## Known interaction, disclosed (issue #580)

Deep 20-qubit workloads carry a pre-existing ~3.5% seed-dependent SVD-convergence panic rate that reshuffles under ANY floating-point reordering: a 256-seed census measured dev at 9/256, this branch at 8/256, and a partial variant at 15/256 — statistically equal, different seeds. Concretely, canonical_cost_workloads deep20_2n at CANON_REPEATS=3 panics on this branch and not on dev (and other repeat counts do the reverse); single-seed observations in this regime are lottery draws, tracked in #580. During development a scale-relocation variant was dropped citing one such single-seed panic; that rationale was noise by the same census — the variant stays out on simplicity grounds, not evidence.

Within-build trajectory hashes are stable (7/7 every workload); cross-build hashes change on five of six canonical workloads (scalar placement changes fp reduction order), consistent with the established cross-revision hash policy. Peak/final bonds and truncation quality are unchanged; discarded weights agree to ~1e-8 relative.

## Verification

Full suites debug+release green including --include-ignored (census, #557/#572 hunts, falsifier matrices); clippy -D warnings both crates (reviewer-verified non-vacuous with an injected canary); fmt. One adversarial review round (REVISE: unguarded consult, attribution/accuracy prose, lottery disclosure) with all must-fixes applied and re-verified.