### PR TITLE
Unify single-qubit gate matrices on one canonical phase-fixed table

### DIFF
--- a/crates/benchmarks/benches/modules/native_statevec_comparison.rs
+++ b/crates/benchmarks/benches/modules/native_statevec_comparison.rs
@@ -75,16 +75,22 @@ fn gpu_circuit(sim: &mut GpuStateVec32, num_qubits: usize, num_layers: usize) {
 
 #[cfg(feature = "cuquantum")]
 mod cuquantum_matrices {
-    use std::f64::consts::FRAC_1_SQRT_2;
+    use pecos_core::gate_type::GateType;
 
-    pub const H: [[f64; 2]; 4] = [
-        [FRAC_1_SQRT_2, 0.0],
-        [FRAC_1_SQRT_2, 0.0],
-        [FRAC_1_SQRT_2, 0.0],
-        [-FRAC_1_SQRT_2, 0.0],
-    ];
+    const fn from_canonical(gate: GateType) -> [[f64; 2]; 4] {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit matrix");
+        };
+        [
+            [matrix[0], matrix[1]],
+            [matrix[2], matrix[3]],
+            [matrix[4], matrix[5]],
+            [matrix[6], matrix[7]],
+        ]
+    }
 
-    pub const X: [[f64; 2]; 4] = [[0.0, 0.0], [1.0, 0.0], [1.0, 0.0], [0.0, 0.0]];
+    pub const H: [[f64; 2]; 4] = from_canonical(GateType::H);
+    pub const X: [[f64; 2]; 4] = from_canonical(GateType::X);
 
     pub const CX: [[f64; 2]; 16] = [
         [1.0, 0.0],

--- a/crates/pecos-core/src/clifford.rs
+++ b/crates/pecos-core/src/clifford.rs
@@ -28,7 +28,7 @@
 //! assert_eq!(p, pecos_core::Pauli::Z);
 //! ```
 
-use crate::gate_type::GateType;
+use crate::gate_type::{GateType, SingleQubitGateMatrix, multiply_2x2, scale_2x2};
 use crate::unitary_rep::UnitaryRep;
 use crate::{Angle64, Pauli, QubitId, Sign};
 use std::fmt;
@@ -225,6 +225,13 @@ const IMAGES_1Q: [(bool, Pauli, bool, Pauli); 24] = [
     (true, Pauli::Y, false, Pauli::X),  // 23: F4dg
 ];
 
+const fn gate_type_matrix(gate: GateType) -> SingleQubitGateMatrix {
+    let Some(matrix) = gate.canonical_1q_matrix() else {
+        panic!("gate has no canonical single-qubit matrix");
+    };
+    matrix
+}
+
 impl Clifford {
     /// Returns all 38 Clifford gate variants (24 single-qubit + 14 two-qubit).
     #[must_use]
@@ -260,6 +267,126 @@ impl Clifford {
     #[must_use]
     pub fn is_2q(self) -> bool {
         self.num_qubits() == 2
+    }
+
+    /// Returns the canonical phase-fixed matrix for a single-qubit Clifford.
+    ///
+    /// Each representative has its exact Clifford-group order: H is H1 and
+    /// all H1-H6 matrices have order two; F is F1 and all F1-F4 matrices and
+    /// their daggers have order three. Matrices for variants without a
+    /// [`GateType`] are const products of canonical named-gate matrices with
+    /// the explicit phase required by that convention.
+    ///
+    /// Returns `None` for two-qubit Clifford gates.
+    #[must_use]
+    pub const fn canonical_1q_matrix(self) -> Option<SingleQubitGateMatrix> {
+        let h_phase_re = std::f64::consts::FRAC_1_SQRT_2;
+        let h_phase_im = -std::f64::consts::FRAC_1_SQRT_2;
+
+        match self {
+            Self::I => Some(gate_type_matrix(GateType::I)),
+            Self::X => Some(gate_type_matrix(GateType::X)),
+            Self::Y => Some(gate_type_matrix(GateType::Y)),
+            Self::Z => Some(gate_type_matrix(GateType::Z)),
+            Self::H => Some(gate_type_matrix(GateType::H)),
+            Self::SX => Some(gate_type_matrix(GateType::SX)),
+            Self::SXdg => Some(gate_type_matrix(GateType::SXdg)),
+            Self::SY => Some(gate_type_matrix(GateType::SY)),
+            Self::SYdg => Some(gate_type_matrix(GateType::SYdg)),
+            Self::SZ => Some(gate_type_matrix(GateType::SZ)),
+            Self::SZdg => Some(gate_type_matrix(GateType::SZdg)),
+            Self::H2 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::Z),
+                    gate_type_matrix(GateType::SY),
+                ),
+                h_phase_re,
+                h_phase_im,
+            )),
+            Self::H3 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::Y),
+                    gate_type_matrix(GateType::SZ),
+                ),
+                h_phase_re,
+                h_phase_im,
+            )),
+            Self::H4 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::X),
+                    gate_type_matrix(GateType::SZ),
+                ),
+                h_phase_re,
+                h_phase_im,
+            )),
+            Self::H5 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::Z),
+                    gate_type_matrix(GateType::SX),
+                ),
+                h_phase_re,
+                h_phase_im,
+            )),
+            Self::H6 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::Y),
+                    gate_type_matrix(GateType::SX),
+                ),
+                h_phase_re,
+                h_phase_im,
+            )),
+            Self::F => Some(gate_type_matrix(GateType::F)),
+            Self::Fdg => Some(gate_type_matrix(GateType::Fdg)),
+            Self::F2 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SY),
+                    gate_type_matrix(GateType::SXdg),
+                ),
+                -1.0,
+                0.0,
+            )),
+            Self::F2dg => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SX),
+                    gate_type_matrix(GateType::SYdg),
+                ),
+                -1.0,
+                0.0,
+            )),
+            Self::F3 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SZ),
+                    gate_type_matrix(GateType::SXdg),
+                ),
+                -1.0,
+                0.0,
+            )),
+            Self::F3dg => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SX),
+                    gate_type_matrix(GateType::SZdg),
+                ),
+                -1.0,
+                0.0,
+            )),
+            Self::F4 => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SX),
+                    gate_type_matrix(GateType::SZ),
+                ),
+                0.0,
+                1.0,
+            )),
+            Self::F4dg => Some(scale_2x2(
+                multiply_2x2(
+                    gate_type_matrix(GateType::SZdg),
+                    gate_type_matrix(GateType::SXdg),
+                ),
+                0.0,
+                -1.0,
+            )),
+            _ => None,
+        }
     }
 
     /// Returns the corresponding `GateType` for this Clifford gate, if one exists.
@@ -477,6 +604,9 @@ impl Clifford {
             "to_unitary_rep_on_qubit called on two-qubit gate {self}"
         );
         let q = q.into();
+        // Divide before modular negation: negating the fixed-point angle first
+        // wraps to 3/4 turn, and halving that would produce 3*pi/4.
+        let minus_pi_over_four = -(Angle64::QUARTER_TURN / 2u64);
         match self {
             // Paulis and identity
             Clifford::I => unitary_rep::I(q),
@@ -492,20 +622,54 @@ impl Clifford {
             Clifford::SZ => unitary_rep::SZ(q),
             Clifford::SZdg => unitary_rep::SZ(q).dg(),
             // Hadamard variants (A * B means "apply B first, then A")
-            Clifford::H2 => unitary_rep::Z(q) * unitary_rep::SY(q),
-            Clifford::H3 => unitary_rep::Y(q) * unitary_rep::SZ(q),
-            Clifford::H4 => unitary_rep::X(q) * unitary_rep::SZ(q),
-            Clifford::H5 => unitary_rep::Z(q) * unitary_rep::SX(q),
-            Clifford::H6 => unitary_rep::Y(q) * unitary_rep::SX(q),
+            Clifford::H2 => {
+                unitary_rep::phase(minus_pi_over_four) * (unitary_rep::Z(q) * unitary_rep::SY(q))
+            }
+            Clifford::H3 => {
+                unitary_rep::phase(minus_pi_over_four) * (unitary_rep::Y(q) * unitary_rep::SZ(q))
+            }
+            Clifford::H4 => {
+                unitary_rep::phase(minus_pi_over_four) * (unitary_rep::X(q) * unitary_rep::SZ(q))
+            }
+            Clifford::H5 => {
+                unitary_rep::phase(minus_pi_over_four) * (unitary_rep::Z(q) * unitary_rep::SX(q))
+            }
+            Clifford::H6 => {
+                unitary_rep::phase(minus_pi_over_four) * (unitary_rep::Y(q) * unitary_rep::SX(q))
+            }
             // Face gates
-            Clifford::F => unitary_rep::SZ(q) * unitary_rep::SX(q),
-            Clifford::Fdg => unitary_rep::SX(q).dg() * unitary_rep::SZ(q).dg(),
-            Clifford::F2 => unitary_rep::SY(q) * unitary_rep::SX(q).dg(),
-            Clifford::F2dg => unitary_rep::SX(q) * unitary_rep::SY(q).dg(),
-            Clifford::F3 => unitary_rep::SZ(q) * unitary_rep::SX(q).dg(),
-            Clifford::F3dg => unitary_rep::SX(q) * unitary_rep::SZ(q).dg(),
-            Clifford::F4 => unitary_rep::SX(q) * unitary_rep::SZ(q),
-            Clifford::F4dg => unitary_rep::SZ(q).dg() * unitary_rep::SX(q).dg(),
+            Clifford::F => {
+                unitary_rep::phase(Angle64::QUARTER_TURN)
+                    * (unitary_rep::SZ(q) * unitary_rep::SX(q))
+            }
+            Clifford::Fdg => {
+                unitary_rep::phase(-Angle64::QUARTER_TURN)
+                    * (unitary_rep::SX(q).dg() * unitary_rep::SZ(q).dg())
+            }
+            Clifford::F2 => {
+                unitary_rep::phase(Angle64::HALF_TURN)
+                    * (unitary_rep::SY(q) * unitary_rep::SX(q).dg())
+            }
+            Clifford::F2dg => {
+                unitary_rep::phase(Angle64::HALF_TURN)
+                    * (unitary_rep::SX(q) * unitary_rep::SY(q).dg())
+            }
+            Clifford::F3 => {
+                unitary_rep::phase(Angle64::HALF_TURN)
+                    * (unitary_rep::SZ(q) * unitary_rep::SX(q).dg())
+            }
+            Clifford::F3dg => {
+                unitary_rep::phase(Angle64::HALF_TURN)
+                    * (unitary_rep::SX(q) * unitary_rep::SZ(q).dg())
+            }
+            Clifford::F4 => {
+                unitary_rep::phase(Angle64::QUARTER_TURN)
+                    * (unitary_rep::SX(q) * unitary_rep::SZ(q))
+            }
+            Clifford::F4dg => {
+                unitary_rep::phase(-Angle64::QUARTER_TURN)
+                    * (unitary_rep::SZ(q).dg() * unitary_rep::SX(q).dg())
+            }
             _ => unreachable!(),
         }
     }
