### PR TITLE
Expose the factor model and maxlog metric through the Python Frontier bindings

### DIFF
--- a/docs/experimental/decoders.md
+++ b/docs/experimental/decoders.md
@@ -14,11 +14,12 @@ Two capabilities live here that the production decoders do not offer:
 
 ## Frontier and BP-Trellis
 
-Both take a Stim-format DEM string and expose the same result surface.
-`FrontierDecoder` and `BpTrellisDecoder` are each a single trellis decoder over
-the same machinery (BP-Trellis adds BP-informed pruning scores); the separate
-`FrontierCommitteeDecoder` runs a two-leg forward/backward committee over them.
-Start with whichever you like and compare.
+`FrontierDecoder.from_dem` and `BpTrellisDecoder.from_dem` take a Stim-format
+DEM string and expose the same result surface. `FrontierDecoder.from_factors`
+also accepts the factor model described below. Each is a single trellis decoder
+over the same machinery (BP-Trellis adds BP-informed pruning scores); the
+separate `FrontierCommitteeDecoder` runs a two-leg forward/backward committee
+over them. Start with whichever you like and compare.
 
 <!--test-name: experimental_decoders_gap-->
 ```python
@@ -55,6 +56,38 @@ assert list(trellis.observable_flips) == [True]
 assert trellis.status == "exact"
 ```
 
+### Factor models
+
+`FrontierDecoder.from_factors(factors, num_detectors, num_observables, ...)`
+accepts a list of independent factors, each containing
+`(probability, detector_indices, observable_indices)` outcome tuples. The
+outcome probabilities in each factor must sum to 1. Binary-shaped factors with
+an empty baseline delegate to the same binary engine as the equivalent DEM.
+
+<!--test-name: experimental_decoder_factors-->
+```python
+import math
+
+from pecos_rslib_exp import FrontierDecoder
+
+factors = [
+    [(0.60, [], []), (0.25, [0], [0]), (0.15, [0], [])],
+    [(0.80, [], []), (0.20, [0], [])],
+]
+result = FrontierDecoder.from_factors(
+    factors,
+    num_detectors=1,
+    num_observables=1,
+    k=10**9,
+    delta=1e6,
+).decode_syndrome([1])
+masses = dict(result.logical_masses)
+
+assert result.observable_flips.mask == 0
+assert math.isclose(masses[0], math.log(0.24), abs_tol=1e-9)
+assert math.isclose(masses[1], math.log(0.20), abs_tol=1e-9)
+```
+
 ### Reading the complementary gap
 
 `logical_masses` holds `(observable_mask, log_mass)` pairs ordered by decreasing
@@ -68,10 +101,11 @@ the masses are the true unnormalized posteriors: a large gap means one logical
 class really was overwhelmingly more likely, and a gap near zero means the
 shot was nearly a coin flip -- a natural candidate for post-selection or a
 soft-output pipeline. Under the integer `maxlog_int` metric (accepted by Python
-`FrontierDecoder` as `metric_mode="maxlog_int"`; the committee remains
-float-only), each terminal mass is instead the best-route (Viterbi) mass for
-that logical class, the gap is a route-mass margin, and `log_evidence` is the
-winning route mass rather than evidence.
+`FrontierDecoder` as `metric_mode="maxlog_int"`; `int_metric_scale` sets the
+quantization units per natural-log unit and defaults to 1024; the committee
+remains float-only), each terminal mass is instead the best-route (Viterbi)
+mass for that logical class, the gap is a route-mass margin, and `log_evidence`
+is the winning route mass rather than evidence.
 When the result was pruned, the gap and the masses describe only what the
 search retained, not a certified confidence -- treat them as search
 diagnostics, not posteriors.

--- a/docs/experimental/decoders.md
+++ b/docs/experimental/decoders.md
@@ -67,10 +67,11 @@ With the default float metric, when `status` is `"exact"` (nothing was pruned),
 the masses are the true unnormalized posteriors: a large gap means one logical
 class really was overwhelmingly more likely, and a gap near zero means the
 shot was nearly a coin flip -- a natural candidate for post-selection or a
-soft-output pipeline. Under the integer `maxlog_int` metric (Rust API only for
-now), each terminal mass is instead the best-route (Viterbi) mass for that
-logical class, the gap is a route-mass margin, and `log_evidence` is the winning
-route mass rather than evidence.
+soft-output pipeline. Under the integer `maxlog_int` metric (accepted by Python
+`FrontierDecoder` as `metric_mode="maxlog_int"`; the committee remains
+float-only), each terminal mass is instead the best-route (Viterbi) mass for
+that logical class, the gap is a route-mass margin, and `log_evidence` is the
+winning route mass rather than evidence.
 When the result was pruned, the gap and the masses describe only what the
 search retained, not a certified confidence -- treat them as search
 diagnostics, not posteriors.

