### PR TITLE
Add batched probability queries sharing prefix projection work

### DIFF
--- a/docs/user-guide/stabilizer-tensor-networks.md
+++ b/docs/user-guide/stabilizer-tensor-networks.md
@@ -33,6 +33,11 @@ p11 = sim.prob_bitstring([True, True])
 assert math.isclose(p00, 0.5, abs_tol=1e-12)
 assert math.isclose(p11, 0.5, abs_tol=1e-12)
 
+# Batched queries share common-prefix projection work and return exactly the
+# per-query results.
+batch = sim.prob_bitstrings([[False, False], [True, True]])
+assert batch == [p00, p11]
+
 # Python reads auto-flush lazy operations and merged RZ rotations.
 accuracy = {
     "state_exact": sim.is_state_exact(),

--- a/exp/pecos-stab-tn/examples/batched_probability_queries.rs
+++ b/exp/pecos-stab-tn/examples/batched_probability_queries.rs
@@ -1,0 +1,241 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Release-mode performance falsifier for shared-prefix probability queries.
+//!
+//! This mirrors the measured cross-implementation workload shape: n=32,
+//! T=n basis-mixed sparse Clifford+T, chi=64, cutoff 1e-12, adaptive
+//! truncation disabled, and 16 deterministic random bitstring queries. It
+//! compares the shared `prob_bitstrings` trie with the mutation baseline of a
+//! fresh singular forced-projection walk per query.
+//!
+//! Run pinned and single-threaded when possible:
+//! `RAYON_NUM_THREADS=1 taskset -c 2 cargo run --release -p pecos-stab-tn --example batched_probability_queries`.
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
+use pecos_stab_tn::stab_mps::StabMps;
+
+const NUM_QUBITS: usize = 32;
+const NUM_QUERIES: usize = 16;
+const CIRCUIT_SEED: u64 = 23_201;
+const TIMED_REPETITIONS: usize = 3;
+
+fn sparse_clifford_t_state() -> StabMps {
+    let mut simulator = StabMps::builder(NUM_QUBITS)
+        .seed(CIRCUIT_SEED)
+        .max_bond_dim(64)
+        .svd_cutoff(1e-12)
+        .max_truncation_error(0.0)
+        .merge_rz(false)
+        .build();
+    for q in 0..NUM_QUBITS {
+        simulator.h(&[QubitId(q)]);
+    }
+    for q in 0..NUM_QUBITS - 1 {
+        simulator.cx(&[(QubitId(q), QubitId(q + 1))]);
+    }
+
+    // Exact gate choices produced by pecos-perf's Python `random.Random`
+    // stream for sparse_t_circuit(n=32, n_t=32, seed=23201).
+    let injections = [
+        (0, 26, true),
+        (19, 11, true),
+        (27, 7, false),
+        (10, 25, false),
+        (12, 25, false),
+        (6, 14, false),
+        (25, 11, false),
+        (28, 31, false),
+        (22, 0, false),
+        (19, 21, true),
+        (9, 21, false),
+        (28, 7, false),
+        (14, 24, false),
+        (5, 6, true),
+        (21, 5, false),
+        (4, 14, false),
+        (28, 2, false),
+        (2, 18, true),
+        (7, 6, true),
+        (11, 25, false),
+        (12, 4, false),
+        (11, 18, false),
+        (28, 26, true),
+        (18, 15, false),
+        (19, 7, true),
+        (16, 12, false),
+        (4, 29, true),
+        (18, 20, false),
+        (25, 8, true),
+        (10, 9, false),
+        (29, 7, true),
+        (19, 17, true),
+    ];
+    let s_targets = [28, 8, 5, 16, 0, 14, 7, 1];
+    for (injection, &(target, other, dagger)) in injections.iter().enumerate() {
+        let angle = if dagger {
+            -std::f64::consts::FRAC_PI_4
+        } else {
+            std::f64::consts::FRAC_PI_4
+        };
+        simulator.rz(Angle64::from_radians(angle), &[QubitId(target)]);
+        simulator.h(&[QubitId(target)]);
+        if injection & 1 == 0 {
+            simulator.cx(&[(QubitId(target), QubitId(other))]);
+        } else {
+            simulator.cz(&[(QubitId(target), QubitId(other))]);
+        }
+        if injection % 4 == 3 {
+            let q = s_targets[injection / 4];
+            simulator.sz(&[QubitId(q)]);
+        }
+    }
+    simulator.flush();
+    simulator
+}
+
+fn random_queries() -> Vec<Vec<bool>> {
+    // Exact unique queries produced by pecos-perf's `_queries(32, 23201)`;
+    // each mask bit q becomes query[q].
+    let masks = [
+        0x2244_c5d0_u32,
+        0x88d7_f354,
+        0x37f3_360d,
+        0xacaa_0389,
+        0xaa6b_4fd0,
+        0x1b30_c687,
+        0x049f_ecbd,
+        0x2932_a1fb,
+        0x3bac_8b5b,
+        0xf42b_e99c,
+        0xdf9c_7891,
+        0x42f1_2ff2,
+        0x4fe1_0f33,
+        0x4caa_06b3,
+        0xf8d3_f1c8,
+        0x1381_bcc5,
+    ];
+    masks
+        .into_iter()
+        .map(|mask| (0..NUM_QUBITS).map(|q| mask >> q & 1 != 0).collect())
+        .collect()
+}
+
+fn median(samples: &mut [Duration]) -> Duration {
+    samples.sort_unstable();
+    samples[samples.len() / 2]
+}
+
+fn distinct_nonempty_prefixes(queries: &[Vec<bool>]) -> usize {
+    let mut prefixes = std::collections::HashSet::new();
+    for query in queries {
+        for depth in 1..=query.len() {
+            prefixes.insert(query[..depth].to_vec());
+        }
+    }
+    prefixes.len()
+}
+
+fn main() {
+    let simulator = sparse_clifford_t_state();
+    let queries = random_queries();
+
+    // Prime numerical-library and allocator one-time work outside the table.
+    let singular_warmup = queries
+        .iter()
+        .map(|bits| simulator.prob_bitstring(bits))
+        .collect::<Vec<_>>();
+    let batched_warmup = simulator.prob_bitstrings(&queries);
+    assert_eq!(
+        singular_warmup
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>(),
+        batched_warmup
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>()
+    );
+    black_box((&singular_warmup, &batched_warmup));
+
+    let mut individual_totals = Vec::with_capacity(TIMED_REPETITIONS);
+    let mut individual_by_query = (0..NUM_QUERIES)
+        .map(|_| Vec::with_capacity(TIMED_REPETITIONS))
+        .collect::<Vec<_>>();
+    let mut batched_totals = Vec::with_capacity(TIMED_REPETITIONS);
+    for _ in 0..TIMED_REPETITIONS {
+        let individual_start = Instant::now();
+        let mut individual = Vec::with_capacity(NUM_QUERIES);
+        for (query_index, bits) in queries.iter().enumerate() {
+            let query_start = Instant::now();
+            individual.push(simulator.prob_bitstring(bits));
+            individual_by_query[query_index].push(query_start.elapsed());
+        }
+        individual_totals.push(individual_start.elapsed());
+
+        let batched_start = Instant::now();
+        let batched = simulator.prob_bitstrings(&queries);
+        batched_totals.push(batched_start.elapsed());
+        assert_eq!(
+            individual
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            batched
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+        );
+        black_box((individual, batched));
+    }
+
+    let individual = median(&mut individual_totals).as_secs_f64() * 1_000.0;
+    let batched = median(&mut batched_totals).as_secs_f64() * 1_000.0;
+    let slowest_singular = individual_by_query
+        .iter_mut()
+        .map(|samples| median(samples).as_secs_f64() * 1_000.0)
+        .fold(0.0_f64, f64::max);
+    let speedup = individual / batched;
+    let distinct_prefixes = distinct_nonempty_prefixes(&queries);
+
+    println!(
+        "| n | T | queries | path | forced-projection prefixes | median query time | relative to batch |"
+    );
+    println!("|---:|---:|---:|:---|---:|---:|---:|");
+    println!(
+        "| {NUM_QUBITS} | {NUM_QUBITS} | {NUM_QUERIES} | 16 singular fresh walks | \
+         {} | {individual:.3} ms | {speedup:.2}x |",
+        NUM_QUBITS * NUM_QUERIES
+    );
+    println!(
+        "| {NUM_QUBITS} | {NUM_QUBITS} | {NUM_QUERIES} | shared-prefix batch | \
+         {distinct_prefixes} | {batched:.3} ms | 1.00x |"
+    );
+    println!(
+        "| {NUM_QUBITS} | {NUM_QUBITS} | 1 | slowest singular walk | \
+         {NUM_QUBITS} | {slowest_singular:.3} ms | {:.2}x |",
+        slowest_singular / batched
+    );
+    println!(
+        "batch/fresh-sum={:.3}; batch/slowest-singular={:.3}; agreement=bit-for-bit",
+        batched / individual,
+        batched / slowest_singular
+    );
+    assert!(
+        speedup > 1.05,
+        "shared query trie did not beat fresh singular walks: speedup={speedup:.3}x"
+    );
+}

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -877,6 +877,38 @@ struct PrefixSamplingContext<'a> {
     output: &'a mut Vec<Vec<bool>>,
 }
 