@@ -777,6 +941,104 @@ impl fmt::Display for Clifford {
 mod tests {
     use super::*;
 
+    const MATRIX_TOLERANCE: f64 = 1e-14;
+
+    fn matrix_power(matrix: SingleQubitGateMatrix, exponent: usize) -> SingleQubitGateMatrix {
+        let identity = gate_type_matrix(GateType::I);
+        (0..exponent).fold(identity, |product, _| multiply_2x2(product, matrix))
+    }
+
+    fn adjoint(matrix: SingleQubitGateMatrix) -> SingleQubitGateMatrix {
+        [
+            matrix[0], -matrix[1], matrix[4], -matrix[5], matrix[2], -matrix[3], matrix[6],
+            -matrix[7],
+        ]
+    }
+
+    fn max_matrix_error(lhs: SingleQubitGateMatrix, rhs: SingleQubitGateMatrix) -> f64 {
+        lhs.into_iter()
+            .zip(rhs)
+            .map(|(actual, expected)| (actual - expected).abs())
+            .fold(0.0, f64::max)
+    }
+
+    fn matrix_contract_holds(table: &[SingleQubitGateMatrix; 24]) -> bool {
+        let identity = table[Clifford::I as usize];
+        for &gate in Clifford::all_1q() {
+            let order = match gate {
+                Clifford::I => 1,
+                Clifford::X
+                | Clifford::Y
+                | Clifford::Z
+                | Clifford::H
+                | Clifford::H2
+                | Clifford::H3
+                | Clifford::H4
+                | Clifford::H5
+                | Clifford::H6 => 2,
+                Clifford::SX
+                | Clifford::SXdg
+                | Clifford::SY
+                | Clifford::SYdg
+                | Clifford::SZ
+                | Clifford::SZdg => 4,
+                Clifford::F
+                | Clifford::Fdg
+                | Clifford::F2
+                | Clifford::F2dg
+                | Clifford::F3
+                | Clifford::F3dg
+                | Clifford::F4
+                | Clifford::F4dg => 3,
+                _ => unreachable!(),
+            };
+            if max_matrix_error(matrix_power(table[gate as usize], order), identity)
+                > MATRIX_TOLERANCE
+            {
+                return false;
+            }
+        }
+
+        for &gate in &[
+            Clifford::H,
+            Clifford::H2,
+            Clifford::H3,
+            Clifford::H4,
+            Clifford::H5,
+            Clifford::H6,
+        ] {
+            if max_matrix_error(table[gate as usize], adjoint(table[gate as usize]))
+                > MATRIX_TOLERANCE
+            {
+                return false;
+            }
+        }
+
+        for (gate, dagger) in [
+            (Clifford::SX, Clifford::SXdg),
+            (Clifford::SY, Clifford::SYdg),
+            (Clifford::SZ, Clifford::SZdg),
+            (Clifford::F, Clifford::Fdg),
+            (Clifford::F2, Clifford::F2dg),
+            (Clifford::F3, Clifford::F3dg),
+            (Clifford::F4, Clifford::F4dg),
+        ] {
+            if max_matrix_error(table[dagger as usize], adjoint(table[gate as usize]))
+                > MATRIX_TOLERANCE
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn canonical_matrix_table() -> [SingleQubitGateMatrix; 24] {
+        Clifford::all_1q().map(|gate| {
+            gate.canonical_1q_matrix()
+                .expect("single-qubit Clifford must have a canonical matrix")
+        })
+    }
+
     // ====== Collection tests ======
 
     #[test]
@@ -854,6 +1116,167 @@ mod tests {
         for &a in Clifford::all_1q() {
             for &b in Clifford::all_1q() {
                 let _ = a.compose(b);
+            }
+        }
+    }
+
+    #[test]
+    fn canonical_matrices_have_exact_group_orders_hermiticity_and_adjoints() {
+        let table = canonical_matrix_table();
+        assert!(matrix_contract_holds(&table));
+    }
+
+    #[test]
+    fn derived_h_and_f_families_match_the_phase_fixed_oracle() {
+        let r = std::f64::consts::FRAC_1_SQRT_2;
+        let oracle = [
+            (Clifford::H2, [r, 0.0, -r, 0.0, -r, 0.0, -r, 0.0]),
+            (Clifford::H3, [0.0, 0.0, r, -r, r, r, 0.0, 0.0]),
+            (Clifford::H4, [0.0, 0.0, r, r, r, -r, 0.0, 0.0]),
+            (Clifford::H5, [r, 0.0, 0.0, -r, 0.0, r, -r, 0.0]),
+            (Clifford::H6, [-r, 0.0, 0.0, -r, 0.0, r, r, 0.0]),
+            (Clifford::F, [-0.5, 0.5, 0.5, 0.5, -0.5, 0.5, -0.5, -0.5]),
+            (
+                Clifford::Fdg,
+                [-0.5, -0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5],
+            ),
+            (Clifford::F2, [-0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5, -0.5]),
+            (Clifford::F2dg, [-0.5, -0.5, -0.5, 0.5, 0.5, 0.5, -0.5, 0.5]),
+            (Clifford::F3, [-0.5, 0.5, -0.5, -0.5, 0.5, -0.5, -0.5, -0.5]),
+            (Clifford::F3dg, [-0.5, -0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5]),
+            (Clifford::F4, [-0.5, 0.5, -0.5, 0.5, 0.5, 0.5, -0.5, -0.5]),
+            (
+                Clifford::F4dg,
+                [-0.5, -0.5, 0.5, -0.5, -0.5, -0.5, -0.5, 0.5],
+            ),
+        ];
+
+        for (gate, expected) in oracle {
+            let actual = gate.canonical_1q_matrix().unwrap();
+            let error = max_matrix_error(actual, expected);
+            assert!(
+                error <= MATRIX_TOLERANCE,
+                "{gate}: derived matrix differs from oracle by {error:e}; actual={actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_clifford_guard_rejects_each_global_phase_mutation() {
+        let table = canonical_matrix_table();
+        let phase = std::f64::consts::FRAC_1_SQRT_2;
+        for &gate in Clifford::all_1q() {
+            let mut mutant = table;
+            mutant[gate as usize] = scale_2x2(mutant[gate as usize], phase, phase);
+            assert!(
+                !matrix_contract_holds(&mutant),
+                "exp(i*pi/4) phase mutation of {gate} escaped the order/adjoint guards"
+            );
+        }
+    }
+
+    #[test]
+    fn documented_h_and_f_pauli_actions_match_the_canonical_matrices() {
+        let actions = [
+            (
+                Clifford::H,
+                [(false, Pauli::Z), (true, Pauli::Y), (false, Pauli::X)],
+            ),
+            (
+                Clifford::H2,
+                [(true, Pauli::Z), (true, Pauli::Y), (true, Pauli::X)],
+            ),
+            (
+                Clifford::H3,
+                [(false, Pauli::Y), (false, Pauli::X), (true, Pauli::Z)],
+            ),
+            (
+                Clifford::H4,
+                [(true, Pauli::Y), (true, Pauli::X), (true, Pauli::Z)],
+            ),
+            (
+                Clifford::H5,
+                [(true, Pauli::X), (false, Pauli::Z), (false, Pauli::Y)],
+            ),
+            (
+                Clifford::H6,
+                [(true, Pauli::X), (true, Pauli::Z), (true, Pauli::Y)],
+            ),
+            (
+                Clifford::F,
+                [(false, Pauli::Y), (false, Pauli::Z), (false, Pauli::X)],
+            ),
+            (
+                Clifford::Fdg,
+                [(false, Pauli::Z), (false, Pauli::X), (false, Pauli::Y)],
+            ),
+            (
+                Clifford::F2,
+                [(true, Pauli::Z), (true, Pauli::X), (false, Pauli::Y)],
+            ),
+            (
+                Clifford::F2dg,
+                [(true, Pauli::Y), (false, Pauli::Z), (true, Pauli::X)],
+            ),
+            (
+                Clifford::F3,
+                [(false, Pauli::Y), (true, Pauli::Z), (true, Pauli::X)],
+            ),
+            (
+                Clifford::F3dg,
+                [(true, Pauli::Z), (false, Pauli::X), (true, Pauli::Y)],
+            ),
+            (
+                Clifford::F4,
+                [(false, Pauli::Z), (true, Pauli::X), (true, Pauli::Y)],
+            ),
+            (
+                Clifford::F4dg,
+                [(true, Pauli::Y), (true, Pauli::Z), (false, Pauli::X)],
+            ),
+        ];
+
+        for (gate, expected) in actions {
+            for (pauli, (negated, image)) in
+                [Pauli::X, Pauli::Y, Pauli::Z].into_iter().zip(expected)
+            {
+                let expected_sign = if negated {
+                    Sign::MinusOne
+                } else {
+                    Sign::PlusOne
+                };
+                assert_eq!(
+                    gate.conjugate(pauli),
+                    (expected_sign, image),
+                    "{gate}: {pauli:?}"
+                );
+
+                let pauli_gate = match pauli {
+                    Pauli::X => GateType::X,
+                    Pauli::Y => GateType::Y,
+                    Pauli::Z => GateType::Z,
+                    Pauli::I => unreachable!(),
+                };
+                let image_gate = match image {
+                    Pauli::X => GateType::X,
+                    Pauli::Y => GateType::Y,
+                    Pauli::Z => GateType::Z,
+                    Pauli::I => unreachable!(),
+                };
+                let unitary = gate.canonical_1q_matrix().unwrap();
+                let actual = multiply_2x2(
+                    multiply_2x2(unitary, gate_type_matrix(pauli_gate)),
+                    adjoint(unitary),
+                );
+                let expected_matrix = scale_2x2(
+                    gate_type_matrix(image_gate),
+                    if negated { -1.0 } else { 1.0 },
+                    0.0,
+                );
+                assert!(
+                    max_matrix_error(actual, expected_matrix) <= MATRIX_TOLERANCE,
+                    "{gate}: canonical matrix has wrong {pauli:?} conjugation"
+                );
             }
         }
     }

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -27,13 +27,14 @@ pub enum GateType {
     SYdg = 7,
     SZ = 8,
     SZdg = 9,
+    /// Hadamard gate, occupying the H1 slot in the H1-H6 family.
     H = 10,
     // H2 = 11
     // H3 = 12
     // H4 = 13
     // H5 = 14
     // H6 = 15
-    /// F gate (face gate)
+    /// F gate (face gate), occupying the F1 slot in the F1-F4 family.
     F = 16,
     /// F-dagger gate
     Fdg = 17,
@@ -133,6 +134,199 @@ pub enum GateType {
     Custom = 255,
 }
 
+/// Row-major 2x2 complex matrix stored as `(real, imaginary)` pairs.
+///
+/// The entries are `[a.re, a.im, b.re, b.im, c.re, c.im, d.re, d.im]` for
+/// `[[a, b], [c, d]]`.
+pub type SingleQubitGateMatrix = [f64; 8];
+
+/// Converts a canonical f64 matrix to f32 in a constant context.
+///
+/// Canonical gate entries are finite zero or normal-range values. Conversion
+/// uses IEEE-754 round-to-nearest, ties-to-even; an out-of-contract future
+/// entry fails constant evaluation instead of silently changing semantics.
+#[must_use]
+pub const fn single_qubit_matrix_to_f32(matrix: SingleQubitGateMatrix) -> [f32; 8] {
+    let mut converted = [0.0; 8];
+    let mut index = 0;
+    while index < matrix.len() {
+        converted[index] = finite_normal_f64_to_f32(matrix[index]);
+        index += 1;
+    }
+    converted
+}
+
+const fn finite_normal_f64_to_f32(value: f64) -> f32 {
+    let bits = value.to_bits();
+    let sign = if bits >> 63 == 0 { 0 } else { 1_u32 << 31 };
+    let exponent_bits = ((bits >> 52) & 0x7ff).to_le_bytes();
+    let exponent = i32::from_le_bytes([exponent_bits[0], exponent_bits[1], 0, 0]);
+    let fraction = bits & ((1_u64 << 52) - 1);
+
+    if exponent == 0 {
+        assert!(fraction == 0, "canonical matrix contains a subnormal f64");
+        return f32::from_bits(sign);
+    }
+    assert!(
+        exponent != 0x7ff,
+        "canonical matrix contains a non-finite f64"
+    );
+
+    let mut target_exponent = exponent - 1023 + 127;
+    assert!(
+        target_exponent > 0 && target_exponent < 0xff,
+        "canonical matrix entry is outside normal f32 range"
+    );
+
+    let significand = (1_u64 << 52) | fraction;
+    let discarded_mask = (1_u64 << 29) - 1;
+    let discarded = significand & discarded_mask;
+    let halfway = 1_u64 << 28;
+    let mut rounded = significand >> 29;
+    if discarded > halfway || (discarded == halfway && rounded & 1 == 1) {
+        rounded += 1;
+    }
+    if rounded == 1_u64 << 24 {
+        rounded >>= 1;
+        target_exponent += 1;
+        assert!(target_exponent < 0xff, "canonical matrix overflows f32");
+    }
+
+    let rounded_bytes = rounded.to_le_bytes();
+    let target_fraction =
+        u32::from_le_bytes([rounded_bytes[0], rounded_bytes[1], rounded_bytes[2], 0])
+            & ((1_u32 << 23) - 1);
+    let target_exponent = u32::from_le_bytes(target_exponent.to_le_bytes());
+    f32::from_bits(sign | (target_exponent << 23) | target_fraction)
+}
+
+/// Named, phase-fixed single-qubit gates with canonical matrices.
+///
+/// Non-dagger gates precede dagger gates so consumers that identify matrices
+/// projectively can retain the non-dagger preference for self-inverse gates.
+pub const NAMED_SINGLE_QUBIT_GATES: [GateType; 15] = [
+    GateType::I,
+    GateType::X,
+    GateType::Y,
+    GateType::Z,
+    GateType::H,
+    GateType::F,
+    GateType::Fdg,
+    GateType::SX,
+    GateType::SXdg,
+    GateType::SY,
+    GateType::SYdg,
+    GateType::SZ,
+    GateType::SZdg,
+    GateType::T,
+    GateType::Tdg,
+];
+
+const SX_MATRIX: SingleQubitGateMatrix = [0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5];
+
+// Conventional phase-fixed sqrt(Y), not RY(pi/2):
+// (1/2) [[1+i, -1-i], [1+i, 1+i]].
+const SY_MATRIX: SingleQubitGateMatrix = [0.5, 0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5];
+
+// Exact adjoint of the conventional phase-fixed sqrt(Y):
+// (1/2) [[1-i, 1-i], [-1+i, 1-i]].
+const SY_DAGGER_MATRIX: SingleQubitGateMatrix = [0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5];
+
+const SZ_MATRIX: SingleQubitGateMatrix = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+
+const H_MATRIX: SingleQubitGateMatrix = [
+    std::f64::consts::FRAC_1_SQRT_2,
+    0.0,
+    std::f64::consts::FRAC_1_SQRT_2,
+    0.0,
+    std::f64::consts::FRAC_1_SQRT_2,
+    0.0,
+    -std::f64::consts::FRAC_1_SQRT_2,
+    0.0,
+];
+
+const T_MATRIX: SingleQubitGateMatrix = [
+    1.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    std::f64::consts::FRAC_1_SQRT_2,
+    std::f64::consts::FRAC_1_SQRT_2,
+];
+
+const X_MATRIX: SingleQubitGateMatrix = multiply_2x2(SX_MATRIX, SX_MATRIX);
+const Y_MATRIX: SingleQubitGateMatrix = multiply_2x2(SY_MATRIX, SY_MATRIX);
+const Z_MATRIX: SingleQubitGateMatrix = multiply_2x2(SZ_MATRIX, SZ_MATRIX);
+const I_MATRIX: SingleQubitGateMatrix = multiply_2x2(Z_MATRIX, Z_MATRIX);
+// F is F1. The factor i selects the order-three representative:
+// F = i * SZ * SX.
+const F_MATRIX: SingleQubitGateMatrix = scale_2x2(multiply_2x2(SZ_MATRIX, SX_MATRIX), 0.0, 1.0);
+
+const fn multiply_complex(lhs_re: f64, lhs_im: f64, rhs_re: f64, rhs_im: f64) -> (f64, f64) {
+    (
+        lhs_re * rhs_re - lhs_im * rhs_im,
+        lhs_re * rhs_im + lhs_im * rhs_re,
+    )
+}
+
+const fn add_complex(lhs: (f64, f64), rhs: (f64, f64)) -> (f64, f64) {
+    (lhs.0 + rhs.0, lhs.1 + rhs.1)
+}
+
+pub(crate) const fn multiply_2x2(
+    lhs: SingleQubitGateMatrix,
+    rhs: SingleQubitGateMatrix,
+) -> SingleQubitGateMatrix {
+    let a = add_complex(
+        multiply_complex(lhs[0], lhs[1], rhs[0], rhs[1]),
+        multiply_complex(lhs[2], lhs[3], rhs[4], rhs[5]),
+    );
+    let b = add_complex(
+        multiply_complex(lhs[0], lhs[1], rhs[2], rhs[3]),
+        multiply_complex(lhs[2], lhs[3], rhs[6], rhs[7]),
+    );
+    let c = add_complex(
+        multiply_complex(lhs[4], lhs[5], rhs[0], rhs[1]),
+        multiply_complex(lhs[6], lhs[7], rhs[4], rhs[5]),
+    );
+    let d = add_complex(
+        multiply_complex(lhs[4], lhs[5], rhs[2], rhs[3]),
+        multiply_complex(lhs[6], lhs[7], rhs[6], rhs[7]),
+    );
+    [a.0, a.1, b.0, b.1, c.0, c.1, d.0, d.1]
+}
+
+pub(crate) const fn scale_2x2(
+    matrix: SingleQubitGateMatrix,
+    phase_re: f64,
+    phase_im: f64,
+) -> SingleQubitGateMatrix {
+    let a = multiply_complex(matrix[0], matrix[1], phase_re, phase_im);
+    let b = multiply_complex(matrix[2], matrix[3], phase_re, phase_im);
+    let c = multiply_complex(matrix[4], matrix[5], phase_re, phase_im);
+    let d = multiply_complex(matrix[6], matrix[7], phase_re, phase_im);
+    [a.0, a.1, b.0, b.1, c.0, c.1, d.0, d.1]
+}
+
+const fn conjugate_imaginary(value: f64) -> f64 {
+    if value == 0.0 { 0.0 } else { -value }
+}
+
+const fn adjoint_2x2(matrix: SingleQubitGateMatrix) -> SingleQubitGateMatrix {
+    [
+        matrix[0],
+        conjugate_imaginary(matrix[1]),
+        matrix[4],
+        conjugate_imaginary(matrix[5]),
+        matrix[2],
+        conjugate_imaginary(matrix[3]),
+        matrix[6],
+        conjugate_imaginary(matrix[7]),
+    ]
+}
+
 impl From<u8> for GateType {
     fn from(value: u8) -> Self {
         match value {
@@ -195,6 +389,46 @@ impl From<u8> for GateType {
 }
 
 impl GateType {
+    /// Returns the canonical phase-fixed matrix for a named single-qubit gate.
+    ///
+    /// Matrices are row-major `(real, imaginary)` pairs in the order described
+    /// by [`SingleQubitGateMatrix`]. Parameterized rotations deliberately have
+    /// no entry: `RP(theta) = exp(-i theta P / 2)` remains a separate family.
+    ///
+    /// The roots use conventional phases, so `SX^2 = X`, `SY^2 = Y`,
+    /// `SZ^2 = Z`, `T^2 = SZ`, and every dagger is the exact adjoint of its
+    /// partner. `H` is H1 and satisfies `H^2 = I`; `F` is F1 and uses
+    /// `F = i * SZ * SX`, so `F^3 = I`. In particular:
+    ///
+    /// - `SX = exp(i*pi/4) RX(pi/2)`
+    /// - `SY = exp(i*pi/4) RY(pi/2)`
+    /// - `SZ = exp(i*pi/4) RZ(pi/2)`
+    /// - `T = exp(i*pi/8) RZ(pi/4)`
+    ///
+    /// The dagger gates have the conjugate phase multiplying the corresponding
+    /// negative-angle rotation.
+    #[must_use]
+    pub const fn canonical_1q_matrix(self) -> Option<SingleQubitGateMatrix> {
+        match self {
+            GateType::I => Some(I_MATRIX),
+            GateType::X => Some(X_MATRIX),
+            GateType::Y => Some(Y_MATRIX),
+            GateType::Z => Some(Z_MATRIX),
+            GateType::SX => Some(SX_MATRIX),
+            GateType::SXdg => Some(adjoint_2x2(SX_MATRIX)),
+            GateType::SY => Some(SY_MATRIX),
+            GateType::SYdg => Some(SY_DAGGER_MATRIX),
+            GateType::SZ => Some(SZ_MATRIX),
+            GateType::SZdg => Some(adjoint_2x2(SZ_MATRIX)),
+            GateType::H => Some(H_MATRIX),
+            GateType::F => Some(F_MATRIX),
+            GateType::Fdg => Some(adjoint_2x2(F_MATRIX)),
+            GateType::T => Some(T_MATRIX),
+            GateType::Tdg => Some(adjoint_2x2(T_MATRIX)),
+            _ => None,
+        }
+    }
+
     /// Returns true if this gate type is a meta-gate (annotation, not physical).
     ///
     /// Meta-gates have a position in the DAG but do not affect quantum state
@@ -589,6 +823,189 @@ impl std::str::FromStr for GateType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const CLOSURE_TOLERANCE: f64 = 1e-14;
+
+    fn canonical_table() -> [SingleQubitGateMatrix; NAMED_SINGLE_QUBIT_GATES.len()] {
+        NAMED_SINGLE_QUBIT_GATES.map(|gate| {
+            gate.canonical_1q_matrix()
+                .expect("named single-qubit gate must have a canonical matrix")
+        })
+    }
+
+    fn table_matrix(
+        table: &[SingleQubitGateMatrix; NAMED_SINGLE_QUBIT_GATES.len()],
+        gate: GateType,
+    ) -> SingleQubitGateMatrix {
+        let index = NAMED_SINGLE_QUBIT_GATES
+            .iter()
+            .position(|candidate| *candidate == gate)
+            .expect("gate must be present in canonical table");
+        table[index]
+    }
+
+    fn matrix_power(matrix: SingleQubitGateMatrix, exponent: usize) -> SingleQubitGateMatrix {
+        let mut result = I_MATRIX;
+        for _ in 0..exponent {
+            result = multiply_2x2(result, matrix);
+        }
+        result
+    }
+
+    fn max_matrix_error(lhs: SingleQubitGateMatrix, rhs: SingleQubitGateMatrix) -> f64 {
+        lhs.into_iter()
+            .zip(rhs)
+            .map(|(actual, expected)| (actual - expected).abs())
+            .fold(0.0, f64::max)
+    }
+
+    fn closure_relations(
+        table: &[SingleQubitGateMatrix; NAMED_SINGLE_QUBIT_GATES.len()],
+    ) -> Vec<(&'static str, SingleQubitGateMatrix, SingleQubitGateMatrix)> {
+        let matrix = |gate| table_matrix(table, gate);
+        let mut relations = vec![
+            (
+                "SX^2 = X",
+                matrix_power(matrix(GateType::SX), 2),
+                matrix(GateType::X),
+            ),
+            (
+                "SXdg^2 = X",
+                matrix_power(matrix(GateType::SXdg), 2),
+                matrix(GateType::X),
+            ),
+            (
+                "SY^2 = Y",
+                matrix_power(matrix(GateType::SY), 2),
+                matrix(GateType::Y),
+            ),
+            (
+                "SYdg^2 = Y",
+                matrix_power(matrix(GateType::SYdg), 2),
+                matrix(GateType::Y),
+            ),
+            (
+                "SZ^2 = Z",
+                matrix_power(matrix(GateType::SZ), 2),
+                matrix(GateType::Z),
+            ),
+            (
+                "SZdg^2 = Z",
+                matrix_power(matrix(GateType::SZdg), 2),
+                matrix(GateType::Z),
+            ),
+            (
+                "T^2 = SZ",
+                matrix_power(matrix(GateType::T), 2),
+                matrix(GateType::SZ),
+            ),
+            (
+                "Tdg^2 = SZdg",
+                matrix_power(matrix(GateType::Tdg), 2),
+                matrix(GateType::SZdg),
+            ),
+            (
+                "T^4 = Z",
+                matrix_power(matrix(GateType::T), 4),
+                matrix(GateType::Z),
+            ),
+            (
+                "T^8 = I",
+                matrix_power(matrix(GateType::T), 8),
+                matrix(GateType::I),
+            ),
+            (
+                "H^2 = I",
+                matrix_power(matrix(GateType::H), 2),
+                matrix(GateType::I),
+            ),
+            (
+                "X^2 = I",
+                matrix_power(matrix(GateType::X), 2),
+                matrix(GateType::I),
+            ),
+            (
+                "Y^2 = I",
+                matrix_power(matrix(GateType::Y), 2),
+                matrix(GateType::I),
+            ),
+            (
+                "Z^2 = I",
+                matrix_power(matrix(GateType::Z), 2),
+                matrix(GateType::I),
+            ),
+            (
+                "F = i * SZ * SX",
+                matrix(GateType::F),
+                scale_2x2(
+                    multiply_2x2(matrix(GateType::SZ), matrix(GateType::SX)),
+                    0.0,
+                    1.0,
+                ),
+            ),
+            (
+                "F^3 = I",
+                matrix_power(matrix(GateType::F), 3),
+                matrix(GateType::I),
+            ),
+            (
+                "Fdg^3 = I",
+                matrix_power(matrix(GateType::Fdg), 3),
+                matrix(GateType::I),
+            ),
+        ];
+
+        for (gate, dagger, label) in [
+            (GateType::SX, GateType::SXdg, "SXdg = SX adjoint"),
+            (GateType::SY, GateType::SYdg, "SYdg = SY adjoint"),
+            (GateType::SZ, GateType::SZdg, "SZdg = SZ adjoint"),
+            (GateType::F, GateType::Fdg, "Fdg = F adjoint"),
+            (GateType::T, GateType::Tdg, "Tdg = T adjoint"),
+        ] {
+            relations.push((label, matrix(dagger), adjoint_2x2(matrix(gate))));
+        }
+
+        relations
+    }
+
+    fn closure_holds(table: &[SingleQubitGateMatrix; NAMED_SINGLE_QUBIT_GATES.len()]) -> bool {
+        closure_relations(table)
+            .into_iter()
+            .all(|(_, lhs, rhs)| max_matrix_error(lhs, rhs) <= CLOSURE_TOLERANCE)
+    }
+
+    #[test]
+    fn canonical_single_qubit_matrices_close_phase_exactly() {
+        let table = canonical_table();
+        for (label, actual, expected) in closure_relations(&table) {
+            let error = max_matrix_error(actual, expected);
+            assert!(
+                error <= CLOSURE_TOLERANCE,
+                "{label}: max entrywise error {error:e} exceeds phase-exact tolerance \
+                 {CLOSURE_TOLERANCE:e}; actual={actual:?}, expected={expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn closure_guard_rejects_a_phase_mutation_of_every_canonical_matrix() {
+        let table = canonical_table();
+        let phase_re = std::f64::consts::FRAC_1_SQRT_2;
+        let phase_im = std::f64::consts::FRAC_1_SQRT_2;
+
+        for (index, gate) in NAMED_SINGLE_QUBIT_GATES.into_iter().enumerate() {
+            let mut mutant = table;
+            for entry in mutant[index].as_chunks_mut::<2>().0 {
+                let phased = multiply_complex(entry[0], entry[1], phase_re, phase_im);
+                entry[0] = phased.0;
+                entry[1] = phased.1;
+            }
+            assert!(
+                !closure_holds(&mutant),
+                "exp(i*pi/4) phase mutation of {gate:?} escaped every closure relation"
+            );
+        }
+    }
 
     #[test]
     fn test_gate_type_id_conversion() {

--- a/crates/pecos-core/src/op.rs
+++ b/crates/pecos-core/src/op.rs
@@ -56,7 +56,7 @@
 use crate::clifford_rep::CliffordRep;
 use crate::qubit_support::{assert_distinct_qubits, overlapping_qubits};
 use crate::unitary_rep::{PhaseValue, UnitaryRep};
-use crate::{Angle64, PauliString, QubitId};
+use crate::{Angle64, Clifford, PauliString, QubitId};
 use std::fmt;
 use std::ops::{BitAnd, Mul, Neg};
 
@@ -1022,146 +1022,143 @@ pub fn SZdg(qubit: impl Into<QubitId>) -> Op {
     cliff(CliffordRep::szdg(q.0), crate::unitary_rep::SZ(q).dg())
 }
 
-/// H2 gate (SY * Z decomposition).
+/// H2 gate: `exp(-i*pi/4) * Z * SY`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn H2(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::h2(q.0),
-        crate::unitary_rep::Z(q) * crate::unitary_rep::SY(q),
+        Clifford::H2.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// H3 gate (SZ * Y decomposition).
+/// H3 gate: `exp(-i*pi/4) * Y * SZ`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn H3(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::h3(q.0),
-        crate::unitary_rep::Y(q) * crate::unitary_rep::SZ(q),
+        Clifford::H3.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// H4 gate (SZ * X decomposition).
+/// H4 gate: `exp(-i*pi/4) * X * SZ`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn H4(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::h4(q.0),
-        crate::unitary_rep::X(q) * crate::unitary_rep::SZ(q),
+        Clifford::H4.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// H5 gate (SX * Z decomposition).
+/// H5 gate: `exp(-i*pi/4) * Z * SX`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn H5(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::h5(q.0),
-        crate::unitary_rep::Z(q) * crate::unitary_rep::SX(q),
+        Clifford::H5.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// H6 gate (SX * Y decomposition).
+/// H6 gate: `exp(-i*pi/4) * Y * SX`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn H6(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::h6(q.0),
-        crate::unitary_rep::Y(q) * crate::unitary_rep::SX(q),
+        Clifford::H6.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// Face gate F (SX * SZ decomposition).
+/// Face gate F/F1: `i * SZ * SX`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
-    cliff(
-        CliffordRep::f(q.0),
-        crate::unitary_rep::SZ(q) * crate::unitary_rep::SX(q),
-    )
+    cliff(CliffordRep::f(q.0), Clifford::F.to_unitary_rep_on_qubit(q))
 }
 
-/// Face gate F-dagger (`SZdg` * `SXdg` decomposition).
+/// Face gate F-dagger/F1-dagger: `-i * SXdg * SZdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn Fdg(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::fdg(q.0),
-        crate::unitary_rep::SX(q).dg() * crate::unitary_rep::SZ(q).dg(),
+        Clifford::Fdg.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F2 gate (`SXdg` * SY decomposition).
+/// F2 gate: `-SY * SXdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F2(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f2(q.0),
-        crate::unitary_rep::SY(q) * crate::unitary_rep::SX(q).dg(),
+        Clifford::F2.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F2-dagger gate (`SYdg` * SX decomposition).
+/// F2-dagger gate: `-SX * SYdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F2dg(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f2dg(q.0),
-        crate::unitary_rep::SX(q) * crate::unitary_rep::SY(q).dg(),
+        Clifford::F2dg.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F3 gate (`SXdg` * SZ decomposition).
+/// F3 gate: `-SZ * SXdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F3(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f3(q.0),
-        crate::unitary_rep::SZ(q) * crate::unitary_rep::SX(q).dg(),
+        Clifford::F3.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F3-dagger gate (SX * `SZdg` decomposition).
+/// F3-dagger gate: `-SX * SZdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F3dg(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f3dg(q.0),
-        crate::unitary_rep::SX(q) * crate::unitary_rep::SZ(q).dg(),
+        Clifford::F3dg.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F4 gate (SX * SZ decomposition).
+/// F4 gate: `i * SX * SZ`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F4(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f4(q.0),
-        crate::unitary_rep::SX(q) * crate::unitary_rep::SZ(q),
+        Clifford::F4.to_unitary_rep_on_qubit(q),
     )
 }
 
-/// F4-dagger gate (`SZdg` * `SXdg` decomposition).
+/// F4-dagger gate: `-i * SZdg * SXdg`.
 #[allow(non_snake_case)]
 #[must_use]
 pub fn F4dg(qubit: impl Into<QubitId>) -> Op {
     let q = qubit.into();
     cliff(
         CliffordRep::f4dg(q.0),
-        crate::unitary_rep::SZ(q).dg() * crate::unitary_rep::SX(q).dg(),
+        Clifford::F4dg.to_unitary_rep_on_qubit(q),
     )
 }
 

--- a/crates/pecos-core/src/unitary_rep.rs
+++ b/crates/pecos-core/src/unitary_rep.rs
@@ -784,7 +784,7 @@ impl FromStr for UnitaryRep {
     ///
     /// Rotation gates: `"RX(pi/4) 0"`, `"RZ(pi/2) 0"`, `"RZZ(pi) 0 1"`
     ///
-    /// Named rotations: `"T 0"`, `"Tdg 0"`, `"S 0"`, `"Sdg 0"`
+    /// Phase-fixed named gates: `"T 0"`, `"Tdg 0"`, `"S 0"`, `"Sdg 0"`
     ///
     /// # Pauli syntax
     ///
@@ -795,7 +795,9 @@ impl FromStr for UnitaryRep {
     /// Single Pauli with space: `"X 0"`, `"Z 3"` (treated same as `"X0"`, `"Z3"`)
     ///
     /// **Note**: Gate names take priority over Pauli parsing. `"S 0"` parses as an
-    /// S gate (RZ(pi/2)), not as Pauli S on qubit 0. Similarly for `"H 0"`, `"T 0"`, etc.
+    /// phase-fixed S gate, not as Pauli S on qubit 0. Similarly for `"H 0"`,
+    /// `"T 0"`, etc. Parameterized syntax such as `"RZ(pi/2) 0"` remains a
+    /// rotation and therefore differs from S by its documented global phase.
     /// Use sparse Pauli syntax without spaces (e.g., `"X0"`) to avoid ambiguity.
     ///
     /// # Examples
@@ -875,7 +877,8 @@ impl FromStr for UnitaryRep {
 
         match upper.as_str() {
             // Single-qubit fixed gates
-            "H" | "F" | "FDG" | "SX" | "SXDG" | "SY" | "SYDG" | "CH" => {
+            "H" | "F" | "FDG" | "SX" | "SXDG" | "SY" | "SYDG" | "S" | "SZ" | "SDG" | "SZDG"
+            | "T" | "TDG" | "CH" => {
                 let gate_type = match upper.as_str() {
                     "H" => GateType::H,
                     "F" => GateType::F,
@@ -884,6 +887,10 @@ impl FromStr for UnitaryRep {
                     "SXDG" => GateType::SXdg,
                     "SY" => GateType::SY,
                     "SYDG" => GateType::SYdg,
+                    "S" | "SZ" => GateType::SZ,
+                    "SDG" | "SZDG" => GateType::SZdg,
+                    "T" => GateType::T,
+                    "TDG" => GateType::Tdg,
                     "CH" => GateType::CH,
                     _ => unreachable!(),
                 };
@@ -901,60 +908,6 @@ impl FromStr for UnitaryRep {
                     require_distinct_parsed_qubits(gate_name, &qubits)?;
                 }
                 Ok(UnitaryRep::gate(gate_type, SmallVec::from_vec(qubits)))
-            }
-
-            // Named rotations (these produce Rotation variants)
-            "T" => {
-                let qubits = parse_qubits(&qubit_tokens)?;
-                if qubits.len() != 1 {
-                    return Err(ParseUnitaryRepError {
-                        message: format!("T requires 1 qubit, got {}", qubits.len()),
-                    });
-                }
-                Ok(UnitaryRep::rotation(
-                    RotationType::RZ,
-                    Angle64::HALF_TURN / 4,
-                    smallvec::smallvec![qubits[0]],
-                ))
-            }
-            "TDG" => {
-                let qubits = parse_qubits(&qubit_tokens)?;
-                if qubits.len() != 1 {
-                    return Err(ParseUnitaryRepError {
-                        message: format!("Tdg requires 1 qubit, got {}", qubits.len()),
-                    });
-                }
-                Ok(UnitaryRep::rotation(
-                    RotationType::RZ,
-                    Angle64::ZERO - Angle64::HALF_TURN / 4,
-                    smallvec::smallvec![qubits[0]],
-                ))
-            }
-            "S" | "SZ" => {
-                let qubits = parse_qubits(&qubit_tokens)?;
-                if qubits.len() != 1 {
-                    return Err(ParseUnitaryRepError {
-                        message: format!("{gate_name} requires 1 qubit, got {}", qubits.len()),
-                    });
-                }
-                Ok(UnitaryRep::rotation(
-                    RotationType::RZ,
-                    Angle64::QUARTER_TURN,
-                    smallvec::smallvec![qubits[0]],
-                ))
-            }
-            "SDG" | "SZDG" => {
-                let qubits = parse_qubits(&qubit_tokens)?;
-                if qubits.len() != 1 {
-                    return Err(ParseUnitaryRepError {
-                        message: format!("{gate_name} requires 1 qubit, got {}", qubits.len()),
-                    });
-                }
-                Ok(UnitaryRep::rotation(
-                    RotationType::RZ,
-                    Angle64::ZERO - Angle64::QUARTER_TURN,
-                    smallvec::smallvec![qubits[0]],
-                ))
             }
 
             // Two-qubit fixed gates
@@ -1159,9 +1112,11 @@ impl UnitaryRep {
                     qubits.clone(),
                 )
             }
-            Self::Gate(Unitary::Named(gate_type), _) => {
+            Self::Gate(Unitary::Named(gate_type), qubits) => {
                 if gate_type.is_self_adjoint() {
                     self.clone()
+                } else if let Some(dagger) = phase_fixed_named_adjoint(*gate_type) {
+                    Self::Gate(Unitary::Named(dagger), qubits.clone())
                 } else {
                     Self::Adjoint(Box::new(self.clone()))
                 }
@@ -1639,7 +1594,8 @@ impl UnitaryRep {
 
     /// Simplifies this gate expression by:
     /// - Merging adjacent rotations of the same type on the same qubits
-    /// - Canceling inverse operations (rotation + its negation)
+    /// - Closing phase-fixed named root powers (`SX^2 = X`, `T^8 = I`, etc.)
+    /// - Canceling inverse operations
     /// - Removing identity operations (zero-angle rotations)
     /// - Flattening single-element containers
     #[must_use]
@@ -2695,7 +2651,7 @@ fn flatten_compose(parts: Vec<UnitaryRep>) -> Vec<UnitaryRep> {
     result
 }
 
-/// Merge adjacent rotations of the same type on the same qubits.
+/// Merge adjacent rotations or phase-fixed named roots on the same qubits.
 fn merge_adjacent_rotations(parts: Vec<UnitaryRep>) -> Vec<UnitaryRep> {
     if parts.len() < 2 {
         return parts;
@@ -2768,8 +2724,101 @@ fn try_merge_rotations(a: &UnitaryRep, b: &UnitaryRep) -> Option<UnitaryRep> {
                 None
             }
         }
+        _ => try_merge_phase_fixed_named_gates(a, b),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PhaseFixedRootFamily {
+    SX,
+    SY,
+    Z8,
+    H,
+    F,
+}
+
+fn phase_fixed_root_power(gate: GateType) -> Option<(PhaseFixedRootFamily, u8, u8)> {
+    match gate {
+        GateType::SX => Some((PhaseFixedRootFamily::SX, 1, 4)),
+        GateType::SXdg => Some((PhaseFixedRootFamily::SX, 3, 4)),
+        GateType::X => Some((PhaseFixedRootFamily::SX, 2, 4)),
+        GateType::SY => Some((PhaseFixedRootFamily::SY, 1, 4)),
+        GateType::SYdg => Some((PhaseFixedRootFamily::SY, 3, 4)),
+        GateType::Y => Some((PhaseFixedRootFamily::SY, 2, 4)),
+        GateType::T => Some((PhaseFixedRootFamily::Z8, 1, 8)),
+        GateType::SZ => Some((PhaseFixedRootFamily::Z8, 2, 8)),
+        GateType::Z => Some((PhaseFixedRootFamily::Z8, 4, 8)),
+        GateType::SZdg => Some((PhaseFixedRootFamily::Z8, 6, 8)),
+        GateType::Tdg => Some((PhaseFixedRootFamily::Z8, 7, 8)),
+        GateType::H => Some((PhaseFixedRootFamily::H, 1, 2)),
+        GateType::F => Some((PhaseFixedRootFamily::F, 1, 3)),
+        GateType::Fdg => Some((PhaseFixedRootFamily::F, 2, 3)),
         _ => None,
     }
+}
+
+fn phase_fixed_named_gate(rep: &UnitaryRep) -> Option<(GateType, &SmallVec<[usize; 3]>)> {
+    match rep {
+        UnitaryRep::Gate(Unitary::Named(gate), qubits) => Some((*gate, qubits)),
+        UnitaryRep::Adjoint(inner) => match inner.as_ref() {
+            UnitaryRep::Gate(Unitary::Named(gate), qubits) => {
+                let dagger = phase_fixed_named_adjoint(*gate)
+                    .or_else(|| gate.is_self_adjoint().then_some(*gate))?;
+                Some((dagger, qubits))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn phase_fixed_named_adjoint(gate: GateType) -> Option<GateType> {
+    match gate {
+        GateType::SX => Some(GateType::SXdg),
+        GateType::SXdg => Some(GateType::SX),
+        GateType::SY => Some(GateType::SYdg),
+        GateType::SYdg => Some(GateType::SY),
+        GateType::SZ => Some(GateType::SZdg),
+        GateType::SZdg => Some(GateType::SZ),
+        GateType::T => Some(GateType::Tdg),
+        GateType::Tdg => Some(GateType::T),
+        GateType::F => Some(GateType::Fdg),
+        GateType::Fdg => Some(GateType::F),
+        _ => None,
+    }
+}
+
+fn try_merge_phase_fixed_named_gates(a: &UnitaryRep, b: &UnitaryRep) -> Option<UnitaryRep> {
+    let (gate_a, qubits_a) = phase_fixed_named_gate(a)?;
+    let (gate_b, qubits_b) = phase_fixed_named_gate(b)?;
+    if qubits_a != qubits_b {
+        return None;
+    }
+    let (family_a, power_a, order_a) = phase_fixed_root_power(gate_a)?;
+    let (family_b, power_b, order_b) = phase_fixed_root_power(gate_b)?;
+    if family_a != family_b || order_a != order_b {
+        return None;
+    }
+    let power = (power_a + power_b) % order_a;
+    let gate = match (family_a, power) {
+        (_, 0) => GateType::I,
+        (PhaseFixedRootFamily::SX, 1) => GateType::SX,
+        (PhaseFixedRootFamily::SX, 2) => GateType::X,
+        (PhaseFixedRootFamily::SX, 3) => GateType::SXdg,
+        (PhaseFixedRootFamily::SY, 1) => GateType::SY,
+        (PhaseFixedRootFamily::SY, 2) => GateType::Y,
+        (PhaseFixedRootFamily::SY, 3) => GateType::SYdg,
+        (PhaseFixedRootFamily::Z8, 1) => GateType::T,
+        (PhaseFixedRootFamily::Z8, 2) => GateType::SZ,
+        (PhaseFixedRootFamily::Z8, 4) => GateType::Z,
+        (PhaseFixedRootFamily::Z8, 6) => GateType::SZdg,
+        (PhaseFixedRootFamily::Z8, 7) => GateType::Tdg,
+        (PhaseFixedRootFamily::H, 1) => GateType::H,
+        (PhaseFixedRootFamily::F, 1) => GateType::F,
+        (PhaseFixedRootFamily::F, 2) => GateType::Fdg,
+        _ => return None,
+    };
+    Some(UnitaryRep::gate(gate, qubits_a.clone()))
 }
 
 /// Convert a rotation (type + angle) to a named `GateType` if one exists.
@@ -3159,63 +3208,72 @@ pub fn Zs(qubits: impl Into<Qubits>) -> UnitaryRep {
     }
 }
 
-/// SX gate (sqrt X): RX(π/2)
+/// Conventional SX gate (sqrt X).
+///
+/// `SX = exp(i*pi/4) * RX(pi/2)`; the parameterized rotation retains its
+/// `exp(-i*theta*X/2)` convention.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SX(qubit: impl Into<QubitId>) -> UnitaryRep {
-    RX(Angle64::QUARTER_TURN, qubit.into().0)
+    UnitaryRep::gate(GateType::SX, smallvec::smallvec![qubit.into().0])
 }
 
 /// SX gates on multiple qubits.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SXs(qubits: impl Into<Qubits>) -> UnitaryRep {
-    qubits.into().apply(|q| RX(Angle64::QUARTER_TURN, q))
+    qubits.into().apply(SX)
 }
 
-/// SY gate (sqrt Y): RY(π/2)
+/// Conventional SY gate (sqrt Y).
+///
+/// `SY = exp(i*pi/4) * RY(pi/2)`; the parameterized rotation retains its
+/// `exp(-i*theta*Y/2)` convention.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SY(qubit: impl Into<QubitId>) -> UnitaryRep {
-    RY(Angle64::QUARTER_TURN, qubit.into().0)
+    UnitaryRep::gate(GateType::SY, smallvec::smallvec![qubit.into().0])
 }
 
 /// SY gates on multiple qubits.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SYs(qubits: impl Into<Qubits>) -> UnitaryRep {
-    qubits.into().apply(|q| RY(Angle64::QUARTER_TURN, q))
+    qubits.into().apply(SY)
 }
 
-/// SZ gate (sqrt Z): RZ(π/2)
+/// Conventional SZ gate (sqrt Z), also called S.
+///
+/// `SZ = exp(i*pi/4) * RZ(pi/2)`; the parameterized rotation retains its
+/// `exp(-i*theta*Z/2)` convention.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SZ(qubit: impl Into<QubitId>) -> UnitaryRep {
-    RZ(Angle64::QUARTER_TURN, qubit.into().0)
+    UnitaryRep::gate(GateType::SZ, smallvec::smallvec![qubit.into().0])
 }
 
 /// SZ gates on multiple qubits.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn SZs(qubits: impl Into<Qubits>) -> UnitaryRep {
-    qubits.into().apply(|q| RZ(Angle64::QUARTER_TURN, q))
+    qubits.into().apply(SZ)
 }
 
-/// Projective T representation: `RZ(π/4) = exp(-iπ/8) T`.
+/// Conventional T gate, `diag(1, exp(i*pi/4))`.
 ///
-/// `UnitaryRep` intentionally discards this global phase so `Angle64` rotation
-/// arithmetic retains the `T^2`, `T^4`, and `T^8` simplification chain.
+/// `T = exp(i*pi/8) * RZ(pi/4)`; the parameterized rotation retains its
+/// `exp(-i*theta*Z/2)` convention.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn T(qubit: impl Into<QubitId>) -> UnitaryRep {
-    RZ(Angle64::HALF_TURN / 4, qubit.into().0)
+    UnitaryRep::gate(GateType::T, smallvec::smallvec![qubit.into().0])
 }
 
-/// Projective T representations on multiple qubits (each up to global phase).
+/// Conventional T gates on multiple qubits.
 #[must_use]
 #[allow(non_snake_case)]
 pub fn Ts(qubits: impl Into<Qubits>) -> UnitaryRep {
-    qubits.into().apply(|q| RZ(Angle64::HALF_TURN / 4, q))
+    qubits.into().apply(T)
 }
 
 /// Hadamard gate: RZ(π) * RY(π/2) (up to global phase)
@@ -3753,15 +3811,10 @@ mod tests {
     fn test_adjoint() {
         let t = T(0);
         let t_dg = t.dg();
-
-        // T† should have negated angle
-        if let UnitaryRep::Gate(Unitary::Rotation { angle, .. }, _) = t_dg {
-            let t_angle = Angle64::HALF_TURN / 4;
-            let expected = negate_angle(t_angle);
-            assert_eq!(angle, expected);
-        } else {
-            panic!("Expected Gate(Rotation)");
-        }
+        assert!(matches!(
+            t_dg,
+            UnitaryRep::Gate(Unitary::Named(GateType::Tdg), _)
+        ));
     }
 
     #[test]
@@ -3828,18 +3881,18 @@ mod tests {
 
         if let UnitaryRep::Compose(parts) = circuit {
             assert_eq!(parts.len(), 3);
-            // All should be rotations
+            // All are phase-fixed named roots.
             assert!(matches!(
                 &parts[0],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::SX), _)
             ));
             assert!(matches!(
                 &parts[1],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::SY), _)
             ));
             assert!(matches!(
                 &parts[2],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::SZ), _)
             ));
         } else {
             panic!("Expected Compose");
@@ -3868,24 +3921,14 @@ mod tests {
 
     #[test]
     fn test_simplify_merge_adjacent() {
-        // SZ * SZ = Z (RZ(π/2) + RZ(π/2) = RZ(π))
+        // The phase-fixed roots close exactly: SZ * SZ = Z.
         let circuit = SZ(0) * SZ(0);
         let simplified = circuit.simplify();
 
-        // Should merge into a single rotation
-        if let UnitaryRep::Gate(
-            Unitary::Rotation {
-                angle,
-                rotation_type,
-            },
-            _,
-        ) = simplified
-        {
-            assert_eq!(rotation_type, RotationType::RZ);
-            assert_eq!(angle, Angle64::HALF_TURN); // π
-        } else {
-            panic!("Expected single Gate(Rotation), got {simplified:?}");
-        }
+        assert!(matches!(
+            simplified,
+            UnitaryRep::Gate(Unitary::Named(GateType::Z), _)
+        ));
     }
 
     #[test]
@@ -3918,15 +3961,14 @@ mod tests {
 
     #[test]
     fn test_simplify_multiple_merges() {
-        // T * T * T * T = Z (4 * π/4 = π)
+        // The phase-fixed T root has T^4 = Z exactly.
         let circuit = T(0) * T(0) * T(0) * T(0);
         let simplified = circuit.simplify();
 
-        if let UnitaryRep::Gate(Unitary::Rotation { angle, .. }, _) = simplified {
-            assert_eq!(angle, Angle64::HALF_TURN);
-        } else {
-            panic!("Expected single Gate(Rotation)");
-        }
+        assert!(matches!(
+            simplified,
+            UnitaryRep::Gate(Unitary::Named(GateType::Z), _)
+        ));
     }
 
     #[test]
@@ -4351,18 +4393,18 @@ mod tests {
 
         if let UnitaryRep::Tensor(parts) = multi {
             assert_eq!(parts.len(), 3);
-            // Each should be a rotation
+            // Each should be a phase-fixed named T gate.
             assert!(matches!(
                 &parts[0],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::T), _)
             ));
             assert!(matches!(
                 &parts[1],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::T), _)
             ));
             assert!(matches!(
                 &parts[2],
-                UnitaryRep::Gate(Unitary::Rotation { .. }, _)
+                UnitaryRep::Gate(Unitary::Named(GateType::T), _)
             ));
         } else {
             panic!("Expected Tensor variant, got {multi:?}");
@@ -4392,7 +4434,10 @@ mod tests {
         let h = H(2);
 
         assert!(matches!(x, UnitaryRep::Pauli(_)));
-        assert!(matches!(t, UnitaryRep::Gate(Unitary::Rotation { .. }, _)));
+        assert!(matches!(
+            t,
+            UnitaryRep::Gate(Unitary::Named(GateType::T), _)
+        ));
         assert!(matches!(
             h,
             UnitaryRep::Gate(Unitary::Named(GateType::H), _)
@@ -4567,29 +4612,7 @@ mod tests {
         let from_range = Ts(2..=2);
         let direct = T(2);
 
-        // Both should be Rotation variants
-        if let (
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    angle: a1,
-                    rotation_type: r1,
-                },
-                _,
-            ),
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    angle: a2,
-                    rotation_type: r2,
-                },
-                _,
-            ),
-        ) = (&from_range, &direct)
-        {
-            assert_eq!(a1, a2);
-            assert_eq!(r1, r2);
-        } else {
-            panic!("Expected Gate(Rotation) variants, got {from_range:?} and {direct:?}");
-        }
+        assert_eq!(from_range, direct);
     }
 
     // --- Conjugation tests ---
@@ -4665,32 +4688,20 @@ mod tests {
         let sz = SZ(0);
         let result = x.conj(&sz);
 
-        // Verify structure: Compose([SZ, X, SZ†])
+        // Compose stores application order: [SZdg, X, SZ].
         if let UnitaryRep::Compose(parts) = result {
             assert_eq!(parts.len(), 3);
-            // First element is SZ (positive angle)
+            // First applied is the named phase-fixed SZdg.
             assert!(matches!(
                 &parts[0],
-                UnitaryRep::Gate(
-                    Unitary::Rotation {
-                        rotation_type: RotationType::RZ,
-                        ..
-                    },
-                    _
-                )
+                UnitaryRep::Gate(Unitary::Named(GateType::SZdg), _)
             ));
             // Middle element is X
             assert!(matches!(&parts[1], UnitaryRep::Pauli(_)));
-            // Last element is SZ† (negative angle)
+            // Last applied is the named phase-fixed SZ.
             assert!(matches!(
                 &parts[2],
-                UnitaryRep::Gate(
-                    Unitary::Rotation {
-                        rotation_type: RotationType::RZ,
-                        ..
-                    },
-                    _
-                )
+                UnitaryRep::Gate(Unitary::Named(GateType::SZ), _)
             ));
         } else {
             panic!("Expected Compose variant, got {result:?}");
@@ -4704,32 +4715,20 @@ mod tests {
         let sz = SZ(0);
         let result = x.conjdg(&sz);
 
-        // Verify structure: Compose([SZ†, X, SZ])
+        // Compose stores application order: [SZ, X, SZdg].
         if let UnitaryRep::Compose(parts) = result {
             assert_eq!(parts.len(), 3);
-            // First element is SZ† (negative angle)
+            // First applied is the named phase-fixed SZ.
             assert!(matches!(
                 &parts[0],
-                UnitaryRep::Gate(
-                    Unitary::Rotation {
-                        rotation_type: RotationType::RZ,
-                        ..
-                    },
-                    _
-                )
+                UnitaryRep::Gate(Unitary::Named(GateType::SZ), _)
             ));
             // Middle element is X
             assert!(matches!(&parts[1], UnitaryRep::Pauli(_)));
-            // Last element is SZ (positive angle)
+            // Last applied is the named phase-fixed SZdg.
             assert!(matches!(
                 &parts[2],
-                UnitaryRep::Gate(
-                    Unitary::Rotation {
-                        rotation_type: RotationType::RZ,
-                        ..
-                    },
-                    _
-                )
+                UnitaryRep::Gate(Unitary::Named(GateType::SZdg), _)
             ));
         } else {
             panic!("Expected Compose variant, got {result:?}");
@@ -4880,41 +4879,31 @@ mod tests {
 
     #[test]
     fn test_pow_rotation_simplify() {
-        // T^2 = S (RZ(π/4)^2 = RZ(π/2)) after simplification
+        // The phase-fixed root relation T^2 = SZ survives simplification.
         let t = T(0);
         let result = t.pow(2).simplify();
 
-        if let UnitaryRep::Gate(
-            Unitary::Rotation {
-                angle,
-                rotation_type,
-            },
-            _,
-        ) = result
-        {
-            assert_eq!(rotation_type, RotationType::RZ);
-            assert_eq!(angle, Angle64::QUARTER_TURN);
-        } else {
-            panic!("Expected Gate(Rotation), got {result:?}");
-        }
+        assert!(matches!(
+            result,
+            UnitaryRep::Gate(Unitary::Named(GateType::SZ), _)
+        ));
     }
 
     #[test]
     fn test_pow_four_t_simplify() {
-        // T^4 = Z (RZ(π/4)^4 = RZ(π)) after simplification
+        // The phase-fixed root relation T^4 = Z survives simplification.
         let t = T(0);
         let result = t.pow(4).simplify();
 
-        if let UnitaryRep::Gate(Unitary::Rotation { angle, .. }, _) = result {
-            assert_eq!(angle, Angle64::HALF_TURN);
-        } else {
-            panic!("Expected Gate(Rotation), got {result:?}");
-        }
+        assert!(matches!(
+            result,
+            UnitaryRep::Gate(Unitary::Named(GateType::Z), _)
+        ));
     }
 
     #[test]
     fn test_pow_eight_t_simplify() {
-        // Projectively, T^8 = I: Angle64 wraps RZ(2π) to RZ(0).
+        // The phase-fixed root relation is T^8 = I exactly.
         let t = T(0);
         let result = t.pow(8).simplify();
         assert!(result.is_identity());
@@ -5025,8 +5014,8 @@ mod tests {
 
     #[test]
     fn test_decompose_rotation() {
-        let t = T(0);
-        let gates = t.decompose();
+        let rz = RZ(Angle64::HALF_TURN / 4, 0);
+        let gates = rz.decompose();
         assert_eq!(gates.len(), 1);
         assert_eq!(gates[0].gate_type, GateType::RZ);
         assert_eq!(gates[0].angles.len(), 1);
@@ -5054,10 +5043,8 @@ mod tests {
         let gates = t_dg.decompose();
 
         assert_eq!(gates.len(), 1);
-        assert_eq!(gates[0].gate_type, GateType::RZ);
-        // Angle should be negated
-        let expected_angle = Angle64::ZERO - (Angle64::HALF_TURN / 4);
-        assert_eq!(gates[0].angles[0], expected_angle);
+        assert_eq!(gates[0].gate_type, GateType::Tdg);
+        assert!(gates[0].angles.is_empty());
     }
 
     #[test]
@@ -5067,9 +5054,8 @@ mod tests {
         let s_dg = s.dg();
         let gates = s_dg.decompose();
 
-        // S is a rotation, S† negates the angle
         assert_eq!(gates.len(), 1);
-        assert_eq!(gates[0].gate_type, GateType::RZ);
+        assert_eq!(gates[0].gate_type, GateType::SZdg);
     }
 
     // --- as_pauli_string / into_pauli_string tests ---
@@ -5199,13 +5185,7 @@ mod tests {
         let op: UnitaryRep = "T 0".parse().unwrap();
         assert!(matches!(
             op,
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    rotation_type: RotationType::RZ,
-                    ..
-                },
-                _
-            )
+            UnitaryRep::Gate(Unitary::Named(GateType::T), _)
         ));
     }
 
@@ -5214,13 +5194,7 @@ mod tests {
         let op: UnitaryRep = "S 0".parse().unwrap();
         assert!(matches!(
             op,
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    rotation_type: RotationType::RZ,
-                    ..
-                },
-                _
-            )
+            UnitaryRep::Gate(Unitary::Named(GateType::SZ), _)
         ));
     }
 
@@ -5486,13 +5460,7 @@ mod tests {
         let op: UnitaryRep = "Tdg 0".parse().unwrap();
         assert!(matches!(
             op,
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    rotation_type: RotationType::RZ,
-                    ..
-                },
-                _
-            )
+            UnitaryRep::Gate(Unitary::Named(GateType::Tdg), _)
         ));
     }
 
@@ -5501,13 +5469,7 @@ mod tests {
         let op: UnitaryRep = "Sdg 0".parse().unwrap();
         assert!(matches!(
             op,
-            UnitaryRep::Gate(
-                Unitary::Rotation {
-                    rotation_type: RotationType::RZ,
-                    ..
-                },
-                _
-            )
+            UnitaryRep::Gate(Unitary::Named(GateType::SZdg), _)
         ));
     }
 

--- a/crates/pecos-cuquantum/src/statevec.rs
+++ b/crates/pecos-cuquantum/src/statevec.rs
@@ -4,7 +4,8 @@
 //! which accelerates state vector quantum simulation on CUDA GPUs.
 
 use crate::error::{CuQuantumError, Result, TryClone, check_status};
-use pecos_core::{Angle64, QubitId};
+use pecos_core::gate_type::GateType;
+use pecos_core::{Angle64, Clifford, QubitId};
 use pecos_cuquantum_sys::{
     CuQuantumBackend, cuDoubleComplex, cudaDataType_t, cudaMemcpyKind_cudaMemcpyDeviceToDevice,
     cudaMemcpyKind_cudaMemcpyHostToDevice, custatevecCollapseOp_t, custatevecComputeType_t,
@@ -15,6 +16,30 @@ use pecos_simulators::{
 };
 use std::ffi::c_void;
 use std::ptr;
+
+const fn canonical_single_qubit_matrix(gate: GateType) -> [[f64; 2]; 4] {
+    let Some(matrix) = gate.canonical_1q_matrix() else {
+        panic!("gate has no canonical single-qubit matrix");
+    };
+    [
+        [matrix[0], matrix[1]],
+        [matrix[2], matrix[3]],
+        [matrix[4], matrix[5]],
+        [matrix[6], matrix[7]],
+    ]
+}
+
+const fn canonical_clifford_matrix(gate: Clifford) -> [[f64; 2]; 4] {
+    let Some(matrix) = gate.canonical_1q_matrix() else {
+        panic!("gate has no canonical single-qubit Clifford matrix");
+    };
+    [
+        [matrix[0], matrix[1]],
+        [matrix[2], matrix[3]],
+        [matrix[4], matrix[5]],
+        [matrix[6], matrix[7]],
+    ]
+}
 
 /// State vector simulator using NVIDIA cuStateVec
 ///
@@ -547,8 +572,7 @@ impl QuantumSimulator for CuStateVec {
 
 impl CliffordGateable for CuStateVec {
     fn sz(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // S gate = [[1, 0], [0, i]]
-        let matrix = [[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 1.0]];
+        let matrix = canonical_single_qubit_matrix(GateType::SZ);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -556,13 +580,47 @@ impl CliffordGateable for CuStateVec {
     }
 
     fn h(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let inv_sqrt2 = std::f64::consts::FRAC_1_SQRT_2;
-        let matrix = [
-            [inv_sqrt2, 0.0],
-            [inv_sqrt2, 0.0],
-            [inv_sqrt2, 0.0],
-            [-inv_sqrt2, 0.0],
-        ];
+        let matrix = canonical_single_qubit_matrix(GateType::H);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::H2);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::H3);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::H4);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::H5);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::H6);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -592,7 +650,7 @@ impl CliffordGateable for CuStateVec {
     // Override some gates for efficiency (direct GPU implementation)
 
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let matrix = [[0.0, 0.0], [1.0, 0.0], [1.0, 0.0], [0.0, 0.0]];
+        let matrix = canonical_single_qubit_matrix(GateType::X);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -600,7 +658,7 @@ impl CliffordGateable for CuStateVec {
     }
 
     fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let matrix = [[0.0, 0.0], [0.0, -1.0], [0.0, 1.0], [0.0, 0.0]];
+        let matrix = canonical_single_qubit_matrix(GateType::Y);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -608,7 +666,7 @@ impl CliffordGateable for CuStateVec {
     }
 
     fn z(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let matrix = [[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [-1.0, 0.0]];
+        let matrix = canonical_single_qubit_matrix(GateType::Z);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -616,8 +674,87 @@ impl CliffordGateable for CuStateVec {
     }
 
     fn szdg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // S-dagger gate = [[1, 0], [0, -i]]
-        let matrix = [[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -1.0]];
+        let matrix = canonical_single_qubit_matrix(GateType::SZdg);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_single_qubit_matrix(GateType::SY);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_single_qubit_matrix(GateType::SYdg);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::Fdg);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F2);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F2dg);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F3);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F3dg);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F4);
+        for &q in qubits {
+            self.apply_matrix_1q(q.0, &matrix);
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let matrix = canonical_clifford_matrix(Clifford::F4dg);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -715,10 +852,7 @@ impl ArbitraryRotationGateable for CuStateVec {
 
     // Override T gate for efficiency
     fn t(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // T = [[1, 0], [0, e^(i*pi/4)]]
-        let cos = std::f64::consts::FRAC_PI_4.cos();
-        let sin = std::f64::consts::FRAC_PI_4.sin();
-        let matrix = [[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [cos, sin]];
+        let matrix = canonical_single_qubit_matrix(GateType::T);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -727,10 +861,7 @@ impl ArbitraryRotationGateable for CuStateVec {
 
     // Override T-dagger for efficiency
     fn tdg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // T-dagger = [[1, 0], [0, e^(-i*pi/4)]]
-        let cos = std::f64::consts::FRAC_PI_4.cos();
-        let sin = std::f64::consts::FRAC_PI_4.sin();
-        let matrix = [[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [cos, -sin]];
+        let matrix = canonical_single_qubit_matrix(GateType::Tdg);
         for &q in qubits {
             self.apply_matrix_1q(q.0, &matrix);
         }
@@ -750,12 +881,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_gate_matrix_values() {
-        // Test that our gate matrices are correct (pure Rust, no FFI)
-        let inv_sqrt2 = std::f64::consts::FRAC_1_SQRT_2;
-
-        // H gate should have 1/sqrt(2) entries
-        assert!((inv_sqrt2 - std::f64::consts::FRAC_1_SQRT_2).abs() < 1e-10);
+    fn canonical_gate_matrix_conversion_preserves_every_entry() {
+        for gate in pecos_core::gate_type::NAMED_SINGLE_QUBIT_GATES {
+            let canonical = gate
+                .canonical_1q_matrix()
+                .expect("named single-qubit gate must have a canonical matrix");
+            let converted = canonical_single_qubit_matrix(gate);
+            assert_eq!(
+                converted,
+                [
+                    [canonical[0], canonical[1]],
+                    [canonical[2], canonical[3]],
+                    [canonical[4], canonical[5]],
+                    [canonical[6], canonical[7]],
+                ]
+            );
+        }
     }
 
     #[test]

--- a/crates/pecos-gpu-sims/src/gpu.rs
+++ b/crates/pecos-gpu-sims/src/gpu.rs
@@ -1568,6 +1568,41 @@ impl CliffordGateable for GpuStateVec32 {
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::H2);
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::H3);
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::H4);
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::H5);
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::H6);
+        }
+        self
+    }
+
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             self.queue_single_gate(q.index() as u32, gates::X);
@@ -1627,6 +1662,62 @@ impl CliffordGateable for GpuStateVec32 {
     fn szdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             self.queue_single_gate(q.index() as u32, gates::SDG);
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F);
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::FDG);
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F2);
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F2DG);
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F3);
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F3DG);
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F4);
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, gates::F4DG);
         }
         self
     }

--- a/crates/pecos-gpu-sims/src/gpu64.rs
+++ b/crates/pecos-gpu-sims/src/gpu64.rs
@@ -1261,6 +1261,46 @@ impl CliffordGateable for GpuStateVec64 {
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::H2);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::H3);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::H4);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::H5);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::H6);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
         let m = Self::matrix_f32_to_f64(gates::X);
         for &q in qubits {
@@ -1327,6 +1367,70 @@ impl CliffordGateable for GpuStateVec64 {
 
     fn szdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         let m = Self::matrix_f32_to_f64(gates::SDG);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::FDG);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F2);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F2DG);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F3);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F3DG);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F4);
