### PR TITLE
Return the signed half-angle from Angle::half_angle_sin_cos for negative angles

### DIFF
--- a/crates/pecos-core/src/angle/trig.rs
+++ b/crates/pecos-core/src/angle/trig.rs
@@ -352,15 +352,40 @@ where
     ///
     /// Common in quantum computing where rotation gates use half-angle
     /// components (e.g., `cos(theta/2)` and `sin(theta/2)` for RX, RY gates).
-    /// Halving the fixed-point fraction is exact (integer division by 2).
+    /// Halving the fixed-point fraction is exact (integer division by 2). For
+    /// fractions strictly greater than half a turn the signed principal value
+    /// is negative: its half is the unsigned half minus pi, so both trig
+    /// outputs are negated. Exactly half a turn is +pi, matching
+    /// [`to_radians_signed`](Self::to_radians_signed)'s `(-pi, pi]` range.
+    ///
+    /// The sign test is made on the fixed-point fraction, not on a converted
+    /// f64. Near half a turn that is strictly more accurate: fractions one
+    /// unit above `HALF_TURN` have a negative principal value, but converting
+    /// them to radians rounds to exactly pi, so an f64-based test would call
+    /// them positive. Do not "simplify" this to agree with
+    /// `to_radians_signed` bit for bit.
     ///
     /// # Panics
-    /// Panics if `T` cannot represent the value 2 (unreachable for all
-    /// standard unsigned integer types).
+    /// Panics if `T` cannot represent the value 2 or its fraction cannot be
+    /// converted to `u128` (unreachable for all standard unsigned integer
+    /// types).
     #[inline]
     pub fn half_angle_sin_cos(&self) -> (f64, f64) {
         let half = Self::new(self.fraction / T::from_u32(2).expect("2 must be representable"));
-        half.sin_cos()
+        let (sin_half, cos_half) = half.sin_cos();
+        let bit_count = std::mem::size_of::<T>() * 8;
+        let fraction = self
+            .fraction
+            .to_u128()
+            .expect("Failed to convert fraction to u128");
+        // Strictly greater: `to_radians_signed` maps to (-pi, pi], so exactly
+        // half a turn is +pi, not -pi. Using the top bit alone would negate it
+        // and flip RZ(pi) from -iZ to +iZ.
+        let is_negative = fraction > (1_u128 << (bit_count - 1));
+        (
+            apply_sign(sin_half, is_negative),
+            apply_sign(cos_half, is_negative),
+        )
     }
 
     /// Returns `e^(i*theta) = cos(theta) + i*sin(theta)` as a `Complex64`.