+/// Tableau/MPS state owned by one node of a forced-projection prefix tree.
+///
+/// Both batched probability queries and prefix-tree sampling use this type so
+/// the clone-at-branch and atomic-projection rules have a single owner.
+#[derive(Clone)]
+struct PrefixProjectionState {
+    tableau: SparseStabY,
+    mps: Mps,
+}
+
+impl PrefixProjectionState {
+    fn project_z(&mut self, qubit: usize, outcome: bool) -> Result<f64, MpsError> {
+        measure::project_forced_z(&mut self.tableau, &mut self.mps, qubit, outcome)
+    }
+}
+
+#[derive(Default)]
+struct ProbabilityQueryTrieNode {
+    children: [Option<Box<Self>>; 2],
+    query_indices: Vec<usize>,
+}
+
+impl ProbabilityQueryTrieNode {
+    fn insert(&mut self, bitstring: &[bool], query_index: usize) {
+        let mut node = self;
+        for &bit in bitstring {
+            node = node.children[usize::from(bit)].get_or_insert_with(|| Box::new(Self::default()));
+        }
+        node.query_indices.push(query_index);
+    }
+}
+
 impl StabMps {
     /// Create a builder for configuring the simulator.
     #[must_use]
@@ -1361,6 +1393,122 @@ impl StabMps {
         total_prob.clamp(0.0, 1.0)
     }
 
+    /// Probabilities of measuring each requested computational-basis
+    /// bitstring, sharing forced projections across common prefixes.
+    ///
+    /// Each input and the corresponding output use the same convention as
+    /// [`Self::prob_bitstring`]: `bitstrings[i][q]` specifies qubit `q`, and
+    /// `probabilities[i]` is exactly the result of the corresponding singular
+    /// call, including its configured MPS-truncation and endpoint behavior.
+    /// Input order and duplicates are preserved. An empty input returns an
+    /// empty output.
+    ///
+    /// The query set is represented as a prefix trie over qubits
+    /// `0..num_qubits`. A node with one occupied child moves its working
+    /// tableau/MPS state into that child without cloning. A branch point makes
+    /// one clone and gives one working state to each child. Thus every
+    /// distinct query prefix receives exactly one atomic forced projection.
+    /// If the accumulated probability reaches the singular API's snapped-zero
+    /// threshold, the entire query subtree remains exactly `0.0`.
+    ///
+    /// Call [`Self::flush`] first when lazy measurement or RZ merging is
+    /// enabled, and materialize a tracked Pauli frame when it must be included.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any bitstring length doesn't match `num_qubits`, or if forced
+    /// projection encounters an unrecoverable numerical MPS state.
+    #[must_use]
+    pub fn prob_bitstrings<B: AsRef<[bool]>>(&self, bitstrings: &[B]) -> Vec<f64> {
+        let mut trie = ProbabilityQueryTrieNode::default();
+        for (query_index, bitstring) in bitstrings.iter().enumerate() {
+            let bitstring = bitstring.as_ref();
+            assert_eq!(
+                bitstring.len(),
+                self.num_qubits,
+                "bitstring length mismatch at query {query_index}"
+            );
+            trie.insert(bitstring, query_index);
+        }
+        if bitstrings.is_empty() {
+            return Vec::new();
+        }
+
+        let state = PrefixProjectionState {
+            tableau: self.tableau.clone(),
+            mps: self.mps.clone(),
+        };
+        let mut probabilities = vec![0.0; bitstrings.len()];
+        expect_mps_operation(
+            Self::probability_query_prefix_tree(&trie, state, 0, 1.0, &mut probabilities),
+            "StabMps::prob_bitstrings forced projection",
+        );
+        probabilities
+    }
+
+    fn probability_query_prefix_tree(
+        node: &ProbabilityQueryTrieNode,
+        mut state: PrefixProjectionState,
+        qubit: usize,
+        total_probability: f64,
+        probabilities: &mut [f64],
+    ) -> Result<(), MpsError> {
+        if qubit == state.tableau.num_qubits() {
+            let probability = total_probability.clamp(0.0, 1.0);
+            for &query_index in &node.query_indices {
+                probabilities[query_index] = probability;
+            }
+            return Ok(());
+        }
+
+        match (&node.children[0], &node.children[1]) {
+            (Some(zero), Some(one)) => {
+                let mut zero_state = state.clone();
+                let zero_probability = total_probability * zero_state.project_z(qubit, false)?;
+                if zero_probability >= 1e-30 {
+                    Self::probability_query_prefix_tree(
+                        zero,
+                        zero_state,
+                        qubit + 1,
+                        zero_probability,
+                        probabilities,
+                    )?;
+                }
+
+                let one_probability = total_probability * state.project_z(qubit, true)?;
+                if one_probability >= 1e-30 {
+                    Self::probability_query_prefix_tree(
+                        one,
+                        state,
+                        qubit + 1,
+                        one_probability,
+                        probabilities,
+                    )?;
+                }
+            }
+            (Some(child), None) | (None, Some(child)) => {
+                let outcome = node.children[1].is_some();
+                let child_probability = total_probability * state.project_z(qubit, outcome)?;
+                if child_probability >= 1e-30 {
+                    Self::probability_query_prefix_tree(
+                        child,
+                        state,
+                        qubit + 1,
+                        child_probability,
+                        probabilities,
+                    )?;
+                }
+            }
+            (None, None) => {
+                debug_assert!(
+                    node.query_indices.is_empty(),
+                    "probability-query trie leaf before the final qubit"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Second Rényi entropy `S_2` = -`ln(Tr_A(ρ_A²))` at a bipartition
     /// (qubits 0..cut vs qubits cut..N).
     ///
@@ -1821,22 +1969,19 @@ impl StabMps {
             num_qubits: self.num_qubits,
             output: &mut shots,
         };
+        let mut state = PrefixProjectionState {
+            tableau: working.tableau,
+            mps: working.mps,
+        };
         expect_mps_operation(
-            Self::sample_prefix_tree(
-                &mut working.tableau,
-                &mut working.mps,
-                num_shots,
-                &mut prefix,
-                &mut context,
-            ),
+            Self::sample_prefix_tree(&mut state, num_shots, &mut prefix, &mut context),
             "StabMps::sample_bitstrings prefix projection",
         );
         shots
     }
 
     fn sample_prefix_tree(
-        tableau: &mut SparseStabY,
-        mps: &mut Mps,
+        state: &mut PrefixProjectionState,
         num_shots: usize,
         prefix: &mut Vec<bool>,
         context: &mut PrefixSamplingContext<'_>,
@@ -1854,11 +1999,8 @@ impl StabMps {
         // pre-reduction can produce a trivial MPS, and a second entry would take
         // the trivial fast path instead of completing the in-progress general
         // projection as `prob_bitstring` does.
-        let mut zero_tableau = tableau.clone();
-        let mut zero_mps = mps.clone();
-        let probability_zero =
-            measure::project_forced_z(&mut zero_tableau, &mut zero_mps, q, context.frame_x[q])?
-                .clamp(0.0, 1.0);
+        let mut zero_state = state.clone();
+        let probability_zero = zero_state.project_z(q, context.frame_x[q])?.clamp(0.0, 1.0);
         let probability_one = 1.0 - probability_zero;
         let num_zero = if probability_zero == 0.0 {
             0
@@ -1873,13 +2015,12 @@ impl StabMps {
 
         if num_zero > 0 {
             prefix.push(false);
-            Self::sample_prefix_tree(&mut zero_tableau, &mut zero_mps, num_zero, prefix, context)?;
+            Self::sample_prefix_tree(&mut zero_state, num_zero, prefix, context)?;
             prefix.pop();
         }
 
         if num_one > 0 {
-            let projected_probability =
-                measure::project_forced_z(tableau, mps, q, !context.frame_x[q])?;
+            let projected_probability = state.project_z(q, !context.frame_x[q])?;
             // Invariant: `probability_zero` and this forced-projection
             // probability deterministically recompute the same expectation on
             // identical parent states. A positive one-branch probability
@@ -1890,7 +2031,7 @@ impl StabMps {
                 "positive-probability one branch rejected by forced projection at qubit {q}"
             );
             prefix.push(true);
-            Self::sample_prefix_tree(tableau, mps, num_one, prefix, context)?;
+            Self::sample_prefix_tree(state, num_one, prefix, context)?;
             prefix.pop();
         }
         Ok(())

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -178,6 +178,12 @@ fn cheap_product_zero_site_test(mps: &Mps, site: usize) -> Option<bool> {
 // value. Thus that workload contains no observed marginal in (1e-15, 1e-12].
 const PRODUCT_ZERO_PROBABILITY_TOLERANCE: f64 = 1e-15;
 
+// A running bitstring probability below this is reported as exactly zero.
+// The singular and batched query walks MUST share this constant: the batched
+// API's contract is bit-for-bit agreement with per-query singular calls, and
+// that guarantee is load-bearing on the two paths pruning identically.
+const QUERY_ZERO_PROBABILITY_FLOOR: f64 = 1e-30;
+
 #[cfg(test)]
 const STORED_PROOF_SOUNDNESS_TOLERANCE: f64 = 5e-16;
 
@@ -1386,7 +1392,7 @@ impl StabMps {
                 "StabMps::prob_bitstring forced projection",
             );
             total_prob *= pi_q;
-            if total_prob < 1e-30 {
+            if total_prob < QUERY_ZERO_PROBABILITY_FLOOR {
                 return 0.0;
             }
         }
@@ -1440,7 +1446,14 @@ impl StabMps {
         };
         let mut probabilities = vec![0.0; bitstrings.len()];
         expect_mps_operation(
-            Self::probability_query_prefix_tree(&trie, state, 0, 1.0, &mut probabilities),
+            Self::probability_query_prefix_tree(
+                &trie,
+                state,
+                self.num_qubits,
+                0,
+                1.0,
+                &mut probabilities,
+            ),
             "StabMps::prob_bitstrings forced projection",
         );
         probabilities
@@ -1449,11 +1462,12 @@ impl StabMps {
     fn probability_query_prefix_tree(
         node: &ProbabilityQueryTrieNode,
         mut state: PrefixProjectionState,
+        num_qubits: usize,
         qubit: usize,
         total_probability: f64,
         probabilities: &mut [f64],
     ) -> Result<(), MpsError> {
-        if qubit == state.tableau.num_qubits() {
+        if qubit == num_qubits {
             let probability = total_probability.clamp(0.0, 1.0);
             for &query_index in &node.query_indices {
                 probabilities[query_index] = probability;
@@ -1465,10 +1479,13 @@ impl StabMps {
             (Some(zero), Some(one)) => {
                 let mut zero_state = state.clone();
                 let zero_probability = total_probability * zero_state.project_z(qubit, false)?;
-                if zero_probability >= 1e-30 {
+                // NaN must follow the singular walk (which keeps projecting on
+                // NaN) rather than being silently pruned to zero.
+                if zero_probability.is_nan() || zero_probability >= QUERY_ZERO_PROBABILITY_FLOOR {
                     Self::probability_query_prefix_tree(
                         zero,
                         zero_state,
+                        num_qubits,
                         qubit + 1,
                         zero_probability,
                         probabilities,
@@ -1476,10 +1493,11 @@ impl StabMps {
                 }
 
                 let one_probability = total_probability * state.project_z(qubit, true)?;
-                if one_probability >= 1e-30 {
+                if one_probability.is_nan() || one_probability >= QUERY_ZERO_PROBABILITY_FLOOR {
                     Self::probability_query_prefix_tree(
                         one,
                         state,
+                        num_qubits,
                         qubit + 1,
                         one_probability,
                         probabilities,
@@ -1489,10 +1507,11 @@ impl StabMps {
             (Some(child), None) | (None, Some(child)) => {
                 let outcome = node.children[1].is_some();
                 let child_probability = total_probability * state.project_z(qubit, outcome)?;
-                if child_probability >= 1e-30 {
+                if child_probability.is_nan() || child_probability >= QUERY_ZERO_PROBABILITY_FLOOR {
                     Self::probability_query_prefix_tree(
                         child,
                         state,
+                        num_qubits,
                         qubit + 1,
                         child_probability,
                         probabilities,

--- a/exp/pecos-stab-tn/tests/verification.rs
+++ b/exp/pecos-stab-tn/tests/verification.rs
@@ -2476,17 +2476,26 @@ fn assert_honest_clifford_t_readouts_match_dense(
                 } else {
                     dense_state_vector_probabilities(&stn)
                 };
-                for (outcome, &expected) in dense_probabilities.iter().enumerate() {
-                    let bits = (0..num_qubits)
-                        .map(|q| ((outcome >> q) & 1) != 0)
-                        .collect::<Vec<_>>();
-                    let actual = stn.prob_bitstring(&bits);
+                let bitstrings = (0..dense_probabilities.len())
+                    .map(|outcome| {
+                        (0..num_qubits)
+                            .map(|q| ((outcome >> q) & 1) != 0)
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
+                let batched_probabilities = stn.prob_bitstrings(&bitstrings);
+                for (outcome, ((bits, &actual), &expected)) in bitstrings
+                    .iter()
+                    .zip(&batched_probabilities)
+                    .zip(&dense_probabilities)
+                    .enumerate()
+                {
                     let probability_delta = (actual - expected).abs();
                     worst_probability_delta = worst_probability_delta.max(probability_delta);
                     assert!(
                         probability_delta <= allowed_delta,
                         "{label}: n={num_qubits} t={t_count} seed={circuit_seed} \
-                         outcome={outcome}: prob_bitstring={actual:.16}, \
+                         outcome={outcome}: prob_bitstrings={actual:.16}, \
                          dense={expected:.16}, delta={probability_delta:.3e}, \
                          recorded_weight={recorded_weight:.3e}, \
                          allowed_delta={allowed_delta:.3e}, gates={gates:?}"
@@ -2496,7 +2505,7 @@ fn assert_honest_clifford_t_readouts_match_dense(
                     // same probability weight. Complex-phase behavior has
                     // separate unit coverage; this assertion isolates the
                     // sequential projection machinery shared with the issue.
-                    let iterative_probability = stn.amplitude_iterative(&bits).norm_sqr();
+                    let iterative_probability = stn.amplitude_iterative(bits).norm_sqr();
                     let iterative_delta = (iterative_probability - expected).abs();
                     worst_iterative_delta = worst_iterative_delta.max(iterative_delta);
                     assert!(
@@ -2513,7 +2522,7 @@ fn assert_honest_clifford_t_readouts_match_dense(
         }
     }
     eprintln!(
-        "{label}: circuits={circuits}, circuits with discarded weight={circuits_with_discarded_weight}, largest recorded weight={largest_recorded_weight:.3e}, largest allowed delta={largest_allowed_delta:.3e}, worst prob_bitstring delta={worst_probability_delta:.3e}, worst |amplitude_iterative|^2 delta={worst_iterative_delta:.3e}"
+        "{label}: circuits={circuits}, circuits with discarded weight={circuits_with_discarded_weight}, largest recorded weight={largest_recorded_weight:.3e}, largest allowed delta={largest_allowed_delta:.3e}, worst prob_bitstrings delta={worst_probability_delta:.3e}, worst |amplitude_iterative|^2 delta={worst_iterative_delta:.3e}"
     );
 }
 
@@ -2539,6 +2548,123 @@ fn test_prob_bitstring_honest_clifford_t_wide_seed_sweep_matches_dense_state_vec
     // arm here would duplicate the exact arm byte for byte. Nonzero-budget
     // read coverage lives in the weak-branch fixture below, whose branch is
     // engineered to sit under the budget.
+}
+
+#[test]
+fn test_prob_bitstrings_randomized_matches_singular_bit_for_bit() {
+    fn query_set(num_qubits: usize, seed: u64) -> Vec<Vec<bool>> {
+        let mut random = seed;
+        let mut queries = vec![vec![false; num_qubits], vec![true; num_qubits]];
+
+        // Four queries share a deliberately long prefix; the following four
+        // are independently generated and normally split near the root.
+        for suffix_index in 0..4 {
+            let mut bits = vec![false; num_qubits];
+            let shared_depth = num_qubits.saturating_sub(2);
+            for (q, bit) in bits.iter_mut().enumerate().skip(shared_depth) {
+                *bit = (suffix_index >> (q - shared_depth)) & 1 != 0;
+            }
+            queries.push(bits);
+        }
+        for _ in 0..4 {
+            queries.push(
+                (0..num_qubits)
+                    .map(|_| next_seeded_gate_choice(&mut random) & 1 != 0)
+                    .collect(),
+            );
+        }
+
+        // Preserve duplicate positions rather than deduplicating trie leaves.
+        queries.push(queries[0].clone());
+        queries.push(queries[3].clone());
+        queries
+    }
+
+    let mut truncating_circuits_with_discarded_weight = 0;
+    for truncating in [false, true] {
+        for num_qubits in 3..=6 {
+            for seed_family in 0..4_u64 {
+                let circuit_seed = 0xBA7C_0000
+                    + u64::from(truncating) * 0x10_0000
+                    + num_qubits as u64 * 100
+                    + seed_family;
+                let gates = seeded_clifford_t_circuit(num_qubits, num_qubits + 2, circuit_seed);
+                let (max_bond_dim, svd_cutoff, max_truncation_error) = if truncating {
+                    (2, 1e-10, 1e-6)
+                } else {
+                    (64, 0.0, 0.0)
+                };
+                let mut stn = StabMps::builder(num_qubits)
+                    .seed(circuit_seed)
+                    .max_bond_dim(max_bond_dim)
+                    .svd_cutoff(svd_cutoff)
+                    .max_truncation_error(max_truncation_error)
+                    .merge_rz(false)
+                    .build();
+                apply_seeded_clifford_t_to_stn(&mut stn, &gates);
+                stn.flush();
+                if truncating && stn.summed_discarded_weight() > 0.0 {
+                    truncating_circuits_with_discarded_weight += 1;
+                }
+
+                let queries = query_set(num_qubits, circuit_seed ^ 0x5151_5151);
+                let singular = queries
+                    .iter()
+                    .map(|bits| stn.prob_bitstring(bits))
+                    .collect::<Vec<_>>();
+                let batched = stn.prob_bitstrings(&queries);
+                assert_eq!(batched.len(), queries.len());
+                for (query_index, (&actual, &expected)) in batched.iter().zip(&singular).enumerate()
+                {
+                    assert_eq!(
+                        actual.to_bits(),
+                        expected.to_bits(),
+                        "truncating={truncating} n={num_qubits} seed={circuit_seed} \
+                         query={query_index} bits={:?}: batched={actual:.17e}, \
+                         singular={expected:.17e}",
+                        queries[query_index]
+                    );
+                }
+            }
+        }
+    }
+    assert!(
+        truncating_circuits_with_discarded_weight > 0,
+        "truncating agreement arm never exercised a discarded-weight state"
+    );
+
+    // Every false-q0 query is an endpoint-zero subtree. It must be pruned to
+    // the same positive zero returned by the singular API, while the inhabited
+    // branch and duplicate leaf retain their ordinary probabilities.
+    let mut endpoint = StabMps::new(4);
+    endpoint.x(&[QubitId(0)]);
+    let endpoint_queries = vec![
+        vec![false, false, false, false],
+        vec![false, false, false, true],
+        vec![false, true, true, true],
+        vec![true, false, false, false],
+        vec![true, false, false, false],
+    ];
+    let singular = endpoint_queries
+        .iter()
+        .map(|bits| endpoint.prob_bitstring(bits))
+        .collect::<Vec<_>>();
+    let batched = endpoint.prob_bitstrings(&endpoint_queries);
+    assert_eq!(
+        batched
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>(),
+        singular
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(batched[..3], [0.0; 3]);
+    assert_eq!(batched[3..], [1.0; 2]);
+
+    let empty: Vec<Vec<bool>> = Vec::new();
+    assert!(endpoint.prob_bitstrings(&empty).is_empty());
 }
 
 fn apply_weak_branch_readout_fixture(stn: &mut StabMps) {

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -344,6 +344,21 @@ impl PyStabMps {
         Ok(bits)
     }
 
+    fn bitstrings(&self, value: &Bound<'_, PyAny>, method: &str) -> PyResult<Vec<Vec<bool>>> {
+        let iterator = value.try_iter().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "{method}: queries must be an iterable of bitstrings"
+            ))
+        })?;
+        iterator
+            .enumerate()
+            .map(|(query_index, item)| {
+                let item = item?;
+                self.bitstring(&item, &format!("{method}: query {query_index}"))
+            })
+            .collect()
+    }
+
     fn pauli_kind(value: &str) -> PyResult<PauliKind> {
         match value {
             "X" => Ok(PauliKind::X),
@@ -572,9 +587,10 @@ impl PyStabMps {
     /// Indexing is little-endian: the entry for `bits` is at
     /// `sum(int(bits[q]) << q)`. This allocates `2**num_qubits` amplitudes and
     /// constructs dense operators, so it is restricted to `num_qubits <= 14`.
-    /// Prefer `amplitude_iterative`, `prob_bitstring`, `pauli_expectation`, or
-    /// `sample_bitstrings` for scalable reads. Pending work is auto-flushed;
-    /// a tracked Pauli frame must be materialized explicitly.
+    /// Prefer `amplitude_iterative`, `prob_bitstring`, `prob_bitstrings`,
+    /// `pauli_expectation`, or `sample_bitstrings` for scalable reads. Pending
+    /// work is auto-flushed; a tracked Pauli frame must be materialized
+    /// explicitly.
     ///
     /// Raises `ValueError` when more than 14 qubits are present.
     fn state_vector(&mut self, py: Python<'_>) -> PyResult<Py<PyList>> {
@@ -677,6 +693,26 @@ impl PyStabMps {
         let bitstring = self.bitstring(bitstring, "prob_bitstring")?;
         self.inner.flush();
         Ok(self.inner.prob_bitstring(&bitstring))
+    }
+
+    /// Return computational-basis probabilities for a batch of bitstrings.
+    ///
+    /// The outer iterable contains query bitstrings, each with exactly
+    /// `num_qubits` actual Python `bool` values. For every query,
+    /// `bitstring[q]` specifies qubit `q`. Results preserve input order and
+    /// duplicates and equal the corresponding `prob_bitstring` calls, while
+    /// common-prefix forced projections are shared. An empty batch returns an
+    /// empty list. Pending work is auto-flushed; materialize a tracked Pauli
+    /// frame explicitly.
+    ///
+    /// Raises `ValueError` for a malformed batch or bitstring.
+    fn prob_bitstrings(&mut self, bitstrings: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
+        let bitstrings = self.bitstrings(bitstrings, "prob_bitstrings")?;
+        if bitstrings.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.inner.flush();
+        Ok(self.inner.prob_bitstrings(&bitstrings))
     }
 
     /// Return second Renyi entropy across the cut after qubits `[0, cut)`.

--- a/python/pecos-rslib-exp/src/stab_mps_bindings.rs
+++ b/python/pecos-rslib-exp/src/stab_mps_bindings.rs
@@ -708,10 +708,12 @@ impl PyStabMps {
     /// Raises `ValueError` for a malformed batch or bitstring.
     fn prob_bitstrings(&mut self, bitstrings: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
         let bitstrings = self.bitstrings(bitstrings, "prob_bitstrings")?;
+        // Flush before the empty-batch return so the documented auto-flush
+        // holds for every call, matching prob_bitstring.
+        self.inner.flush();
         if bitstrings.is_empty() {
             return Ok(Vec::new());
         }
-        self.inner.flush();
         Ok(self.inner.prob_bitstrings(&bitstrings))
     }
 

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -135,6 +135,10 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     assert q0_one.amplitude([True, False]) == (1.0, 0.0)
     assert q0_one.amplitude_iterative([True, False]) == (1.0, 0.0)
     assert math.isclose(q0_one.prob_bitstring([True, False]), 1.0)
+    assert q0_one.prob_bitstrings(
+        [[True, False], [False, False], [True, False]]
+    ) == [1.0, 0.0, 1.0]
+    assert q0_one.prob_bitstrings([]) == []
 
     merged = exp.StabMps(2, seed=17, merge_rz=True)
     merged.run_1q_gate("H", 0)
@@ -164,6 +168,21 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
         q0_one.amplitude([True])
     with pytest.raises(ValueError, match="bitstring item 0 must be bool"):
         q0_one.prob_bitstring([1, False])
+    with pytest.raises(
+        ValueError,
+        match="prob_bitstrings: query 0: bitstring item 0 must be bool",
+    ):
+        q0_one.prob_bitstrings([[1, False]])
+    with pytest.raises(
+        ValueError,
+        match="prob_bitstrings: query 1: bitstring length 1, expected 2",
+    ):
+        q0_one.prob_bitstrings([[True, False], [True]])
+    with pytest.raises(
+        ValueError,
+        match="prob_bitstrings: queries must be an iterable of bitstrings",
+    ):
+        q0_one.prob_bitstrings(1)
     with pytest.raises(IndexError):
         q0_one.frame_x_bit(2)
     with pytest.raises(IndexError):

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -136,7 +136,7 @@ def test_stab_mps_bitstring_convention_auto_flush_and_validation():
     assert q0_one.amplitude_iterative([True, False]) == (1.0, 0.0)
     assert math.isclose(q0_one.prob_bitstring([True, False]), 1.0)
     assert q0_one.prob_bitstrings(
-        [[True, False], [False, False], [True, False]]
+        [[True, False], [False, False], [True, False]],
     ) == [1.0, 0.0, 1.0]
     assert q0_one.prob_bitstrings([]) == []
 


### PR DESCRIPTION
Adds `StabMps::prob_bitstrings` (Rust and Python): batched probability queries over a prefix trie of the query set, sharing forced-projection work across queries the way the tree sampler shares it across shots — one clone per branch point, clone-free single-child descent, and exact zero-subtree pruning. The tree sampler and the batch API now share one `PrefixProjectionState` abstraction owning the clone-and-project invariant; review verified the refactored sampler is bit-identical to dev by 288-configuration checksum comparison against a rebuilt dev binary, and the singular `prob_bitstring` is untouched.

## Contract

`prob_bitstrings(queries)[i]` equals `prob_bitstring(queries[i])` bit-for-bit: both walks use identical qubit order, floating-point multiplication order, projection primitive, and a single shared named zero floor (review-verified across exhaustive tries at n<=9, truncating configs, last-bit branches, order permutations, duplicates, and mid-walk threshold crossings). NaN probabilities follow the singular path rather than being pruned. The #557 sweeps now route their full bitstring sets through the batch API (worst dense-oracle delta 9.85e-16 over 640 circuits).

## Measured effect — an honest partial

On the cross-implementation benchmark's losing cell (n=32, T=32, 16 query masks, committed as a release example): 1.54x over independent walks (0.65x of the naive sum). The limit is structural: that query set shares only 9.4% of its projection prefixes — though those are the root-adjacent, most expensive ones, which is why 9.4% of prefixes buys 35% of the time. Closing the remaining gap against a fully batched contraction requires sharing expectation/pre-reduction work across sibling branches — a different mechanism, deferred to a design pass rather than stretched into this one. The example asserts the speedup so the sharing cannot silently regress.

## Verification

Full suites debug and release (340 lib + 26 + 93 + 3 release); all release-ignored lanes including the re-routed #557 sweeps; 1,200-circuit census 0 panics; clippy -D warnings both crates; fmt. Independent adversarial review (MERGEABLE): sampler bit-identity proven by execution, agreement claim attacked exhaustively, zero pruning verified by construction and constructed threshold-crossing cases, Python validation probed across malformed inputs, perf reproduced. All review recommendations applied (shared named floor constant, explicit NaN routing, single-source qubit count, empty-batch flush consistency, user-guide entry).

Follow-up recorded for the pecos-perf adapter: replace the independent query loop with one `prob_bitstrings` call.