+        for &q in qubits {
+            self.queue_single_gate(q.index() as u32, m);
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        let m = Self::matrix_f32_to_f64(gates::F4DG);
         for &q in qubits {
             self.queue_single_gate(q.index() as u32, m);
         }

--- a/crates/pecos-gpu-sims/src/gpu_auto.rs
+++ b/crates/pecos-gpu-sims/src/gpu_auto.rs
@@ -84,8 +84,56 @@ impl CliffordGateable for GpuStateVecAuto {
     fn h(&mut self, qubits: &[QubitId]) -> &mut Self {
         dispatch_mut!(self, h(qubits))
     }
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, h2(qubits))
+    }
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, h3(qubits))
+    }
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, h4(qubits))
+    }
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, h5(qubits))
+    }
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, h6(qubits))
+    }
+    fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, y(qubits))
+    }
     fn sz(&mut self, qubits: &[QubitId]) -> &mut Self {
         dispatch_mut!(self, sz(qubits))
+    }
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, sy(qubits))
+    }
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, sydg(qubits))
+    }
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f(qubits))
+    }
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, fdg(qubits))
+    }
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f2(qubits))
+    }
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f2dg(qubits))
+    }
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f3(qubits))
+    }
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f3dg(qubits))
+    }
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f4(qubits))
+    }
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        dispatch_mut!(self, f4dg(qubits))
     }
     fn cx(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         dispatch_mut!(self, cx(pairs))

--- a/crates/pecos-gpu-sims/src/lib.rs
+++ b/crates/pecos-gpu-sims/src/lib.rs
@@ -90,84 +90,98 @@ pub type DefaultGpuStab = GpuStab<pecos_random::PecosRng>;
 /// Default multi-shot GPU stabilizer simulator using `PecosRng`
 pub type DefaultGpuStabMulti = GpuStabMulti<pecos_random::PecosRng>;
 
-use std::f64::consts::FRAC_1_SQRT_2;
-
 /// Standard gate matrices as [`a_re`, `a_im`, `b_re`, `b_im`, `c_re`, `c_im`, `d_re`, `d_im`]
 // GPU shaders work with f32 for performance. The precision loss from f64->f32
 // conversion is acceptable for quantum simulation (errors are ~1e-7).
 #[allow(clippy::cast_possible_truncation)]
 pub mod gates {
-    use super::FRAC_1_SQRT_2;
+    use pecos_core::Clifford;
+    use pecos_core::gate_type::{GateType, single_qubit_matrix_to_f32};
+
+    const fn canonical(gate: GateType) -> [f32; 8] {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit matrix");
+        };
+        single_qubit_matrix_to_f32(matrix)
+    }
+
+    const fn canonical_clifford(gate: Clifford) -> [f32; 8] {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit Clifford matrix");
+        };
+        single_qubit_matrix_to_f32(matrix)
+    }
 
     /// Identity gate
-    pub const I: [f32; 8] = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    pub const I: [f32; 8] = canonical(GateType::I);
 
     /// Pauli-X gate (NOT)
-    pub const X: [f32; 8] = [0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+    pub const X: [f32; 8] = canonical(GateType::X);
 
     /// Pauli-Y gate
-    pub const Y: [f32; 8] = [0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0];
+    pub const Y: [f32; 8] = canonical(GateType::Y);
 
     /// Pauli-Z gate
-    pub const Z: [f32; 8] = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0];
+    pub const Z: [f32; 8] = canonical(GateType::Z);
 
-    /// Hadamard gate
-    pub const H: [f32; 8] = [
-        FRAC_1_SQRT_2 as f32,
-        0.0,
-        FRAC_1_SQRT_2 as f32,
-        0.0,
-        FRAC_1_SQRT_2 as f32,
-        0.0,
-        -(FRAC_1_SQRT_2 as f32),
-        0.0,
-    ];
+    /// Hadamard gate H/H1
+    pub const H: [f32; 8] = canonical(GateType::H);
+
+    /// H2 gate
+    pub const H2: [f32; 8] = canonical_clifford(Clifford::H2);
+    /// H3 gate
+    pub const H3: [f32; 8] = canonical_clifford(Clifford::H3);
+    /// H4 gate
+    pub const H4: [f32; 8] = canonical_clifford(Clifford::H4);
+    /// H5 gate
+    pub const H5: [f32; 8] = canonical_clifford(Clifford::H5);
+    /// H6 gate
+    pub const H6: [f32; 8] = canonical_clifford(Clifford::H6);
 
     /// S gate (sqrt(Z))
-    pub const S: [f32; 8] = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    pub const S: [f32; 8] = canonical(GateType::SZ);
 
     /// S-dagger gate
-    pub const SDG: [f32; 8] = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0];
+    pub const SDG: [f32; 8] = canonical(GateType::SZdg);
 
     /// Conventional T gate, `diag(1, exp(i*pi/4))`.
     ///
     /// This is `exp(i*pi/8) RZ(pi/4)`.
-    pub const T: [f32; 8] = [
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        FRAC_1_SQRT_2 as f32,
-        FRAC_1_SQRT_2 as f32,
-    ];
+    pub const T: [f32; 8] = canonical(GateType::T);
 
     /// Conventional T-dagger gate, `diag(1, exp(-i*pi/4))`.
     ///
     /// This is `exp(-i*pi/8) RZ(-pi/4)`.
-    pub const TDG: [f32; 8] = [
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        FRAC_1_SQRT_2 as f32,
-        -(FRAC_1_SQRT_2 as f32),
-    ];
+    pub const TDG: [f32; 8] = canonical(GateType::Tdg);
 
     /// SX gate (sqrt(X))
-    pub const SX: [f32; 8] = [0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5];
+    pub const SX: [f32; 8] = canonical(GateType::SX);
 
     /// SX-dagger gate
-    pub const SXDG: [f32; 8] = [0.5, -0.5, 0.5, 0.5, 0.5, 0.5, 0.5, -0.5];
+    pub const SXDG: [f32; 8] = canonical(GateType::SXdg);
 
     /// SY gate (sqrt(Y))
-    pub const SY: [f32; 8] = [0.5, 0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5];
+    pub const SY: [f32; 8] = canonical(GateType::SY);
 
     /// SY-dagger gate
-    pub const SYDG: [f32; 8] = [0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5];
+    pub const SYDG: [f32; 8] = canonical(GateType::SYdg);
+
+    /// Face gate F/F1
+    pub const F: [f32; 8] = canonical(GateType::F);
+    /// Adjoint Face gate F/F1
+    pub const FDG: [f32; 8] = canonical(GateType::Fdg);
+    /// F2 gate
+    pub const F2: [f32; 8] = canonical_clifford(Clifford::F2);
+    /// Adjoint F2 gate
+    pub const F2DG: [f32; 8] = canonical_clifford(Clifford::F2dg);
+    /// F3 gate
+    pub const F3: [f32; 8] = canonical_clifford(Clifford::F3);
+    /// Adjoint F3 gate
+    pub const F3DG: [f32; 8] = canonical_clifford(Clifford::F3dg);
+    /// F4 gate
+    pub const F4: [f32; 8] = canonical_clifford(Clifford::F4);
+    /// Adjoint F4 gate
+    pub const F4DG: [f32; 8] = canonical_clifford(Clifford::F4dg);
 
     /// Create RX(theta) gate matrix
     #[must_use]