@@ -693,12 +718,61 @@ mod tests {
     // -- half_angle_sin_cos -----------------------------------------------
 
     #[test]
-    fn half_angle_matches_manual_halving() {
-        // half_angle_sin_cos(HALF_TURN) should equal sin_cos(QUARTER_TURN)
-        let (s, c) = Angle64::HALF_TURN.half_angle_sin_cos();
-        let (s_ref, c_ref) = Angle64::QUARTER_TURN.sin_cos();
-        assert!((s - s_ref).abs() < TOL, "sin mismatch: {s} vs {s_ref}");
-        assert!((c - c_ref).abs() < TOL, "cos mismatch: {c} vs {c_ref}");
+    fn half_angle_uses_signed_principal_value() {
+        macro_rules! check {
+            ($angle:ty, $fraction:ty) => {{
+                let cases = [
+                    ("zero", <$angle>::ZERO, <$angle>::ZERO),
+                    (
+                        "positive Clifford",
+                        <$angle>::QUARTER_TURN,
+                        <$angle>::QUARTER_TURN / 2,
+                    ),
+                    (
+                        "positive non-Clifford",
+                        <$angle>::QUARTER_TURN / 2,
+                        <$angle>::QUARTER_TURN / 4,
+                    ),
+                    (
+                        "half turn is +pi, matching to_radians_signed's (-pi, pi]",
+                        <$angle>::HALF_TURN,
+                        <$angle>::QUARTER_TURN,
+                    ),
+                    (
+                        "negative Clifford",
+                        <$angle>::THREE_QUARTERS_TURN,
+                        -(<$angle>::QUARTER_TURN / 2),
+                    ),
+                    (
+                        "negative non-Clifford",
+                        -(<$angle>::QUARTER_TURN / 2),
+                        -(<$angle>::QUARTER_TURN / 4),
+                    ),
+                    (
+                        "near full turn",
+                        <$angle>::new(<$fraction>::MAX),
+                        <$angle>::new(<$fraction>::MAX),
+                    ),
+                ];
+
+                for (label, angle, signed_half) in cases {
+                    let actual = angle.half_angle_sin_cos();
+                    let expected = signed_half.sin_cos();
+                    assert_eq!(
+                        actual,
+                        expected,
+                        "{} {label}: angle={angle:?}",
+                        stringify!($angle)
+                    );
+                }
+            }};
+        }
+
+        check!(Angle8, u8);
+        check!(Angle16, u16);
+        check!(Angle32, u32);
+        check!(Angle64, u64);
+        check!(Angle128, u128);
     }
 
     #[test]
@@ -723,7 +797,13 @@ mod tests {
             let frac: u64 = rng.random();
             let angle = Angle64::new(frac);
             let (s, c) = angle.half_angle_sin_cos();
-            let halved = Angle64::new(frac / 2);
+            let unsigned_half = frac / 2;
+            let signed_half = if frac > Angle64::HALF_TURN.fraction() {
+                unsigned_half.wrapping_sub(Angle64::HALF_TURN.fraction())
+            } else {
+                unsigned_half
+            };
+            let halved = Angle64::new(signed_half);
             let (s_ref, c_ref) = halved.sin_cos();
             assert!((s - s_ref).abs() < TOL, "sin mismatch for frac={frac}");
             assert!((c - c_ref).abs() < TOL, "cos mismatch for frac={frac}");


### PR DESCRIPTION
Closes #599. Split out of #601 so it can land on its own: it is a pre-existing defect, independent of the T-gate convention work, and much smaller.

## The defect

`Angle::half_angle_sin_cos` computed the half-angle by halving the stored fixed-point fraction:

```rust
let half = Self::new(self.fraction / T::from_u32(2).expect("2 must be representable"));
half.sin_cos()
```

`Angle` stores an unsigned fraction of a full turn in `[0, 2^BITS)`, so an angle with a negative principal value is stored wrapped, near the top of the range. Halving that stored value gives the true half-angle **plus pi**, so both returned components come back negated:

    theta = -pi/4 : returned (+0.382683, -0.923880), correct (-0.382683, +0.923880)  -> factor -1
    theta = -pi/8 : returned (+0.195090, -0.980785), correct (-0.195090, +0.980785)  -> factor -1
    theta = +pi/4 : returned (+0.382683, +0.923880), correct (+0.382683, +0.923880)  -> agrees

Positive principal values were correct, so the defect was invisible to any test exercising only positive angles.

## Why it went unnoticed

Rotation gates are built as `RZ(theta) = cos(theta/2) I - i sin(theta/2) Z`. Negating both half-angle components yields `-RZ(theta)`: a global phase of `-1`. That is unobservable in probabilities, in density-matrix evolution, and in any comparison that quotients global phase -- which is what PECOS's state-comparison helpers do. It becomes observable only where absolute amplitudes matter or a tracked global phase is exposed.

## Affected callers on `dev`

- `crates/pecos-simulators/src/stab_vec.rs` -- non-Clifford `RZ` materialisation, for negative angles
- `exp/pecos-stab-tn/src/stab_mps/mast.rs` -- its `correction_angle` can be negative, so that branch was applying `-RZ(phi)`

Both are fixed by this change; neither needed an edit of its own.

## The fix

Corrected in the helper rather than at the call sites, and kept in fixed point. The sign test is made on the fraction, not on a converted `f64`, which is deliberate and strictly more accurate near half a turn: fractions one unit above `HALF_TURN` have a negative principal value but round to exactly `pi` in `f64`, so an `f64`-based test would call them positive. The doc comment says not to "simplify" this into agreement with `to_radians_signed`.

The boundary is strictly greater than half a turn, so exactly half a turn keeps the `+pi` principal value, matching `to_radians_signed`'s `(-pi, pi]` range. This matters: `RZ(pi)` must be `-iZ`, and using the top bit alone would have negated it to `+iZ`.

## Verification

- `cargo test -p pecos-core` -- passes, including a new generic test over `Angle8`, `Angle16`, `Angle32`, `Angle64` and `Angle128` covering positive, negative, zero, exact Clifford, half-turn and near-full-turn inputs
- `cargo test -p pecos-simulators` -- passes
- `cargo test -p pecos-stab-tn --lib` -- 341 passed
- Full CI lint recipe (clippy from inside each crate directory with `--locked`, plus `pecos --no-default-features`), `cargo fmt --check` and pre-commit -- clean

No existing expected value needed changing: the affected results were off by a global phase that no current test pinned.

## Relationship to #601

#601 contains this same fix, because a correct `Tdg` depends on it. If this lands first, #601 should be rebased and the overlap will drop out.