--- a/docs/user-guide/decoders.md
+++ b/docs/user-guide/decoders.md
@@ -356,7 +356,8 @@ written with `^` separators passes: each component is graphlike). See
 BP-Trellis decoders, which additionally report a per-shot complementary gap,
 and for provenance-based decomposition of a hyperedge model into a graphlike
 one. Frontier's exact default-float masses are true unnormalized posteriors.
-Under its integer `maxlog_int` metric (Rust API only for now), terminal masses
+Under its integer `maxlog_int` metric (accepted by Python `FrontierDecoder` as
+`metric_mode="maxlog_int"`; the committee remains float-only), terminal masses
 are per-label best-route (Viterbi) masses, the gap is a route-mass margin, and
 `log_evidence` is the winner's mass rather than evidence.
 

--- a/exp/pecos-trellis/src/factor.rs
+++ b/exp/pecos-trellis/src/factor.rs
@@ -74,14 +74,18 @@ impl FactorModel {
         num_detectors: usize,
         num_observables: usize,
     ) -> Result<Self, DecoderError> {
-        if num_detectors > u32::MAX as usize {
+        // Indices are u32, so the largest addressable width is u32::MAX + 1
+        // (index u32::MAX exists) -- the same contract as the DEM parser,
+        // which accepts `D4294967295` and reports that width.
+        const MAX_WIDTH: usize = u32::MAX as usize + 1;
+        if num_detectors > MAX_WIDTH {
             return Err(DecoderError::InvalidConfiguration(format!(
-                "num_detectors {num_detectors} exceeds the u32 detector-index range"
+                "num_detectors {num_detectors} exceeds the u32 index-addressable width {MAX_WIDTH}"
             )));
         }
-        if num_observables > u32::MAX as usize {
+        if num_observables > MAX_WIDTH {
             return Err(DecoderError::InvalidConfiguration(format!(
-                "num_observables {num_observables} exceeds the u32 observable-index range"
+                "num_observables {num_observables} exceeds the u32 index-addressable width {MAX_WIDTH}"
             )));
         }
 
@@ -258,16 +262,32 @@ mod tests {
 
     #[cfg(target_pointer_width = "64")]
     #[test]
-    fn factor_model_widths_are_bounded_by_the_u32_index_range() {
-        let max_width = u32::MAX as usize;
+    fn factor_model_widths_are_bounded_by_the_u32_addressable_width() {
+        // Index u32::MAX exists, so width u32::MAX + 1 is addressable -- the
+        // DEM parser accepts `D4294967295` and reports exactly this width, and
+        // TryFrom<&SparseDem> must not reject a DEM the parser accepts.
+        let max_width = u32::MAX as usize + 1;
         FactorModel::new(Vec::new(), max_width, max_width).unwrap();
+        let outcome = Outcome {
+            probability: 1.0,
+            detectors: vec![u32::MAX],
+            observables: Vec::new(),
+        };
+        FactorModel::new(
+            vec![Factor {
+                outcomes: vec![outcome],
+            }],
+            max_width,
+            0,
+        )
+        .unwrap();
 
         let too_wide = max_width + 1;
         let detector_error = FactorModel::new(Vec::new(), too_wide, 0).unwrap_err();
         assert_eq!(
             detector_error.to_string(),
             format!(
-                "Invalid configuration: num_detectors {too_wide} exceeds the u32 detector-index range"
+                "Invalid configuration: num_detectors {too_wide} exceeds the u32 index-addressable width {max_width}"
             )
         );
 
@@ -275,7 +295,7 @@ mod tests {
         assert_eq!(
             observable_error.to_string(),
             format!(
-                "Invalid configuration: num_observables {too_wide} exceeds the u32 observable-index range"
+                "Invalid configuration: num_observables {too_wide} exceeds the u32 index-addressable width {max_width}"
             )
         );
     }

--- a/exp/pecos-trellis/src/factor.rs
+++ b/exp/pecos-trellis/src/factor.rs
@@ -65,15 +65,26 @@ impl FactorModel {
     ///
     /// # Errors
     ///
-    /// Returns [`DecoderError::InvalidConfiguration`] if a factor has no
-    /// outcomes, an outcome probability or index is invalid, an outcome
-    /// repeats an index, or a factor's probabilities do not sum to one within
-    /// `1e-10`.
+    /// Returns [`DecoderError::InvalidConfiguration`] if a declared width
+    /// exceeds the `u32` outcome-index range, a factor has no outcomes, an
+    /// outcome probability or index is invalid, an outcome repeats an index,
+    /// or a factor's probabilities do not sum to one within `1e-10`.
     pub fn new(
         factors: Vec<Factor>,
         num_detectors: usize,
         num_observables: usize,
     ) -> Result<Self, DecoderError> {
+        if num_detectors > u32::MAX as usize {
+            return Err(DecoderError::InvalidConfiguration(format!(
+                "num_detectors {num_detectors} exceeds the u32 detector-index range"
+            )));
+        }
+        if num_observables > u32::MAX as usize {
+            return Err(DecoderError::InvalidConfiguration(format!(
+                "num_observables {num_observables} exceeds the u32 observable-index range"
+            )));
+        }
+
         for (factor_index, factor) in factors.iter().enumerate() {
             if factor.outcomes.is_empty() {
                 return Err(DecoderError::InvalidConfiguration(format!(
@@ -244,6 +255,30 @@ fn validate_outcome_indices(
 mod tests {
     use super::{Factor, FactorModel, Outcome};
     use crate::deadline_column_order_for_factors;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn factor_model_widths_are_bounded_by_the_u32_index_range() {
+        let max_width = u32::MAX as usize;
+        FactorModel::new(Vec::new(), max_width, max_width).unwrap();
+
+        let too_wide = max_width + 1;
+        let detector_error = FactorModel::new(Vec::new(), too_wide, 0).unwrap_err();
+        assert_eq!(
+            detector_error.to_string(),
+            format!(
+                "Invalid configuration: num_detectors {too_wide} exceeds the u32 detector-index range"
+            )
+        );
+
+        let observable_error = FactorModel::new(Vec::new(), 0, too_wide).unwrap_err();
+        assert_eq!(
+            observable_error.to_string(),
+            format!(
+                "Invalid configuration: num_observables {too_wide} exceeds the u32 observable-index range"
+            )
+        );
+    }
 
     #[test]
     fn factor_ordering_errors_name_the_factor() {

--- a/exp/pecos-trellis/src/factor.rs
+++ b/exp/pecos-trellis/src/factor.rs
@@ -76,14 +76,16 @@ impl FactorModel {
     ) -> Result<Self, DecoderError> {
         // Indices are u32, so the largest addressable width is u32::MAX + 1
         // (index u32::MAX exists) -- the same contract as the DEM parser,
-        // which accepts `D4294967295` and reports that width.
-        const MAX_WIDTH: usize = u32::MAX as usize + 1;
-        if num_detectors > MAX_WIDTH {
+        // which accepts `D4294967295` and reports that width. Compare in
+        // u64: on a 32-bit target `u32::MAX as usize + 1` would be a
+        // const-eval overflow, while every usize is representable in u64.
+        const MAX_WIDTH: u64 = u32::MAX as u64 + 1;
+        if num_detectors as u64 > MAX_WIDTH {
             return Err(DecoderError::InvalidConfiguration(format!(
                 "num_detectors {num_detectors} exceeds the u32 index-addressable width {MAX_WIDTH}"
             )));
         }
-        if num_observables > MAX_WIDTH {
+        if num_observables as u64 > MAX_WIDTH {
             return Err(DecoderError::InvalidConfiguration(format!(
                 "num_observables {num_observables} exceeds the u32 index-addressable width {MAX_WIDTH}"
             )));

--- a/python/pecos-rslib-exp/src/frontier_bindings.rs
+++ b/python/pecos-rslib-exp/src/frontier_bindings.rs
@@ -44,7 +44,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for ColumnOrderArgument {
         }
         Err(PyValueError::new_err(
             "column_order must be 'deadline_reorder', 'time_order', \
-             'backward_deadline_reorder', or a list of mechanism indices",
+             'backward_deadline_reorder', or a list of column indices",
         ))
     }
 }
@@ -104,7 +104,7 @@ fn resolve_column_order(
                 .map_err(|e| runtime_error(&e)),
             _ => Err(PyValueError::new_err(format!(
                 "invalid column_order {name:?}; expected 'deadline_reorder', 'time_order', \
-                 'backward_deadline_reorder', or a list of mechanism indices"
+                 'backward_deadline_reorder', or a list of column indices"
             ))),
         },
         ColumnOrderArgument::Explicit(order) => Ok(Some(order)),
@@ -126,7 +126,7 @@ fn resolve_factor_column_order(
                 .map_err(|error| runtime_error(&error)),
             _ => Err(PyValueError::new_err(format!(
                 "invalid column_order {name:?}; expected 'deadline_reorder', 'time_order', \
-                 'backward_deadline_reorder', or a list of factor indices"
+                 'backward_deadline_reorder', or a list of column indices"
             ))),
         },
         ColumnOrderArgument::Explicit(order) => Ok(Some(order)),
@@ -536,6 +536,7 @@ impl PyFrontierDecoder {
         metric_mode: &str,
         int_metric_scale: i32,
     ) -> PyResult<Self> {
+        let metric_mode = parse_metric_mode(metric_mode)?;
         let factors = factors
             .into_iter()
             .map(|outcomes| Factor {
@@ -550,7 +551,7 @@ impl PyFrontierDecoder {
             })
             .collect();
         let model = FactorModel::new(factors, num_detectors, num_observables)
-            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+            .map_err(|error| runtime_error(&error))?;
         let column_order = resolve_factor_column_order(&model, column_order)?;
         let config = RustFrontierConfig {
             k,
@@ -559,7 +560,7 @@ impl PyFrontierDecoder {
             column_order,
             merge_indistinguishable,
             bp_score_iterations,
-            metric_mode: parse_metric_mode(metric_mode)?,
+            metric_mode,
             int_metric_scale,
         };
         let inner = RustFrontierDecoder::from_factor_model(&model, config)

--- a/python/pecos-rslib-exp/src/frontier_bindings.rs
+++ b/python/pecos-rslib-exp/src/frontier_bindings.rs
@@ -11,11 +11,13 @@
 // the License.
 
 use pecos_frontier::{
-    CommitteeDirection, CommitteeMember, CommitteeStatus, DecoderError,
+    CommitteeDirection, CommitteeMember, CommitteeStatus, DecoderError, Factor, FactorModel,
     FrontierCommittee as RustFrontierCommittee,
     FrontierCommitteeResult as RustFrontierCommitteeResult, FrontierConfig as RustFrontierConfig,
     FrontierDecoder as RustFrontierDecoder, FrontierResult as RustFrontierResult, FrontierStatus,
-    ObsMask, SparseDem, backward_deadline_column_order, deadline_column_order,
+    MetricMode, ObsMask, Outcome, SparseDem, backward_deadline_column_order,
+    backward_deadline_column_order_for_factors, deadline_column_order,
+    deadline_column_order_for_factors,
 };
 use pyo3::Borrowed;
 use pyo3::exceptions::{PyAttributeError, PyRuntimeError, PyValueError};
@@ -26,6 +28,9 @@ enum ColumnOrderArgument {
     Name(String),
     Explicit(Vec<usize>),
 }
+
+type FactorOutcomeArgument = (f64, Vec<u32>, Vec<u32>);
+type FactorModelArgument = Vec<Vec<FactorOutcomeArgument>>;
 
 impl<'a, 'py> FromPyObject<'a, 'py> for ColumnOrderArgument {
     type Error = PyErr;
@@ -52,6 +57,17 @@ impl Default for ColumnOrderArgument {
 
 fn runtime_error(error: &DecoderError) -> PyErr {
     PyRuntimeError::new_err(error.to_string())
+}
+
+fn parse_metric_mode(metric_mode: &str) -> PyResult<MetricMode> {
+    match metric_mode.trim() {
+        "logsumexp_float" | "float" | "exact" => Ok(MetricMode::LogSumExpFloat),
+        "frontierLite" | "frontier_lite" | "frontier-lite" | "frontierlite" | "maxlog_int"
+        | "max_log_int" | "viterbi_int" => Ok(MetricMode::MaxLogInt),
+        _ => Err(PyValueError::new_err(
+            "metric_mode must be 'logsumexp_float' or 'maxlog_int'",
+        )),
+    }
 }
 
 fn sparse_index_error(index: u64, num_detectors: usize) -> PyErr {
@@ -95,6 +111,28 @@ fn resolve_column_order(
     }
 }
 
+fn resolve_factor_column_order(
+    model: &FactorModel,
+    column_order: ColumnOrderArgument,
+) -> PyResult<Option<Vec<usize>>> {
+    match column_order {
+        ColumnOrderArgument::Name(name) => match name.as_str() {
+            "deadline_reorder" => deadline_column_order_for_factors(model)
+                .map(Some)
+                .map_err(|error| runtime_error(&error)),
+            "time_order" => Ok(None),
+            "backward_deadline_reorder" => backward_deadline_column_order_for_factors(model)
+                .map(Some)
+                .map_err(|error| runtime_error(&error)),
+            _ => Err(PyValueError::new_err(format!(
+                "invalid column_order {name:?}; expected 'deadline_reorder', 'time_order', \
+                 'backward_deadline_reorder', or a list of factor indices"
+            ))),
+        },
+        ColumnOrderArgument::Explicit(order) => Ok(Some(order)),
+    }
+}
+
 fn parse_dem_and_config(
     dem_str: &str,
     k: usize,
@@ -103,9 +141,12 @@ fn parse_dem_and_config(
     bp_score_iterations: usize,
     column_order: ColumnOrderArgument,
     merge_indistinguishable: bool,
+    metric_mode: &str,
+    int_metric_scale: i32,
 ) -> PyResult<(SparseDem, RustFrontierConfig)> {
     let dem = SparseDem::from_dem_str(dem_str).map_err(|e| runtime_error(&e))?;
     let column_order = resolve_column_order(&dem, column_order)?;
+    let metric_mode = parse_metric_mode(metric_mode)?;
     Ok((
         dem,
         RustFrontierConfig {
@@ -115,10 +156,8 @@ fn parse_dem_and_config(
             column_order,
             merge_indistinguishable,
             bp_score_iterations,
-            // The integer max-log metric is not yet exposed to Python; the
-            // bindings pin the default float metric until that surface lands.
-            metric_mode: pecos_trellis::MetricMode::LogSumExpFloat,
-            int_metric_scale: 1024,
+            metric_mode,
+            int_metric_scale,
         },
     ))
 }
@@ -442,8 +481,8 @@ impl PyFrontierDecoder {
     /// Construct a native Frontier decoder from a Stim-format DEM string.
     #[staticmethod]
     #[pyo3(
-        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false),
-        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False)"
+        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false, metric_mode="logsumexp_float", int_metric_scale=1024),
+        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False, metric_mode='logsumexp_float', int_metric_scale=1024)"
     )]
     fn from_dem(
         dem: &str,
@@ -453,6 +492,8 @@ impl PyFrontierDecoder {
         bp_score_iterations: usize,
         column_order: ColumnOrderArgument,
         merge_indistinguishable: bool,
+        metric_mode: &str,
+        int_metric_scale: i32,
     ) -> PyResult<Self> {
         let (dem, config) = parse_dem_and_config(
             dem,
@@ -462,10 +503,66 @@ impl PyFrontierDecoder {
             bp_score_iterations,
             column_order,
             merge_indistinguishable,
+            metric_mode,
+            int_metric_scale,
         )?;
         let num_detectors = dem.num_detectors;
         let num_observables = dem.num_observables;
         let inner = RustFrontierDecoder::from_sparse_dem(&dem, config)
+            .map_err(|error| runtime_error(&error))?;
+        Ok(Self {
+            inner,
+            num_detectors,
+            num_observables,
+        })
+    }
+
+    /// Construct a native Frontier decoder from a multi-outcome factor model.
+    #[staticmethod]
+    #[pyo3(
+        signature = (factors, num_detectors, num_observables, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false, metric_mode="logsumexp_float", int_metric_scale=1024),
+        text_signature = "(factors, num_detectors, num_observables, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False, metric_mode='logsumexp_float', int_metric_scale=1024)"
+    )]
+    fn from_factors(
+        factors: FactorModelArgument,
+        num_detectors: usize,
+        num_observables: usize,
+        k: usize,
+        delta: f64,
+        score_alpha: f64,
+        bp_score_iterations: usize,
+        column_order: ColumnOrderArgument,
+        merge_indistinguishable: bool,
+        metric_mode: &str,
+        int_metric_scale: i32,
+    ) -> PyResult<Self> {
+        let factors = factors
+            .into_iter()
+            .map(|outcomes| Factor {
+                outcomes: outcomes
+                    .into_iter()
+                    .map(|(probability, detectors, observables)| Outcome {
+                        probability,
+                        detectors,
+                        observables,
+                    })
+                    .collect(),
+            })
+            .collect();
+        let model = FactorModel::new(factors, num_detectors, num_observables)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        let column_order = resolve_factor_column_order(&model, column_order)?;
+        let config = RustFrontierConfig {
+            k,
+            delta,
+            score_alpha,
+            column_order,
+            merge_indistinguishable,
+            bp_score_iterations,
+            metric_mode: parse_metric_mode(metric_mode)?,
+            int_metric_scale,
+        };
+        let inner = RustFrontierDecoder::from_factor_model(&model, config)
             .map_err(|error| runtime_error(&error))?;
         Ok(Self {
             inner,
@@ -538,8 +635,8 @@ impl PyFrontierCommitteeDecoder {
     /// Construct a native forward/backward committee from a Stim-format DEM.
     #[staticmethod]
     #[pyo3(
-        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false),
-        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False)"
+        signature = (dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order=ColumnOrderArgument::default(), merge_indistinguishable=false, metric_mode="logsumexp_float", int_metric_scale=1024),
+        text_signature = "(dem, *, k=64, delta=50.0, score_alpha=0.8, bp_score_iterations=0, column_order='deadline_reorder', merge_indistinguishable=False, metric_mode='logsumexp_float', int_metric_scale=1024)"
     )]
     fn from_dem(
         dem: &str,
@@ -549,6 +646,8 @@ impl PyFrontierCommitteeDecoder {
         bp_score_iterations: usize,
         column_order: ColumnOrderArgument,
         merge_indistinguishable: bool,
+        metric_mode: &str,
+        int_metric_scale: i32,
     ) -> PyResult<Self> {
         let (dem, config) = parse_dem_and_config(
             dem,
@@ -558,6 +657,8 @@ impl PyFrontierCommitteeDecoder {
             bp_score_iterations,
             column_order,
             merge_indistinguishable,
+            metric_mode,
+            int_metric_scale,
         )?;
         let num_detectors = dem.num_detectors;
         let num_observables = dem.num_observables;

--- a/python/quantum-pecos/tests/qec/test_frontier_decoder.py
+++ b/python/quantum-pecos/tests/qec/test_frontier_decoder.py
@@ -36,6 +36,8 @@ N1_FACTORS = [
     [(0.80, [], []), (0.20, [0], [])],
 ]
 
+METRIC_FLIP_DEM = "error(0.20) D0 L0\nerror(0.15) D0\nerror(0.15) D0\n"
+
 
 def test_sparse_and_dense_decode_agree() -> None:
     decoder = FrontierDecoder.from_dem(SMALL_DEM)
@@ -109,10 +111,9 @@ def test_factor_model_decode_preserves_degeneracy_mass() -> None:
 
 
 def test_maxlog_metric_can_flip_the_prediction() -> None:
-    dem = "error(0.20) D0 L0\nerror(0.15) D0\nerror(0.15) D0\n"
-    default_result = FrontierDecoder.from_dem(dem).decode_syndrome([1])
+    default_result = FrontierDecoder.from_dem(METRIC_FLIP_DEM).decode_syndrome([1])
     maxlog_result = FrontierDecoder.from_dem(
-        dem,
+        METRIC_FLIP_DEM,
         k=10**9,
         delta=1e6,
         metric_mode="frontier_lite",
@@ -121,7 +122,29 @@ def test_maxlog_metric_can_flip_the_prediction() -> None:
     assert default_result.observable_flips.mask == 0
     assert maxlog_result.observable_flips.mask == 1
     assert maxlog_result.status == "exact"
-    assert all(isinstance(log_mass, float) for _, log_mass in maxlog_result.logical_masses)
+    assert maxlog_result.logical_masses[0] == (1, -1.93359375)
+
+
+@pytest.mark.parametrize(
+    ("int_metric_scale", "expected_masses"),
+    [
+        (1, [(1, -1.0), (0, -2.0)]),
+        (1024, [(1, -1.93359375), (0, -2.28125)]),
+    ],
+)
+def test_maxlog_int_metric_scale_is_forwarded(
+    int_metric_scale: int,
+    expected_masses: list[tuple[int, float]],
+) -> None:
+    result = FrontierDecoder.from_dem(
+        METRIC_FLIP_DEM,
+        k=10**9,
+        delta=1e6,
+        metric_mode="maxlog_int",
+        int_metric_scale=int_metric_scale,
+    ).decode_syndrome([1])
+
+    assert result.logical_masses == expected_masses
 
 
 @pytest.mark.parametrize(
@@ -150,6 +173,14 @@ def test_metric_mode_aliases_are_accepted_with_surrounding_whitespace(metric_mod
 def test_metric_and_factor_model_error_paths() -> None:
     with pytest.raises(ValueError, match=r"logsumexp_float.*maxlog_int"):
         FrontierDecoder.from_dem(SMALL_DEM, metric_mode="not_a_metric")
+    with pytest.raises(ValueError, match=r"logsumexp_float.*maxlog_int"):
+        FrontierDecoder.from_factors(
+            N1_FACTORS,
+            1,
+            1,
+            column_order="not_an_order",
+            metric_mode="not_a_metric",
+        )
     with pytest.raises(RuntimeError, match="integer max-log metric is not supported"):
         FrontierCommitteeDecoder.from_dem(SMALL_DEM, metric_mode="maxlog_int")
     with pytest.raises(RuntimeError, match="delta must be finite under maxlog_int"):
@@ -165,26 +196,28 @@ def test_metric_and_factor_model_error_paths() -> None:
             1,
             bp_score_iterations=1,
         )
-    with pytest.raises(ValueError, match="outcome probabilities must sum to 1"):
+    with pytest.raises(RuntimeError, match="outcome probabilities must sum to 1"):
         FrontierDecoder.from_factors(
             [[(0.6, [], []), (0.3, [0], [])]],
             1,
             0,
         )
+    with pytest.raises(
+        RuntimeError,
+        match="num_detectors 1000000000000000 exceeds the u32 detector-index range",
+    ):
+        FrontierDecoder.from_factors(
+            [[(0.5, [], []), (0.5, [0], [])]],
+            10**15,
+            1,
+        )
 
 
-@pytest.mark.parametrize("column_order", ["deadline_reorder", "backward_deadline_reorder"])
-def test_factor_model_named_column_orders_construct_and_decode(column_order: str) -> None:
-    decoder = FrontierDecoder.from_factors(
-        N1_FACTORS,
-        1,
-        1,
-        column_order=column_order,
-    )
-    assert decoder.decode_syndrome([1]).status == "exact"
-
-
-def test_binary_factor_model_delegates_identically_to_dem() -> None:
+@pytest.mark.parametrize(
+    "column_order",
+    ["time_order", "deadline_reorder", "backward_deadline_reorder"],
+)
+def test_binary_factor_model_delegates_identically_to_dem(column_order: str) -> None:
     factors = [
         [(0.9, [], []), (0.1, [0], [0])],
         [(0.8, [], []), (0.2, [1], [])],
@@ -194,7 +227,7 @@ def test_binary_factor_model_delegates_identically_to_dem() -> None:
         "delta": 1e6,
         "score_alpha": 0.7,
         "bp_score_iterations": 2,
-        "column_order": "time_order",
+        "column_order": column_order,
     }
     factor_decoder = FrontierDecoder.from_factors(factors, 2, 1, **config)
     dem_decoder = FrontierDecoder.from_dem(SMALL_DEM, **config)

--- a/python/quantum-pecos/tests/qec/test_frontier_decoder.py
+++ b/python/quantum-pecos/tests/qec/test_frontier_decoder.py
@@ -204,7 +204,7 @@ def test_metric_and_factor_model_error_paths() -> None:
         )
     with pytest.raises(
         RuntimeError,
-        match="num_detectors 1000000000000000 exceeds the u32 detector-index range",
+        match="num_detectors 1000000000000000 exceeds the u32 index-addressable width 4294967296",
     ):
         FrontierDecoder.from_factors(
             [[(0.5, [], []), (0.5, [0], [])]],

--- a/python/quantum-pecos/tests/qec/test_frontier_decoder.py
+++ b/python/quantum-pecos/tests/qec/test_frontier_decoder.py
@@ -31,6 +31,11 @@ error(0.1) D0 L0
 error(0.2) D1
 """
 
+N1_FACTORS = [
+    [(0.60, [], []), (0.25, [0], [0]), (0.15, [0], [])],
+    [(0.80, [], []), (0.20, [0], [])],
+]
+
 
 def test_sparse_and_dense_decode_agree() -> None:
     decoder = FrontierDecoder.from_dem(SMALL_DEM)
@@ -84,6 +89,124 @@ def test_column_order_variants_and_validation() -> None:
         FrontierDecoder.from_dem(SMALL_DEM, column_order=object())
     with pytest.raises(RuntimeError, match="permutation"):
         FrontierDecoder.from_dem(SMALL_DEM, column_order=[0, 0])
+
+
+def test_factor_model_decode_preserves_degeneracy_mass() -> None:
+    decoder = FrontierDecoder.from_factors(
+        N1_FACTORS,
+        1,
+        1,
+        k=10**9,
+        delta=1e6,
+    )
+
+    result = decoder.decode_syndrome([1])
+    logical_masses = dict(result.logical_masses)
+
+    assert result.observable_flips.mask == 0
+    assert logical_masses[0] == pytest.approx(math.log(0.24), abs=1e-9)
+    assert logical_masses[1] == pytest.approx(math.log(0.20), abs=1e-9)
+
+
+def test_maxlog_metric_can_flip_the_prediction() -> None:
+    dem = "error(0.20) D0 L0\nerror(0.15) D0\nerror(0.15) D0\n"
+    default_result = FrontierDecoder.from_dem(dem).decode_syndrome([1])
+    maxlog_result = FrontierDecoder.from_dem(
+        dem,
+        k=10**9,
+        delta=1e6,
+        metric_mode="frontier_lite",
+    ).decode_syndrome([1])
+
+    assert default_result.observable_flips.mask == 0
+    assert maxlog_result.observable_flips.mask == 1
+    assert maxlog_result.status == "exact"
+    assert all(isinstance(log_mass, float) for _, log_mass in maxlog_result.logical_masses)
+
+
+@pytest.mark.parametrize(
+    "metric_mode",
+    [
+        "logsumexp_float",
+        "float",
+        "exact",
+        "frontierLite",
+        "frontier_lite",
+        "frontier-lite",
+        "frontierlite",
+        "maxlog_int",
+        "max_log_int",
+        "viterbi_int",
+    ],
+)
+def test_metric_mode_aliases_are_accepted_with_surrounding_whitespace(metric_mode: str) -> None:
+    decoder = FrontierDecoder.from_dem(
+        "error(0.1) D0\n",
+        metric_mode=f"  {metric_mode}  ",
+    )
+    assert decoder.decode_syndrome([0]).status == "exact"
+
+
+def test_metric_and_factor_model_error_paths() -> None:
+    with pytest.raises(ValueError, match=r"logsumexp_float.*maxlog_int"):
+        FrontierDecoder.from_dem(SMALL_DEM, metric_mode="not_a_metric")
+    with pytest.raises(RuntimeError, match="integer max-log metric is not supported"):
+        FrontierCommitteeDecoder.from_dem(SMALL_DEM, metric_mode="maxlog_int")
+    with pytest.raises(RuntimeError, match="delta must be finite under maxlog_int"):
+        FrontierDecoder.from_dem(
+            SMALL_DEM,
+            delta=float("inf"),
+            metric_mode="maxlog_int",
+        )
+    with pytest.raises(RuntimeError, match="BP-guided pruning requires a binary model"):
+        FrontierDecoder.from_factors(
+            N1_FACTORS,
+            1,
+            1,
+            bp_score_iterations=1,
+        )
+    with pytest.raises(ValueError, match="outcome probabilities must sum to 1"):
+        FrontierDecoder.from_factors(
+            [[(0.6, [], []), (0.3, [0], [])]],
+            1,
+            0,
+        )
+
+
+@pytest.mark.parametrize("column_order", ["deadline_reorder", "backward_deadline_reorder"])
+def test_factor_model_named_column_orders_construct_and_decode(column_order: str) -> None:
+    decoder = FrontierDecoder.from_factors(
+        N1_FACTORS,
+        1,
+        1,
+        column_order=column_order,
+    )
+    assert decoder.decode_syndrome([1]).status == "exact"
+
+
+def test_binary_factor_model_delegates_identically_to_dem() -> None:
+    factors = [
+        [(0.9, [], []), (0.1, [0], [0])],
+        [(0.8, [], []), (0.2, [1], [])],
+    ]
+    config = {
+        "k": 10**9,
+        "delta": 1e6,
+        "score_alpha": 0.7,
+        "bp_score_iterations": 2,
+        "column_order": "time_order",
+    }
+    factor_decoder = FrontierDecoder.from_factors(factors, 2, 1, **config)
+    dem_decoder = FrontierDecoder.from_dem(SMALL_DEM, **config)
+
+    for syndrome in ([0, 0], [1, 0], [0, 1], [1, 1]):
+        factor_result = factor_decoder.decode_syndrome(syndrome)
+        dem_result = dem_decoder.decode_syndrome(syndrome)
+        assert factor_result.observable_flips.mask == dem_result.observable_flips.mask
+        assert factor_result.log_evidence == dem_result.log_evidence
+        assert factor_result.runner_up_gap == dem_result.runner_up_gap
+        assert factor_result.logical_masses == dem_result.logical_masses
+        assert factor_result.status == dem_result.status
 
 
 def test_committee_easy_tie_selects_forward() -> None:


### PR DESCRIPTION
## Summary

Stacked on #589 (which stacks on #587); retarget as the stack merges. Exposes the Phase A/B engine surface to Python.

- `FrontierDecoder.from_dem` and `FrontierCommitteeDecoder.from_dem` gain `metric_mode` (upstream's full alias set: `logsumexp_float`/`float`/`exact` and `frontier_lite`/`maxlog_int`/`viterbi_int` variants) and `int_metric_scale` keyword arguments. The committee's max-log rejection surfaces as a clean `RuntimeError` from the engine.
- New `FrontierDecoder.from_factors(factors, num_detectors, num_observables, ...)`: a list of factors, each a list of `(probability, detectors, observables)` outcome tuples, validated by the engine; named column orders resolve through the factor-model ordering functions, never by laundering the model through a DEM.
- Error-type convention held file-wide: binding-level argument parsing raises `ValueError`; every engine `DecoderError` maps to `RuntimeError`.
- `FactorModel::new` now bounds the declared widths at the `u32` outcome-index range — an adversarial probe showed `from_factors(..., 10**15, 1)` previously aborted the interpreter with a failed 8 PB allocation instead of raising.
- Docs: factor-model section with a tested example fence, `int_metric_scale` documented, and the maxlog clauses updated (decoder accepts it from Python; committee remains float-only).

## Verification

- 28 Python tests in `tests/qec/test_frontier_decoder.py`, including: hand-derived degeneracy masses through `from_factors`; the metric-flip case (float predicts label 0, `maxlog_int` predicts 1); exact `==` pins of `int_metric_scale` behavior at scales 1 and 1024; delegation equality vs `from_dem` parametrized over all three named column orders; and error paths for every guard (unknown metric, committee+maxlog, infinite delta under maxlog, BP+N-ary, bad probability sums, oversized widths).
- Doc example fences regenerated and executed by the doc-test framework (Rust crate and generated Python docs both green).
- An independent adversarial review ran against the diff and upstream's alias table; every finding was verified and closed (the interpreter-abort guard and the error-type unification came from it). New guards mutation-tested.
- `cargo clippy --all-targets -- -D warnings` (including `pecos-rslib-exp`), `cargo fmt --check`, the three-crate engine test battery, `maturin develop` + full pytest file, and the repo-wide pre-commit lane all pass.