--- a/crates/pecos-gpu-sims/tests/gate_matrix_convention.rs
+++ b/crates/pecos-gpu-sims/tests/gate_matrix_convention.rs
@@ -1,0 +1,503 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+//! Phase-exact agreement between the canonical named-gate table and the
+//! independent state-vector/GPU single-qubit tables.
+
+use num_complex::Complex64;
+use pecos_core::gate_type::{GateType, NAMED_SINGLE_QUBIT_GATES};
+use pecos_core::{Angle64, Clifford, QubitId};
+use pecos_gpu_sims::gates as gpu_gates;
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, StateVecSoA, StateVecSoA32};
+
+type Matrix2 = [[Complex64; 2]; 2];
+
+// f64 products through T^8 accumulate a few ulps. This tolerance gives ample
+// roundoff headroom without coming remotely close to accepting a phase change.
+const F64_TOLERANCE: f64 = 1e-12;
+// The f32 tables retain roughly seven decimal digits and include rounded
+// 1/sqrt(2) entries, so they need a tolerance near f32 machine precision.
+const F32_TOLERANCE: f64 = 1e-6;
+
+fn canonical_matrix(gate: GateType) -> Matrix2 {
+    let matrix = gate
+        .canonical_1q_matrix()
+        .expect("named single-qubit gate must have a canonical matrix");
+    [
+        [
+            Complex64::new(matrix[0], matrix[1]),
+            Complex64::new(matrix[2], matrix[3]),
+        ],
+        [
+            Complex64::new(matrix[4], matrix[5]),
+            Complex64::new(matrix[6], matrix[7]),
+        ],
+    ]
+}
+
+fn canonical_clifford_matrix(gate: Clifford) -> Matrix2 {
+    let matrix = gate
+        .canonical_1q_matrix()
+        .expect("single-qubit Clifford must have a canonical matrix");
+    [
+        [
+            Complex64::new(matrix[0], matrix[1]),
+            Complex64::new(matrix[2], matrix[3]),
+        ],
+        [
+            Complex64::new(matrix[4], matrix[5]),
+            Complex64::new(matrix[6], matrix[7]),
+        ],
+    ]
+}
+
+fn max_entrywise_error(lhs: &Matrix2, rhs: &Matrix2) -> f64 {
+    lhs.iter()
+        .flatten()
+        .zip(rhs.iter().flatten())
+        .map(|(actual, expected)| (actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
+fn matrix_times_state(matrix: &Matrix2, state: &[Complex64; 2]) -> [Complex64; 2] {
+    [
+        matrix[0][0] * state[0] + matrix[0][1] * state[1],
+        matrix[1][0] * state[0] + matrix[1][1] * state[1],
+    ]
+}
+
+fn max_state_error(lhs: &[Complex64; 2], rhs: &[Complex64; 2]) -> f64 {
+    lhs.iter()
+        .zip(rhs)
+        .map(|(actual, expected)| (actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
+fn assert_phase_exact_state_eq(
+    label: &str,
+    actual: &[Complex64; 2],
+    expected: &[Complex64; 2],
+    tolerance: f64,
+) {
+    let error = max_state_error(actual, expected);
+    assert!(
+        error <= tolerance,
+        "{label}: max state error {error:e} exceeds phase-exact tolerance {tolerance:e}; \
+         actual={actual:?}, expected={expected:?}"
+    );
+
+    let phase = Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
+    let phase_mutant = expected.map(|amplitude| amplitude * phase);
+    assert!(
+        max_state_error(actual, &phase_mutant) > tolerance,
+        "{label}: exp(i*pi/4) matrix-phase mutant escaped the kernel guard"
+    );
+}
+
+fn assert_phase_exact_matrix_eq(label: &str, actual: &Matrix2, expected: &Matrix2, tolerance: f64) {
+    let error = max_entrywise_error(actual, expected);
+    assert!(
+        error <= tolerance,
+        "{label}: max entrywise error {error:e} exceeds phase-exact tolerance {tolerance:e}; \
+         actual={actual:?}, expected={expected:?}"
+    );
+
+    // Mutation check every comparison: a projectively equivalent matrix with
+    // an exp(i*pi/4) scalar must be rejected by this phase-sensitive guard.
+    let phase = Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
+    let mut phase_mutant = *actual;
+    for entry in phase_mutant.iter_mut().flatten() {
+        *entry *= phase;
+    }
+    assert!(
+        max_entrywise_error(&phase_mutant, expected) > tolerance,
+        "{label}: exp(i*pi/4) global-phase mutant escaped the exactness guard"
+    );
+}
+
+fn apply_f64(sim: &mut StateVecSoA, gate: GateType) {
+    let qubit = [QubitId(0)];
+    match gate {
+        GateType::I => sim.identity(&qubit),
+        GateType::X => sim.x(&qubit),
+        GateType::Y => sim.y(&qubit),
+        GateType::Z => sim.z(&qubit),
+        GateType::H => sim.h(&qubit),
+        GateType::F => sim.f(&qubit),
+        GateType::Fdg => sim.fdg(&qubit),
+        GateType::SX => sim.sx(&qubit),
+        GateType::SXdg => sim.sxdg(&qubit),
+        GateType::SY => sim.sy(&qubit),
+        GateType::SYdg => sim.sydg(&qubit),
+        GateType::SZ => sim.sz(&qubit),
+        GateType::SZdg => sim.szdg(&qubit),
+        GateType::T => sim.t(&qubit),
+        GateType::Tdg => sim.tdg(&qubit),
+        other => panic!("unsupported f64 single-qubit table gate {other:?}"),
+    };
+}
+
+fn f64_simulator_matrix(gate: GateType) -> Matrix2 {
+    let mut matrix = [[Complex64::new(0.0, 0.0); 2]; 2];
+    for basis in 0..2 {
+        let mut sim = StateVecSoA::new(1);
+        sim.prepare_computational_basis(basis);
+        apply_f64(&mut sim, gate);
+        for (row, matrix_row) in matrix.iter_mut().enumerate() {
+            matrix_row[basis] = sim.get_amplitude(row);
+        }
+    }
+    matrix
+}
+
+fn apply_f32(sim: &mut StateVecSoA32, gate: GateType) {
+    let qubit = [QubitId(0)];
+    match gate {
+        GateType::I => sim.identity(&qubit),
+        GateType::X => sim.x(&qubit),
+        GateType::Y => sim.y(&qubit),
+        GateType::Z => sim.z(&qubit),
+        GateType::H => sim.h(&qubit),
+        GateType::F => sim.f(&qubit),
+        GateType::Fdg => sim.fdg(&qubit),
+        GateType::SX => sim.sx(&qubit),
+        GateType::SXdg => sim.sxdg(&qubit),
+        GateType::SY => sim.sy(&qubit),
+        GateType::SYdg => sim.sydg(&qubit),
+        GateType::SZ => sim.sz(&qubit),
+        GateType::SZdg => sim.szdg(&qubit),
+        GateType::T => sim.t(&qubit),
+        GateType::Tdg => sim.tdg(&qubit),
+        other => panic!("unsupported f32 single-qubit table gate {other:?}"),
+    };
+}
+
+fn f32_simulator_matrix(gate: GateType) -> Matrix2 {
+    let mut matrix = [[Complex64::new(0.0, 0.0); 2]; 2];
+    for basis in 0..2 {
+        let mut sim = StateVecSoA32::new(1);
+        if basis == 1 {
+            sim.x(&[QubitId(0)]);
+            sim.flush();
+        }
+        apply_f32(&mut sim, gate);
+        for (row, matrix_row) in matrix.iter_mut().enumerate() {
+            let amplitude = sim.get_amplitude(row);
+            matrix_row[basis] = Complex64::new(f64::from(amplitude.re), f64::from(amplitude.im));
+        }
+    }
+    matrix
+}
+
+fn gpu_matrix(gate: GateType) -> Matrix2 {
+    let entries = match gate {
+        GateType::I => gpu_gates::I,
+        GateType::X => gpu_gates::X,
+        GateType::Y => gpu_gates::Y,
+        GateType::Z => gpu_gates::Z,
+        GateType::H => gpu_gates::H,
+        GateType::SX => gpu_gates::SX,
+        GateType::SXdg => gpu_gates::SXDG,
+        GateType::SY => gpu_gates::SY,
+        GateType::SYdg => gpu_gates::SYDG,
+        GateType::SZ => gpu_gates::S,
+        GateType::SZdg => gpu_gates::SDG,
+        GateType::T => gpu_gates::T,
+        GateType::Tdg => gpu_gates::TDG,
+        GateType::F => gpu_gates::F,
+        GateType::Fdg => gpu_gates::FDG,
+        other => panic!("unsupported GPU single-qubit table gate {other:?}"),
+    };
+    [
+        [
+            Complex64::new(f64::from(entries[0]), f64::from(entries[1])),
+            Complex64::new(f64::from(entries[2]), f64::from(entries[3])),
+        ],
+        [
+            Complex64::new(f64::from(entries[4]), f64::from(entries[5])),
+            Complex64::new(f64::from(entries[6]), f64::from(entries[7])),
+        ],
+    ]
+}
+
+fn apply_clifford_f64(sim: &mut StateVecSoA, gate: Clifford) {
+    let qubit = [QubitId(0)];
+    match gate {
+        Clifford::H => sim.h(&qubit),
+        Clifford::H2 => sim.h2(&qubit),
+        Clifford::H3 => sim.h3(&qubit),
+        Clifford::H4 => sim.h4(&qubit),
+        Clifford::H5 => sim.h5(&qubit),
+        Clifford::H6 => sim.h6(&qubit),
+        Clifford::F => sim.f(&qubit),
+        Clifford::Fdg => sim.fdg(&qubit),
+        Clifford::F2 => sim.f2(&qubit),
+        Clifford::F2dg => sim.f2dg(&qubit),
+        Clifford::F3 => sim.f3(&qubit),
+        Clifford::F3dg => sim.f3dg(&qubit),
+        Clifford::F4 => sim.f4(&qubit),
+        Clifford::F4dg => sim.f4dg(&qubit),
+        _ => panic!("unsupported extended f64 Clifford {gate}"),
+    };
+}
+
+fn apply_clifford_f32(sim: &mut StateVecSoA32, gate: Clifford) {
+    let qubit = [QubitId(0)];
+    match gate {
+        Clifford::H => sim.h(&qubit),
+        Clifford::H2 => sim.h2(&qubit),
+        Clifford::H3 => sim.h3(&qubit),
+        Clifford::H4 => sim.h4(&qubit),
+        Clifford::H5 => sim.h5(&qubit),
+        Clifford::H6 => sim.h6(&qubit),
+        Clifford::F => sim.f(&qubit),
+        Clifford::Fdg => sim.fdg(&qubit),
+        Clifford::F2 => sim.f2(&qubit),
+        Clifford::F2dg => sim.f2dg(&qubit),
+        Clifford::F3 => sim.f3(&qubit),
+        Clifford::F3dg => sim.f3dg(&qubit),
+        Clifford::F4 => sim.f4(&qubit),
+        Clifford::F4dg => sim.f4dg(&qubit),
+        _ => panic!("unsupported extended f32 Clifford {gate}"),
+    };
+}
+
+fn clifford_f64_matrix(gate: Clifford) -> Matrix2 {
+    let mut matrix = [[Complex64::new(0.0, 0.0); 2]; 2];
+    for basis in 0..2 {
+        let mut sim = StateVecSoA::new(1);
+        sim.prepare_computational_basis(basis);
+        apply_clifford_f64(&mut sim, gate);
+        for (row, matrix_row) in matrix.iter_mut().enumerate() {
+            matrix_row[basis] = sim.get_amplitude(row);
+        }
+    }
+    matrix
+}
+
+fn clifford_f32_matrix(gate: Clifford) -> Matrix2 {
+    let mut matrix = [[Complex64::new(0.0, 0.0); 2]; 2];
+    for basis in 0..2 {
+        let mut sim = StateVecSoA32::new(1);
+        if basis == 1 {
+            sim.x(&[QubitId(0)]);
+            sim.flush();
+        }
+        apply_clifford_f32(&mut sim, gate);
+        for (row, matrix_row) in matrix.iter_mut().enumerate() {
+            let amplitude = sim.get_amplitude(row);
+            matrix_row[basis] = Complex64::new(f64::from(amplitude.re), f64::from(amplitude.im));
+        }
+    }
+    matrix
+}
+
+fn gpu_clifford_matrix(gate: Clifford) -> Matrix2 {
+    let entries = match gate {
+        Clifford::H => gpu_gates::H,
+        Clifford::H2 => gpu_gates::H2,
+        Clifford::H3 => gpu_gates::H3,
+        Clifford::H4 => gpu_gates::H4,
+        Clifford::H5 => gpu_gates::H5,
+        Clifford::H6 => gpu_gates::H6,
+        Clifford::F => gpu_gates::F,
+        Clifford::Fdg => gpu_gates::FDG,
+        Clifford::F2 => gpu_gates::F2,
+        Clifford::F2dg => gpu_gates::F2DG,
+        Clifford::F3 => gpu_gates::F3,
+        Clifford::F3dg => gpu_gates::F3DG,
+        Clifford::F4 => gpu_gates::F4,
+        Clifford::F4dg => gpu_gates::F4DG,
+        _ => panic!("unsupported extended GPU Clifford {gate}"),
+    };
+    [
+        [
+            Complex64::new(f64::from(entries[0]), f64::from(entries[1])),
+            Complex64::new(f64::from(entries[2]), f64::from(entries[3])),
+        ],
+        [
+            Complex64::new(f64::from(entries[4]), f64::from(entries[5])),
+            Complex64::new(f64::from(entries[6]), f64::from(entries[7])),
+        ],
+    ]
+}
+
+fn prepare_f64_kernel_input() -> (StateVecSoA, [Complex64; 2]) {
+    let mut sim = StateVecSoA::new(1);
+    let qubit = [QubitId(0)];
+    sim.ry(Angle64::from_radians(0.731), &qubit)
+        .rz(Angle64::from_radians(-0.417), &qubit);
+    sim.flush();
+    let input = [sim.get_amplitude(0), sim.get_amplitude(1)];
+    sim.set_fusion(false);
+    (sim, input)
+}
+
+fn prepare_f32_kernel_input() -> (StateVecSoA32, [Complex64; 2]) {
+    let mut sim = StateVecSoA32::new(1);
+    let qubit = [QubitId(0)];
+    sim.ry(Angle64::from_radians(0.731), &qubit)
+        .rz(Angle64::from_radians(-0.417), &qubit);
+    sim.flush();
+    let first = sim.get_amplitude(0);
+    let second = sim.get_amplitude(1);
+    let input = [
+        Complex64::new(f64::from(first.re), f64::from(first.im)),
+        Complex64::new(f64::from(second.re), f64::from(second.im)),
+    ];
+    sim.set_fusion(false);
+    (sim, input)
+}
+
+#[test]
+fn handwritten_single_qubit_kernels_match_canonical_phase_exactly() {
+    // Both amplitudes of this fixed input are nonzero and complex, so every
+    // matrix entry contributes. The f64 tolerance covers a few arithmetic ulps;
+    // the f32 tolerance is near f32 machine precision. A pi/4 phase error is
+    // roughly six orders of magnitude larger than even the f32 tolerance.
+    for gate in [
+        GateType::X,
+        GateType::Y,
+        GateType::Z,
+        GateType::H,
+        GateType::SX,
+        GateType::SXdg,
+        GateType::SY,
+        GateType::SYdg,
+        GateType::SZ,
+        GateType::SZdg,
+        GateType::T,
+        GateType::Tdg,
+    ] {
+        let (mut sim, input) = prepare_f64_kernel_input();
+        apply_f64(&mut sim, gate);
+        let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        let expected = matrix_times_state(&canonical_matrix(gate), &input);
+        assert_phase_exact_state_eq(
+            &format!("StateVecSoA arithmetic {gate:?}"),
+            &actual,
+            &expected,
+            F64_TOLERANCE,
+        );
+    }
+
+    for gate in [
+        GateType::X,
+        GateType::Y,
+        GateType::Z,
+        GateType::H,
+        GateType::SX,
+        GateType::SXdg,
+        GateType::SY,
+        GateType::SYdg,
+        GateType::SZ,
+        GateType::SZdg,
+    ] {
+        let (mut sim, input) = prepare_f32_kernel_input();
+        apply_f32(&mut sim, gate);
+        let first = sim.get_amplitude(0);
+        let second = sim.get_amplitude(1);
+        let actual = [
+            Complex64::new(f64::from(first.re), f64::from(first.im)),
+            Complex64::new(f64::from(second.re), f64::from(second.im)),
+        ];
+        let expected = matrix_times_state(&canonical_matrix(gate), &input);
+        assert_phase_exact_state_eq(
+            &format!("StateVecSoA32 arithmetic {gate:?}"),
+            &actual,
+            &expected,
+            F32_TOLERANCE,
+        );
+    }
+
+    for (label, gate) in [
+        ("StateVecSoA arithmetic H3", Clifford::H3),
+        ("StateVecSoA arithmetic H4", Clifford::H4),
+    ] {
+        let (mut sim, input) = prepare_f64_kernel_input();
+        let qubit = [QubitId(0)];
+        match gate {
+            Clifford::H3 => sim.h3(&qubit),
+            Clifford::H4 => sim.h4(&qubit),
+            _ => unreachable!("only H3 and H4 have arithmetic kernels"),
+        };
+        let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        let expected = matrix_times_state(&canonical_clifford_matrix(gate), &input);
+        assert_phase_exact_state_eq(label, &actual, &expected, F64_TOLERANCE);
+    }
+}
+
+#[test]
+fn single_qubit_simulator_tables_match_canonical_phase_exactly() {
+    for gate in NAMED_SINGLE_QUBIT_GATES {
+        let canonical = canonical_matrix(gate);
+        assert_phase_exact_matrix_eq(
+            &format!("StateVecSoA::{gate:?}"),
+            &f64_simulator_matrix(gate),
+            &canonical,
+            F64_TOLERANCE,
+        );
+        assert_phase_exact_matrix_eq(
+            &format!("StateVecSoA32::{gate:?}"),
+            &f32_simulator_matrix(gate),
+            &canonical,
+            F32_TOLERANCE,
+        );
+        let gpu = gpu_matrix(gate);
+        assert_phase_exact_matrix_eq(
+            &format!("gpu_gates::{gate:?}"),
+            &gpu,
+            &canonical,
+            F32_TOLERANCE,
+        );
+    }
+
+    // The additional H/F-family matrices are derived from the canonical
+    // Clifford table in f64, f32 and GPU precision.
+    for gate in [
+        Clifford::H,
+        Clifford::H2,
+        Clifford::H3,
+        Clifford::H4,
+        Clifford::H5,
+        Clifford::H6,
+        Clifford::F,
+        Clifford::Fdg,
+        Clifford::F2,
+        Clifford::F2dg,
+        Clifford::F3,
+        Clifford::F3dg,
+        Clifford::F4,
+        Clifford::F4dg,
+    ] {
+        let expected = canonical_clifford_matrix(gate);
+        assert_phase_exact_matrix_eq(
+            &format!("StateVecSoA::{gate}"),
+            &clifford_f64_matrix(gate),
+            &expected,
+            F64_TOLERANCE,
+        );
+        assert_phase_exact_matrix_eq(
+            &format!("StateVecSoA32::{gate}"),
+            &clifford_f32_matrix(gate),
+            &expected,
+            F32_TOLERANCE,
+        );
+        assert_phase_exact_matrix_eq(
+            &format!("gpu_gates::{gate}"),
+            &gpu_clifford_matrix(gate),
+            &expected,
+            F32_TOLERANCE,
+        );
+    }
+}

--- a/crates/pecos-quantum/src/pass.rs
+++ b/crates/pecos-quantum/src/pass.rs
@@ -2150,8 +2150,8 @@ mod tests {
             GateType::SYdg => Some(unitary_rep::SY(q0).dg()),
             GateType::SZ => Some(unitary_rep::SZ(q0)),
             GateType::SZdg => Some(unitary_rep::SZ(q0).dg()),
-            GateType::F => Some(unitary_rep::SZ(q0) * unitary_rep::SX(q0)),
-            GateType::Fdg => Some(unitary_rep::SX(q0).dg() * unitary_rep::SZ(q0).dg()),
+            GateType::F => Some(Clifford::F.to_unitary_rep_on_qubit(q0)),
+            GateType::Fdg => Some(Clifford::Fdg.to_unitary_rep_on_qubit(q0)),
             GateType::T => Some(unitary_rep::T(q0)),
             GateType::Tdg => Some(unitary_rep::T(q0).dg()),
             GateType::RX => {

--- a/crates/pecos-quantum/src/unitary_matrix.rs
+++ b/crates/pecos-quantum/src/unitary_matrix.rs
@@ -40,7 +40,7 @@ use std::sync::LazyLock;
 
 use pecos_core::clifford::Clifford;
 use pecos_core::clifford_rep::CliffordRep;
-use pecos_core::gate_type::GateType;
+use pecos_core::gate_type::{GateType, NAMED_SINGLE_QUBIT_GATES};
 use pecos_core::unitary_rep::{RotationType, Unitary, UnitaryRep};
 use pecos_core::{Angle64, Op, Pauli, PauliString, Phase};
 
@@ -868,25 +868,6 @@ fn extract_rotation_angle(
     })
 }
 
-/// Non-parameterized unitary gate types (non-dg before dg for self-inverse preference).
-const NAMED_GATE_1Q: [GateType; 15] = [
-    GateType::I,
-    GateType::X,
-    GateType::Y,
-    GateType::Z,
-    GateType::H,
-    GateType::F,
-    GateType::Fdg,
-    GateType::SX,
-    GateType::SXdg,
-    GateType::SY,
-    GateType::SYdg,
-    GateType::SZ,
-    GateType::SZdg,
-    GateType::T,
-    GateType::Tdg,
-];
-
 const NAMED_GATE_2Q: [GateType; 11] = [
     GateType::CX,
     GateType::CY,
@@ -921,7 +902,7 @@ fn build_unitary_table(
 
 /// Cached canonical forms for gate identification.
 static UNITARY_1Q_TABLE: LazyLock<Vec<(Unitary, DMatrix<Complex64>)>> =
-    LazyLock::new(|| build_unitary_table(&NAMED_GATE_1Q, 1));
+    LazyLock::new(|| build_unitary_table(&NAMED_SINGLE_QUBIT_GATES, 1));
 
 static UNITARY_2Q_TABLE: LazyLock<Vec<(Unitary, DMatrix<Complex64>)>> =
     LazyLock::new(|| build_unitary_table(&NAMED_GATE_2Q, 2));
@@ -1502,6 +1483,22 @@ pub fn matrices_equiv_up_to_phase(
 
 // --- Helper functions for matrix construction ---
 
+fn canonical_single_qubit_matrix(gate: GateType) -> DMatrix<Complex64> {
+    let entries = gate
+        .canonical_1q_matrix()
+        .expect("named single-qubit gate must have a canonical matrix");
+    DMatrix::from_row_slice(
+        2,
+        2,
+        &[
+            Complex64::new(entries[0], entries[1]),
+            Complex64::new(entries[2], entries[3]),
+            Complex64::new(entries[4], entries[5]),
+            Complex64::new(entries[6], entries[7]),
+        ],
+    )
+}
+
 /// Converts a [`PauliString`] to a dense matrix (implementation).
 fn pauli_string_to_matrix_impl(ps: &PauliString, num_qubits: usize) -> DMatrix<Complex64> {
     let dim = 1 << num_qubits;
@@ -1523,18 +1520,13 @@ fn pauli_string_to_matrix_impl(ps: &PauliString, num_qubits: usize) -> DMatrix<C
 
 /// Returns the 2x2 matrix for a single Pauli operator.
 fn single_pauli_matrix(pauli: Pauli) -> DMatrix<Complex64> {
-    let zero = Complex64::new(0.0, 0.0);
-    let one = Complex64::new(1.0, 0.0);
-    let i = Complex64::new(0.0, 1.0);
-    let neg_i = Complex64::new(0.0, -1.0);
-    let neg_one = Complex64::new(-1.0, 0.0);
-
-    match pauli {
-        Pauli::I => DMatrix::from_row_slice(2, 2, &[one, zero, zero, one]),
-        Pauli::X => DMatrix::from_row_slice(2, 2, &[zero, one, one, zero]),
-        Pauli::Y => DMatrix::from_row_slice(2, 2, &[zero, neg_i, i, zero]),
-        Pauli::Z => DMatrix::from_row_slice(2, 2, &[one, zero, zero, neg_one]),
-    }
+    let gate = match pauli {
+        Pauli::I => GateType::I,
+        Pauli::X => GateType::X,
+        Pauli::Y => GateType::Y,
+        Pauli::Z => GateType::Z,
+    };
+    canonical_single_qubit_matrix(gate)
 }
 
 /// Embeds a single-qubit gate into a larger Hilbert space.
@@ -1728,27 +1720,6 @@ fn u2q_to_matrix(
     &b0 * &b1 * &int * &a0 * &a1
 }
 
-/// The face gate `F`, the single source for both `F` and `Fdg`.
-///
-/// `F` applies `SX` then `SZ`, so as a matrix product it is `SZ * SX`, not
-/// `SX * SZ`. Getting that order backwards yields `F4` instead, which is a
-/// different (and separately implemented) face gate -- that was issue #379.
-/// With `SX = (1+i)/2 * [[1,-i],[-i,1]]` and `SZ = diag(1,i)`:
-///
-/// ```text
-/// F = (1+i)/2 * [[1, -i],
-///                [1,  i]]
-/// ```
-///
-/// conjugating `X -> Y -> Z -> X`. `Fdg` is this matrix's adjoint, which
-/// conjugates `X -> Z -> Y -> X`.
-fn face_gate_f() -> DMatrix<Complex64> {
-    let f = Complex64::new(0.5, 0.5);
-    let one = Complex64::new(1.0, 0.0);
-    let i = Complex64::new(0.0, 1.0);
-    DMatrix::from_row_slice(2, 2, &[f * one, f * -i, f * one, f * i])
-}
-
 /// Constructs a two-qubit Pauli tensor product matrix.
 fn two_qubit_pauli_matrix(
     p1: Pauli,
@@ -1768,89 +1739,25 @@ fn two_qubit_pauli_matrix(
 fn gate_to_matrix(gate_type: GateType, qubits: &[usize], num_qubits: usize) -> DMatrix<Complex64> {
     let zero = Complex64::new(0.0, 0.0);
     let one = Complex64::new(1.0, 0.0);
-    let i = Complex64::new(0.0, 1.0);
-    let neg_i = Complex64::new(0.0, -1.0);
-    let neg_one = Complex64::new(-1.0, 0.0);
     let sqrt2_inv = Complex64::new(1.0 / 2.0_f64.sqrt(), 0.0);
 
     match gate_type {
-        GateType::I => {
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, one]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::X => {
-            let gate = DMatrix::from_row_slice(2, 2, &[zero, one, one, zero]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::Y => {
-            let gate = DMatrix::from_row_slice(2, 2, &[zero, neg_i, i, zero]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::Z => {
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, neg_one]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::H => {
-            let gate =
-                DMatrix::from_row_slice(2, 2, &[sqrt2_inv, sqrt2_inv, sqrt2_inv, -sqrt2_inv]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SX => {
-            // SX = (1+i)/2 * [[1, -i], [-i, 1]]
-            let factor = Complex64::new(0.5, 0.5);
-            let gate = DMatrix::from_row_slice(
-                2,
-                2,
-                &[factor * one, factor * neg_i, factor * neg_i, factor * one],
-            );
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SXdg => {
-            let factor = Complex64::new(0.5, -0.5);
-            let gate = DMatrix::from_row_slice(
-                2,
-                2,
-                &[factor * one, factor * i, factor * i, factor * one],
-            );
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SY => {
-            // SY = exp(-i*pi/4 * Y) = (1/sqrt(2)) * [[1, -1], [1, 1]]
-            let gate =
-                DMatrix::from_row_slice(2, 2, &[sqrt2_inv, -sqrt2_inv, sqrt2_inv, sqrt2_inv]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SYdg => {
-            // SYdg = SY† = (1/sqrt(2)) * [[1, 1], [-1, 1]]
-            let gate =
-                DMatrix::from_row_slice(2, 2, &[sqrt2_inv, sqrt2_inv, -sqrt2_inv, sqrt2_inv]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SZ => {
-            // S = diag(1, i)
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, i]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::SZdg => {
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, neg_i]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::F => embed_single_qubit_gate(&face_gate_f(), qubits[0], num_qubits),
-        GateType::Fdg => {
-            // Derived as F's adjoint rather than hand-written, so the two can
-            // never disagree. Conjugates X->Z->Y->X.
-            let gate = face_gate_f().adjoint();
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::T => {
-            // T = diag(1, e^{i*pi/4})
-            let exp_pi_4 = Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, exp_pi_4]);
-            embed_single_qubit_gate(&gate, qubits[0], num_qubits)
-        }
-        GateType::Tdg => {
-            let exp_neg_pi_4 = Complex64::from_polar(1.0, -std::f64::consts::FRAC_PI_4);
-            let gate = DMatrix::from_row_slice(2, 2, &[one, zero, zero, exp_neg_pi_4]);
+        GateType::I
+        | GateType::X
+        | GateType::Y
+        | GateType::Z
+        | GateType::H
+        | GateType::SX
+        | GateType::SXdg
+        | GateType::SY
+        | GateType::SYdg
+        | GateType::SZ
+        | GateType::SZdg
+        | GateType::F
+        | GateType::Fdg
+        | GateType::T
+        | GateType::Tdg => {
+            let gate = canonical_single_qubit_matrix(gate_type);
             embed_single_qubit_gate(&gate, qubits[0], num_qubits)
         }
         GateType::CX => controlled_gate(
@@ -2050,6 +1957,130 @@ mod tests {
     use pecos_random::PecosRng;
     use std::f64::consts::PI;
 
+    // This is numerical equality of the phase-fixed matrices, not equivalence
+    // modulo global phase. The tolerance covers roundoff accumulated by T^8
+    // while remaining many orders of magnitude below a pi/4 phase mutation.
+    const PHASE_EXACT_TOLERANCE: f64 = 1e-12;
+
+    fn named_1q_matrix(gate: GateType) -> DMatrix<Complex64> {
+        gate_to_matrix(gate, &[0], 1)
+    }
+
+    fn max_entrywise_error(a: &DMatrix<Complex64>, b: &DMatrix<Complex64>) -> f64 {
+        assert_eq!(a.shape(), b.shape());
+        a.iter()
+            .zip(b.iter())
+            .map(|(lhs, rhs)| (lhs - rhs).norm())
+            .fold(0.0, f64::max)
+    }
+
+    fn assert_phase_exact_matrix_eq(
+        identity: &str,
+        actual: &DMatrix<Complex64>,
+        expected: &DMatrix<Complex64>,
+    ) {
+        let error = max_entrywise_error(actual, expected);
+        assert!(
+            error <= PHASE_EXACT_TOLERANCE,
+            "{identity}: max entrywise error {error:e} exceeds phase-exact tolerance \
+             {PHASE_EXACT_TOLERANCE}; actual={actual:?}; expected={expected:?}"
+        );
+
+        // Mutation check: this same assertion must reject a pure global-phase
+        // change, even though it represents the same projective operation.
+        let phase = Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
+        let phase_mutant = actual * phase;
+        let mutation_error = max_entrywise_error(&phase_mutant, expected);
+        assert!(
+            mutation_error > PHASE_EXACT_TOLERANCE,
+            "{identity}: exp(i*pi/4) global-phase mutant escaped the exactness guard"
+        );
+    }
+
+    #[test]
+    fn named_single_qubit_table_has_phase_exact_algebraic_closure() {
+        let i = named_1q_matrix(GateType::I);
+        let x = named_1q_matrix(GateType::X);
+        let y = named_1q_matrix(GateType::Y);
+        let z = named_1q_matrix(GateType::Z);
+        let h = named_1q_matrix(GateType::H);
+        let f = named_1q_matrix(GateType::F);
+        let sx = named_1q_matrix(GateType::SX);
+        let sxdg = named_1q_matrix(GateType::SXdg);
+        let sy = named_1q_matrix(GateType::SY);
+        let sydg = named_1q_matrix(GateType::SYdg);
+        let sz = named_1q_matrix(GateType::SZ);
+        let szdg = named_1q_matrix(GateType::SZdg);
+        let t = named_1q_matrix(GateType::T);
+        let tdg = named_1q_matrix(GateType::Tdg);
+
+        for (identity, root, pauli) in [
+            ("SX^2 = X", &sx, &x),
+            ("SXdg^2 = X", &sxdg, &x),
+            ("SY^2 = Y", &sy, &y),
+            ("SYdg^2 = Y", &sydg, &y),
+            ("SZ^2 = Z", &sz, &z),
+            ("SZdg^2 = Z", &szdg, &z),
+        ] {
+            assert_phase_exact_matrix_eq(identity, &(root * root), pauli);
+        }
+
+        let t2 = &t * &t;
+        let tdg2 = &tdg * &tdg;
+        let t4 = &t2 * &t2;
+        let t8 = &t4 * &t4;
+        assert_phase_exact_matrix_eq("T^2 = SZ", &t2, &sz);
+        assert_phase_exact_matrix_eq("Tdg^2 = SZdg", &tdg2, &szdg);
+        assert_phase_exact_matrix_eq("T^4 = Z", &t4, &z);
+        assert_phase_exact_matrix_eq("T^8 = I", &t8, &i);
+
+        for (identity, gate) in [
+            ("H^2 = I", &h),
+            ("X^2 = I", &x),
+            ("Y^2 = I", &y),
+            ("Z^2 = I", &z),
+        ] {
+            assert_phase_exact_matrix_eq(identity, &(gate * gate), &i);
+        }
+
+        for (name, gate, dagger) in [
+            ("Fdg = F adjoint", &f, GateType::Fdg),
+            ("SXdg = SX adjoint", &sx, GateType::SXdg),
+            ("SYdg = SY adjoint", &sy, GateType::SYdg),
+            ("SZdg = SZ adjoint", &sz, GateType::SZdg),
+            ("Tdg = T adjoint", &t, GateType::Tdg),
+        ] {
+            assert_phase_exact_matrix_eq(name, &named_1q_matrix(dagger), &gate.adjoint());
+        }
+
+        // The canonical F/F1 contract documents this application/product order
+        // and fixes the scalar so the representative itself has order three.
+        let f_product = (&sz * &sx) * Complex64::i();
+        assert_phase_exact_matrix_eq("F = i * SZ * SX", &f, &f_product);
+        assert_phase_exact_matrix_eq("F^3 = I", &(&(&f * &f) * &f), &i);
+        let fdg = named_1q_matrix(GateType::Fdg);
+        assert_phase_exact_matrix_eq("Fdg^3 = I", &(&(&fdg * &fdg) * &fdg), &i);
+    }
+
+    #[test]
+    fn all_single_qubit_clifford_expressions_match_the_canonical_phase() {
+        for &gate in pecos_core::Clifford::all_1q() {
+            let actual = to_matrix(&gate.to_unitary_rep_on_qubit(0)).into_inner();
+            let entries = gate.canonical_1q_matrix().unwrap();
+            let expected = DMatrix::from_row_slice(
+                2,
+                2,
+                &[
+                    Complex64::new(entries[0], entries[1]),
+                    Complex64::new(entries[2], entries[3]),
+                    Complex64::new(entries[4], entries[5]),
+                    Complex64::new(entries[6], entries[7]),
+                ],
+            );
+            assert_phase_exact_matrix_eq(&format!("{gate} expression"), &actual, &expected);
+        }
+    }
+
     // --- Basic to_matrix tests ---
 
     #[test]
@@ -2121,22 +2152,32 @@ mod tests {
     fn test_t_gate_matrix() {
         let t = T(0);
         let mat = to_matrix(&t);
-        // UnitaryRep::T is projective: RZ(π/4) = e^{-iπ/8} diag(1, e^{iπ/4}).
-        let exp_neg = Complex64::from_polar(1.0, -PI / 8.0);
-        let exp_pos = Complex64::from_polar(1.0, PI / 8.0);
-        assert!((mat[(0, 0)] - exp_neg).norm() < 1e-10);
-        assert!((mat[(1, 1)] - exp_pos).norm() < 1e-10);
+        assert!((mat[(0, 0)] - Complex64::new(1.0, 0.0)).norm() < 1e-10);
+        assert!((mat[(1, 1)] - Complex64::from_polar(1.0, PI / 4.0)).norm() < 1e-10);
+
+        // The parameterized rotation remains RZ(pi/4) = exp(-i*pi/8) * T.
+        let rz = to_matrix(&RZ(Angle64::HALF_TURN / 4, 0)).into_inner();
+        assert_phase_exact_matrix_eq(
+            "RZ(pi/4) = exp(-i*pi/8) * T",
+            &rz,
+            &(mat.into_inner() * Complex64::from_polar(1.0, -PI / 8.0)),
+        );
     }
 
     #[test]
     fn test_s_gate_matrix() {
         let s = SZ(0);
         let mat = to_matrix(&s);
-        // S = RZ(π/2) = diag(e^{-iπ/4}, e^{iπ/4})
-        let exp_neg = Complex64::from_polar(1.0, -PI / 4.0);
-        let exp_pos = Complex64::from_polar(1.0, PI / 4.0);
-        assert!((mat[(0, 0)] - exp_neg).norm() < 1e-10);
-        assert!((mat[(1, 1)] - exp_pos).norm() < 1e-10);
+        assert!((mat[(0, 0)] - Complex64::new(1.0, 0.0)).norm() < 1e-10);
+        assert!((mat[(1, 1)] - Complex64::i()).norm() < 1e-10);
+
+        // The parameterized rotation remains RZ(pi/2) = exp(-i*pi/4) * SZ.
+        let rz = to_matrix(&RZ(Angle64::QUARTER_TURN, 0)).into_inner();
+        assert_phase_exact_matrix_eq(
+            "RZ(pi/2) = exp(-i*pi/4) * SZ",
+            &rz,
+            &(mat.into_inner() * Complex64::from_polar(1.0, -PI / 4.0)),
+        );
     }
 
     #[test]
@@ -2737,8 +2778,7 @@ mod tests {
 
     #[test]
     fn try_to_unitary_identifies_all_named_1q_gates() {
-        use super::NAMED_GATE_1Q;
-        for &gate in &NAMED_GATE_1Q {
+        for &gate in &NAMED_SINGLE_QUBIT_GATES {
             let mat = UnitaryMatrix(super::gate_to_matrix(gate, &[0], 1));
             assert_eq!(
                 mat.try_to_unitary(),
@@ -2805,6 +2845,15 @@ mod tests {
         let t_mat = T(0).to_matrix();
         let phased = &t_mat * Complex64::new(0.0, -1.0);
         assert_eq!(phased.try_to_unitary(), Some(Unitary::Named(GateType::T)));
+
+        // The phase-fixed SY table entry must remain recognizable after its
+        // convention change, including through the documented up-to-phase path.
+        let sy_mat = UnitaryMatrix(named_1q_matrix(GateType::SY));
+        let phased_sy = &sy_mat * Complex64::from_polar(1.0, PI / 4.0);
+        assert_eq!(
+            phased_sy.try_to_unitary(),
+            Some(Unitary::Named(GateType::SY))
+        );
 
         // 5*CX should still be identified as CX
         let cx_mat = CX(0, 1).to_matrix();

--- a/crates/pecos-quantum/tests/op_matrix_tests.rs
+++ b/crates/pecos-quantum/tests/op_matrix_tests.rs
@@ -14,7 +14,7 @@
 //!
 //! For each Clifford gate, the Op stores both a `CliffordRep` (tableau) and a
 //! `UnitaryRep` (expression). This test verifies that the `UnitaryRep` expression
-//! produces a matrix equivalent (up to global phase) to the expected gate.
+//! produces the phase-fixed matrix of the expected gate.
 
 use pecos_core::Angle64;
 use pecos_core::op;
@@ -23,9 +23,27 @@ use pecos_quantum::unitary_matrix::{ToMatrix, UnitaryMatrix, unitaries_equiv};
 /// Verify a 1-qubit Clifford Op's `UnitaryRep` matches a reference `UnitaryRep`.
 fn check_1q_clifford(gate: pecos_core::Op, reference: &pecos_core::UnitaryRep, name: &str) {
     let ur = gate.into_unitary().unwrap();
+    let actual = ur.to_matrix().into_inner();
+    let expected = reference.to_matrix().into_inner();
+    let error = actual
+        .iter()
+        .zip(expected.iter())
+        .map(|(lhs, rhs)| (lhs - rhs).norm())
+        .fold(0.0, f64::max);
     assert!(
-        unitaries_equiv(&ur, reference),
-        "{name}: UnitaryRep decomposition does not match reference"
+        error < 1e-12,
+        "{name}: phase-fixed UnitaryRep differs from reference by {error:e}"
+    );
+
+    let phase = num_complex::Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
+    let mutant_error = actual
+        .iter()
+        .zip(expected.iter())
+        .map(|(lhs, rhs)| (*lhs * phase - rhs).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        mutant_error > 1e-12,
+        "{name}: phase mutation escaped exact guard"
     );
 }
 
@@ -84,36 +102,41 @@ fn op_szdg_matches_unitary_rep() {
 
 #[test]
 fn op_h2_decomposition_correct() {
-    // H2 = Z * SY (apply SY first, then Z)
-    let reference = pecos_core::unitary_rep::Z(0) * pecos_core::unitary_rep::SY(0);
+    // H2 = exp(-i*pi/4) * Z * SY (apply SY first, then Z)
+    let reference = pecos_core::unitary_rep::phase(-(Angle64::QUARTER_TURN / 2u64))
+        * (pecos_core::unitary_rep::Z(0) * pecos_core::unitary_rep::SY(0));
     check_1q_clifford(op::H2(0), &reference, "H2");
 }
 
 #[test]
 fn op_h3_decomposition_correct() {
-    // H3 = Y * SZ (apply SZ first, then Y)
-    let reference = pecos_core::unitary_rep::Y(0) * pecos_core::unitary_rep::SZ(0);
+    // H3 = exp(-i*pi/4) * Y * SZ (apply SZ first, then Y)
+    let reference = pecos_core::unitary_rep::phase(-(Angle64::QUARTER_TURN / 2u64))
+        * (pecos_core::unitary_rep::Y(0) * pecos_core::unitary_rep::SZ(0));
     check_1q_clifford(op::H3(0), &reference, "H3");
 }
 
 #[test]
 fn op_h4_decomposition_correct() {
-    // H4 = X * SZ (apply SZ first, then X)
-    let reference = pecos_core::unitary_rep::X(0) * pecos_core::unitary_rep::SZ(0);
+    // H4 = exp(-i*pi/4) * X * SZ (apply SZ first, then X)
+    let reference = pecos_core::unitary_rep::phase(-(Angle64::QUARTER_TURN / 2u64))
+        * (pecos_core::unitary_rep::X(0) * pecos_core::unitary_rep::SZ(0));
     check_1q_clifford(op::H4(0), &reference, "H4");
 }
 
 #[test]
 fn op_h5_decomposition_correct() {
-    // H5 = Z * SX (apply SX first, then Z)
-    let reference = pecos_core::unitary_rep::Z(0) * pecos_core::unitary_rep::SX(0);
+    // H5 = exp(-i*pi/4) * Z * SX (apply SX first, then Z)
+    let reference = pecos_core::unitary_rep::phase(-(Angle64::QUARTER_TURN / 2u64))
+        * (pecos_core::unitary_rep::Z(0) * pecos_core::unitary_rep::SX(0));
     check_1q_clifford(op::H5(0), &reference, "H5");
 }
 
 #[test]
 fn op_h6_decomposition_correct() {
-    // H6 = Y * SX (apply SX first, then Y)
-    let reference = pecos_core::unitary_rep::Y(0) * pecos_core::unitary_rep::SX(0);
+    // H6 = exp(-i*pi/4) * Y * SX (apply SX first, then Y)
+    let reference = pecos_core::unitary_rep::phase(-(Angle64::QUARTER_TURN / 2u64))
+        * (pecos_core::unitary_rep::Y(0) * pecos_core::unitary_rep::SX(0));
     check_1q_clifford(op::H6(0), &reference, "H6");
 }
 
@@ -123,56 +146,65 @@ fn op_h6_decomposition_correct() {
 
 #[test]
 fn op_f_decomposition_correct() {
-    // F = SZ * SX (apply SX first, then SZ)
-    let reference = pecos_core::unitary_rep::SZ(0) * pecos_core::unitary_rep::SX(0);
+    // F = i * SZ * SX (apply SX first, then SZ)
+    let reference = pecos_core::unitary_rep::phase(Angle64::QUARTER_TURN)
+        * (pecos_core::unitary_rep::SZ(0) * pecos_core::unitary_rep::SX(0));
     check_1q_clifford(op::F(0), &reference, "F");
 }
 
 #[test]
 fn op_fdg_decomposition_correct() {
-    let reference = (pecos_core::unitary_rep::SZ(0) * pecos_core::unitary_rep::SX(0)).dg();
+    // Fdg = -i * SXdg * SZdg.
+    let reference = pecos_core::unitary_rep::phase(-Angle64::QUARTER_TURN)
+        * (pecos_core::unitary_rep::SX(0).dg() * pecos_core::unitary_rep::SZ(0).dg());
     check_1q_clifford(op::Fdg(0), &reference, "Fdg");
 }
 
 #[test]
 fn op_f2_decomposition_correct() {
-    // F2 = SY * SXdg (apply SXdg first, then SY)
-    let reference = pecos_core::unitary_rep::SY(0) * pecos_core::unitary_rep::SX(0).dg();
+    // F2 = -SY * SXdg (apply SXdg first, then SY)
+    let reference = pecos_core::unitary_rep::phase(Angle64::HALF_TURN)
+        * (pecos_core::unitary_rep::SY(0) * pecos_core::unitary_rep::SX(0).dg());
     check_1q_clifford(op::F2(0), &reference, "F2");
 }
 
 #[test]
 fn op_f2dg_decomposition_correct() {
-    // F2dg = SX * SYdg (apply SYdg first, then SX)
-    let reference = pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SY(0).dg();
+    // F2dg = -SX * SYdg (apply SYdg first, then SX)
+    let reference = pecos_core::unitary_rep::phase(Angle64::HALF_TURN)
+        * (pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SY(0).dg());
     check_1q_clifford(op::F2dg(0), &reference, "F2dg");
 }
 
 #[test]
 fn op_f3_decomposition_correct() {
-    // F3 = SZ * SXdg (apply SXdg first, then SZ)
-    let reference = pecos_core::unitary_rep::SZ(0) * pecos_core::unitary_rep::SX(0).dg();
+    // F3 = -SZ * SXdg (apply SXdg first, then SZ)
+    let reference = pecos_core::unitary_rep::phase(Angle64::HALF_TURN)
+        * (pecos_core::unitary_rep::SZ(0) * pecos_core::unitary_rep::SX(0).dg());
     check_1q_clifford(op::F3(0), &reference, "F3");
 }
 
 #[test]
 fn op_f3dg_decomposition_correct() {
-    // F3dg = SX * SZdg (apply SZdg first, then SX)
-    let reference = pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SZ(0).dg();
+    // F3dg = -SX * SZdg (apply SZdg first, then SX)
+    let reference = pecos_core::unitary_rep::phase(Angle64::HALF_TURN)
+        * (pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SZ(0).dg());
     check_1q_clifford(op::F3dg(0), &reference, "F3dg");
 }
 
 #[test]
 fn op_f4_decomposition_correct() {
-    // F4 = SX * SZ (apply SZ first, then SX)
-    let reference = pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SZ(0);
+    // F4 = i * SX * SZ (apply SZ first, then SX)
+    let reference = pecos_core::unitary_rep::phase(Angle64::QUARTER_TURN)
+        * (pecos_core::unitary_rep::SX(0) * pecos_core::unitary_rep::SZ(0));
     check_1q_clifford(op::F4(0), &reference, "F4");
 }
 
 #[test]
 fn op_f4dg_decomposition_correct() {
-    // F4dg = SZdg * SXdg (apply SXdg first, then SZdg)
-    let reference = pecos_core::unitary_rep::SZ(0).dg() * pecos_core::unitary_rep::SX(0).dg();
+    // F4dg = -i * SZdg * SXdg (apply SXdg first, then SZdg)
+    let reference = pecos_core::unitary_rep::phase(-Angle64::QUARTER_TURN)
+        * (pecos_core::unitary_rep::SZ(0).dg() * pecos_core::unitary_rep::SX(0).dg());
     check_1q_clifford(op::F4dg(0), &reference, "F4dg");
 }
 

--- a/crates/pecos-quantum/tests/unitary_matrix_tests.rs
+++ b/crates/pecos-quantum/tests/unitary_matrix_tests.rs
@@ -1005,7 +1005,7 @@ fn cx_qubit_order_matters() {
     );
 }
 
-// --- Face gate cycle: F^3 = I (up to phase) ---
+// --- Face gate cycle: F^3 = I exactly ---
 
 #[test]
 fn face_gates_have_order_3() {
@@ -1022,9 +1022,10 @@ fn face_gates_have_order_3() {
     ] {
         let mat = cliff.to_matrix();
         let cubed = &(&mat * &mat) * &mat;
+        let diff = (&cubed - &identity).norm();
         assert!(
-            cubed.equiv_up_to_phase(&identity),
-            "{cliff:?}^3 should be identity up to phase"
+            diff < 1e-10,
+            "{cliff:?}^3 should be identity, diff = {diff}"
         );
     }
 }
@@ -1090,9 +1091,10 @@ fn s_gates_have_order_4() {
         let mat = cliff.to_matrix();
         let sq = &mat * &mat;
         let fourth = &sq * &sq;
+        let diff = (&fourth - &identity).norm();
         assert!(
-            fourth.equiv_up_to_phase(&identity),
-            "{cliff:?}^4 should be identity up to phase"
+            diff < 1e-10,
+            "{cliff:?}^4 should be identity, diff = {diff}"
         );
     }
 }
@@ -1106,16 +1108,14 @@ fn t_gate_has_order_8() {
         let sq = &mat * &mat;
         let fourth = &sq * &sq;
         let eighth = &fourth * &fourth;
-        assert!(
-            eighth.equiv_up_to_phase(&identity),
-            "{gt:?}^8 should be identity up to phase"
-        );
+        let diff = (&eighth - &identity).norm();
+        assert!(diff < 1e-10, "{gt:?}^8 should be identity, diff = {diff}");
     }
 }
 
 #[test]
 fn s_gate_squared_is_pauli() {
-    // SX^2 = X, SY^2 = Y, SZ^2 = Z (up to phase)
+    // SX^2 = X, SY^2 = Y, SZ^2 = Z exactly.
     let pairs = [
         (Clifford::SX, Pauli::X),
         (Clifford::SY, Pauli::Y),
@@ -1125,9 +1125,10 @@ fn s_gate_squared_is_pauli() {
         let mat = s_gate.to_matrix();
         let sq = &mat * &mat;
         let pauli_mat = pauli.to_matrix();
+        let diff = (&sq - &pauli_mat).norm();
         assert!(
-            sq.equiv_up_to_phase(&pauli_mat),
-            "{s_gate:?}^2 should equal {pauli:?} up to phase"
+            diff < 1e-10,
+            "{s_gate:?}^2 should equal {pauli:?}, diff = {diff}"
         );
     }
 }
@@ -1140,9 +1141,11 @@ fn all_1q_clifford_adjoint_matches_inverse_matrix() {
         let mat = cliff.to_matrix();
         let mat_adj = mat.adjoint();
         let inv_mat = cliff.inverse().to_matrix();
+        let diff = (&mat_adj - &inv_mat).norm();
         assert!(
-            mat_adj.equiv_up_to_phase(&inv_mat),
-            "Clifford::{cliff:?}.to_matrix().adjoint() should match {cliff:?}.inverse().to_matrix()"
+            diff < 1e-10,
+            "Clifford::{cliff:?}.to_matrix().adjoint() should match \
+             {cliff:?}.inverse().to_matrix(), diff = {diff}"
         );
     }
 }

--- a/crates/pecos-simulators/src/clifford_gateable.rs
+++ b/crates/pecos-simulators/src/clifford_gateable.rs
@@ -178,6 +178,14 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
+    ///
+    /// # Global-phase convention
+    ///
+    /// The default `Z`-then-`X` decomposition evaluates to `X * Z = -i Y`,
+    /// so it implements `Y` only projectively. This is intentional for
+    /// representations such as tableaus. Any simulator that preserves complex
+    /// amplitudes and global phase must override this method with the
+    /// phase-fixed Pauli matrix.
     #[inline]
     fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
         self.z(qubits).x(qubits)
@@ -212,8 +220,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies a square root of X (SX) gate to the specified qubits.
     ///
-    /// The SX gate is equivalent to a rotation by π/2 radians around the X axis
-    /// of the Bloch sphere.
+    /// The conventional phase-fixed named gate is
+    /// `SX = exp(i*pi/4) RX(pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -240,8 +248,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies the adjoint (inverse) of the square root of X gate.
     ///
-    /// The SX† gate is equivalent to a rotation by -π/2 radians around the X axis
-    /// of the Bloch sphere.
+    /// The conventional phase-fixed named gate is
+    /// `SX† = exp(-i*pi/4) RX(-pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -268,8 +276,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies a square root of Y (SY) gate to the specified qubits.
     ///
-    /// The SY gate is equivalent to a rotation by π/2 radians around the Y axis
-    /// of the Bloch sphere.
+    /// The conventional phase-fixed named gate is
+    /// `SY = exp(i*pi/4) RY(pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -283,12 +291,20 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// SY = 1/√2 [[1,  -1],
-    ///            [1,   1]]
+    /// SY = 1/2 [[1+i, -1-i],
+    ///           [1+i,  1+i]]
     /// ```
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
+    ///
+    /// # Global-phase convention
+    ///
+    /// The default `Z`-then-`H` decomposition evaluates to `RY(pi/2)`, so it
+    /// implements `SY` only up to the global phase `exp(-i*pi/4)`. This is
+    /// intentional for projective representations such as tableaus. Any
+    /// simulator that preserves complex amplitudes and global phase must
+    /// override this method with the conventional phase-fixed matrix.
     #[inline]
     fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
         self.z(qubits).h(qubits)
@@ -296,8 +312,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies the adjoint (inverse) of the square root of Y gate.
     ///
-    /// The SY† gate is equivalent to a rotation by -π/2 radians around the Y axis
-    /// of the Bloch sphere.
+    /// The conventional phase-fixed named gate is
+    /// `SY† = exp(-i*pi/4) RY(-pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -311,12 +327,20 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// SY† = 1/√2 [[ 1,  1],
-    ///            [-1,  1]]
+    /// SY† = 1/2 [[ 1-i, 1-i],
+    ///            [-1+i, 1-i]]
     /// ```
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
+    ///
+    /// # Global-phase convention
+    ///
+    /// The default `H`-then-`Z` decomposition evaluates to `RY(-pi/2)`, so it
+    /// implements `SY†` only up to the global phase `exp(i*pi/4)`. This is
+    /// intentional for projective representations such as tableaus. Any
+    /// simulator that preserves complex amplitudes and global phase must
+    /// override this method with the conventional phase-fixed matrix.
     #[inline]
     fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
         self.h(qubits).z(qubits)
@@ -324,8 +348,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies a square root of Z (SZ) gate to the specified qubits.
     ///
-    /// The SZ gate (also known as the S gate) is equivalent to a rotation by π/2 radians
-    /// around the Z axis of the Bloch sphere.
+    /// The conventional phase-fixed named gate (also known as S) is
+    /// `SZ = exp(i*pi/4) RZ(pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -349,8 +373,8 @@ pub trait CliffordGateable: QuantumSimulator {
 
     /// Applies the adjoint (inverse) of the square root of Z gate.
     ///
-    /// The SZ† gate is equivalent to a rotation by -π/2 radians around the Z axis
-    /// of the Bloch sphere.
+    /// The conventional phase-fixed named gate is
+    /// `SZ† = exp(-i*pi/4) RZ(-pi/2)`.
     ///
     /// # Arguments
     /// * `qubits` - Target qubit indices.
@@ -417,8 +441,11 @@ pub trait CliffordGateable: QuantumSimulator {
     /// # Matrix Representation
     /// ```text
     /// H2 = 1/√2 [[ 1, -1],
-    ///            [-1,  1]]
+    ///            [-1, -1]]
     /// ```
+    /// Equivalently, `H2 = exp(-i*pi/4) * Z * SY`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -443,9 +470,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// H3 = 1/√2 [[1,  i],
-    ///            [i,  1]]
+    /// H3 = [[0, (1-i)/√2],
+    ///       [(1+i)/√2, 0]]
     /// ```
+    /// Equivalently, `H3 = exp(-i*pi/4) * Y * SZ`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -470,9 +500,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// H4 = 1/√2 [[ 1, -i],
-    ///            [-i,  1]]
+    /// H4 = [[0, (1+i)/√2],
+    ///       [(1-i)/√2, 0]]
     /// ```
+    /// Equivalently, `H4 = exp(-i*pi/4) * X * SZ`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -497,9 +530,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// H5 = 1/√2 [[-1,  1],
-    ///            [ 1,  1]]
+    /// H5 = 1/√2 [[ 1, -i],
+    ///            [ i, -1]]
     /// ```
+    /// Equivalently, `H5 = exp(-i*pi/4) * Z * SX`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -524,9 +560,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// H6 = 1/√2 [[-1, -1],
-    ///            [-1,  1]]
+    /// H6 = 1/√2 [[-1, -i],
+    ///            [ i,  1]]
     /// ```
+    /// Equivalently, `H6 = exp(-i*pi/4) * Y * SX`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -551,9 +590,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F = 1/√2 [[1,  -i],
-    ///           [i,   1]]
+    /// F = 1/2 [[-1+i,  1+i],
+    ///          [-1+i, -1-i]]
     /// ```
+    /// Equivalently, `F = i * SZ * SX`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -578,9 +620,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F† = 1/√2 [[1,   i],
-    ///            [-i,  1]]
+    /// F† = 1/2 [[-1-i, -1-i],
+    ///           [ 1-i, -1+i]]
     /// ```
+    /// Equivalently, `Fdg = -i * SXdg * SZdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -605,9 +650,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F2 = 1/√2 [[-1,  -i],
-    ///            [-i,   1]]
+    /// F2 = 1/2 [[-1+i,  1-i],
+    ///           [-1-i, -1-i]]
     /// ```
+    /// Equivalently, `F2 = -SY * SXdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -632,9 +680,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F2† = 1/√2 [[-1,   i],
-    ///            [ i,   1]]
+    /// F2† = 1/2 [[-1-i, -1+i],
+    ///           [ 1+i, -1+i]]
     /// ```
+    /// Equivalently, `F2dg = -SX * SYdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -659,9 +710,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F3 = 1/√2 [[ 1,  -i],
-    ///            [-i,  -1]]
+    /// F3 = 1/2 [[-1+i, -1-i],
+    ///           [ 1-i, -1-i]]
     /// ```
+    /// Equivalently, `F3 = -SZ * SXdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -686,9 +740,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F3† = 1/√2 [[ 1,   i],
-    ///            [ i,  -1]]
+    /// F3† = 1/2 [[-1-i,  1+i],
+    ///           [-1+i, -1+i]]
     /// ```
+    /// Equivalently, `F3dg = -SX * SZdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -713,9 +770,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F4 = 1/√2 [[-i,  -1],
-    ///            [ 1,  -i]]
+    /// F4 = 1/2 [[-1+i, -1+i],
+    ///           [ 1+i, -1-i]]
     /// ```
+    /// Equivalently, `F4 = i * SX * SZ`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.
@@ -740,9 +800,12 @@ pub trait CliffordGateable: QuantumSimulator {
     ///
     /// # Matrix Representation
     /// ```text
-    /// F4† = 1/√2 [[ i,   1],
-    ///            [-1,   i]]
+    /// F4† = 1/2 [[-1-i,  1-i],
+    ///           [-1-i, -1+i]]
     /// ```
+    /// Equivalently, `F4dg = -i * SZdg * SXdg`.
+    /// The default decomposition omits that global phase and is exact only
+    /// projectively; phase-carrying implementations must override it.
     ///
     /// # Returns
     /// * `&mut Self` - Returns the simulator for method chaining.

--- a/crates/pecos-simulators/src/stab_vec/ch_form.rs
+++ b/crates/pecos-simulators/src/stab_vec/ch_form.rs
@@ -2099,6 +2099,46 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CliffordGateable for CHFormGener
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sy(qubits).z(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).y(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).x(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).z(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).y(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
     fn cx(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         for &(q0, q1) in pairs {
             self.apply_cx(q0.index(), q1.index());
@@ -2132,6 +2172,97 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CliffordGateable for CHFormGener
             self.apply_h(q.index());
             self.apply_z(q.index());
             self.apply_h(q.index());
+        }
+        self
+    }
+
+    fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // The projective Z-then-X decomposition is XZ = -iY.
+        self.z(qubits).x(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(2);
+        }
+        self
+    }
+
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // The projective Z-then-H decomposition is HZ = exp(-i*pi/4) SY.
+        self.z(qubits).h(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(1);
+        }
+        self
+    }
+
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // The projective H-then-Z decomposition is ZH = exp(i*pi/4) SYdg.
+        self.h(qubits).z(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(7);
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).sz(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(2);
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sxdg(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(6);
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sy(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(4);
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sydg(qubits).sx(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(4);
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sz(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(4);
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sx(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(4);
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).sx(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(2);
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).szdg(qubits);
+        for _ in qubits {
+            self.omega.mul_phase(6);
         }
         self
     }

--- a/crates/pecos-simulators/src/state_vec_aos.rs
+++ b/crates/pecos-simulators/src/state_vec_aos.rs
@@ -13,7 +13,8 @@
 use super::arbitrary_rotation_gateable::ArbitraryRotationGateable;
 use super::clifford_gateable::{CliffordGateable, MeasurementResult};
 use super::quantum_simulator::QuantumSimulator;
-use pecos_core::{Angle64, QubitId, RngManageable};
+use pecos_core::gate_type::GateType;
+use pecos_core::{Angle64, Clifford, QubitId, RngManageable};
 use pecos_random::{PecosRng, Rng, RngProbabilityExt, SeedableRng};
 
 use core::fmt::Debug;
@@ -340,6 +341,38 @@ where
         self
     }
 
+    fn apply_canonical_single_qubit_gate(
+        &mut self,
+        gate: GateType,
+        qubits: &[QubitId],
+    ) -> &mut Self {
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("named single-qubit gate must have a canonical matrix");
+        let u00 = Complex64::new(matrix[0], matrix[1]);
+        let u01 = Complex64::new(matrix[2], matrix[3]);
+        let u10 = Complex64::new(matrix[4], matrix[5]);
+        let u11 = Complex64::new(matrix[6], matrix[7]);
+        for &q in qubits {
+            self.single_qubit_rotation(q.index(), u00, u01, u10, u11);
+        }
+        self
+    }
+
+    fn apply_canonical_clifford(&mut self, gate: Clifford, qubits: &[QubitId]) -> &mut Self {
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("single-qubit Clifford must have a canonical matrix");
+        let u00 = Complex64::new(matrix[0], matrix[1]);
+        let u01 = Complex64::new(matrix[2], matrix[3]);
+        let u10 = Complex64::new(matrix[4], matrix[5]);
+        let u11 = Complex64::new(matrix[6], matrix[7]);
+        for &q in qubits {
+            self.single_qubit_rotation(q.index(), u00, u01, u10, u11);
+        }
+        self
+    }
+
     /// Apply a general two-qubit unitary given by a 4x4 complex matrix
     /// U = [[u00, u01, u02, u03],
     ///      [u10, u11, u12, u13],
@@ -574,6 +607,66 @@ where
             }
         }
         self
+    }
+
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H2, qubits)
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H3, qubits)
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H4, qubits)
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H5, qubits)
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H6, qubits)
+    }
+
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_single_qubit_gate(GateType::SY, qubits)
+    }
+
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_single_qubit_gate(GateType::SYdg, qubits)
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F, qubits)
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::Fdg, qubits)
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F2, qubits)
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F2dg, qubits)
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F3, qubits)
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F3dg, qubits)
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F4, qubits)
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F4dg, qubits)
     }
 
     /// Implementation of controlled-X (CNOT) gate for state vectors.

--- a/crates/pecos-simulators/src/state_vec_soa.rs
+++ b/crates/pecos-simulators/src/state_vec_soa.rs
@@ -91,7 +91,7 @@ impl Complex2x2 {
     /// Matrix multiplication: self * other
     /// Computes the product of two 2x2 complex matrices.
     #[inline]
-    fn mul(&self, other: &Self) -> Self {
+    const fn mul(&self, other: &Self) -> Self {
         // (a1*a2 + b1*c2, a1*b2 + b1*d2)
         // (c1*a2 + d1*c2, c1*b2 + d1*d2)
         Self {
@@ -126,284 +126,76 @@ impl Complex2x2 {
 /// Pre-defined gate matrices for fusion
 mod gate_matrices {
     use super::Complex2x2;
+    use pecos_core::Clifford;
+    use pecos_core::gate_type::GateType;
 
-    const INV_SQRT2: f64 = std::f64::consts::FRAC_1_SQRT_2;
+    const fn from_canonical(gate: GateType) -> Complex2x2 {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit matrix");
+        };
+        Complex2x2 {
+            a_re: matrix[0],
+            a_im: matrix[1],
+            b_re: matrix[2],
+            b_im: matrix[3],
+            c_re: matrix[4],
+            c_im: matrix[5],
+            d_re: matrix[6],
+            d_im: matrix[7],
+        }
+    }
 
-    /// Hadamard gate: (1/sqrt(2)) * [[1, 1], [1, -1]]
-    pub const H: Complex2x2 = Complex2x2 {
-        a_re: INV_SQRT2,
-        a_im: 0.0,
-        b_re: INV_SQRT2,
-        b_im: 0.0,
-        c_re: INV_SQRT2,
-        c_im: 0.0,
-        d_re: -INV_SQRT2,
-        d_im: 0.0,
-    };
+    const fn from_clifford(gate: Clifford) -> Complex2x2 {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit Clifford matrix");
+        };
+        Complex2x2 {
+            a_re: matrix[0],
+            a_im: matrix[1],
+            b_re: matrix[2],
+            b_im: matrix[3],
+            c_re: matrix[4],
+            c_im: matrix[5],
+            d_re: matrix[6],
+            d_im: matrix[7],
+        }
+    }
 
-    /// X gate: [[0, 1], [1, 0]]
-    pub const X: Complex2x2 = Complex2x2 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 1.0,
-        b_im: 0.0,
-        c_re: 1.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
+    pub const H: Complex2x2 = from_canonical(GateType::H);
+    pub const X: Complex2x2 = from_canonical(GateType::X);
+    pub const Y: Complex2x2 = from_canonical(GateType::Y);
+    pub const Z: Complex2x2 = from_canonical(GateType::Z);
+    pub const SZ: Complex2x2 = from_canonical(GateType::SZ);
+    pub const SZDG: Complex2x2 = from_canonical(GateType::SZdg);
+    pub const SX: Complex2x2 = from_canonical(GateType::SX);
+    pub const SXDG: Complex2x2 = from_canonical(GateType::SXdg);
+    pub const SY: Complex2x2 = from_canonical(GateType::SY);
+    pub const SYDG: Complex2x2 = from_canonical(GateType::SYdg);
+    pub const F: Complex2x2 = from_canonical(GateType::F);
+    pub const FDG: Complex2x2 = from_canonical(GateType::Fdg);
 
-    /// Y gate: [[0, -i], [i, 0]]
-    pub const Y: Complex2x2 = Complex2x2 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: -1.0,
-        c_re: 0.0,
-        c_im: 1.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
-
-    /// Z gate: [[1, 0], [0, -1]]
-    pub const Z: Complex2x2 = Complex2x2 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: -1.0,
-        d_im: 0.0,
-    };
-
-    /// S gate (SZ): [[1, 0], [0, i]]
-    pub const SZ: Complex2x2 = Complex2x2 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: 1.0,
-    };
-
-    /// S-dagger gate (SZDG): [[1, 0], [0, -i]]
-    pub const SZDG: Complex2x2 = Complex2x2 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: -1.0,
-    };
-
-    /// SX gate: (1/2)[[1+i, 1-i], [1-i, 1+i]]
-    pub const SX: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    /// SXDG gate: (1/2)[[1-i, 1+i], [1+i, 1-i]]
-    pub const SXDG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    /// SY gate: (1/2)[[1+i, -1-i], [1+i, 1+i]]
-    pub const SY: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: -0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    /// SYDG gate: (1/2)[[1-i, 1-i], [-1+i, 1-i]]
-    pub const SYDG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    /// F gate = SZ * SX: (1/2)[[1+i, 1-i], [1+i, -1+i]]
-    pub const F: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: -0.5,
-        d_im: 0.5,
-    };
-
-    /// FDG gate = SXDG * SZDG: (1/2)[[1-i, 1-i], [1+i, -1-i]]
-    pub const FDG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: -0.5,
-        d_im: -0.5,
-    };
-
-    /// H2 gate: Z * SY = (1/2)[[1+i, -(1+i)], [-(1+i), -(1+i)]]
-    pub const H2: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: -0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: -0.5,
-        d_re: -0.5,
-        d_im: -0.5,
-    };
-
-    /// H3 gate: Y * SZ = [[0, 1], [i, 0]]
-    pub const H3: Complex2x2 = Complex2x2 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 1.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 1.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
-
-    /// H4 gate: X * SZ = [[0, i], [1, 0]]
-    pub const H4: Complex2x2 = Complex2x2 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 1.0,
-        c_re: 1.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
-
-    /// H5 gate: Z * SX = (1/2)[[1+i, 1-i], [-(1-i), -(1+i)]]
-    pub const H5: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: 0.5,
-        d_re: -0.5,
-        d_im: -0.5,
-    };
-
-    /// H6 gate: Y * SX = (1/2)[[-1-i, 1-i], [-1+i, 1+i]]
-    pub const H6: Complex2x2 = Complex2x2 {
-        a_re: -0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    /// F2 gate: SY * SXDG = (1/2)[[1-i, -1+i], [1+i, 1+i]]
-    pub const F2: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: -0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    /// F2DG gate: SX * SYDG = (1/2)[[1+i, 1-i], [-1-i, 1-i]]
-    pub const F2DG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: -0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    /// F3 gate: SZ * SXDG = (1/2)[[1-i, 1+i], [-1+i, 1+i]]
-    pub const F3: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: -0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    /// F3DG gate: SX * SZDG = (1/2)[[1+i, -1-i], [1-i, 1-i]]
-    pub const F3DG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: -0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    /// F4 gate: SX * SZ = (1/2)[[1+i, 1+i], [1-i, -1+i]]
-    pub const F4: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: -0.5,
-        d_im: 0.5,
-    };
-
-    /// F4DG gate: SZDG * SXDG = (1/2)[[1-i, 1+i], [1-i, -1-i]]
-    pub const F4DG: Complex2x2 = Complex2x2 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: -0.5,
-        d_im: -0.5,
-    };
+    /// H2 gate: exp(-i*pi/4) * Z * SY
+    pub const H2: Complex2x2 = from_clifford(Clifford::H2);
+    /// H3 gate: exp(-i*pi/4) * Y * SZ
+    pub const H3: Complex2x2 = from_clifford(Clifford::H3);
+    /// H4 gate: exp(-i*pi/4) * X * SZ
+    pub const H4: Complex2x2 = from_clifford(Clifford::H4);
+    /// H5 gate: exp(-i*pi/4) * Z * SX
+    pub const H5: Complex2x2 = from_clifford(Clifford::H5);
+    /// H6 gate: exp(-i*pi/4) * Y * SX
+    pub const H6: Complex2x2 = from_clifford(Clifford::H6);
+    /// F2 gate: -SY * SXDG
+    pub const F2: Complex2x2 = from_clifford(Clifford::F2);
+    /// F2DG gate: -SX * SYDG
+    pub const F2DG: Complex2x2 = from_clifford(Clifford::F2dg);
+    /// F3 gate: -SZ * SXDG
+    pub const F3: Complex2x2 = from_clifford(Clifford::F3);
+    /// F3DG gate: -SX * SZDG
+    pub const F3DG: Complex2x2 = from_clifford(Clifford::F3dg);
+    /// F4 gate: i * SX * SZ
+    pub const F4: Complex2x2 = from_clifford(Clifford::F4);
+    /// F4DG gate: -i * SZDG * SXDG
+    pub const F4DG: Complex2x2 = from_clifford(Clifford::F4dg);
 }
 
 /// Optimized state vector simulator with `SoA` layout.
@@ -1901,7 +1693,7 @@ where
         }
     }
 
-    /// Specialized H3 gate: [[0, 1], [i, 0]] - swap with i on lower
+    /// Specialized H3 gate: [[0, (1-i)/sqrt(2)], [(1+i)/sqrt(2), 0]].
     #[inline]
     fn apply_h3_gate(&mut self, q: usize) {
         let step = 1 << q;
@@ -1916,17 +1708,18 @@ where
                 let b_re = self.real[paired_j];
                 let b_im = self.imag[paired_j];
 
-                // new_a = b
-                // new_b = i * a = (-a_im, a_re)
-                self.real[j] = b_re;
-                self.imag[j] = b_im;
-                self.real[paired_j] = -a_im;
-                self.imag[paired_j] = a_re;
+                // new_a = (1-i) * b / sqrt(2)
+                // new_b = (1+i) * a / sqrt(2)
+                let scale = std::f64::consts::FRAC_1_SQRT_2;
+                self.real[j] = (b_re + b_im) * scale;
+                self.imag[j] = (b_im - b_re) * scale;
+                self.real[paired_j] = (a_re - a_im) * scale;
+                self.imag[paired_j] = (a_re + a_im) * scale;
             }
         }
     }
 
-    /// Specialized H4 gate: [[0, i], [1, 0]] - swap with i on upper
+    /// Specialized H4 gate: [[0, (1+i)/sqrt(2)], [(1-i)/sqrt(2), 0]].
     #[inline]
     fn apply_h4_gate(&mut self, q: usize) {
         let step = 1 << q;
@@ -1941,12 +1734,13 @@ where
                 let b_re = self.real[paired_j];
                 let b_im = self.imag[paired_j];
 
-                // new_a = i * b = (-b_im, b_re)
-                // new_b = a
-                self.real[j] = -b_im;
-                self.imag[j] = b_re;
-                self.real[paired_j] = a_re;
-                self.imag[paired_j] = a_im;
+                // new_a = (1+i) * b / sqrt(2)
+                // new_b = (1-i) * a / sqrt(2)
+                let scale = std::f64::consts::FRAC_1_SQRT_2;
+                self.real[j] = (b_re - b_im) * scale;
+                self.imag[j] = (b_re + b_im) * scale;
+                self.real[paired_j] = (a_re + a_im) * scale;
+                self.imag[paired_j] = (a_im - a_re) * scale;
             }
         }
     }

--- a/crates/pecos-simulators/src/state_vec_soa32.rs
+++ b/crates/pecos-simulators/src/state_vec_soa32.rs
@@ -22,6 +22,8 @@
 use crate::clifford_gateable::MeasurementResult;
 use crate::{ArbitraryRotationGateable, CliffordGateable, QuantumSimulator};
 use num_complex::Complex;
+use pecos_core::Clifford;
+use pecos_core::gate_type::{GateType, single_qubit_matrix_to_f32};
 use pecos_core::{Angle64, QubitId};
 use pecos_random::{PecosRng, Rng, RngExt};
 use std::fmt::Debug;
@@ -46,6 +48,41 @@ struct Complex2x2_32 {
 }
 
 impl Complex2x2_32 {
+    // This table intentionally stores the canonical f64 values at simulator f32 precision.
+    const fn from_canonical(gate: GateType) -> Self {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit matrix");
+        };
+        let matrix = single_qubit_matrix_to_f32(matrix);
+        Self {
+            a_re: matrix[0],
+            a_im: matrix[1],
+            b_re: matrix[2],
+            b_im: matrix[3],
+            c_re: matrix[4],
+            c_im: matrix[5],
+            d_re: matrix[6],
+            d_im: matrix[7],
+        }
+    }
+
+    const fn from_clifford(gate: Clifford) -> Self {
+        let Some(matrix) = gate.canonical_1q_matrix() else {
+            panic!("gate has no canonical single-qubit Clifford matrix");
+        };
+        let matrix = single_qubit_matrix_to_f32(matrix);
+        Self {
+            a_re: matrix[0],
+            a_im: matrix[1],
+            b_re: matrix[2],
+            b_im: matrix[3],
+            c_re: matrix[4],
+            c_im: matrix[5],
+            d_re: matrix[6],
+            d_im: matrix[7],
+        }
+    }
+
     #[inline]
     fn is_identity(&self) -> bool {
         const EPS: f32 = 1e-6;
@@ -92,140 +129,34 @@ impl Complex2x2_32 {
 
 mod gate_matrices_32 {
     use super::Complex2x2_32;
+    use pecos_core::Clifford;
+    use pecos_core::gate_type::GateType;
 
-    const INV_SQRT2: f32 = std::f32::consts::FRAC_1_SQRT_2;
-
-    pub const H: Complex2x2_32 = Complex2x2_32 {
-        a_re: INV_SQRT2,
-        a_im: 0.0,
-        b_re: INV_SQRT2,
-        b_im: 0.0,
-        c_re: INV_SQRT2,
-        c_im: 0.0,
-        d_re: -INV_SQRT2,
-        d_im: 0.0,
-    };
-
-    pub const X: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 1.0,
-        b_im: 0.0,
-        c_re: 1.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
-
-    pub const Y: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: -1.0,
-        c_re: 0.0,
-        c_im: 1.0,
-        d_re: 0.0,
-        d_im: 0.0,
-    };
-
-    pub const Z: Complex2x2_32 = Complex2x2_32 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: -1.0,
-        d_im: 0.0,
-    };
-
-    pub const SZ: Complex2x2_32 = Complex2x2_32 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: 1.0,
-    };
-
-    pub const SZDG: Complex2x2_32 = Complex2x2_32 {
-        a_re: 1.0,
-        a_im: 0.0,
-        b_re: 0.0,
-        b_im: 0.0,
-        c_re: 0.0,
-        c_im: 0.0,
-        d_re: 0.0,
-        d_im: -1.0,
-    };
-
-    pub const SX: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    pub const SXDG: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    pub const SY: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: -0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: 0.5,
-    };
-
-    pub const SYDG: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: -0.5,
-        c_im: 0.5,
-        d_re: 0.5,
-        d_im: -0.5,
-    };
-
-    pub const F: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: 0.5,
-        b_re: 0.5,
-        b_im: -0.5,
-        c_re: 0.5,
-        c_im: 0.5,
-        d_re: -0.5,
-        d_im: 0.5,
-    };
-
-    pub const FDG: Complex2x2_32 = Complex2x2_32 {
-        a_re: 0.5,
-        a_im: -0.5,
-        b_re: 0.5,
-        b_im: 0.5,
-        c_re: 0.5,
-        c_im: -0.5,
-        d_re: -0.5,
-        d_im: -0.5,
-    };
+    pub const H: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::H);
+    pub const H2: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::H2);
+    pub const H3: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::H3);
+    pub const H4: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::H4);
+    pub const H5: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::H5);
+    pub const H6: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::H6);
+    pub const X: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::X);
+    pub const Y: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::Y);
+    pub const Z: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::Z);
+    pub const SZ: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SZ);
+    pub const SZDG: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SZdg);
+    pub const SX: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SX);
+    pub const SXDG: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SXdg);
+    pub const SY: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SY);
+    pub const SYDG: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::SYdg);
+    pub const F: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::F);
+    pub const FDG: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::Fdg);
+    pub const F2: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F2);
+    pub const F2DG: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F2dg);
+    pub const F3: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F3);
+    pub const F3DG: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F3dg);
+    pub const F4: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F4);
+    pub const F4DG: Complex2x2_32 = Complex2x2_32::from_clifford(Clifford::F4dg);
+    pub const T: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::T);
+    pub const TDG: Complex2x2_32 = Complex2x2_32::from_canonical(GateType::Tdg);
 }
 
 // =============================================================================
@@ -746,10 +677,10 @@ where
                     let diff_re = a_re - b_re;
                     let diff_im = a_im - b_im;
 
-                    let new_a_re: [f32; 8] = ((sum_re + diff_re) * half).into();
-                    let new_a_im: [f32; 8] = ((sum_im + diff_im) * half).into();
-                    let new_b_re: [f32; 8] = ((sum_re - diff_re) * half).into();
-                    let new_b_im: [f32; 8] = ((sum_im - diff_im) * half).into();
+                    let new_a_re: [f32; 8] = ((diff_re - diff_im) * half).into();
+                    let new_a_im: [f32; 8] = ((diff_re + diff_im) * half).into();
+                    let new_b_re: [f32; 8] = ((sum_re - sum_im) * half).into();
+                    let new_b_im: [f32; 8] = ((sum_re + sum_im) * half).into();
 
                     self.real[j..j + 8].copy_from_slice(&new_a_re);
                     self.imag[j..j + 8].copy_from_slice(&new_a_im);
@@ -774,10 +705,10 @@ where
                     let diff_re = a_re - b_re;
                     let diff_im = a_im - b_im;
 
-                    self.real[j] = (sum_re + diff_re) * 0.5;
-                    self.imag[j] = (sum_im + diff_im) * 0.5;
-                    self.real[paired_j] = (sum_re - diff_re) * 0.5;
-                    self.imag[paired_j] = (sum_im - diff_im) * 0.5;
+                    self.real[j] = (diff_re - diff_im) * 0.5;
+                    self.imag[j] = (diff_re + diff_im) * 0.5;
+                    self.real[paired_j] = (sum_re - sum_im) * 0.5;
+                    self.imag[paired_j] = (sum_re + sum_im) * 0.5;
                 }
             }
         }
@@ -806,10 +737,10 @@ where
                     let diff_re = a_re - b_re;
                     let diff_im = a_im - b_im;
 
-                    let new_a_re: [f32; 8] = ((sum_re - diff_re) * half).into();
-                    let new_a_im: [f32; 8] = ((sum_im - diff_im) * half).into();
-                    let new_b_re: [f32; 8] = ((sum_re + diff_re) * half).into();
-                    let new_b_im: [f32; 8] = ((sum_im + diff_im) * half).into();
+                    let new_a_re: [f32; 8] = ((sum_re + sum_im) * half).into();
+                    let new_a_im: [f32; 8] = ((sum_im - sum_re) * half).into();
+                    let new_b_re: [f32; 8] = ((-diff_re - diff_im) * half).into();
+                    let new_b_im: [f32; 8] = ((diff_re - diff_im) * half).into();
 
                     self.real[j..j + 8].copy_from_slice(&new_a_re);
                     self.imag[j..j + 8].copy_from_slice(&new_a_im);
@@ -834,10 +765,10 @@ where
                     let diff_re = a_re - b_re;
                     let diff_im = a_im - b_im;
 
-                    self.real[j] = (sum_re - diff_re) * 0.5;
-                    self.imag[j] = (sum_im - diff_im) * 0.5;
-                    self.real[paired_j] = (sum_re + diff_re) * 0.5;
-                    self.imag[paired_j] = (sum_im + diff_im) * 0.5;
+                    self.real[j] = (sum_re + sum_im) * 0.5;
+                    self.imag[j] = (sum_im - sum_re) * 0.5;
+                    self.real[paired_j] = (-diff_re - diff_im) * 0.5;
+                    self.imag[paired_j] = (diff_re - diff_im) * 0.5;
                 }
             }
         }
@@ -973,6 +904,41 @@ where
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::H2);
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::H3);
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::H4);
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::H5);
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::H6);
+        }
+        self
+    }
+
     #[inline]
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
@@ -1093,6 +1059,48 @@ where
     fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             self.queue_gate(q.index(), &gate_matrices_32::FDG);
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F2);
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F2DG);
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F3);
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F3DG);
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F4);
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.queue_gate(q.index(), &gate_matrices_32::F4DG);
         }
         self
     }
@@ -1359,39 +1367,15 @@ where
     }
 
     fn t(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let c = std::f32::consts::FRAC_1_SQRT_2;
-        let matrix = Complex2x2_32 {
-            a_re: 1.0,
-            a_im: 0.0,
-            b_re: 0.0,
-            b_im: 0.0,
-            c_re: 0.0,
-            c_im: 0.0,
-            d_re: c,
-            d_im: c,
-        };
-
         for &q in qubits {
-            self.queue_gate(q.index(), &matrix);
+            self.queue_gate(q.index(), &gate_matrices_32::T);
         }
         self
     }
 
     fn tdg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        let c = std::f32::consts::FRAC_1_SQRT_2;
-        let matrix = Complex2x2_32 {
-            a_re: 1.0,
-            a_im: 0.0,
-            b_re: 0.0,
-            b_im: 0.0,
-            c_re: 0.0,
-            c_im: 0.0,
-            d_re: c,
-            d_im: -c,
-        };
-
         for &q in qubits {
-            self.queue_gate(q.index(), &matrix);
+            self.queue_gate(q.index(), &gate_matrices_32::TDG);
         }
         self
     }

--- a/crates/pecos-simulators/src/state_vec_sparse_aos.rs
+++ b/crates/pecos-simulators/src/state_vec_sparse_aos.rs
@@ -51,7 +51,7 @@
 use crate::clifford_gateable::MeasurementResult;
 use crate::{ArbitraryRotationGateable, CliffordGateable, QuantumSimulator};
 use num_complex::Complex64;
-use pecos_core::{Angle64, QubitId};
+use pecos_core::{Angle64, Clifford, QubitId};
 use pecos_random::{PecosRng, Rng, RngExt, RngProbabilityExt};
 use std::f64::consts::FRAC_1_SQRT_2;
 use std::fmt::Debug;
@@ -836,6 +836,21 @@ impl<R: Rng> SparseStateVecAoS<R> {
 
         std::mem::swap(&mut self.amplitudes, &mut self.scratch);
     }
+
+    fn apply_canonical_clifford(&mut self, gate: Clifford, qubits: &[QubitId]) -> &mut Self {
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("single-qubit Clifford must have a canonical matrix");
+        let a = Complex64::new(matrix[0], matrix[1]);
+        let b = Complex64::new(matrix[2], matrix[3]);
+        let c = Complex64::new(matrix[4], matrix[5]);
+        let d = Complex64::new(matrix[6], matrix[7]);
+        for &q in qubits {
+            self.ensure_sorted();
+            self.apply_single_qubit_gate(q.0, a, b, c, d);
+        }
+        self
+    }
 }
 
 // =============================================================================
@@ -870,6 +885,26 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecAoS<R> {
             self.apply_h_simd(q.0);
         }
         self
+    }
+
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H2, qubits)
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H3, qubits)
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H4, qubits)
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H5, qubits)
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::H6, qubits)
     }
 
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
@@ -1076,6 +1111,38 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecAoS<R> {
             self.apply_single_qubit_gate(q.0, a, b, c, a);
         }
         self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F, qubits)
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::Fdg, qubits)
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F2, qubits)
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F2dg, qubits)
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F3, qubits)
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F3dg, qubits)
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F4, qubits)
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.apply_canonical_clifford(Clifford::F4dg, qubits)
     }
 
     // -------------------------------------------------------------------------

--- a/crates/pecos-simulators/src/state_vec_sparse_soa.rs
+++ b/crates/pecos-simulators/src/state_vec_sparse_soa.rs
@@ -1910,6 +1910,12 @@ impl<R: Rng> SparseStateVecSoA<R> {
         self.frame_phases[q] =
             (self.frame_phases[q] + PHASE_COCYCLE[old][gate_idx.index() as usize] + gate_delta) % 8;
     }
+
+    fn add_named_gate_phase(&mut self, qubits: &[QubitId], phase: u8) {
+        for &q in qubits {
+            self.frame_phases[q.0] = (self.frame_phases[q.0] + phase) % 8;
+        }
+    }
 }
 
 // --- QuantumSimulator trait implementation ---
@@ -2014,6 +2020,84 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
         for &q in qubits {
             self.compose_frame(q.0, CliffordFrame::H, 0);
         }
+        self
+    }
+
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sy(qubits).z(qubits);
+        self.add_named_gate_phase(qubits, 7);
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).y(qubits);
+        self.add_named_gate_phase(qubits, 7);
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).x(qubits);
+        self.add_named_gate_phase(qubits, 7);
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).z(qubits);
+        self.add_named_gate_phase(qubits, 7);
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).y(qubits);
+        self.add_named_gate_phase(qubits, 7);
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).sz(qubits);
+        self.add_named_gate_phase(qubits, 2);
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sxdg(qubits);
+        self.add_named_gate_phase(qubits, 6);
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sy(qubits);
+        self.add_named_gate_phase(qubits, 4);
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sydg(qubits).sx(qubits);
+        self.add_named_gate_phase(qubits, 4);
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sz(qubits);
+        self.add_named_gate_phase(qubits, 4);
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sx(qubits);
+        self.add_named_gate_phase(qubits, 4);
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).sx(qubits);
+        self.add_named_gate_phase(qubits, 2);
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).szdg(qubits);
+        self.add_named_gate_phase(qubits, 6);
         self
     }
 

--- a/crates/pecos-simulators/src/state_vector_test_utils.rs
+++ b/crates/pecos-simulators/src/state_vector_test_utils.rs
@@ -2262,34 +2262,19 @@ pub fn verify_face_gates<S: StateVectorSimulator>(sim: &mut S) {
         );
     }
 
-    // F^3 = I (up to global phase): F cycles X->Y->Z->X, so 3 applications = identity
+    // The phase-fixed F/F1 representative has exact order three.
     sim.reset();
     sim.h(&qid(0));
     let before: Vec<_> = (0..n).map(|i| sim.get_amplitude(i)).collect();
     sim.f(&qid(0));
     sim.f(&qid(0));
     sim.f(&qid(0));
-    // Check global phase equivalence
-    let mut phase_ratio = None;
     for (i, &bef) in before.iter().enumerate() {
         let after = sim.get_amplitude(i);
-        if bef.norm() < TOLERANCE && after.norm() < TOLERANCE {
-            continue;
-        }
         assert!(
-            bef.norm() > TOLERANCE && after.norm() > TOLERANCE,
-            "F^3: index {i} zero mismatch"
+            (after - bef).norm() < TOLERANCE,
+            "F^3 = I: amplitude {i} differs phase-exactly: after={after:?}, before={bef:?}"
         );
-        let ratio = after / bef;
-        match phase_ratio {
-            None => phase_ratio = Some(ratio),
-            Some(expected) => {
-                assert!(
-                    (ratio - expected).norm() < TOLERANCE,
-                    "F^3: inconsistent phase at index {i}: {ratio:?} vs {expected:?}"
-                );
-            }
-        }
     }
 }
 

--- a/crates/pecos-simulators/tests/cross_simulator_tests.rs
+++ b/crates/pecos-simulators/tests/cross_simulator_tests.rs
@@ -18,7 +18,7 @@
 
 use pecos_core::QubitId;
 use pecos_core::clifford::Clifford;
-use pecos_simulators::{CliffordGateable, SparseStab, StateVec, qid};
+use pecos_simulators::{CliffordGateable, SparseStab, StateVec, StateVecSoA32, qid};
 
 type GateTestEntry = (
     Clifford,
@@ -54,6 +54,16 @@ fn cross_check_1q(cliff: Clifford) {
                 "Z-basis mismatch for {cliff}: SparseStab={}, StateVec prob0={prob0}",
                 results[0].outcome
             );
+
+            let mut sv32 = StateVecSoA32::new(1);
+            apply_1q_clifford(&mut sv32, cliff);
+            let prob0 = sv32.get_amplitude(0).norm_sqr();
+            assert_eq!(
+                results[0].outcome,
+                prob0 <= 0.5,
+                "Z-basis mismatch for {cliff}: SparseStab={}, StateVecSoA32 prob0={prob0}",
+                results[0].outcome
+            );
         }
     }
 
@@ -72,6 +82,17 @@ fn cross_check_1q(cliff: Clifford) {
             assert_eq!(
                 results[0].outcome, expected_outcome,
                 "X-basis mismatch for {cliff}: SparseStab={}, StateVec prob0={prob0}",
+                results[0].outcome
+            );
+
+            let mut sv32 = StateVecSoA32::new(1);
+            apply_1q_clifford(&mut sv32, cliff);
+            sv32.h(&qid(0));
+            let prob0 = sv32.get_amplitude(0).norm_sqr();
+            assert_eq!(
+                results[0].outcome,
+                prob0 <= 0.5,
+                "X-basis mismatch for {cliff}: SparseStab={}, StateVecSoA32 prob0={prob0}",
                 results[0].outcome
             );
         }
@@ -93,6 +114,17 @@ fn cross_check_1q(cliff: Clifford) {
             assert_eq!(
                 results[0].outcome, expected_outcome,
                 "Y-basis mismatch for {cliff}: SparseStab={}, StateVec prob0={prob0}",
+                results[0].outcome
+            );
+
+            let mut sv32 = StateVecSoA32::new(1);
+            apply_1q_clifford(&mut sv32, cliff);
+            sv32.sx(&qid(0));
+            let prob0 = sv32.get_amplitude(0).norm_sqr();
+            assert_eq!(
+                results[0].outcome,
+                prob0 <= 0.5,
+                "Y-basis mismatch for {cliff}: SparseStab={}, StateVecSoA32 prob0={prob0}",
                 results[0].outcome
             );
         }
@@ -158,7 +190,7 @@ fn cross_check_2q(
     }
 }
 
-fn apply_1q_clifford(sim: &mut StateVec, cliff: Clifford) {
+fn apply_1q_clifford<S: CliffordGateable>(sim: &mut S, cliff: Clifford) {
     match cliff {
         Clifford::I => {}
         Clifford::X => {

--- a/crates/pecos-simulators/tests/dense_matrix_matches_simulator.rs
+++ b/crates/pecos-simulators/tests/dense_matrix_matches_simulator.rs
@@ -163,16 +163,25 @@ fn dense_matrices_match_the_simulator_for_two_qubit_cliffords() {
     }
 }
 
-/// `F` is the `SX`-then-`SZ` face rotation cycling `X -> Y -> Z -> X`, and
-/// `Fdg` is its reverse, `X -> Z -> Y -> X`. Pinned explicitly because the
-/// composition order is the exact thing #379 got backwards, and because
-/// `SX * SZ` is `F4` -- a real, separately implemented gate, so the mistake
-/// produces a valid Clifford rather than anything obviously broken.
+/// `F = i SZ * SX` is the `SX`-then-`SZ` face rotation cycling
+/// `X -> Y -> Z -> X`, and `Fdg = -i SXdg * SZdg` is its reverse,
+/// `X -> Z -> Y -> X`. Pinned explicitly because the composition order is the
+/// exact thing #379 got backwards, and because `SX * SZ` is the projective
+/// representative of `F4` -- a real, separately implemented gate, so the
+/// mistake produces a valid Clifford rather than anything obviously broken.
 #[test]
 fn face_gate_composition_order_is_pinned() {
-    for (face, decomposition) in [
-        (GateType::F, [GateType::SX, GateType::SZ]),
-        (GateType::Fdg, [GateType::SZdg, GateType::SXdg]),
+    for (face, decomposition, phase) in [
+        (
+            GateType::F,
+            [GateType::SX, GateType::SZ],
+            num_complex::Complex64::new(0.0, 1.0),
+        ),
+        (
+            GateType::Fdg,
+            [GateType::SZdg, GateType::SXdg],
+            num_complex::Complex64::new(0.0, -1.0),
+        ),
     ] {
         let composed = {
             let mut sim = StateVecSoA::new(1);
@@ -192,8 +201,8 @@ fn face_gate_composition_order_is_pinned() {
         };
         for (a, b) in composed.iter().zip(&native) {
             assert!(
-                (a - b).norm() < 1e-9,
-                "{face:?} must equal {decomposition:?} applied in order"
+                (phase * a - b).norm() < 1e-9,
+                "{face:?} must equal {phase} times {decomposition:?} applied in order"
             );
         }
     }

--- a/crates/pecos-simulators/tests/matrix_sim_consistency_tests.rs
+++ b/crates/pecos-simulators/tests/matrix_sim_consistency_tests.rs
@@ -22,7 +22,9 @@ use num_complex::Complex64;
 use pecos_core::Angle64;
 use pecos_core::clifford::Clifford;
 use pecos_quantum::unitary_matrix::{ToMatrix, UnitaryMatrix};
-use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, QubitId, StateVec, qid};
+use pecos_simulators::{
+    ArbitraryRotationGateable, CliffordGateable, QubitId, StateVec, StateVecSoA32, qid,
+};
 
 type GateAction = (Clifford, Box<dyn Fn(&mut StateVec)>);
 type NamedAction = (&'static str, Box<dyn Fn(&mut StateVec)>);
@@ -86,10 +88,42 @@ fn sim_matches_matrix_1q_cliffords() {
             matches,
             "Simulator disagrees with matrix for 1q gate {cliff}"
         );
+
+        let mut sim32 = StateVecSoA32::new(1);
+        apply_1q_clifford(&mut sim32, cliff);
+        let actual32: Vec<Complex64> = (0..2)
+            .map(|basis| {
+                let amplitude = sim32.get_amplitude(basis);
+                Complex64::new(f64::from(amplitude.re), f64::from(amplitude.im))
+            })
+            .collect();
+        let tolerance = 1e-6;
+        let matches32 = if actual32[0].norm() < tolerance && expected[0].norm() < tolerance {
+            actual32
+                .iter()
+                .zip(expected.iter())
+                .all(|(a, b)| (a.norm() - b.norm()).abs() < tolerance)
+        } else if let Some((a, b)) = actual32
+            .iter()
+            .zip(expected.iter())
+            .find(|(a, b)| a.norm() > tolerance && b.norm() > tolerance)
+        {
+            let ratio = b / a;
+            actual32
+                .iter()
+                .zip(expected.iter())
+                .all(|(a, b)| (a * ratio - b).norm() < tolerance)
+        } else {
+            false
+        };
+        assert!(
+            matches32,
+            "StateVecSoA32 disagrees with matrix for 1q gate {cliff}"
+        );
     }
 }
 
-fn apply_1q_clifford(sim: &mut StateVec, cliff: Clifford) {
+fn apply_1q_clifford<S: CliffordGateable>(sim: &mut S, cliff: Clifford) {
     match cliff {
         Clifford::I => {}
         Clifford::X => {

--- a/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
+++ b/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at https://www.apache.org/licenses/LICENSE-2.0
+
+//! Phase-exact named-gate checks for amplitude-carrying CPU simulators.
+
+use num_complex::Complex64;
+use pecos_core::gate_type::{GateType, NAMED_SINGLE_QUBIT_GATES};
+use pecos_core::{Angle64, Clifford, QubitId};
+use pecos_simulators::state_vector_test_utils::StateVectorSimulator;
+use pecos_simulators::{
+    ArbitraryRotationGateable, CHForm, CliffordGateable, SparseStateVecAoS, SparseStateVecSoA,
+    StateVecAoS, StateVecSoA, StateVecSoA32,
+};
+
+const F64_TOLERANCE: f64 = 1e-12;
+const F32_TOLERANCE: f64 = 1e-6;
+
+fn canonical_times_state(gate: GateType, state: &[Complex64; 2]) -> [Complex64; 2] {
+    let matrix = gate
+        .canonical_1q_matrix()
+        .expect("named single-qubit gate must have a canonical matrix");
+    let a = Complex64::new(matrix[0], matrix[1]);
+    let b = Complex64::new(matrix[2], matrix[3]);
+    let c = Complex64::new(matrix[4], matrix[5]);
+    let d = Complex64::new(matrix[6], matrix[7]);
+    [a * state[0] + b * state[1], c * state[0] + d * state[1]]
+}
+
+fn canonical_clifford_times_state(gate: Clifford, state: &[Complex64; 2]) -> [Complex64; 2] {
+    let matrix = gate
+        .canonical_1q_matrix()
+        .expect("single-qubit Clifford must have a canonical matrix");
+    let a = Complex64::new(matrix[0], matrix[1]);
+    let b = Complex64::new(matrix[2], matrix[3]);
+    let c = Complex64::new(matrix[4], matrix[5]);
+    let d = Complex64::new(matrix[6], matrix[7]);
+    [a * state[0] + b * state[1], c * state[0] + d * state[1]]
+}
+
+fn max_error(actual: &[Complex64; 2], expected: &[Complex64; 2]) -> f64 {
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
+fn assert_phase_exact(
+    simulator: &str,
+    gate: &str,
+    actual: &[Complex64; 2],
+    expected: &[Complex64; 2],
+    tolerance: f64,
+) {
+    let error = max_error(actual, expected);
+    assert!(
+        error <= tolerance,
+        "{simulator}::{gate} differs from the canonical matrix by {error:e}; \
+         actual={actual:?}, expected={expected:?}"
+    );
+
+    let root_half = std::f64::consts::FRAC_1_SQRT_2;
+    let phase = Complex64::new(root_half, root_half);
+    let mutant = expected.map(|amplitude| amplitude * phase);
+    assert!(
+        max_error(actual, &mutant) > tolerance,
+        "{simulator}::{gate} accepted an exp(i*pi/4) phase mutation"
+    );
+}
+
+fn apply_clifford_gate<S: CliffordGateable>(sim: &mut S, gate: Clifford) {
+    let qubit = [QubitId(0)];
+    match gate {
+        Clifford::I => sim.identity(&qubit),
+        Clifford::X => sim.x(&qubit),
+        Clifford::Y => sim.y(&qubit),
+        Clifford::Z => sim.z(&qubit),
+        Clifford::H => sim.h(&qubit),
+        Clifford::H2 => sim.h2(&qubit),
+        Clifford::H3 => sim.h3(&qubit),
+        Clifford::H4 => sim.h4(&qubit),
+        Clifford::H5 => sim.h5(&qubit),
+        Clifford::H6 => sim.h6(&qubit),
+        Clifford::SX => sim.sx(&qubit),
+        Clifford::SXdg => sim.sxdg(&qubit),
+        Clifford::SY => sim.sy(&qubit),
+        Clifford::SYdg => sim.sydg(&qubit),
+        Clifford::SZ => sim.sz(&qubit),
+        Clifford::SZdg => sim.szdg(&qubit),
+        Clifford::F => sim.f(&qubit),
+        Clifford::Fdg => sim.fdg(&qubit),
+        Clifford::F2 => sim.f2(&qubit),
+        Clifford::F2dg => sim.f2dg(&qubit),
+        Clifford::F3 => sim.f3(&qubit),
+        Clifford::F3dg => sim.f3dg(&qubit),
+        Clifford::F4 => sim.f4(&qubit),
+        Clifford::F4dg => sim.f4dg(&qubit),
+        _ => panic!("unsupported Clifford gate {gate}"),
+    };
+}
+
+fn apply_named_gate<S: CliffordGateable + ArbitraryRotationGateable>(sim: &mut S, gate: GateType) {
+    let qubit = [QubitId(0)];
+    match gate {
+        GateType::I => sim.identity(&qubit),
+        GateType::X => sim.x(&qubit),
+        GateType::Y => sim.y(&qubit),
+        GateType::Z => sim.z(&qubit),
+        GateType::H => sim.h(&qubit),
+        GateType::F => sim.f(&qubit),
+        GateType::Fdg => sim.fdg(&qubit),
+        GateType::SX => sim.sx(&qubit),
+        GateType::SXdg => sim.sxdg(&qubit),
+        GateType::SY => sim.sy(&qubit),
+        GateType::SYdg => sim.sydg(&qubit),
+        GateType::SZ => sim.sz(&qubit),
+        GateType::SZdg => sim.szdg(&qubit),
+        GateType::T => sim.t(&qubit),
+        GateType::Tdg => sim.tdg(&qubit),
+        other => panic!("unsupported named single-qubit gate {other:?}"),
+    };
+}
+
+fn check_state_vector<S>(simulator: &str, tolerance: f64)
+where
+    S: StateVectorSimulator + ArbitraryRotationGateable,
+{
+    for gate in NAMED_SINGLE_QUBIT_GATES {
+        let mut sim = S::with_seed(1, 42);
+        let qubit = [QubitId(0)];
+        sim.ry(Angle64::from_radians(0.731), &qubit)
+            .rz(Angle64::from_radians(-0.417), &qubit);
+        let input = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        apply_named_gate(&mut sim, gate);
+        let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        let expected = canonical_times_state(gate, &input);
+        assert_phase_exact(
+            simulator,
+            &format!("{gate:?}"),
+            &actual,
+            &expected,
+            tolerance,
+        );
+    }
+}
+
+fn check_state_vector_cliffords<S>(simulator: &str, tolerance: f64)
+where
+    S: StateVectorSimulator + ArbitraryRotationGateable,
+{
+    for &gate in Clifford::all_1q() {
+        let mut sim = S::with_seed(1, 42);
+        let qubit = [QubitId(0)];
+        sim.ry(Angle64::from_radians(0.731), &qubit)
+            .rz(Angle64::from_radians(-0.417), &qubit);
+        let input = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        apply_clifford_gate(&mut sim, gate);
+        let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
+        let expected = canonical_clifford_times_state(gate, &input);
+        assert_phase_exact(simulator, &gate.to_string(), &actual, &expected, tolerance);
+    }
+}
+
+#[test]
+fn phase_carrying_cpu_simulators_match_named_gate_conventions() {
+    check_state_vector::<StateVecSoA>("StateVecSoA", F64_TOLERANCE);
+    check_state_vector::<StateVecAoS>("StateVecAoS", F64_TOLERANCE);
+    check_state_vector::<SparseStateVecSoA>("SparseStateVecSoA", F64_TOLERANCE);
+    check_state_vector::<SparseStateVecAoS>("SparseStateVecAoS", F64_TOLERANCE);
+    check_state_vector::<StateVecSoA32>("StateVecSoA32", F32_TOLERANCE);
+
+    check_state_vector_cliffords::<StateVecSoA>("StateVecSoA", F64_TOLERANCE);
+    check_state_vector_cliffords::<StateVecAoS>("StateVecAoS", F64_TOLERANCE);
+    check_state_vector_cliffords::<SparseStateVecSoA>("SparseStateVecSoA", F64_TOLERANCE);
+    check_state_vector_cliffords::<SparseStateVecAoS>("SparseStateVecAoS", F64_TOLERANCE);
+    check_state_vector_cliffords::<StateVecSoA32>("StateVecSoA32", F32_TOLERANCE);
+}
+
+#[test]
+fn ch_form_matches_named_clifford_conventions() {
+    for gate in NAMED_SINGLE_QUBIT_GATES {
+        if matches!(gate, GateType::T | GateType::Tdg) {
+            continue;
+        }
+
+        let mut sim = CHForm::new(1);
+        let qubit = [QubitId(0)];
+        sim.h(&qubit).sz(&qubit);
+        let input_state = sim.state_vector();
+        let input = [input_state[0], input_state[1]];
+
+        match gate {
+            GateType::I => sim.identity(&qubit),
+            GateType::X => sim.x(&qubit),
+            GateType::Y => sim.y(&qubit),
+            GateType::Z => sim.z(&qubit),
+            GateType::H => sim.h(&qubit),
+            GateType::F => sim.f(&qubit),
+            GateType::Fdg => sim.fdg(&qubit),
+            GateType::SX => sim.sx(&qubit),
+            GateType::SXdg => sim.sxdg(&qubit),
+            GateType::SY => sim.sy(&qubit),
+            GateType::SYdg => sim.sydg(&qubit),
+            GateType::SZ => sim.sz(&qubit),
+            GateType::SZdg => sim.szdg(&qubit),
+            GateType::T | GateType::Tdg => unreachable!(),
+            other => panic!("unsupported named single-qubit gate {other:?}"),
+        };
+
+        let state = sim.state_vector();
+        let actual = [state[0], state[1]];
+        let expected = canonical_times_state(gate, &input);
+        assert_phase_exact(
+            "CHForm",
+            &format!("{gate:?}"),
+            &actual,
+            &expected,
+            F64_TOLERANCE,
+        );
+    }
+
+    for &gate in Clifford::all_1q() {
+        let mut sim = CHForm::new(1);
+        let qubit = [QubitId(0)];
+        sim.h(&qubit).sz(&qubit);
+        let input_state = sim.state_vector();
+        let input = [input_state[0], input_state[1]];
+        apply_clifford_gate(&mut sim, gate);
+        let state = sim.state_vector();
+        let actual = [state[0], state[1]];
+        let expected = canonical_clifford_times_state(gate, &input);
+        assert_phase_exact(
+            "CHForm",
+            &gate.to_string(),
+            &actual,
+            &expected,
+            F64_TOLERANCE,
+        );
+    }
+}

--- a/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
+++ b/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
@@ -48,6 +48,14 @@ fn max_error(actual: &[Complex64; 2], expected: &[Complex64; 2]) -> f64 {
         .fold(0.0, f64::max)
 }
 
+fn max_state_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
 fn assert_phase_exact(
     simulator: &str,
     gate: &str,
@@ -71,57 +79,113 @@ fn assert_phase_exact(
     );
 }
 
-fn apply_clifford_gate<S: CliffordGateable>(sim: &mut S, gate: Clifford) {
-    let qubit = [QubitId(0)];
+fn assert_phase_exact_state(
+    simulator: &str,
+    gate: &str,
+    actual: &[Complex64],
+    expected: &[Complex64],
+    tolerance: f64,
+) {
+    let error = max_state_error(actual, expected);
+    assert!(
+        error <= tolerance,
+        "{simulator}::{gate} differs from the canonical matrix by {error:e}; \
+         actual={actual:?}, expected={expected:?}"
+    );
+
+    let root_half = std::f64::consts::FRAC_1_SQRT_2;
+    let phase = Complex64::new(root_half, root_half);
+    let mutant: Vec<_> = expected.iter().map(|amplitude| amplitude * phase).collect();
+    assert!(
+        max_state_error(actual, &mutant) > tolerance,
+        "{simulator}::{gate} accepted an exp(i*pi/4) phase mutation"
+    );
+}
+
+fn apply_canonical_matrix(
+    state: &mut [Complex64],
+    matrix: pecos_core::gate_type::SingleQubitGateMatrix,
+    qubit: QubitId,
+) {
+    let a = Complex64::new(matrix[0], matrix[1]);
+    let b = Complex64::new(matrix[2], matrix[3]);
+    let c = Complex64::new(matrix[4], matrix[5]);
+    let d = Complex64::new(matrix[6], matrix[7]);
+    let step = 1 << qubit.index();
+    for block in state.chunks_exact_mut(step * 2) {
+        let (zero, one) = block.split_at_mut(step);
+        for (zero, one) in zero.iter_mut().zip(one) {
+            let input_zero = *zero;
+            let input_one = *one;
+            *zero = a * input_zero + b * input_one;
+            *one = c * input_zero + d * input_one;
+        }
+    }
+}
+
+fn apply_clifford_gate<S: CliffordGateable>(sim: &mut S, gate: Clifford, qubits: &[QubitId]) {
     match gate {
-        Clifford::I => sim.identity(&qubit),
-        Clifford::X => sim.x(&qubit),
-        Clifford::Y => sim.y(&qubit),
-        Clifford::Z => sim.z(&qubit),
-        Clifford::H => sim.h(&qubit),
-        Clifford::H2 => sim.h2(&qubit),
-        Clifford::H3 => sim.h3(&qubit),
-        Clifford::H4 => sim.h4(&qubit),
-        Clifford::H5 => sim.h5(&qubit),
-        Clifford::H6 => sim.h6(&qubit),
-        Clifford::SX => sim.sx(&qubit),
-        Clifford::SXdg => sim.sxdg(&qubit),
-        Clifford::SY => sim.sy(&qubit),
-        Clifford::SYdg => sim.sydg(&qubit),
-        Clifford::SZ => sim.sz(&qubit),
-        Clifford::SZdg => sim.szdg(&qubit),
-        Clifford::F => sim.f(&qubit),
-        Clifford::Fdg => sim.fdg(&qubit),
-        Clifford::F2 => sim.f2(&qubit),
-        Clifford::F2dg => sim.f2dg(&qubit),
-        Clifford::F3 => sim.f3(&qubit),
-        Clifford::F3dg => sim.f3dg(&qubit),
-        Clifford::F4 => sim.f4(&qubit),
-        Clifford::F4dg => sim.f4dg(&qubit),
+        Clifford::I => sim.identity(qubits),
+        Clifford::X => sim.x(qubits),
+        Clifford::Y => sim.y(qubits),
+        Clifford::Z => sim.z(qubits),
+        Clifford::H => sim.h(qubits),
+        Clifford::H2 => sim.h2(qubits),
+        Clifford::H3 => sim.h3(qubits),
+        Clifford::H4 => sim.h4(qubits),
+        Clifford::H5 => sim.h5(qubits),
+        Clifford::H6 => sim.h6(qubits),
+        Clifford::SX => sim.sx(qubits),
+        Clifford::SXdg => sim.sxdg(qubits),
+        Clifford::SY => sim.sy(qubits),
+        Clifford::SYdg => sim.sydg(qubits),
+        Clifford::SZ => sim.sz(qubits),
+        Clifford::SZdg => sim.szdg(qubits),
+        Clifford::F => sim.f(qubits),
+        Clifford::Fdg => sim.fdg(qubits),
+        Clifford::F2 => sim.f2(qubits),
+        Clifford::F2dg => sim.f2dg(qubits),
+        Clifford::F3 => sim.f3(qubits),
+        Clifford::F3dg => sim.f3dg(qubits),
+        Clifford::F4 => sim.f4(qubits),
+        Clifford::F4dg => sim.f4dg(qubits),
         _ => panic!("unsupported Clifford gate {gate}"),
     };
 }
 
-fn apply_named_gate<S: CliffordGateable + ArbitraryRotationGateable>(sim: &mut S, gate: GateType) {
-    let qubit = [QubitId(0)];
+fn apply_named_clifford_gate<S: CliffordGateable>(sim: &mut S, gate: GateType, qubits: &[QubitId]) {
     match gate {
-        GateType::I => sim.identity(&qubit),
-        GateType::X => sim.x(&qubit),
-        GateType::Y => sim.y(&qubit),
-        GateType::Z => sim.z(&qubit),
-        GateType::H => sim.h(&qubit),
-        GateType::F => sim.f(&qubit),
-        GateType::Fdg => sim.fdg(&qubit),
-        GateType::SX => sim.sx(&qubit),
-        GateType::SXdg => sim.sxdg(&qubit),
-        GateType::SY => sim.sy(&qubit),
-        GateType::SYdg => sim.sydg(&qubit),
-        GateType::SZ => sim.sz(&qubit),
-        GateType::SZdg => sim.szdg(&qubit),
-        GateType::T => sim.t(&qubit),
-        GateType::Tdg => sim.tdg(&qubit),
+        GateType::I => sim.identity(qubits),
+        GateType::X => sim.x(qubits),
+        GateType::Y => sim.y(qubits),
+        GateType::Z => sim.z(qubits),
+        GateType::H => sim.h(qubits),
+        GateType::F => sim.f(qubits),
+        GateType::Fdg => sim.fdg(qubits),
+        GateType::SX => sim.sx(qubits),
+        GateType::SXdg => sim.sxdg(qubits),
+        GateType::SY => sim.sy(qubits),
+        GateType::SYdg => sim.sydg(qubits),
+        GateType::SZ => sim.sz(qubits),
+        GateType::SZdg => sim.szdg(qubits),
         other => panic!("unsupported named single-qubit gate {other:?}"),
     };
+}
+
+fn apply_named_gate<S: CliffordGateable + ArbitraryRotationGateable>(
+    sim: &mut S,
+    gate: GateType,
+    qubits: &[QubitId],
+) {
+    match gate {
+        GateType::T => {
+            sim.t(qubits);
+        }
+        GateType::Tdg => {
+            sim.tdg(qubits);
+        }
+        _ => apply_named_clifford_gate(sim, gate, qubits),
+    }
 }
 
 fn check_state_vector<S>(simulator: &str, tolerance: f64)
@@ -134,7 +198,7 @@ where
         sim.ry(Angle64::from_radians(0.731), &qubit)
             .rz(Angle64::from_radians(-0.417), &qubit);
         let input = [sim.get_amplitude(0), sim.get_amplitude(1)];
-        apply_named_gate(&mut sim, gate);
+        apply_named_gate(&mut sim, gate, &qubit);
         let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
         let expected = canonical_times_state(gate, &input);
         assert_phase_exact(
@@ -157,10 +221,76 @@ where
         sim.ry(Angle64::from_radians(0.731), &qubit)
             .rz(Angle64::from_radians(-0.417), &qubit);
         let input = [sim.get_amplitude(0), sim.get_amplitude(1)];
-        apply_clifford_gate(&mut sim, gate);
+        apply_clifford_gate(&mut sim, gate, &qubit);
         let actual = [sim.get_amplitude(0), sim.get_amplitude(1)];
         let expected = canonical_clifford_times_state(gate, &input);
         assert_phase_exact(simulator, &gate.to_string(), &actual, &expected, tolerance);
+    }
+}
+
+fn prepare_three_qubit_state<S: StateVectorSimulator + ArbitraryRotationGateable>(sim: &mut S) {
+    sim.ry(Angle64::from_radians(0.731), &[QubitId(0)])
+        .rz(Angle64::from_radians(-0.417), &[QubitId(0)])
+        .rx(Angle64::from_radians(-0.293), &[QubitId(1)])
+        .ry(Angle64::from_radians(0.619), &[QubitId(2)])
+        .cx(&[(QubitId(0), QubitId(1))])
+        .cz(&[(QubitId(1), QubitId(2))]);
+}
+
+fn state_vector<S: StateVectorSimulator>(sim: &mut S) -> Vec<Complex64> {
+    (0..(1 << sim.num_qubits()))
+        .map(|basis_state| sim.get_amplitude(basis_state))
+        .collect()
+}
+
+fn check_three_qubit_multi_target_calls<S, F>(simulator: &str, tolerance: f64, configure: F)
+where
+    S: StateVectorSimulator + ArbitraryRotationGateable,
+    F: Fn(&mut S) + Copy,
+{
+    let targets = [QubitId(0), QubitId(2)];
+    for gate in NAMED_SINGLE_QUBIT_GATES {
+        let mut sim = S::with_seed(3, 42);
+        configure(&mut sim);
+        prepare_three_qubit_state(&mut sim);
+        let mut expected = state_vector(&mut sim);
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("named single-qubit gate must have a canonical matrix");
+        for &target in &targets {
+            apply_canonical_matrix(&mut expected, matrix, target);
+        }
+        apply_named_gate(&mut sim, gate, &targets);
+        let actual = state_vector(&mut sim);
+        assert_phase_exact_state(
+            simulator,
+            &format!("{gate:?} on q0,q2"),
+            &actual,
+            &expected,
+            tolerance,
+        );
+    }
+
+    for &gate in Clifford::all_1q() {
+        let mut sim = S::with_seed(3, 42);
+        configure(&mut sim);
+        prepare_three_qubit_state(&mut sim);
+        let mut expected = state_vector(&mut sim);
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("single-qubit Clifford must have a canonical matrix");
+        for &target in &targets {
+            apply_canonical_matrix(&mut expected, matrix, target);
+        }
+        apply_clifford_gate(&mut sim, gate, &targets);
+        let actual = state_vector(&mut sim);
+        assert_phase_exact_state(
+            simulator,
+            &format!("{gate} on q0,q2"),
+            &actual,
+            &expected,
+            tolerance,
+        );
     }
 }
 
@@ -180,42 +310,59 @@ fn phase_carrying_cpu_simulators_match_named_gate_conventions() {
 }
 
 #[test]
+fn phase_carrying_cpu_simulators_match_multi_target_conventions_on_three_qubits() {
+    check_three_qubit_multi_target_calls::<StateVecSoA, _>("StateVecSoA", F64_TOLERANCE, |_| {});
+    check_three_qubit_multi_target_calls::<StateVecAoS, _>("StateVecAoS", F64_TOLERANCE, |_| {});
+    check_three_qubit_multi_target_calls::<SparseStateVecSoA, _>(
+        "SparseStateVecSoA",
+        F64_TOLERANCE,
+        |_| {},
+    );
+    check_three_qubit_multi_target_calls::<SparseStateVecAoS, _>(
+        "SparseStateVecAoS",
+        F64_TOLERANCE,
+        |_| {},
+    );
+    check_three_qubit_multi_target_calls::<StateVecSoA32, _>(
+        "StateVecSoA32",
+        F32_TOLERANCE,
+        |_| {},
+    );
+    check_three_qubit_multi_target_calls::<StateVecSoA32, _>(
+        "StateVecSoA32(fusion disabled)",
+        F32_TOLERANCE,
+        |sim| sim.set_fusion(false),
+    );
+}
+
+#[test]
 fn ch_form_matches_named_clifford_conventions() {
+    let targets = [QubitId(0), QubitId(2)];
     for gate in NAMED_SINGLE_QUBIT_GATES {
         if matches!(gate, GateType::T | GateType::Tdg) {
             continue;
         }
 
-        let mut sim = CHForm::new(1);
-        let qubit = [QubitId(0)];
-        sim.h(&qubit).sz(&qubit);
+        let mut sim = CHForm::new(3);
+        sim.h(&[QubitId(0), QubitId(2)])
+            .sz(&[QubitId(0)])
+            .cx(&[(QubitId(0), QubitId(1))])
+            .cz(&[(QubitId(1), QubitId(2))]);
         let input_state = sim.state_vector();
-        let input = [input_state[0], input_state[1]];
+        let mut expected = input_state.clone();
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("named single-qubit gate must have a canonical matrix");
+        for &target in &targets {
+            apply_canonical_matrix(&mut expected, matrix, target);
+        }
 
-        match gate {
-            GateType::I => sim.identity(&qubit),
-            GateType::X => sim.x(&qubit),
-            GateType::Y => sim.y(&qubit),
-            GateType::Z => sim.z(&qubit),
-            GateType::H => sim.h(&qubit),
-            GateType::F => sim.f(&qubit),
-            GateType::Fdg => sim.fdg(&qubit),
-            GateType::SX => sim.sx(&qubit),
-            GateType::SXdg => sim.sxdg(&qubit),
-            GateType::SY => sim.sy(&qubit),
-            GateType::SYdg => sim.sydg(&qubit),
-            GateType::SZ => sim.sz(&qubit),
-            GateType::SZdg => sim.szdg(&qubit),
-            GateType::T | GateType::Tdg => unreachable!(),
-            other => panic!("unsupported named single-qubit gate {other:?}"),
-        };
+        apply_named_clifford_gate(&mut sim, gate, &targets);
 
-        let state = sim.state_vector();
-        let actual = [state[0], state[1]];
-        let expected = canonical_times_state(gate, &input);
-        assert_phase_exact(
+        let actual = sim.state_vector();
+        assert_phase_exact_state(
             "CHForm",
-            &format!("{gate:?}"),
+            &format!("{gate:?} on q0,q2"),
             &actual,
             &expected,
             F64_TOLERANCE,
@@ -223,18 +370,24 @@ fn ch_form_matches_named_clifford_conventions() {
     }
 
     for &gate in Clifford::all_1q() {
-        let mut sim = CHForm::new(1);
-        let qubit = [QubitId(0)];
-        sim.h(&qubit).sz(&qubit);
+        let mut sim = CHForm::new(3);
+        sim.h(&[QubitId(0), QubitId(2)])
+            .sz(&[QubitId(0)])
+            .cx(&[(QubitId(0), QubitId(1))])
+            .cz(&[(QubitId(1), QubitId(2))]);
         let input_state = sim.state_vector();
-        let input = [input_state[0], input_state[1]];
-        apply_clifford_gate(&mut sim, gate);
-        let state = sim.state_vector();
-        let actual = [state[0], state[1]];
-        let expected = canonical_clifford_times_state(gate, &input);
-        assert_phase_exact(
+        let mut expected = input_state.clone();
+        let matrix = gate
+            .canonical_1q_matrix()
+            .expect("single-qubit Clifford must have a canonical matrix");
+        for &target in &targets {
+            apply_canonical_matrix(&mut expected, matrix, target);
+        }
+        apply_clifford_gate(&mut sim, gate, &targets);
+        let actual = sim.state_vector();
+        assert_phase_exact_state(
             "CHForm",
-            &gate.to_string(),
+            &format!("{gate} on q0,q2"),
             &actual,
             &expected,
             F64_TOLERANCE,

--- a/crates/pecos-simulators/tests/test_state_vec.rs
+++ b/crates/pecos-simulators/tests/test_state_vec.rs
@@ -1040,7 +1040,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_sq_standard_gate_decompositions() {
-        // Test S = RZ(π/2)
+        // Test SZ = exp(iπ/4) RZ(π/2) projectively.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.sz(&qid(0));
@@ -1806,7 +1806,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f_vs_decomposition() {
-        // F = SX.SZ decomposition (apply sx then sz)
+        // F = i * SZ * SX (apply SX first, then SZ).
         // Test on |0⟩
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
@@ -1858,7 +1858,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_fdg_vs_decomposition() {
-        // FDG = SZDG.SXDG decomposition (apply szdg then sxdg)
+        // Fdg = -i * SXdg * SZdg (apply SZdg first, then SXdg).
         // Test on |0⟩
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
@@ -1920,7 +1920,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f2_vs_decomposition() {
-        // F2 = SXDG.SY (apply SXDG first, then SY)
+        // F2 = -SY * SXdg (apply SXdg first, then SY).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f2(&qid(0));
@@ -1948,7 +1948,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f2dg_vs_decomposition() {
-        // F2DG = SYDG.SX (apply SYDG first, then SX)
+        // F2dg = -SX * SYdg (apply SYdg first, then SX).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f2dg(&qid(0));
@@ -1967,7 +1967,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f3_vs_decomposition() {
-        // F3 = SXDG.SZ (apply SXDG first, then SZ)
+        // F3 = -SZ * SXdg (apply SXdg first, then SZ).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f3(&qid(0));
@@ -1995,7 +1995,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f3dg_vs_decomposition() {
-        // F3DG = SZDG.SX (apply SZDG first, then SX)
+        // F3dg = -SX * SZdg (apply SZdg first, then SX).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f3dg(&qid(0));
@@ -2014,7 +2014,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f4_vs_decomposition() {
-        // F4 = SZ.SX (apply SZ first, then SX)
+        // F4 = i * SX * SZ (apply SZ first, then SX).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f4(&qid(0));
@@ -2042,7 +2042,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_f4dg_vs_decomposition() {
-        // F4DG = SXDG.SZDG (apply SXDG first, then SZDG)
+        // F4dg = -i * SZdg * SXdg (apply SXdg first, then SZdg).
         let mut direct = StateVec::new(1);
         let mut decomposed = StateVec::new(1);
         direct.f4dg(&qid(0));
@@ -2588,7 +2588,7 @@ mod detailed_sq_gate_cases {
 
     #[test]
     fn test_sqrt_gates_vs_rotations() {
-        // SX = RX(π/2)
+        // SX = exp(iπ/4) RX(π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));
@@ -2599,7 +2599,7 @@ mod detailed_sq_gate_cases {
 
         assert_states_equal(q1.state(), q2.state());
 
-        // SXDG = RX(-π/2)
+        // SXdg = exp(-iπ/4) RX(-π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));
@@ -2610,7 +2610,7 @@ mod detailed_sq_gate_cases {
 
         assert_states_equal(q1.state(), q2.state());
 
-        // SY = RY(π/2)
+        // SY = exp(iπ/4) RY(π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));
@@ -2621,7 +2621,7 @@ mod detailed_sq_gate_cases {
 
         assert_states_equal(q1.state(), q2.state());
 
-        // SYDG = RY(-π/2)
+        // SYdg = exp(-iπ/4) RY(-π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));
@@ -2632,7 +2632,7 @@ mod detailed_sq_gate_cases {
 
         assert_states_equal(q1.state(), q2.state());
 
-        // SZ = RZ(π/2)
+        // SZ = exp(iπ/4) RZ(π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));
@@ -2643,7 +2643,7 @@ mod detailed_sq_gate_cases {
 
         assert_states_equal(q1.state(), q2.state());
 
-        // SZDG = RZ(-π/2)
+        // SZdg = exp(-iπ/4) RZ(-π/2), compared projectively here.
         let mut q1 = StateVec::new(1);
         let mut q2 = StateVec::new(1);
         q1.h(&qid(0));

--- a/crates/pecos-simulators/tests/three_simulator_comparison_tests.rs
+++ b/crates/pecos-simulators/tests/three_simulator_comparison_tests.rs
@@ -4,6 +4,7 @@ use pecos_simulators::CliffordGateable;
 use pecos_simulators::DensityMatrix;
 use pecos_simulators::QuantumSimulator;
 use pecos_simulators::StateVec;
+use pecos_simulators::StateVecSoA32;
 use pecos_simulators::{QubitId, SparseStab, qid};
 use std::f64::consts::PI;
 
@@ -15,15 +16,24 @@ fn assert_probs_equal(p1: f64, p2: f64) {
     );
 }
 
+fn assert_probs_equal_f32(p1: f64, p2: f64) {
+    assert!(
+        (p1 - p2).abs() < 1e-6,
+        "StateVecSoA32 probabilities differ: {p1} vs {p2}"
+    );
+}
+
 // Helper function to compare probabilities for all three simulators
 fn compare_all_probabilities(
     sv: &mut StateVec,
+    sv32: &mut StateVecSoA32,
     dm: &mut DensityMatrix,
     stab: &SparseStab,
     num_qubits: usize,
 ) {
     for i in 0..(1 << num_qubits) {
         let sv_prob = sv.probability(i);
+        let sv32_prob = sv32.probability(i);
         let dm_prob = dm.probability(i);
 
         // For stabilizer, calculate probability by measuring qubits
@@ -56,24 +66,28 @@ fn compare_all_probabilities(
         assert_probs_equal(sv_prob, dm_prob);
         assert_probs_equal(sv_prob, stab_prob);
         assert_probs_equal(dm_prob, stab_prob);
+        assert_probs_equal_f32(sv32_prob, sv_prob);
+        assert_probs_equal_f32(sv32_prob, dm_prob);
+        assert_probs_equal_f32(sv32_prob, stab_prob);
     }
 }
 
 // Helper function to compare a clifford circuit among all three simulators
 fn compare_clifford_circuit<F>(num_qubits: usize, circuit_fn: F)
 where
-    F: Fn(&mut StateVec, &mut DensityMatrix, &mut SparseStab),
+    F: Fn(&mut StateVec, &mut StateVecSoA32, &mut DensityMatrix, &mut SparseStab),
 {
     let seed = 42; // Fixed seed for determinism
     let mut sv = StateVec::with_seed(num_qubits, seed);
+    let mut sv32 = StateVecSoA32::with_seed(num_qubits, seed);
     let mut dm = DensityMatrix::with_seed(num_qubits, seed);
     let mut stab = SparseStab::with_seed(num_qubits, seed);
 
     // Apply the circuit to all three simulators
-    circuit_fn(&mut sv, &mut dm, &mut stab);
+    circuit_fn(&mut sv, &mut sv32, &mut dm, &mut stab);
 
     // Compare the resulting states
-    compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+    compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
 }
 
 // Helper function to compare a general circuit between StateVec and DensityMatrix
@@ -100,43 +114,49 @@ where
 fn test_initial_state_consistency() {
     for num_qubits in 1..=5 {
         let mut sv = StateVec::new(num_qubits);
+        let mut sv32 = StateVecSoA32::new(num_qubits);
         let mut dm = DensityMatrix::new(num_qubits);
         let stab = SparseStab::new(num_qubits);
 
-        compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+        compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
     }
 }
 
 #[test]
 fn test_basic_gates_consistency() {
     // Test X, H gates on a single qubit across all simulators
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.x(&qid(0));
+        sv32.x(&qid(0));
         dm.x(&qid(0));
         stab.x(&qid(0));
     });
 
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0));
+        sv32.h(&qid(0));
         dm.h(&qid(0));
         stab.h(&qid(0));
     });
 
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.y(&qid(0));
+        sv32.y(&qid(0));
         dm.y(&qid(0));
         stab.y(&qid(0));
     });
 
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.z(&qid(0));
+        sv32.z(&qid(0));
         dm.z(&qid(0));
         stab.z(&qid(0));
     });
 
     // Test sequence of gates
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).z(&qid(0)).h(&qid(0)); // Effective X gate
+        sv32.h(&qid(0)).z(&qid(0)).h(&qid(0)); // Effective X gate
         dm.h(&qid(0)).z(&qid(0)).h(&qid(0));
         stab.h(&qid(0)).z(&qid(0)).h(&qid(0));
     });
@@ -145,21 +165,24 @@ fn test_basic_gates_consistency() {
 #[test]
 fn test_phase_gates_consistency() {
     // Test phase gates (S = sqrt of Z)
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.sz(&qid(0));
+        sv32.sz(&qid(0));
         dm.sz(&qid(0));
         stab.sz(&qid(0));
     });
 
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).sz(&qid(0)).h(&qid(0));
+        sv32.h(&qid(0)).sz(&qid(0)).h(&qid(0));
         dm.h(&qid(0)).sz(&qid(0)).h(&qid(0));
         stab.h(&qid(0)).sz(&qid(0)).h(&qid(0));
     });
 
     // Test that S^2 = Z
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.sz(&qid(0)).sz(&qid(0));
+        sv32.sz(&qid(0)).sz(&qid(0));
         dm.sz(&qid(0)).sz(&qid(0));
         stab.sz(&qid(0)).sz(&qid(0));
     });
@@ -168,22 +191,25 @@ fn test_phase_gates_consistency() {
 #[test]
 fn test_multi_qubit_gates_consistency() {
     // Test two-qubit CNOT gate
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.cx(&[(QubitId(0), QubitId(1))]);
+        sv32.cx(&[(QubitId(0), QubitId(1))]);
         dm.cx(&[(QubitId(0), QubitId(1))]);
         stab.cx(&[(QubitId(0), QubitId(1))]);
     });
 
     // Test CZ gate
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.cz(&[(QubitId(0), QubitId(1))]);
+        sv32.cz(&[(QubitId(0), QubitId(1))]);
         dm.cz(&[(QubitId(0), QubitId(1))]);
         stab.cz(&[(QubitId(0), QubitId(1))]);
     });
 
     // Test SWAP gate
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.swap(&[(QubitId(0), QubitId(1))]);
+        sv32.swap(&[(QubitId(0), QubitId(1))]);
         dm.swap(&[(QubitId(0), QubitId(1))]);
         stab.swap(&[(QubitId(0), QubitId(1))]);
     });
@@ -192,29 +218,36 @@ fn test_multi_qubit_gates_consistency() {
 #[test]
 fn test_bell_state_consistency() {
     // Test creation of Bell state |Φ⁺⟩ = (|00⟩ + |11⟩)/√2
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]);
     });
 
     // Test creation of Bell state |Φ⁻⟩ = (|00⟩ - |11⟩)/√2
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).z(&qid(1));
+        sv32.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).z(&qid(1));
         dm.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).z(&qid(1));
         stab.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).z(&qid(1));
     });
 
     // Test creation of Bell state |Ψ⁺⟩ = (|01⟩ + |10⟩)/√2
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).x(&qid(1));
+        sv32.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).x(&qid(1));
         dm.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).x(&qid(1));
         stab.h(&qid(0)).cx(&[(QubitId(0), QubitId(1))]).x(&qid(1));
     });
 
     // Test creation of Bell state |Ψ⁻⟩ = (|01⟩ - |10⟩)/√2
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0))
+            .cx(&[(QubitId(0), QubitId(1))])
+            .z(&qid(0))
+            .x(&qid(1));
+        sv32.h(&qid(0))
             .cx(&[(QubitId(0), QubitId(1))])
             .z(&qid(0))
             .x(&qid(1));
@@ -233,14 +266,16 @@ fn test_bell_state_consistency() {
 fn test_ghz_state_consistency() {
     // Test creation of GHZ state (|000⟩ + |111⟩)/√2 with increasing number of qubits
     for num_qubits in 3..=5 {
-        compare_clifford_circuit(num_qubits, |sv, dm, stab| {
+        compare_clifford_circuit(num_qubits, |sv, sv32, dm, stab| {
             sv.h(&qid(0));
+            sv32.h(&qid(0));
             dm.h(&qid(0));
             stab.h(&qid(0));
 
             // Entangle all qubits
             for i in 0..(num_qubits - 1) {
                 sv.cx(&[(QubitId(i), QubitId(i + 1))]);
+                sv32.cx(&[(QubitId(i), QubitId(i + 1))]);
                 dm.cx(&[(QubitId(i), QubitId(i + 1))]);
                 stab.cx(&[(QubitId(i), QubitId(i + 1))]);
             }
@@ -255,80 +290,95 @@ fn test_measurement_consistency() {
 
     // Test Z-basis measurement
     let mut sv = StateVec::with_seed(num_qubits, seed);
+    let mut sv32 = StateVecSoA32::with_seed(num_qubits, seed);
     let mut dm = DensityMatrix::with_seed(num_qubits, seed);
     let mut stab = SparseStab::with_seed(num_qubits, seed);
 
     // Put qubits in superposition
     sv.h(&qid(0));
+    sv32.h(&qid(0));
     dm.h(&qid(0));
     stab.h(&qid(0));
 
     // With identical seeds, measurements should give identical results
     let sv_result = sv.mz(&qid(0)).into_iter().next().unwrap();
+    let sv32_result = sv32.mz(&qid(0)).into_iter().next().unwrap();
     let dm_result = dm.mz(&qid(0)).into_iter().next().unwrap();
     let stab_result = stab.mz(&qid(0)).into_iter().next().unwrap();
 
     assert_eq!(sv_result.outcome, dm_result.outcome);
+    assert_eq!(sv_result.outcome, sv32_result.outcome);
     assert_eq!(sv_result.outcome, stab_result.outcome);
     assert_eq!(dm_result.outcome, stab_result.outcome);
 
     assert_eq!(sv_result.is_deterministic, dm_result.is_deterministic);
+    assert_eq!(sv_result.is_deterministic, sv32_result.is_deterministic);
     assert_eq!(sv_result.is_deterministic, stab_result.is_deterministic);
     assert_eq!(dm_result.is_deterministic, stab_result.is_deterministic);
 
     // After measurement, states should be consistent
-    compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+    compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
 
     // Test X-basis measurement (H→Z→H)
     let mut sv = StateVec::with_seed(num_qubits, seed);
+    let mut sv32 = StateVecSoA32::with_seed(num_qubits, seed);
     let mut dm = DensityMatrix::with_seed(num_qubits, seed);
     let mut stab = SparseStab::with_seed(num_qubits, seed);
 
     // Prepare |0⟩, then apply Z to get a deterministic result
     sv.z(&qid(0));
+    sv32.z(&qid(0));
     dm.z(&qid(0));
     stab.z(&qid(0));
 
     // Measure in X basis
     let sv_result = sv.mx(&qid(0)).into_iter().next().unwrap();
+    let sv32_result = sv32.mx(&qid(0)).into_iter().next().unwrap();
     let dm_result = dm.mx(&qid(0)).into_iter().next().unwrap();
     let stab_result = stab.mx(&qid(0)).into_iter().next().unwrap();
 
     assert_eq!(sv_result.outcome, dm_result.outcome);
+    assert_eq!(sv_result.outcome, sv32_result.outcome);
     assert_eq!(sv_result.outcome, stab_result.outcome);
     assert_eq!(dm_result.outcome, stab_result.outcome);
 
     assert_eq!(sv_result.is_deterministic, dm_result.is_deterministic);
+    assert_eq!(sv_result.is_deterministic, sv32_result.is_deterministic);
     assert_eq!(sv_result.is_deterministic, stab_result.is_deterministic);
     assert_eq!(dm_result.is_deterministic, stab_result.is_deterministic);
 
     // After measurement, all states should still be consistent
-    compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+    compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
 }
 
 #[test]
 fn test_complex_circuit_consistency() {
     // Test more complex Clifford circuits
     for num_qubits in 3..=4 {
-        compare_clifford_circuit(num_qubits, |sv, dm, stab| {
+        compare_clifford_circuit(num_qubits, |sv, sv32, dm, stab| {
             // Create GHZ state
             sv.h(&qid(0));
+            sv32.h(&qid(0));
             dm.h(&qid(0));
             stab.h(&qid(0));
 
             for i in 0..(num_qubits - 1) {
                 sv.cx(&[(QubitId(i), QubitId(i + 1))]);
+                sv32.cx(&[(QubitId(i), QubitId(i + 1))]);
                 dm.cx(&[(QubitId(i), QubitId(i + 1))]);
                 stab.cx(&[(QubitId(i), QubitId(i + 1))]);
             }
 
             // Apply some additional gates
             sv.h(&qid(1)).sz(&qid(2));
+            sv32.h(&qid(1)).sz(&qid(2));
             dm.h(&qid(1)).sz(&qid(2));
             stab.h(&qid(1)).sz(&qid(2));
 
             if num_qubits > 3 {
                 sv.cz(&[(QubitId(0), QubitId(3))])
+                    .swap(&[(QubitId(1), QubitId(2))]);
+                sv32.cz(&[(QubitId(0), QubitId(3))])
                     .swap(&[(QubitId(1), QubitId(2))]);
                 dm.cz(&[(QubitId(0), QubitId(3))])
                     .swap(&[(QubitId(1), QubitId(2))]);
@@ -388,6 +438,7 @@ fn test_prepare_computational_basis_consistency() {
         // Test each computational basis state
         for i in 0..(1 << num_qubits) {
             let mut sv = StateVec::new(num_qubits);
+            let mut sv32 = StateVecSoA32::new(num_qubits);
             let mut dm = DensityMatrix::new(num_qubits);
             let mut stab = SparseStab::new(num_qubits);
 
@@ -395,6 +446,7 @@ fn test_prepare_computational_basis_consistency() {
             // based on the bits of i
             for q in 0..num_qubits {
                 if (i >> q) & 1 == 1 {
+                    sv32.x(&qid(q));
                     stab.x(&qid(q));
                 }
             }
@@ -404,7 +456,7 @@ fn test_prepare_computational_basis_consistency() {
             dm.prepare_computational_basis(i);
 
             // Compare the states
-            compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+            compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
         }
     }
 }
@@ -414,18 +466,20 @@ fn test_prepare_plus_states_consistency() {
     // Test |+⟩ state preparation using H gates
     for num_qubits in 1..=3 {
         let mut sv = StateVec::new(num_qubits);
+        let mut sv32 = StateVecSoA32::new(num_qubits);
         let mut dm = DensityMatrix::new(num_qubits);
         let mut stab = SparseStab::new(num_qubits);
 
         // Apply H to all qubits
         for q in 0..num_qubits {
             sv.h(&qid(q));
+            sv32.h(&qid(q));
             dm.h(&qid(q));
             stab.h(&qid(q));
         }
 
         // Compare the states
-        compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+        compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
     }
 }
 
@@ -434,27 +488,31 @@ fn test_reset_consistency() {
     // Test reset behavior
     for num_qubits in 1..=3 {
         let mut sv = StateVec::new(num_qubits);
+        let mut sv32 = StateVecSoA32::new(num_qubits);
         let mut dm = DensityMatrix::new(num_qubits);
         let mut stab = SparseStab::new(num_qubits);
 
         // Apply some gates to get to a non-trivial state
         sv.h(&qid(0));
+        sv32.h(&qid(0));
         dm.h(&qid(0));
         stab.h(&qid(0));
 
         if num_qubits > 1 {
             sv.cx(&[(QubitId(0), QubitId(1))]);
+            sv32.cx(&[(QubitId(0), QubitId(1))]);
             dm.cx(&[(QubitId(0), QubitId(1))]);
             stab.cx(&[(QubitId(0), QubitId(1))]);
         }
 
         // Reset all simulators
         sv.reset();
+        sv32.reset();
         dm.reset();
         stab.reset();
 
         // Compare the states
-        compare_all_probabilities(&mut sv, &mut dm, &stab, num_qubits);
+        compare_all_probabilities(&mut sv, &mut sv32, &mut dm, &stab, num_qubits);
     }
 }
 
@@ -465,47 +523,55 @@ fn test_reset_consistency() {
 #[test]
 fn test_h_variant_gates_consistency() {
     // Each H variant applied to |0>
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h2(&qid(0));
+        sv32.h2(&qid(0));
         dm.h2(&qid(0));
         stab.h2(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h3(&qid(0));
+        sv32.h3(&qid(0));
         dm.h3(&qid(0));
         stab.h3(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h4(&qid(0));
+        sv32.h4(&qid(0));
         dm.h4(&qid(0));
         stab.h4(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h5(&qid(0));
+        sv32.h5(&qid(0));
         dm.h5(&qid(0));
         stab.h5(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h6(&qid(0));
+        sv32.h6(&qid(0));
         dm.h6(&qid(0));
         stab.h6(&qid(0));
     });
 
     // H variants applied to H|0> = |+>
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).h2(&qid(0));
+        sv32.h(&qid(0)).h2(&qid(0));
         dm.h(&qid(0)).h2(&qid(0));
         stab.h(&qid(0)).h2(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).h3(&qid(0));
+        sv32.h(&qid(0)).h3(&qid(0));
         dm.h(&qid(0)).h3(&qid(0));
         stab.h(&qid(0)).h3(&qid(0));
     });
 
     // All H variants are self-inverse: Hi * Hi = I
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).h2(&qid(0)).h2(&qid(0));
+        sv32.h(&qid(0)).h2(&qid(0)).h2(&qid(0));
         dm.h(&qid(0)).h2(&qid(0)).h2(&qid(0));
         stab.h(&qid(0)).h2(&qid(0)).h2(&qid(0));
     });
@@ -518,64 +584,75 @@ fn test_h_variant_gates_consistency() {
 #[test]
 fn test_f_family_gates_consistency() {
     // Each F variant on |0>
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f(&qid(0));
+        sv32.f(&qid(0));
         dm.f(&qid(0));
         stab.f(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.fdg(&qid(0));
+        sv32.fdg(&qid(0));
         dm.fdg(&qid(0));
         stab.fdg(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f2(&qid(0));
+        sv32.f2(&qid(0));
         dm.f2(&qid(0));
         stab.f2(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f2dg(&qid(0));
+        sv32.f2dg(&qid(0));
         dm.f2dg(&qid(0));
         stab.f2dg(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f3(&qid(0));
+        sv32.f3(&qid(0));
         dm.f3(&qid(0));
         stab.f3(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f3dg(&qid(0));
+        sv32.f3dg(&qid(0));
         dm.f3dg(&qid(0));
         stab.f3dg(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f4(&qid(0));
+        sv32.f4(&qid(0));
         dm.f4(&qid(0));
         stab.f4(&qid(0));
     });
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.f4dg(&qid(0));
+        sv32.f4dg(&qid(0));
         dm.f4dg(&qid(0));
         stab.f4dg(&qid(0));
     });
 
     // F * Fdg = I
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).f(&qid(0)).fdg(&qid(0));
+        sv32.h(&qid(0)).f(&qid(0)).fdg(&qid(0));
         dm.h(&qid(0)).f(&qid(0)).fdg(&qid(0));
         stab.h(&qid(0)).f(&qid(0)).fdg(&qid(0));
     });
 
     // F^3 = I (F is order 3)
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).f(&qid(0)).f(&qid(0)).f(&qid(0));
+        sv32.h(&qid(0)).f(&qid(0)).f(&qid(0)).f(&qid(0));
         dm.h(&qid(0)).f(&qid(0)).f(&qid(0)).f(&qid(0));
         stab.h(&qid(0)).f(&qid(0)).f(&qid(0)).f(&qid(0));
     });
 
     // F on |+>
-    compare_clifford_circuit(1, |sv, dm, stab| {
+    compare_clifford_circuit(1, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).f(&qid(0));
+        sv32.h(&qid(0)).f(&qid(0));
         dm.h(&qid(0)).f(&qid(0));
         stab.h(&qid(0)).f(&qid(0));
     });
@@ -588,75 +665,89 @@ fn test_f_family_gates_consistency() {
 #[test]
 fn test_all_2q_gates_consistency() {
     // SXX family
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).sxx(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).sxx(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).sxx(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).sxx(&[(QubitId(0), QubitId(1))]);
     });
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).sxxdg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).sxxdg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).sxxdg(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).sxxdg(&[(QubitId(0), QubitId(1))]);
     });
 
     // SYY family
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).syy(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).syy(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).syy(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).syy(&[(QubitId(0), QubitId(1))]);
     });
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).syydg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).syydg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).syydg(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).syydg(&[(QubitId(0), QubitId(1))]);
     });
 
     // SZZ family
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).szz(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).szz(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).szz(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).szz(&[(QubitId(0), QubitId(1))]);
     });
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).szzdg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).szzdg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).szzdg(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).szzdg(&[(QubitId(0), QubitId(1))]);
     });
 
     // ISWAP family
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).iswap(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).iswap(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).iswap(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).iswap(&[(QubitId(0), QubitId(1))]);
     });
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).iswapdg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).iswapdg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).iswapdg(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).iswapdg(&[(QubitId(0), QubitId(1))]);
     });
 
     // G family (G is self-inverse)
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).g(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).g(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).g(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).g(&[(QubitId(0), QubitId(1))]);
     });
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).gdg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).gdg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).gdg(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).gdg(&[(QubitId(0), QubitId(1))]);
     });
 
     // CY
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0)).cy(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0)).cy(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0)).cy(&[(QubitId(0), QubitId(1))]);
         stab.h(&qid(0)).cy(&[(QubitId(0), QubitId(1))]);
     });
 
     // ISWAP * ISWAPdg = I
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0))
+            .iswap(&[(QubitId(0), QubitId(1))])
+            .iswapdg(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0))
             .iswap(&[(QubitId(0), QubitId(1))])
             .iswapdg(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0))
@@ -668,8 +759,11 @@ fn test_all_2q_gates_consistency() {
     });
 
     // G * G = I (G is Hermitian)
-    compare_clifford_circuit(2, |sv, dm, stab| {
+    compare_clifford_circuit(2, |sv, sv32, dm, stab| {
         sv.h(&qid(0))
+            .g(&[(QubitId(0), QubitId(1))])
+            .g(&[(QubitId(0), QubitId(1))]);
+        sv32.h(&qid(0))
             .g(&[(QubitId(0), QubitId(1))])
             .g(&[(QubitId(0), QubitId(1))]);
         dm.h(&qid(0))

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -3205,6 +3205,66 @@ impl CliffordGateable for StabMps {
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sy(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).y(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).x(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).y(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
         // X anticommutes with RZ: X·RZ(θ) = RZ(-θ)·X, so applying X
         // after a pending RZ(θ) is equivalent to applying X first then
@@ -3234,6 +3294,103 @@ impl CliffordGateable for StabMps {
         self.tableau.y(qubits);
         for &q in qubits {
             self.propagate_frame_single_qubit(SingleQubitCliffordKind::Y, q.index());
+        }
+        // The phase-free tableau's native Y selects the XZ = -iY projective
+        // representative. Restore the named gate's exact phase here.
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // HZ = exp(-i*pi/4) SY; retain the tableau decomposition and restore
+        // the named gate's exact phase in the amplitude-carrying scalar.
+        self.z(qubits).h(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // ZH = exp(i*pi/4) SYdg; retain the tableau decomposition and restore
+        // the named gate's exact phase in the amplitude-carrying scalar.
+        self.h(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).sz(qubits);
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sxdg(qubits);
+        for _ in qubits {
+            self.global_phase *= -Complex64::i();
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sy(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sydg(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sz(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).szdg(qubits);
+        for _ in qubits {
+            self.global_phase *= -Complex64::i();
         }
         self
     }
@@ -3345,6 +3502,90 @@ mod tests {
         let stn = StabMps::new(2);
         assert_eq!(stn.num_qubits(), 2);
         assert_eq!(stn.max_bond_dim(), 1);
+    }
+
+    #[test]
+    fn test_named_y_family_phases_are_carried_exactly() {
+        let q = [QubitId(0)];
+        let root_half = std::f64::consts::FRAC_1_SQRT_2;
+        let mutation = Complex64::new(root_half, root_half);
+
+        let mut y = StabMps::new(1);
+        y.y(&q);
+        let expected_y = Complex64::i();
+        assert!((y.global_phase - expected_y).norm() < 1e-12);
+        assert!((y.global_phase - expected_y * mutation).norm() > 1e-12);
+
+        let mut sy = StabMps::new(1);
+        sy.sy(&q);
+        let expected_sy = Complex64::new(root_half, root_half);
+        assert!((sy.global_phase - expected_sy).norm() < 1e-12);
+        assert!((sy.global_phase - expected_sy * mutation).norm() > 1e-12);
+
+        let mut sydg = StabMps::new(1);
+        sydg.sydg(&q);
+        let expected_sydg = Complex64::new(root_half, -root_half);
+        assert!((sydg.global_phase - expected_sydg).norm() < 1e-12);
+        assert!((sydg.global_phase - expected_sydg * mutation).norm() > 1e-12);
+    }
+
+    fn apply_order_fixed_clifford(sim: &mut StabMps, gate: pecos_core::Clifford) {
+        let q = [QubitId(0)];
+        match gate {
+            pecos_core::Clifford::H2 => sim.h2(&q),
+            pecos_core::Clifford::H3 => sim.h3(&q),
+            pecos_core::Clifford::H4 => sim.h4(&q),
+            pecos_core::Clifford::H5 => sim.h5(&q),
+            pecos_core::Clifford::H6 => sim.h6(&q),
+            pecos_core::Clifford::F => sim.f(&q),
+            pecos_core::Clifford::Fdg => sim.fdg(&q),
+            pecos_core::Clifford::F2 => sim.f2(&q),
+            pecos_core::Clifford::F2dg => sim.f2dg(&q),
+            pecos_core::Clifford::F3 => sim.f3(&q),
+            pecos_core::Clifford::F3dg => sim.f3dg(&q),
+            pecos_core::Clifford::F4 => sim.f4(&q),
+            pecos_core::Clifford::F4dg => sim.f4dg(&q),
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
+    fn test_order_fixed_clifford_phases_are_carried_exactly() {
+        let mutation = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for (gate, phase8) in [
+            (pecos_core::Clifford::H2, 0),
+            (pecos_core::Clifford::H3, 1),
+            (pecos_core::Clifford::H4, 7),
+            (pecos_core::Clifford::H5, 7),
+            (pecos_core::Clifford::H6, 1),
+            (pecos_core::Clifford::F, 2),
+            (pecos_core::Clifford::Fdg, 6),
+            (pecos_core::Clifford::F2, 5),
+            (pecos_core::Clifford::F2dg, 3),
+            (pecos_core::Clifford::F3, 4),
+            (pecos_core::Clifford::F3dg, 4),
+            (pecos_core::Clifford::F4, 2),
+            (pecos_core::Clifford::F4dg, 6),
+        ] {
+            let mut sim = StabMps::new(1);
+            apply_order_fixed_clifford(&mut sim, gate);
+            let expected =
+                Complex64::from_polar(1.0, f64::from(phase8) * std::f64::consts::FRAC_PI_4);
+            let exact_error = (sim.global_phase - expected).norm();
+            let mutation_error = (sim.global_phase - expected * mutation).norm();
+            assert!(
+                exact_error < 1e-12,
+                "StabMps::{gate} scalar error {exact_error:e}; actual={:?}; expected={expected:?}",
+                sim.global_phase
+            );
+            assert!(
+                mutation_error > 1e-12,
+                "StabMps::{gate} accepted an exp(i*pi/4) phase mutation"
+            );
+        }
     }
 
     fn assert_state_vectors_equal(lhs: &mut StabMps, rhs: &mut StabMps, context: &str) {

--- a/exp/pecos-stab-tn/src/stab_mps.rs
+++ b/exp/pecos-stab-tn/src/stab_mps.rs
@@ -3205,66 +3205,6 @@ impl CliffordGateable for StabMps {
         self
     }
 
-    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sy(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).y(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).x(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).y(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
     fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
         // X anticommutes with RZ: X·RZ(θ) = RZ(-θ)·X, so applying X
         // after a pending RZ(θ) is equivalent to applying X first then
@@ -3294,103 +3234,6 @@ impl CliffordGateable for StabMps {
         self.tableau.y(qubits);
         for &q in qubits {
             self.propagate_frame_single_qubit(SingleQubitCliffordKind::Y, q.index());
-        }
-        // The phase-free tableau's native Y selects the XZ = -iY projective
-        // representative. Restore the named gate's exact phase here.
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // HZ = exp(-i*pi/4) SY; retain the tableau decomposition and restore
-        // the named gate's exact phase in the amplitude-carrying scalar.
-        self.z(qubits).h(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // ZH = exp(i*pi/4) SYdg; retain the tableau decomposition and restore
-        // the named gate's exact phase in the amplitude-carrying scalar.
-        self.h(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).sz(qubits);
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.szdg(qubits).sxdg(qubits);
-        for _ in qubits {
-            self.global_phase *= -Complex64::i();
-        }
-        self
-    }
-
-    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).sy(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sydg(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).sz(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.szdg(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).szdg(qubits);
-        for _ in qubits {
-            self.global_phase *= -Complex64::i();
         }
         self
     }
@@ -3495,7 +3338,8 @@ impl ArbitraryRotationGateable for StabMps {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use pecos_simulators::StabVec;
+    use pecos_core::Clifford;
+    use pecos_simulators::{CHForm, StabVec};
 
     #[test]
     fn test_stn_initial_state() {
@@ -3504,88 +3348,105 @@ mod tests {
         assert_eq!(stn.max_bond_dim(), 1);
     }
 
-    #[test]
-    fn test_named_y_family_phases_are_carried_exactly() {
-        let q = [QubitId(0)];
-        let root_half = std::f64::consts::FRAC_1_SQRT_2;
-        let mutation = Complex64::new(root_half, root_half);
-
-        let mut y = StabMps::new(1);
-        y.y(&q);
-        let expected_y = Complex64::i();
-        assert!((y.global_phase - expected_y).norm() < 1e-12);
-        assert!((y.global_phase - expected_y * mutation).norm() > 1e-12);
-
-        let mut sy = StabMps::new(1);
-        sy.sy(&q);
-        let expected_sy = Complex64::new(root_half, root_half);
-        assert!((sy.global_phase - expected_sy).norm() < 1e-12);
-        assert!((sy.global_phase - expected_sy * mutation).norm() > 1e-12);
-
-        let mut sydg = StabMps::new(1);
-        sydg.sydg(&q);
-        let expected_sydg = Complex64::new(root_half, -root_half);
-        assert!((sydg.global_phase - expected_sydg).norm() < 1e-12);
-        assert!((sydg.global_phase - expected_sydg * mutation).norm() > 1e-12);
-    }
-
-    fn apply_order_fixed_clifford(sim: &mut StabMps, gate: pecos_core::Clifford) {
-        let q = [QubitId(0)];
+    fn apply_single_qubit_clifford<S: CliffordGateable>(
+        sim: &mut S,
+        gate: Clifford,
+        qubits: &[QubitId],
+    ) {
         match gate {
-            pecos_core::Clifford::H2 => sim.h2(&q),
-            pecos_core::Clifford::H3 => sim.h3(&q),
-            pecos_core::Clifford::H4 => sim.h4(&q),
-            pecos_core::Clifford::H5 => sim.h5(&q),
-            pecos_core::Clifford::H6 => sim.h6(&q),
-            pecos_core::Clifford::F => sim.f(&q),
-            pecos_core::Clifford::Fdg => sim.fdg(&q),
-            pecos_core::Clifford::F2 => sim.f2(&q),
-            pecos_core::Clifford::F2dg => sim.f2dg(&q),
-            pecos_core::Clifford::F3 => sim.f3(&q),
-            pecos_core::Clifford::F3dg => sim.f3dg(&q),
-            pecos_core::Clifford::F4 => sim.f4(&q),
-            pecos_core::Clifford::F4dg => sim.f4dg(&q),
-            _ => unreachable!(),
+            Clifford::I => sim.identity(qubits),
+            Clifford::X => sim.x(qubits),
+            Clifford::Y => sim.y(qubits),
+            Clifford::Z => sim.z(qubits),
+            Clifford::H => sim.h(qubits),
+            Clifford::H2 => sim.h2(qubits),
+            Clifford::H3 => sim.h3(qubits),
+            Clifford::H4 => sim.h4(qubits),
+            Clifford::H5 => sim.h5(qubits),
+            Clifford::H6 => sim.h6(qubits),
+            Clifford::SX => sim.sx(qubits),
+            Clifford::SXdg => sim.sxdg(qubits),
+            Clifford::SY => sim.sy(qubits),
+            Clifford::SYdg => sim.sydg(qubits),
+            Clifford::SZ => sim.sz(qubits),
+            Clifford::SZdg => sim.szdg(qubits),
+            Clifford::F => sim.f(qubits),
+            Clifford::Fdg => sim.fdg(qubits),
+            Clifford::F2 => sim.f2(qubits),
+            Clifford::F2dg => sim.f2dg(qubits),
+            Clifford::F3 => sim.f3(qubits),
+            Clifford::F3dg => sim.f3dg(qubits),
+            Clifford::F4 => sim.f4(qubits),
+            Clifford::F4dg => sim.f4dg(qubits),
+            _ => panic!("expected a single-qubit Clifford, got {gate}"),
         };
     }
 
-    #[test]
-    fn test_order_fixed_clifford_phases_are_carried_exactly() {
-        let mutation = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for (gate, phase8) in [
-            (pecos_core::Clifford::H2, 0),
-            (pecos_core::Clifford::H3, 1),
-            (pecos_core::Clifford::H4, 7),
-            (pecos_core::Clifford::H5, 7),
-            (pecos_core::Clifford::H6, 1),
-            (pecos_core::Clifford::F, 2),
-            (pecos_core::Clifford::Fdg, 6),
-            (pecos_core::Clifford::F2, 5),
-            (pecos_core::Clifford::F2dg, 3),
-            (pecos_core::Clifford::F3, 4),
-            (pecos_core::Clifford::F3dg, 4),
-            (pecos_core::Clifford::F4, 2),
-            (pecos_core::Clifford::F4dg, 6),
-        ] {
-            let mut sim = StabMps::new(1);
-            apply_order_fixed_clifford(&mut sim, gate);
-            let expected =
-                Complex64::from_polar(1.0, f64::from(phase8) * std::f64::consts::FRAC_PI_4);
-            let exact_error = (sim.global_phase - expected).norm();
-            let mutation_error = (sim.global_phase - expected * mutation).norm();
-            assert!(
-                exact_error < 1e-12,
-                "StabMps::{gate} scalar error {exact_error:e}; actual={:?}; expected={expected:?}",
-                sim.global_phase
-            );
-            assert!(
-                mutation_error > 1e-12,
-                "StabMps::{gate} accepted an exp(i*pi/4) phase mutation"
-            );
+    fn single_qubit_clifford_order(gate: Clifford) -> usize {
+        let mut power = Clifford::I;
+        for order in 1..=4 {
+            power = gate.compose(power);
+            if power == Clifford::I {
+                return order;
+            }
         }
+        panic!("single-qubit Clifford {gate} has order greater than four");
+    }
+
+    fn state_vector_max_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+        actual
+            .iter()
+            .zip(expected)
+            .map(|(actual, expected)| (actual - expected).norm())
+            .fold(0.0, f64::max)
+    }
+
+    #[test]
+    fn test_stab_mps_clifford_powers_restore_observable_state_phase_exactly() {
+        let mut failures = Vec::new();
+        for &gate in Clifford::all_1q() {
+            let mut sim = StabMps::new(2);
+            sim.h(&[QubitId(0)])
+                .sz(&[QubitId(0)])
+                .cx(&[(QubitId(0), QubitId(1))]);
+            let expected = sim.state_vector();
+            for _ in 0..single_qubit_clifford_order(gate) {
+                apply_single_qubit_clifford(&mut sim, gate, &[QubitId(0)]);
+            }
+            let error = state_vector_max_error(&sim.state_vector(), &expected);
+            if error > 1e-10 {
+                failures.push((gate, error));
+            }
+        }
+        eprintln!(
+            "StabMps: {}/24 exact; failures={failures:?}",
+            24 - failures.len()
+        );
+        assert!(failures.is_empty(), "StabMps phase failures: {failures:?}");
+    }
+
+    #[test]
+    fn test_ch_form_clifford_powers_restore_observable_state_phase_exactly() {
+        let mut failures = Vec::new();
+        for &gate in Clifford::all_1q() {
+            let mut sim = CHForm::new(2);
+            sim.h(&[QubitId(0)])
+                .sz(&[QubitId(0)])
+                .cx(&[(QubitId(0), QubitId(1))]);
+            let expected = sim.state_vector();
+            for _ in 0..single_qubit_clifford_order(gate) {
+                apply_single_qubit_clifford(&mut sim, gate, &[QubitId(0)]);
+            }
+            let error = state_vector_max_error(&sim.state_vector(), &expected);
+            if error > 1e-10 {
+                failures.push((gate, error));
+            }
+        }
+        eprintln!(
+            "CHForm: {}/24 exact; failures={failures:?}",
+            24 - failures.len()
+        );
+        assert!(failures.is_empty(), "CHForm phase failures: {failures:?}");
     }
 
     fn assert_state_vectors_equal(lhs: &mut StabMps, rhs: &mut StabMps, context: &str) {

--- a/exp/pecos-stab-tn/src/stab_mps/mast.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/mast.rs
@@ -732,168 +732,6 @@ impl CliffordGateable for Mast {
         self
     }
 
-    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sy(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).y(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).x(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).y(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // XZ = -iY. Keep the trait default's projective decomposition and
-        // restore the named gate's exact phase in the amplitude scalar.
-        self.z(qubits).x(qubits);
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // HZ = exp(-i*pi/4) SY. The tableau keeps the projective part; the
-        // amplitude scalar restores the conventional named-gate phase.
-        self.z(qubits).h(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // ZH = exp(i*pi/4) SYdg. The tableau keeps the projective part; the
-        // amplitude scalar restores the conventional named-gate phase.
-        self.h(qubits).z(qubits);
-        let phase = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            -std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for _ in qubits {
-            self.global_phase *= phase;
-        }
-        self
-    }
-
-    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sx(qubits).sz(qubits);
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.szdg(qubits).sxdg(qubits);
-        for _ in qubits {
-            self.global_phase *= -Complex64::i();
-        }
-        self
-    }
-
-    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).sy(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sydg(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).sz(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.szdg(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase = -self.global_phase;
-        }
-        self
-    }
-
-    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sz(qubits).sx(qubits);
-        for _ in qubits {
-            self.global_phase *= Complex64::i();
-        }
-        self
-    }
-
-    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
-        self.sxdg(qubits).szdg(qubits);
-        for _ in qubits {
-            self.global_phase *= -Complex64::i();
-        }
-        self
-    }
-
     fn cx(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         // CX doesn't commute with RZ on arbitrary qubits: flush both.
         for &(c, t) in pairs {
@@ -992,7 +830,9 @@ impl ArbitraryRotationGateable for Mast {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stab_mps::StabMps;
     use approx::assert_relative_eq;
+    use pecos_core::Clifford;
 
     fn assert_mast_disent_flags_sound(mast: &Mast, context: &str) {
         super::super::assert_disent_flags_match_stored_mps(&mast.mps, &mast.disent_flags, context);
@@ -1045,88 +885,82 @@ mod tests {
         assert!((mast.global_phase - expected).norm() < 1e-12);
     }
 
-    #[test]
-    fn test_named_y_family_phases_are_carried_exactly() {
-        let q = [QubitId(0)];
-        let root_half = std::f64::consts::FRAC_1_SQRT_2;
-        let mutation = Complex64::new(root_half, root_half);
-
-        let mut y = Mast::new(1, 0);
-        y.y(&q);
-        let expected_y = Complex64::i();
-        assert!((y.global_phase - expected_y).norm() < 1e-12);
-        assert!((y.global_phase - expected_y * mutation).norm() > 1e-12);
-
-        let mut sy = Mast::new(1, 0);
-        sy.sy(&q);
-        let expected_sy = Complex64::new(root_half, root_half);
-        assert!((sy.global_phase - expected_sy).norm() < 1e-12);
-        assert!((sy.global_phase - expected_sy * mutation).norm() > 1e-12);
-
-        let mut sydg = Mast::new(1, 0);
-        sydg.sydg(&q);
-        let expected_sydg = Complex64::new(root_half, -root_half);
-        assert!((sydg.global_phase - expected_sydg).norm() < 1e-12);
-        assert!((sydg.global_phase - expected_sydg * mutation).norm() > 1e-12);
-    }
-
-    fn apply_order_fixed_clifford(mast: &mut Mast, gate: pecos_core::Clifford) {
-        let q = [QubitId(0)];
+    fn apply_single_qubit_clifford(mast: &mut Mast, gate: Clifford, qubits: &[QubitId]) {
         match gate {
-            pecos_core::Clifford::H2 => mast.h2(&q),
-            pecos_core::Clifford::H3 => mast.h3(&q),
-            pecos_core::Clifford::H4 => mast.h4(&q),
-            pecos_core::Clifford::H5 => mast.h5(&q),
-            pecos_core::Clifford::H6 => mast.h6(&q),
-            pecos_core::Clifford::F => mast.f(&q),
-            pecos_core::Clifford::Fdg => mast.fdg(&q),
-            pecos_core::Clifford::F2 => mast.f2(&q),
-            pecos_core::Clifford::F2dg => mast.f2dg(&q),
-            pecos_core::Clifford::F3 => mast.f3(&q),
-            pecos_core::Clifford::F3dg => mast.f3dg(&q),
-            pecos_core::Clifford::F4 => mast.f4(&q),
-            pecos_core::Clifford::F4dg => mast.f4dg(&q),
-            _ => unreachable!(),
+            Clifford::I => mast.identity(qubits),
+            Clifford::X => mast.x(qubits),
+            Clifford::Y => mast.y(qubits),
+            Clifford::Z => mast.z(qubits),
+            Clifford::H => mast.h(qubits),
+            Clifford::H2 => mast.h2(qubits),
+            Clifford::H3 => mast.h3(qubits),
+            Clifford::H4 => mast.h4(qubits),
+            Clifford::H5 => mast.h5(qubits),
+            Clifford::H6 => mast.h6(qubits),
+            Clifford::SX => mast.sx(qubits),
+            Clifford::SXdg => mast.sxdg(qubits),
+            Clifford::SY => mast.sy(qubits),
+            Clifford::SYdg => mast.sydg(qubits),
+            Clifford::SZ => mast.sz(qubits),
+            Clifford::SZdg => mast.szdg(qubits),
+            Clifford::F => mast.f(qubits),
+            Clifford::Fdg => mast.fdg(qubits),
+            Clifford::F2 => mast.f2(qubits),
+            Clifford::F2dg => mast.f2dg(qubits),
+            Clifford::F3 => mast.f3(qubits),
+            Clifford::F3dg => mast.f3dg(qubits),
+            Clifford::F4 => mast.f4(qubits),
+            Clifford::F4dg => mast.f4dg(qubits),
+            _ => panic!("expected a single-qubit Clifford, got {gate}"),
         };
     }
 
-    #[test]
-    fn test_order_fixed_clifford_phases_are_carried_exactly() {
-        let mutation = Complex64::new(
-            std::f64::consts::FRAC_1_SQRT_2,
-            std::f64::consts::FRAC_1_SQRT_2,
-        );
-        for (gate, phase8) in [
-            (pecos_core::Clifford::H2, 0),
-            (pecos_core::Clifford::H3, 1),
-            (pecos_core::Clifford::H4, 7),
-            (pecos_core::Clifford::H5, 7),
-            (pecos_core::Clifford::H6, 1),
-            (pecos_core::Clifford::F, 2),
-            (pecos_core::Clifford::Fdg, 6),
-            (pecos_core::Clifford::F2, 5),
-            (pecos_core::Clifford::F2dg, 3),
-            (pecos_core::Clifford::F3, 4),
-            (pecos_core::Clifford::F3dg, 4),
-            (pecos_core::Clifford::F4, 2),
-            (pecos_core::Clifford::F4dg, 6),
-        ] {
-            let mut mast = Mast::new(1, 0);
-            apply_order_fixed_clifford(&mut mast, gate);
-            let expected =
-                Complex64::from_polar(1.0, f64::from(phase8) * std::f64::consts::FRAC_PI_4);
-            let exact_error = (mast.global_phase - expected).norm();
-            let mutation_error = (mast.global_phase - expected * mutation).norm();
-            assert!(
-                exact_error < 1e-12,
-                "Mast::{gate} scalar error {exact_error:e}; actual={:?}; expected={expected:?}",
-                mast.global_phase
-            );
-            assert!(
-                mutation_error > 1e-12,
-                "Mast::{gate} accepted an exp(i*pi/4) phase mutation"
-            );
+    fn single_qubit_clifford_order(gate: Clifford) -> usize {
+        let mut power = Clifford::I;
+        for order in 1..=4 {
+            power = gate.compose(power);
+            if power == Clifford::I {
+                return order;
+            }
         }
+        panic!("single-qubit Clifford {gate} has order greater than four");
+    }
+
+    fn mast_state_vector(mast: &Mast) -> Vec<Complex64> {
+        let mut view = StabMps::builder(mast.total_qubits).merge_rz(false).build();
+        view.tableau = mast.tableau.clone();
+        view.mps = mast.mps.clone();
+        view.global_phase = mast.global_phase;
+        view.state_vector()
+    }
+
+    #[test]
+    fn test_mast_clifford_powers_restore_observable_state_phase_exactly() {
+        let mut failures = Vec::new();
+        for &gate in Clifford::all_1q() {
+            let mut mast = Mast::new(2, 0);
+            mast.h(&[QubitId(0)])
+                .sz(&[QubitId(0)])
+                .cx(&[(QubitId(0), QubitId(1))]);
+            let expected = mast_state_vector(&mast);
+            for _ in 0..single_qubit_clifford_order(gate) {
+                apply_single_qubit_clifford(&mut mast, gate, &[QubitId(0)]);
+            }
+            let actual = mast_state_vector(&mast);
+            let error = actual
+                .iter()
+                .zip(&expected)
+                .map(|(actual, expected)| (actual - expected).norm())
+                .fold(0.0, f64::max);
+            if error > 1e-10 {
+                failures.push((gate, error));
+            }
+        }
+        eprintln!(
+            "Mast: {}/24 exact; failures={failures:?}",
+            24 - failures.len()
+        );
+        assert!(failures.is_empty(), "Mast phase failures: {failures:?}");
     }
 
     #[test]

--- a/exp/pecos-stab-tn/src/stab_mps/mast.rs
+++ b/exp/pecos-stab-tn/src/stab_mps/mast.rs
@@ -732,6 +732,168 @@ impl CliffordGateable for Mast {
         self
     }
 
+    fn h2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sy(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).y(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).x(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h5(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn h6(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).y(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // XZ = -iY. Keep the trait default's projective decomposition and
+        // restore the named gate's exact phase in the amplitude scalar.
+        self.z(qubits).x(qubits);
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn sy(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // HZ = exp(-i*pi/4) SY. The tableau keeps the projective part; the
+        // amplitude scalar restores the conventional named-gate phase.
+        self.z(qubits).h(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn sydg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        // ZH = exp(i*pi/4) SYdg. The tableau keeps the projective part; the
+        // amplitude scalar restores the conventional named-gate phase.
+        self.h(qubits).z(qubits);
+        let phase = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            -std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for _ in qubits {
+            self.global_phase *= phase;
+        }
+        self
+    }
+
+    fn f(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sx(qubits).sz(qubits);
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn fdg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sxdg(qubits);
+        for _ in qubits {
+            self.global_phase *= -Complex64::i();
+        }
+        self
+    }
+
+    fn f2(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sy(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f2dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sydg(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f3(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).sz(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f3dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.szdg(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase = -self.global_phase;
+        }
+        self
+    }
+
+    fn f4(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sz(qubits).sx(qubits);
+        for _ in qubits {
+            self.global_phase *= Complex64::i();
+        }
+        self
+    }
+
+    fn f4dg(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.sxdg(qubits).szdg(qubits);
+        for _ in qubits {
+            self.global_phase *= -Complex64::i();
+        }
+        self
+    }
+
     fn cx(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         // CX doesn't commute with RZ on arbitrary qubits: flush both.
         for &(c, t) in pairs {
@@ -881,6 +1043,90 @@ mod tests {
         mast.apply_global_phase(Angle64::QUARTER_TURN / 4u64, &[QubitId(0), QubitId(1)]);
         let expected = Complex64::from_polar(1.0, std::f64::consts::FRAC_PI_4);
         assert!((mast.global_phase - expected).norm() < 1e-12);
+    }
+
+    #[test]
+    fn test_named_y_family_phases_are_carried_exactly() {
+        let q = [QubitId(0)];
+        let root_half = std::f64::consts::FRAC_1_SQRT_2;
+        let mutation = Complex64::new(root_half, root_half);
+
+        let mut y = Mast::new(1, 0);
+        y.y(&q);
+        let expected_y = Complex64::i();
+        assert!((y.global_phase - expected_y).norm() < 1e-12);
+        assert!((y.global_phase - expected_y * mutation).norm() > 1e-12);
+
+        let mut sy = Mast::new(1, 0);
+        sy.sy(&q);
+        let expected_sy = Complex64::new(root_half, root_half);
+        assert!((sy.global_phase - expected_sy).norm() < 1e-12);
+        assert!((sy.global_phase - expected_sy * mutation).norm() > 1e-12);
+
+        let mut sydg = Mast::new(1, 0);
+        sydg.sydg(&q);
+        let expected_sydg = Complex64::new(root_half, -root_half);
+        assert!((sydg.global_phase - expected_sydg).norm() < 1e-12);
+        assert!((sydg.global_phase - expected_sydg * mutation).norm() > 1e-12);
+    }
+
+    fn apply_order_fixed_clifford(mast: &mut Mast, gate: pecos_core::Clifford) {
+        let q = [QubitId(0)];
+        match gate {
+            pecos_core::Clifford::H2 => mast.h2(&q),
+            pecos_core::Clifford::H3 => mast.h3(&q),
+            pecos_core::Clifford::H4 => mast.h4(&q),
+            pecos_core::Clifford::H5 => mast.h5(&q),
+            pecos_core::Clifford::H6 => mast.h6(&q),
+            pecos_core::Clifford::F => mast.f(&q),
+            pecos_core::Clifford::Fdg => mast.fdg(&q),
+            pecos_core::Clifford::F2 => mast.f2(&q),
+            pecos_core::Clifford::F2dg => mast.f2dg(&q),
+            pecos_core::Clifford::F3 => mast.f3(&q),
+            pecos_core::Clifford::F3dg => mast.f3dg(&q),
+            pecos_core::Clifford::F4 => mast.f4(&q),
+            pecos_core::Clifford::F4dg => mast.f4dg(&q),
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
+    fn test_order_fixed_clifford_phases_are_carried_exactly() {
+        let mutation = Complex64::new(
+            std::f64::consts::FRAC_1_SQRT_2,
+            std::f64::consts::FRAC_1_SQRT_2,
+        );
+        for (gate, phase8) in [
+            (pecos_core::Clifford::H2, 0),
+            (pecos_core::Clifford::H3, 1),
+            (pecos_core::Clifford::H4, 7),
+            (pecos_core::Clifford::H5, 7),
+            (pecos_core::Clifford::H6, 1),
+            (pecos_core::Clifford::F, 2),
+            (pecos_core::Clifford::Fdg, 6),
+            (pecos_core::Clifford::F2, 5),
+            (pecos_core::Clifford::F2dg, 3),
+            (pecos_core::Clifford::F3, 4),
+            (pecos_core::Clifford::F3dg, 4),
+            (pecos_core::Clifford::F4, 2),
+            (pecos_core::Clifford::F4dg, 6),
+        ] {
+            let mut mast = Mast::new(1, 0);
+            apply_order_fixed_clifford(&mut mast, gate);
+            let expected =
+                Complex64::from_polar(1.0, f64::from(phase8) * std::f64::consts::FRAC_PI_4);
+            let exact_error = (mast.global_phase - expected).norm();
+            let mutation_error = (mast.global_phase - expected * mutation).norm();
+            assert!(
+                exact_error < 1e-12,
+                "Mast::{gate} scalar error {exact_error:e}; actual={:?}; expected={expected:?}",
+                mast.global_phase
+            );
+            assert!(
+                mutation_error > 1e-12,
+                "Mast::{gate} accepted an exp(i*pi/4) phase mutation"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #601; review that first.

## Summary

The same single-qubit gate matrices were hand-transcribed in at least six independent places. They had already drifted apart, and the drift produced three live defects. This PR establishes one canonical phase-fixed table in `pecos-core` and derives every other table from it, so this class of divergence becomes structurally impossible rather than merely detectable.

## The convention

Every named Clifford gate's matrix is the representative whose multiplicative order equals its order in the Clifford group, exactly and with global phase:

- `X, Y, Z` order 2; `SX, SY, SZ` and daggers order 4; `T` order 8
- `H1..H6` order 2, and all Hermitian
- `F1..F4` and daggers order 3

Root closure (`SX^2 = X`, `SZ = T^2`, `Z = T^4`) is the same rule seen from a different angle, not a separate one. Parameterized rotations keep `RP(theta) = exp(-i*theta*P/2)` unchanged; a named discrete gate is never defined as its rotation, and where the two relate the phase factor is stated explicitly.

`H` is `H1` and `F` is `F1`, matching the numbering already reserved in `GateType`.

## Defects fixed

- `StateVecSoA32::FDG` had swapped off-diagonal entries, so `F * FDG != I` (#609).
- `StateVecSoA32::apply_sy_gate` was algebraically the identity, and `apply_sydg_gate` was Pauli X (#610). Both scalar and SIMD branches.
- The GPU `T` gate was `RZ(pi/4)`, differing from the canonical `diag(1, exp(i*pi/4))` by a phase.
- The canonical `SY`/`SYdg` were the rotation representatives, disagreeing with both simulator tables.
- `UnitaryRep`'s named `SX`/`SY`/`SZ`/`T` constructors lowered through rotations, losing the named phases.
- `F`/`F4` satisfied `G^3 = i*I`, `F2`/`F3` satisfied `G^3 = -I`, and `H2..H6` satisfied `G^2 = i*I`. All now satisfy their exact orders.
- Phase-carrying simulators inheriting the projective `sy`/`sydg`/`y` trait defaults now override them exactly, including `Mast`, `StabMps`, and `CHForm`.

## Structure

`GateType::canonical_1q_matrix` returns a const-evaluable row-major `[f64; 8]`; the full 24-element Clifford table derives from it, with `H2..H6` and `F2..F4` as const products of canonical gates carrying explicit phase factors rather than new literals. `pecos-quantum`, both `StateVecSoA` tables, the GPU table, `CuStateVec`, and the benchmark arrays all derive from that single source.

Deliberately left alone, each for a stated reason: `clifford_frame::ELEMENT_MATRIX` (a projective representative table paired with a phase cocycle), tableau and Pauli-propagation representations (no global phase), density-matrix simulators (`U rho U-dagger` cancels global phase identically), two-qubit gates, and the rotation family.

## Verification

Full debug and release suites for `pecos-core`, `pecos-quantum`, `pecos-simulators`, `pecos-qasm`, `pecos-phir`, `pecos-stab-tn`, and `benchmarks`. Clippy `--all-targets -D warnings` across all touched crates including `pecos-cuquantum`; `cargo fmt --check`; `git diff --check`.

Hardware-dependent suites were run at the base commit and at this branch in the same environment, with identical results: `pecos-gpu-sims` 96 passed / 97 failed in both (all failures rejecting llvmpipe as a non-hardware Vulkan adapter), `pecos-cuquantum` 37/37 unit tests passing and 15/20 integration in both (no CUDA device). No test count or failing test changed, and no fallback or suppression was added for those environments.

Every canonical matrix and all 24 Clifford matrices are multiplied by `exp(i*pi/4)` in mutation tests; every corresponding guard rejects the mutation.

`StateVecSoA32` was added to the `cross_simulator_tests`, `matrix_sim_consistency_tests`, and `three_simulator_comparison_tests` rosters, closing the coverage gap that hid the defects above.

No trajectory, output, or golden hash changed: the rephasings are global-phase-only, and the genuine behavior fixes were in paths no fixture covered.
