### PR TITLE
Complete the T convention migration across QASM codegen, rewrites, and the foreign interface

### DIFF
--- a/crates/pecos-core/src/clifford_simplify.rs
+++ b/crates/pecos-core/src/clifford_simplify.rs
@@ -1,6 +1,6 @@
 //! Rotation-to-Clifford simplification using `Angle64` fixed-point comparison.
 //!
-//! When a rotation gate is applied at a special angle (multiples of pi/4 or pi/2),
+//! When a rotation gate is applied at a special Clifford angle,
 //! it is equivalent up to global phase to a named gate. This module provides a single source
 //! of truth for those simplifications so that both PHIR-level passes and engine-level
 //! dispatch can reuse the same logic.
@@ -15,16 +15,6 @@ type A64 = Angle<u64>;
 /// units away from canonical Clifford quarter-turns. Snap only within a tiny
 /// tolerance so genuine non-Clifford rotations still fail loudly.
 const R1XY_CLIFFORD_EPSILON_TURNS: f64 = 1e-9;
-
-/// Eighth-turn (pi/4): `QUARTER_TURN` / 2.
-fn eighth_turn() -> A64 {
-    A64::QUARTER_TURN / 2u64
-}
-
-/// Negative eighth-turn (7*pi/4): -`QUARTER_TURN` / 2.
-fn neg_eighth_turn() -> A64 {
-    -(A64::QUARTER_TURN / 2u64)
-}
 
 /// Try to simplify a single-angle rotation gate to a named Clifford gate.
 ///
@@ -42,8 +32,6 @@ fn neg_eighth_turn() -> A64 {
 /// | RZ(pi)   | HALF_TURN   | Z              |
 /// | RZ(pi/2) | QUARTER_TURN| SZ             |
 /// | RZ(-pi/2)| 3/4 TURN    | SZdg           |
-/// | RZ(pi/4) | EIGHTH_TURN | T              |
-/// | RZ(-pi/4)| NEG_EIGHTH  | Tdg            |
 /// | RX(0)    | 0           | I              |
 /// | RX(pi)   | HALF_TURN   | X              |
 /// | RX(pi/2) | QUARTER_TURN| SX             |
@@ -143,10 +131,6 @@ fn simplify_rz(angle: A64) -> Option<GateType> {
         Some(GateType::SZ)
     } else if angle == A64::THREE_QUARTERS_TURN || angle == neg(A64::QUARTER_TURN) {
         Some(GateType::SZdg)
-    } else if angle == eighth_turn() {
-        Some(GateType::T)
-    } else if angle == neg_eighth_turn() {
-        Some(GateType::Tdg)
     } else {
         None
     }
@@ -277,14 +261,11 @@ mod tests {
             try_simplify_rotation(GateType::RZ, Angle64::THREE_QUARTERS_TURN),
             Some(GateType::SZdg)
         );
-        assert_eq!(
-            try_simplify_rotation(GateType::RZ, eighth_turn()),
-            Some(GateType::T)
-        );
-        assert_eq!(
-            try_simplify_rotation(GateType::RZ, neg_eighth_turn()),
-            Some(GateType::Tdg)
-        );
+        // T/Tdg use the conventional phase-fixed matrices, so symmetric
+        // RZ(+/-pi/4) rotations cannot be replaced by those named gates.
+        let eighth_turn = Angle64::QUARTER_TURN / 2u64;
+        assert_eq!(try_simplify_rotation(GateType::RZ, eighth_turn), None);
+        assert_eq!(try_simplify_rotation(GateType::RZ, -eighth_turn), None);
         // Non-Clifford angle
         assert_eq!(
             try_simplify_rotation(GateType::RZ, Angle64::from_radians(0.123)),
@@ -545,10 +526,7 @@ mod tests {
         );
 
         let neg_quarter_pi = Angle64::from_radians(-std::f64::consts::FRAC_PI_4);
-        assert_eq!(
-            try_simplify_rotation(GateType::RZ, neg_quarter_pi),
-            Some(GateType::Tdg)
-        );
+        assert_eq!(try_simplify_rotation(GateType::RZ, neg_quarter_pi), None);
     }
 
     #[test]

--- a/crates/pecos-foreign/src/gate_support.rs
+++ b/crates/pecos-foreign/src/gate_support.rs
@@ -31,15 +31,17 @@ use pecos_neo::prelude::CircuitRunner;
 /// The runner will:
 /// - Execute `SZ`, `H`, `CX`, `MZ` natively (always supported)
 /// - Execute `RX`, `RZ`, `RZZ` natively if the simulator supports rotations
-/// - Decompose everything else (X, Y, Z, SWAP, T, RXX, RYY, etc.) into the above
+/// - Decompose projectively safe gates (X, Y, Z, SWAP, RXX, RYY, etc.) into the above
+/// - Reject exact T/Tdg execution because the foreign protocol has neither native
+///   callbacks for those gates nor a global-phase operation
 ///
 /// The decomposition uses pecos-neo's `GateDefinitions` which provides standard
-/// decomposition rules (e.g., SWAP -> 3 CX gates, T -> RZ(pi/4) up to phase,
-/// X -> H SZ SZ H).
+/// decomposition rules (e.g., SWAP -> 3 CX gates and X -> H SZ SZ H).
 #[must_use]
 pub fn configure_runner_for_foreign(sim: &ForeignSimulator) -> CircuitRunner<ForeignSimulator> {
     if sim.supports_rotations() {
-        // Use the rotations constructor which enables RX, RZ, RZZ, T, Tdg, etc.
+        // Use the rotations constructor for RX, RZ, RZZ, etc. ForeignSimulator
+        // itself rejects exact T/Tdg before invoking a phase-inexact rotation.
         CircuitRunner::<ForeignSimulator>::rotations()
     } else {
         // Clifford-only: SZ, H, CX, MZ + decompositions for X, Y, Z, SWAP, etc.

--- a/crates/pecos-foreign/src/simulator.rs
+++ b/crates/pecos-foreign/src/simulator.rs
@@ -25,6 +25,12 @@
 //! - `rz` -- Z rotation
 //! - `rzz` -- ZZ rotation
 //!
+//! The protocol has no operation for a global scalar. Consequently,
+//! [`ForeignSimulator`] is suitable only for projective or measurement-only
+//! simulators, and exact named T/Tdg execution is rejected. In particular,
+//! those gates are never silently lowered to the phase-inexact RZ(+/-pi/4)
+//! rotations. A future protocol version can add native T/Tdg callbacks.
+//!
 //! **Lifecycle:**
 //! - `reset` -- reset to initial state
 //! - `destroy` -- free the simulator
@@ -113,6 +119,11 @@ pub struct ForeignSimulatorVTable {
 unsafe impl Send for ForeignSimulator {}
 
 /// A quantum simulator implemented in a foreign language via C ABI.
+///
+/// This interface cannot represent a global scalar and is therefore restricted
+/// to projective or measurement-only foreign simulators. Calls to exact named
+/// T/Tdg gates panic before mutating the foreign simulator; callers that need
+/// those matrices must use an interface with native T/Tdg support.
 pub struct ForeignSimulator {
     handle: *mut (),
     vtable: ForeignSimulatorVTable,
@@ -290,6 +301,27 @@ impl ArbitraryRotationGateable for ForeignSimulator {
         } else {
             panic!("foreign simulator does not support rotation gates (rzz is null)")
         }
+    }
+
+    fn apply_global_phase(&mut self, _phase: Angle64, _qubits: &[QubitId]) -> &mut Self {
+        panic!(
+            "foreign simulator protocol cannot apply a global phase; \
+             use it only for projective or measurement-only simulation"
+        )
+    }
+
+    fn t(&mut self, _qubits: &[QubitId]) -> &mut Self {
+        panic!(
+            "foreign simulator protocol cannot apply exact T: it has no native T \
+             or global-phase operation"
+        )
+    }
+
+    fn tdg(&mut self, _qubits: &[QubitId]) -> &mut Self {
+        panic!(
+            "foreign simulator protocol cannot apply exact Tdg: it has no native Tdg \
+             or global-phase operation"
+        )
     }
 }
 

--- a/crates/pecos-foreign/tests/foreign_simulator_test.rs
+++ b/crates/pecos-foreign/tests/foreign_simulator_test.rs
@@ -181,6 +181,20 @@ fn test_foreign_simulator_rotation_panic() {
 }
 
 #[test]
+#[should_panic(expected = "cannot apply exact T:")]
+fn test_foreign_simulator_rejects_phase_inexact_t() {
+    let mut sim = make_toy_sim(1);
+    sim.t(&[QubitId(0)]);
+}
+
+#[test]
+#[should_panic(expected = "cannot apply exact Tdg:")]
+fn test_foreign_simulator_rejects_phase_inexact_tdg() {
+    let mut sim = make_toy_sim(1);
+    sim.tdg(&[QubitId(0)]);
+}
+
+#[test]
 fn test_foreign_simulator_batch_gates() {
     let mut sim = make_toy_sim(4);
 

--- a/crates/pecos-foreign/tests/neo_integration_test.rs
+++ b/crates/pecos-foreign/tests/neo_integration_test.rs
@@ -159,3 +159,14 @@ fn test_foreign_sim_derived_gates_via_neo() {
         "X on toy sim decomposes to H(SZ(SZ(H))) = double flip = |0>"
     );
 }
+
+#[test]
+#[should_panic(expected = "cannot apply exact T:")]
+fn test_foreign_sim_rejects_phase_inexact_t_via_neo() {
+    let mut commands = CommandQueue::new();
+    commands.push(GateCommand::new(pecos_neo::GateType::T, vec![QubitId(0)]));
+
+    let mut sim = make_toy_sim(1);
+    let mut runner = CircuitRunner::<ForeignSimulator>::rotations();
+    let _ = runner.apply_circuit(&mut sim, &commands);
+}

--- a/crates/pecos-quantum/src/pass.rs
+++ b/crates/pecos-quantum/src/pass.rs
@@ -212,8 +212,6 @@ impl CircuitPass for PassPipeline {
 /// | RZ | pi   | Z   |
 /// | RZ | pi/2 | SZ  |
 /// | RZ | 3pi/2 | `SZdg` |
-/// | RZ | pi/4 | T   |
-/// | RZ | 7pi/4 | `Tdg` |
 /// | RX | pi   | X   |
 /// | RX | pi/2 | SX  |
 /// | RX | 3pi/2 | `SXdg` |
@@ -1627,20 +1625,20 @@ mod tests {
     }
 
     #[test]
-    fn simplify_rz_eighth_turn_to_t() {
+    fn does_not_simplify_rz_eighth_turn_to_t() {
         let eighth = Angle64::from_turn_ratio(1, 8);
         assert_eq!(
             pecos_core::try_simplify_rotation(GateType::RZ, eighth),
-            Some(GateType::T)
+            None
         );
     }
 
     #[test]
-    fn simplify_rz_seven_eighths_to_tdg() {
+    fn does_not_simplify_rz_seven_eighths_to_tdg() {
         let seven_eighths = Angle64::from_turn_ratio(7, 8);
         assert_eq!(
             pecos_core::try_simplify_rotation(GateType::RZ, seven_eighths),
-            Some(GateType::Tdg)
+            None
         );
     }
 
@@ -1870,13 +1868,13 @@ mod tests {
     }
 
     #[test]
-    fn tick_simplify_eighth_turn_to_t() {
+    fn tick_preserves_eighth_turn_rz() {
         let mut tc = TickCircuit::new();
         tc.tick().rz(Angle64::from_turn_ratio(1, 8), &[0]);
         SimplifyRotations.apply_tick(&mut tc);
         let gate = &tc.ticks()[0].gate_batches()[0];
-        assert_eq!(gate.gate_type, GateType::T);
-        assert!(gate.angles.is_empty());
+        assert_eq!(gate.gate_type, GateType::RZ);
+        assert_eq!(gate.angles.as_slice(), &[Angle64::from_turn_ratio(1, 8)]);
     }
 
     // ==================== DagCircuit pass tests ====================
@@ -1983,22 +1981,6 @@ mod tests {
         assert!(unitaries_equiv(
             &unitary_rep::RZ(Angle64::THREE_QUARTERS_TURN, 0),
             &unitary_rep::SZ(0).dg(),
-        ));
-    }
-
-    #[test]
-    fn matrix_rz_eighth_equiv_t() {
-        assert!(unitaries_equiv(
-            &unitary_rep::RZ(Angle64::from_turn_ratio(1, 8), 0),
-            &unitary_rep::T(0),
-        ));
-    }
-
-    #[test]
-    fn matrix_rz_seven_eighths_equiv_tdg() {
-        assert!(unitaries_equiv(
-            &unitary_rep::RZ(Angle64::from_turn_ratio(7, 8), 0),
-            &unitary_rep::T(0).dg(),
         ));
     }
 
@@ -2343,7 +2325,7 @@ mod tests {
 
     #[test]
     fn circuit_equiv_all_single_qubit_simplifications() {
-        // One gate for every single-qubit entry in the mapping table.
+        // Every mapped single-qubit rotation plus the non-rewritable T angles.
         let seventh_eighth = Angle64::from_turn_ratio(7, 8);
         let eighth = Angle64::from_turn_ratio(1, 8);
         let mut original = TickCircuit::new();
@@ -2352,10 +2334,10 @@ mod tests {
             .rz(Angle64::HALF_TURN, &[0]) // -> Z
             .rz(Angle64::QUARTER_TURN, &[1]) // -> SZ
             .rz(Angle64::THREE_QUARTERS_TURN, &[2]) // -> SZdg
-            .rz(eighth, &[3]); // -> T
+            .rz(eighth, &[3]); // preserved: not exact T
         original
             .tick()
-            .rz(seventh_eighth, &[0]) // -> Tdg
+            .rz(seventh_eighth, &[0]) // preserved: not exact Tdg
             .rx(Angle64::HALF_TURN, &[1]) // -> X
             .rx(Angle64::QUARTER_TURN, &[2]) // -> SX
             .rx(Angle64::THREE_QUARTERS_TURN, &[3]); // -> SXdg
@@ -3059,7 +3041,8 @@ mod tests {
             .rz(Angle64::QUARTER_TURN, &[0])
             .rz(Angle64::from_turn_ratio(3, 8), &[1]);
         // Merge: RZ(pi/2)+RZ(pi/2)->RZ(pi) on q0, RZ(1/8)+RZ(1/8)->RZ(1/4) on q1
-        // Simplify up to global phase: RZ(pi)->Z, RZ(pi/4)->T, etc.
+        // Simplify up to global phase: RZ(pi)->Z. RZ(pi/4) remains a
+        // rotation because conventional T carries a different scalar.
         // After CX: same pattern again
         let (b2, a2) = pipeline_stats(&mut c2);
 

--- a/crates/pecos-simulators/src/rotation_test_utils.rs
+++ b/crates/pecos-simulators/src/rotation_test_utils.rs
@@ -233,19 +233,20 @@ pub fn verify_two_qubit_rotation_inverse<S: ArbitraryRotationGateable>(sim: &mut
 
 // --- T Gate Tests ---
 
-/// Verify the conventional T gate has `T^8 = I` exactly (using measurements).
+/// Verify `T^8` is projectively equivalent to identity using measurements.
 ///
-/// `T = diag(1, exp(i*pi/4)) = exp(i*pi/8) RZ(pi/4)`, so its eighth power is
-/// `diag(1, exp(i*2*pi)) = I`.
-pub fn verify_t_eighth_power<S: ArbitraryRotationGateable>(sim: &mut S) {
-    // On |0>: T^8|0> = |0>, measures 0
+/// Measurements cannot distinguish the conventional `T^8 = I` from the old
+/// rotation convention's `RZ(pi/4)^8 = -I`. Amplitude-sensitive coverage of
+/// the exact identity lives in the state-vector test suite.
+pub fn verify_t_eighth_power_projectively<S: ArbitraryRotationGateable>(sim: &mut S) {
+    // On |0>: T^8|0> is projectively |0>, so it measures 0.
     sim.reset();
     for _ in 0..8 {
         sim.t(&qid(0));
     }
     assert_mz(sim, 0, false, "T^8|0>");
 
-    // On |+>: T^8|+> = |+>, measures 0 in X
+    // On |+>: T^8|+> is projectively |+>, so it measures 0 in X.
     sim.reset();
     sim.h(&qid(0));
     for _ in 0..8 {
@@ -1114,7 +1115,7 @@ pub fn run_rotation_gate_tests<S: ArbitraryRotationGateable>(sim: &mut S, num_qu
     verify_rotation_inverse(sim);
 
     // -- T gate --
-    verify_t_eighth_power(sim);
+    verify_t_eighth_power_projectively(sim);
     verify_t_adjoint(sim);
 
     // -- Rotation composition --

--- a/crates/pecos-simulators/tests/density_matrix_tests.rs
+++ b/crates/pecos-simulators/tests/density_matrix_tests.rs
@@ -33,7 +33,7 @@ fn assert_density_matrices_equal(lhs: &mut DensityMatrix, rhs: &mut DensityMatri
 }
 
 #[test]
-fn test_t_identities_are_exact_as_density_channels() {
+fn test_t_identities_projectively_as_density_channels() {
     let q0 = qid(0);
     let mut t_squared = DensityMatrix::new(1);
     let mut sz = DensityMatrix::new(1);

--- a/docs/user-guide/gate-naming-conventions.md
+++ b/docs/user-guide/gate-naming-conventions.md
@@ -169,7 +169,7 @@ Each also has an adjoint variant (Fdg, F2dg, F3dg, F4dg) that performs the inver
 | H | Hadamard | Creates superposition, exchanges X↔Z |
 | F | Face | Cyclic permutation X→Y→Z→X |
 | G | G gate | Symmetric two-qubit Clifford |
-| T | T gate | π/8 phase gate (= RZ(π/4)) |
+| T | T gate | π/8 phase gate (= exp(iπ/8) RZ(π/4)) |
 | U | Universal | General single-qubit unitary U(θ,φ,λ) |
 | SWAP | Swap | Exchange two qubit states |
 | iSWAP | iSwap | Swap with i phase |
@@ -196,19 +196,19 @@ Some gate names in PECOS come from historical conventions in quantum computing l
 
 The T gate is historically named but fits into the root hierarchy:
 
-| Gate | Rotation | Relation |
-|------|----------|----------|
-| Z | RZ(π) | Base gate |
-| SZ (S) | RZ(π/2) | Square root: SZ² = Z |
-| T | RZ(π/4) | Fourth root: T² = SZ, T⁴ = Z |
+| Gate | Symmetric rotation | Exact relation |
+|------|--------------------|----------------|
+| Z | RZ(π) | Z = i RZ(π) |
+| SZ (S) | RZ(π/2) | SZ = exp(iπ/4) RZ(π/2), SZ² = Z |
+| T | RZ(π/4) | T = exp(iπ/8) RZ(π/4), T² = SZ, T⁴ = Z |
 
 Under a fully systematic scheme, T might be named `QZ` (quarter/fourth root of Z) or `FRZ` (fourth root of Z), but `T` is universally recognized in quantum computing and QASM.
 
-**Equivalences** (up to global phase):
+**Exact relationships** (including global phase):
 ```
-T = RZ(π/4)
-T² = SZ = S = RZ(π/2)
-T⁴ = Z = RZ(π)
+T = exp(iπ/8) RZ(π/4)
+T² = SZ = S = exp(iπ/4) RZ(π/2)
+T⁴ = Z = i RZ(π)
 ```
 
 ### Gate Aliases

--- a/docs/user-guide/gates.md
+++ b/docs/user-guide/gates.md
@@ -854,7 +854,8 @@ RZ(θ) = [[e^(-iθ/2),     0     ],
 
 #### T Gate (π/8 Gate)
 
-The T gate is a π/4 rotation around the Z-axis (equivalent to RZ(π/4)).
+The T gate is the conventional phase gate `diag(1, exp(iπ/4))`. Its exact
+relationship to the symmetric rotation family is T = exp(iπ/8) RZ(π/4).
 
 **Matrix:**
 ```

--- a/exp/pecos-neo/docs/design/extensible-gates-test-plan.md
+++ b/exp/pecos-neo/docs/design/extensible-gates-test-plan.md
@@ -306,9 +306,10 @@ fn test_canonicalize_rz_half_turn() {
 fn test_canonicalize_t_gate() {
     let canon = GateCanonicalizer::standard();
 
-    // RZ(π/4) equals T up to global phase.
+    // RZ(π/4) differs from conventional T by a global scalar, so an
+    // exact canonicalizer must leave it as a rotation.
     let result = canon.canonicalize(gates::RZ, &[Angle64::HALF_TURN / 4]);
-    assert_eq!(result, Some(gates::T));
+    assert_eq!(result, None);
 }
 
 #[test]
@@ -737,17 +738,12 @@ fn test_program_serialization_roundtrip() {
 
 ```rust
 #[test]
-fn test_standard_adaptor_decomposes_t() {
+fn test_standard_adaptor_rejects_phase_inexact_t_decomposition() {
     let adaptor = StandardAdaptor::stab_vec();
 
-    assert!(adaptor.can_adapt(gates::T));
-
-    let decomposed = adaptor.adapt(gates::T, &[QubitId(0)], &[], &[]);
-
-    // T equals RZ(π/4) up to global phase.
-    assert_eq!(decomposed.len(), 1);
-    assert_eq!(decomposed[0].gate_id, gates::RZ);
-    assert_eq!(decomposed[0].angles[0], Angle64::HALF_TURN / 4);
+    // This target has no global-phase operation, so it cannot produce a
+    // sequence exactly equivalent to conventional T.
+    assert!(!adaptor.can_adapt(gates::T));
 }
 
 #[test]

--- a/exp/pecos-neo/docs/design/extensible-gates.md
+++ b/exp/pecos-neo/docs/design/extensible-gates.md
@@ -921,7 +921,6 @@ impl StandardAdaptor {
         bits.set(gates::RY.0 as usize, true);
         bits.set(gates::RZZ.0 as usize, true);
         bits.set(gates::SWAP.0 as usize, true);
-        bits.set(gates::T.0 as usize, true);
         Self { can_adapt_bits: bits }
     }
 }
@@ -941,10 +940,6 @@ impl GateAdaptor for StandardAdaptor {
         _params: &[f64],
     ) -> Vec<Gate> {
         match gate_id {
-            gates::T => {
-                // T equals RZ(1/8 turn) up to global phase.
-                vec![Gate::rz(Angle64::from_turns(0.125), qubits)]
-            }
             gates::RX => {
                 // RX(θ) = H RZ(θ) H
                 let theta = angles[0];
@@ -1159,14 +1154,14 @@ impl GateCanonicalizer {
     }
 }
 
-// Usage: T → RZ(π/4)
-let (rz, angle) = canonicalizer.expand(gates::T).unwrap();
+// Usage: SZ → RZ(π/2)
+let (rz, angle) = canonicalizer.expand(gates::SZ).unwrap();
 assert_eq!(rz, gates::RZ);
-assert_eq!(angle.to_turns(), 0.125);
+assert_eq!(angle.to_turns(), 0.25);
 ```
 
 This is useful when:
-- Simulator only supports parameterized gates (e.g., only RZ, not T)
+- Simulator only supports parameterized gates when an exact expansion exists
 - Exporting to formats that don't have fixed gates
 - Optimization passes that work on parameterized form
 

--- a/exp/pecos-neo/src/extensible/adaptor.rs
+++ b/exp/pecos-neo/src/extensible/adaptor.rs
@@ -56,7 +56,10 @@ pub trait GateAdaptor: Send + Sync {
     /// Decompose a gate into a sequence of other gates.
     ///
     /// The adaptor receives the gate ID, qubits, and angles, and returns
-    /// a sequence of gates that are equivalent to the original.
+    /// a sequence of gates that is exactly equivalent to the original, including
+    /// global phase. Implementations must report `false` from [`can_adapt`](Self::can_adapt)
+    /// and fail loudly if asked to adapt a gate for which they can only produce a
+    /// projectively equivalent sequence.
     fn adapt(&self, gate_id: GateId, qubits: &[QubitId], angles: &[Angle64]) -> Vec<AdaptedGate>;
 
     /// Get the set of gates this adaptor can decompose.
@@ -83,16 +86,13 @@ impl StandardAdaptor {
     pub fn stab_vec() -> Self {
         let mut bits = GateSupportSet::new();
 
-        // Gates we can decompose into Clifford+RZ
-        bits.insert(gates::T);
-        bits.insert(gates::Tdg);
+        // Gates we can decompose exactly into Clifford+RZ
         bits.insert(gates::RX);
         bits.insert(gates::RY);
         bits.insert(gates::SWAP);
         bits.insert(gates::RZZ);
         bits.insert(gates::RXX);
         bits.insert(gates::RYY);
-        bits.insert(gates::CCX);
 
         Self {
             can_adapt_bits: bits,
@@ -119,18 +119,6 @@ impl GateAdaptor for StandardAdaptor {
 
     fn adapt(&self, gate_id: GateId, qubits: &[QubitId], angles: &[Angle64]) -> Vec<AdaptedGate> {
         match gate_id {
-            id if id == gates::T => {
-                // T = exp(iπ/8) RZ(π/4); this adaptor discards global phase.
-                let angle = Angle64::HALF_TURN / 4;
-                vec![AdaptedGate::rotation(gates::RZ, qubits[0], angle)]
-            }
-
-            id if id == gates::Tdg => {
-                // Tdg = exp(-iπ/8) RZ(-π/4); this adaptor discards global phase.
-                let angle = Angle64::ZERO - Angle64::HALF_TURN / 4;
-                vec![AdaptedGate::rotation(gates::RZ, qubits[0], angle)]
-            }
-
             id if id == gates::RX => {
                 // RX(θ) = H RZ(θ) H
                 let theta = angles[0];
@@ -209,34 +197,11 @@ impl GateAdaptor for StandardAdaptor {
                 ]
             }
 
-            id if id == gates::CCX => {
-                // CCX (Toffoli) decomposition into Clifford+T
-                // This is a standard decomposition
-                let (q0, q1, q2) = (qubits[0], qubits[1], qubits[2]);
-                let t_angle = Angle64::HALF_TURN / 4;
-                let tdg_angle = Angle64::ZERO - t_angle;
-
-                vec![
-                    AdaptedGate::single(gates::H, q2),
-                    AdaptedGate::two_qubit(gates::CX, q1, q2),
-                    AdaptedGate::rotation(gates::RZ, q2, tdg_angle),
-                    AdaptedGate::two_qubit(gates::CX, q0, q2),
-                    AdaptedGate::rotation(gates::RZ, q2, t_angle),
-                    AdaptedGate::two_qubit(gates::CX, q1, q2),
-                    AdaptedGate::rotation(gates::RZ, q2, tdg_angle),
-                    AdaptedGate::two_qubit(gates::CX, q0, q2),
-                    AdaptedGate::rotation(gates::RZ, q1, t_angle),
-                    AdaptedGate::rotation(gates::RZ, q2, t_angle),
-                    AdaptedGate::single(gates::H, q2),
-                    AdaptedGate::two_qubit(gates::CX, q0, q1),
-                    AdaptedGate::rotation(gates::RZ, q0, t_angle),
-                    AdaptedGate::rotation(gates::RZ, q1, tdg_angle),
-                    AdaptedGate::two_qubit(gates::CX, q0, q1),
-                ]
-            }
-
             _ => {
-                panic!("StandardAdaptor cannot adapt gate {gate_id:?}");
+                panic!(
+                    "StandardAdaptor cannot exactly adapt gate {gate_id:?}; \
+                     the target gate set has no global-phase operation"
+                );
             }
         }
     }
@@ -462,7 +427,7 @@ impl CompositeExtendedAdaptor {
     /// Create a standard composite with common adaptors.
     ///
     /// Includes:
-    /// - `StandardAdaptor` for gate decompositions (T, SWAP, CCX, etc.)
+    /// - `StandardAdaptor` for exact gate decompositions (SWAP, rotations, etc.)
     /// - `StabilizerAdaptor` for joint measurements/preparations
     #[must_use]
     pub fn standard() -> Self {
@@ -541,22 +506,14 @@ mod extended_tests {
         let standard = StandardAdaptor::stab_vec();
         let lifted = LiftedAdaptor::new(standard);
 
-        assert!(lifted.can_adapt(gates::T));
+        assert!(!lifted.can_adapt(gates::T));
         assert!(lifted.can_adapt(gates::SWAP));
 
-        let reqs = lifted.ancilla_requirements(gates::T);
+        let reqs = lifted.ancilla_requirements(gates::SWAP);
         assert_eq!(reqs.count, 0); // Pure unitary, no ancillas
 
-        let seq = lifted.adapt(gates::T, &[QubitId(0)], &[], &[]);
-        assert!(!seq.ops.is_empty());
-
-        // T should decompose to RZ(pi/4)
-        match &seq.ops[0] {
-            AdaptedOp::Gate { gate_id, .. } => {
-                assert_eq!(*gate_id, gates::RZ);
-            }
-            _ => panic!("Expected Gate"),
-        }
+        let seq = lifted.adapt(gates::SWAP, &[QubitId(0), QubitId(1)], &[], &[]);
+        assert_eq!(seq.ops.len(), 3);
     }
 
     #[test]
@@ -564,17 +521,17 @@ mod extended_tests {
         let composite = CompositeExtendedAdaptor::standard();
 
         // Should handle gate decompositions
-        assert!(composite.can_adapt(gates::T));
+        assert!(!composite.can_adapt(gates::T));
         assert!(composite.can_adapt(gates::SWAP));
-        assert!(composite.can_adapt(gates::CCX));
+        assert!(!composite.can_adapt(gates::CCX));
 
         // Should handle stabilizer operations
         assert!(composite.can_adapt(stabilizer_gates::MZX));
         assert!(composite.can_adapt(stabilizer_gates::PZX));
 
         // Gate decomposition (no ancillas)
-        let t_reqs = composite.ancilla_requirements(gates::T);
-        assert_eq!(t_reqs.count, 0);
+        let swap_reqs = composite.ancilla_requirements(gates::SWAP);
+        assert_eq!(swap_reqs.count, 0);
 
         // Stabilizer measurement (needs ancilla)
         let mzx_reqs = composite.ancilla_requirements(stabilizer_gates::MZX);

--- a/exp/pecos-neo/src/extensible/canonicalizer.rs
+++ b/exp/pecos-neo/src/extensible/canonicalizer.rs
@@ -45,8 +45,6 @@ impl GateCanonicalizer {
 
         // RZ rules
         canon.add(gates::RZ, A::ZERO, gates::I);
-        canon.add(gates::RZ, A::HALF_TURN / 4, gates::T); // π/4
-        canon.add(gates::RZ, A::ZERO - A::HALF_TURN / 4, gates::Tdg); // -π/4
         canon.add(gates::RZ, A::QUARTER_TURN, gates::SZ); // π/2
         canon.add(gates::RZ, A::ZERO - A::QUARTER_TURN, gates::SZdg); // -π/2
         canon.add(gates::RZ, A::HALF_TURN, gates::Z); // π

--- a/exp/pecos-neo/src/extensible/tests.rs
+++ b/exp/pecos-neo/src/extensible/tests.rs
@@ -665,13 +665,13 @@ fn test_canonicalize_rz_half_turn() {
 }
 
 #[test]
-fn test_canonicalize_rz_t_gate() {
+fn test_canonicalize_rz_pi_over_four_stays_a_rotation() {
     let canon = GateCanonicalizer::standard();
 
-    // RZ(π/4) canonicalizes to T up to global phase.
+    // Conventional T differs from RZ(π/4) by exp(iπ/8).
     let t_angle = Angle64::HALF_TURN / 4;
     let result = canon.canonicalize(gates::RZ, &[t_angle]);
-    assert_eq!(result, Some(gates::T));
+    assert_eq!(result, None);
 }
 
 #[test]
@@ -966,10 +966,8 @@ fn test_canonicalizer_expand() {
     assert_eq!(gate, gates::RZ);
     assert_eq!(angle, Angle64::QUARTER_TURN);
 
-    // T should expand to RZ(π/4)
-    let (gate, angle) = canon.expand(gates::T).unwrap();
-    assert_eq!(gate, gates::RZ);
-    assert_eq!(angle, Angle64::HALF_TURN / 4);
+    // Conventional T has no exact expansion into the symmetric RZ family.
+    assert!(canon.expand(gates::T).is_none());
 }
 
 #[test]
@@ -1001,7 +999,7 @@ fn test_canonicalizer_get_forms_for() {
     let rz_forms = canon.get_forms_for(gates::RZ);
 
     // RZ has several canonical forms
-    assert!(rz_forms.len() >= 4); // 0, π/4, π/2, π at minimum
+    assert!(rz_forms.len() >= 4); // 0, ±π/2, and π at minimum
 
     // Check one of them
     let sz_form = rz_forms.iter().find(|f| f.to_gate == gates::SZ);
@@ -1396,12 +1394,22 @@ fn test_exact_angle_validator_accepts_canonicalizable() {
     let validator = ExactAngleValidator::new();
     let registry = GateRegistry::new();
 
-    let circuit = vec![
-        make_gate(gates::RZ, &[Angle64::QUARTER_TURN]), // -> SZ
-        make_gate(gates::RZ, &[Angle64::HALF_TURN / 4]), // -> T
-    ];
+    let circuit = vec![make_gate(gates::RZ, &[Angle64::QUARTER_TURN])]; // -> SZ
 
     assert!(validator.validate(&circuit, &registry).is_ok());
+}
+
+#[test]
+fn test_exact_angle_validator_rejects_phase_inexact_t_angle() {
+    let validator = ExactAngleValidator::new();
+    let registry = GateRegistry::new();
+    let circuit = vec![make_gate(gates::RZ, &[Angle64::HALF_TURN / 4])];
+
+    let result = validator.validate(&circuit, &registry);
+    assert!(matches!(
+        result,
+        Err(ValidationError::NonCanonicalAngle { .. })
+    ));
 }
 
 #[test]
@@ -1585,13 +1593,13 @@ fn test_validation_error_display() {
 fn test_standard_adaptor_can_adapt() {
     let adaptor = StandardAdaptor::stab_vec();
 
-    assert!(adaptor.can_adapt(gates::T));
-    assert!(adaptor.can_adapt(gates::Tdg));
+    assert!(!adaptor.can_adapt(gates::T));
+    assert!(!adaptor.can_adapt(gates::Tdg));
     assert!(adaptor.can_adapt(gates::RX));
     assert!(adaptor.can_adapt(gates::RY));
     assert!(adaptor.can_adapt(gates::SWAP));
     assert!(adaptor.can_adapt(gates::RZZ));
-    assert!(adaptor.can_adapt(gates::CCX));
+    assert!(!adaptor.can_adapt(gates::CCX));
 
     // These should NOT be adaptable (they're already in target set)
     assert!(!adaptor.can_adapt(gates::H));
@@ -1600,29 +1608,15 @@ fn test_standard_adaptor_can_adapt() {
 }
 
 #[test]
-fn test_standard_adaptor_t_gate() {
-    let adaptor = StandardAdaptor::stab_vec();
-
-    let result = adaptor.adapt(gates::T, &[QubitId(0)], &[]);
-
-    // The adaptor lowers T to the projectively equivalent RZ(π/4).
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].gate_id, gates::RZ);
-    assert_eq!(result[0].qubits[0], QubitId(0));
-    assert_eq!(result[0].angles[0], Angle64::HALF_TURN / 4);
+#[should_panic(expected = "cannot exactly adapt gate")]
+fn test_standard_adaptor_rejects_phase_inexact_t_lowering() {
+    StandardAdaptor::stab_vec().adapt(gates::T, &[QubitId(0)], &[]);
 }
 
 #[test]
-fn test_standard_adaptor_tdg_gate() {
-    let adaptor = StandardAdaptor::stab_vec();
-
-    let result = adaptor.adapt(gates::Tdg, &[QubitId(0)], &[]);
-
-    // The adaptor lowers Tdg to the projectively equivalent RZ(-π/4).
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].gate_id, gates::RZ);
-    let expected_angle = Angle64::ZERO - Angle64::HALF_TURN / 4;
-    assert_eq!(result[0].angles[0], expected_angle);
+#[should_panic(expected = "cannot exactly adapt gate")]
+fn test_standard_adaptor_rejects_phase_inexact_tdg_lowering() {
+    StandardAdaptor::stab_vec().adapt(gates::Tdg, &[QubitId(0)], &[]);
 }
 
 #[test]
@@ -1667,30 +1661,21 @@ fn test_standard_adaptor_rzz_gate() {
 }
 
 #[test]
-fn test_standard_adaptor_ccx_gate() {
-    let adaptor = StandardAdaptor::stab_vec();
-
-    let result = adaptor.adapt(gates::CCX, &[QubitId(0), QubitId(1), QubitId(2)], &[]);
-
-    // CCX decomposes to ~15 gates
-    assert!(result.len() > 10);
-
-    // Should contain H, CX, and RZ gates
-    assert!(result.iter().any(|g| g.gate_id == gates::H));
-    assert!(result.iter().any(|g| g.gate_id == gates::CX));
-    assert!(result.iter().any(|g| g.gate_id == gates::RZ));
+#[should_panic(expected = "cannot exactly adapt gate")]
+fn test_standard_adaptor_rejects_phase_inexact_ccx_lowering() {
+    StandardAdaptor::stab_vec().adapt(gates::CCX, &[QubitId(0), QubitId(1), QubitId(2)], &[]);
 }
 
 #[test]
 fn test_composite_adaptor() {
     let adaptor = CompositeAdaptor::new().with(StandardAdaptor::stab_vec());
 
-    assert!(adaptor.can_adapt(gates::T));
+    assert!(!adaptor.can_adapt(gates::T));
     assert!(adaptor.can_adapt(gates::SWAP));
 
-    let result = adaptor.adapt(gates::T, &[QubitId(0)], &[]);
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].gate_id, gates::RZ);
+    let result = adaptor.adapt(gates::SWAP, &[QubitId(0), QubitId(1)], &[]);
+    assert_eq!(result.len(), 3);
+    assert!(result.iter().all(|gate| gate.gate_id == gates::CX));
 }
 
 #[test]
@@ -1724,7 +1709,8 @@ fn test_adaptor_adaptable_gates() {
     let adaptor = StandardAdaptor::stab_vec();
     let adaptable = adaptor.adaptable_gates();
 
-    assert!(adaptable.contains(gates::T));
+    assert!(!adaptable.contains(gates::T));
+    assert!(!adaptable.contains(gates::CCX));
     assert!(adaptable.contains(gates::SWAP));
     assert!(!adaptable.contains(gates::H));
 }

--- a/python/quantum-pecos/src/pecos/slr/ast/codegen/qasm.py
+++ b/python/quantum-pecos/src/pecos/slr/ast/codegen/qasm.py
@@ -80,8 +80,8 @@ GATE_TO_QASM: dict[GateKind, str] = {
     # Hadamard
     GateKind.H: "h",
     # Phase gates
-    GateKind.T: "rz(pi/4)",  # Equivalent to T up to OpenQASM global phase
-    GateKind.Tdg: "rz(-pi/4)",  # Equivalent to Tdg up to OpenQASM global phase
+    GateKind.T: "t",
+    GateKind.Tdg: "tdg",
     # Square root gates
     GateKind.SX: "rx(pi/2)",
     GateKind.SY: "ry(pi/2)",

--- a/python/quantum-pecos/src/pecos/slr/gen_codes/gen_qasm.py
+++ b/python/quantum-pecos/src/pecos/slr/gen_codes/gen_qasm.py
@@ -658,10 +658,10 @@ class QASMGenerator(Generator):
                     op_str = self.qgate_sq_qasm(op, "reset")
 
                 case "T":
-                    op_str = self.qgate_sq_qasm(op, "rz(pi/4)")
+                    op_str = self.qgate_sq_qasm(op, "t")
 
                 case "Tdg":
-                    op_str = self.qgate_sq_qasm(op, "rz(-pi/4)")
+                    op_str = self.qgate_sq_qasm(op, "tdg")
 
                 case "SX":
                     op_str = self.qgate_sq_qasm(op, "rx(pi/2)")

--- a/python/quantum-pecos/src/pecos/slr/qeclib/qubit/sq_noncliffords.py
+++ b/python/quantum-pecos/src/pecos/slr/qeclib/qubit/sq_noncliffords.py
@@ -20,14 +20,16 @@ from pecos.slr.qeclib.qubit.qgate_base import QGate
 
 
 class T(QGate):
-    """T gate (π/8 rotation).
+    """Conventional T phase gate, diag(1, exp(iπ/4)).
 
-    This gate performs a π/4 rotation around the Z-axis.
+    Its exact relationship to the symmetric rotation family is
+    T = exp(iπ/8) RZ(π/4).
     """
 
 
 class Tdg(QGate):
-    """T-dagger gate (inverse T gate).
+    """Conventional T-dagger phase gate, diag(1, exp(-iπ/4)).
 
-    This gate performs a -π/4 rotation around the Z-axis.
+    Its exact relationship to the symmetric rotation family is
+    Tdg = exp(-iπ/8) RZ(-π/4).
     """

--- a/python/quantum-pecos/tests/pecos/integration/state_sim_tests/gate_matrix_def.py
+++ b/python/quantum-pecos/tests/pecos/integration/state_sim_tests/gate_matrix_def.py
@@ -159,8 +159,10 @@ def RZ(theta: float) -> pc.Array:
     //{
     //   U(0,0,lambda) q;
     //}.
+
+    Exactly, RZ(theta) = exp(-i*theta*Z/2).
     """
-    return pc.exp(i * (theta / 2)) * pc.linalg.expm(-i * Z * theta / 2)
+    return pc.linalg.expm(-i * Z * theta / 2)
 
 
 assert pc.isclose(RZ(0.0), I).all()
@@ -230,12 +232,12 @@ assert eqv2phase(SqrtZZ(), sqrtzz_def)
 
 def RZZ(theta: float) -> pc.Array:
     """Rotation around ZZ axis."""
-    return pc.exp(i * theta / 2) * pc.linalg.expm(-i * (Z & Z) * theta / 2)
+    return pc.linalg.expm(-i * (Z & Z) * theta / 2)
 
 
 assert pc.isclose(RZZ(0.0), I & I).all()
-assert pc.isclose(RZZ(pi), Z & Z).all()
-assert pc.isclose(RZZ(pi / 2), SqrtZZ()).all()
+assert pc.isclose(RZZ(pi), -i * (Z & Z)).all()
+assert pc.isclose(RZZ(pi / 2), pc.exp(-i * pi / 4) * SqrtZZ()).all()
 
 
 # STANDARD GATES
@@ -329,13 +331,15 @@ def T() -> pc.Array:
 
     gate t() a
     {
-       Rz(pi/4) a;
+       T a;
     }.
+
+    Exactly, T = exp(i*pi/8) RZ(pi/4).
     """
     return pc.diag(pc.array([1, pc.exp(i * pi / 4)], dtype=pc.dtypes.complex128))
 
 
-assert eqv2phase(T(), RZ(pi / 4))
+assert pc.isclose(T(), pc.exp(i * pi / 8) * RZ(pi / 4)).all()
 
 
 def Tdg() -> pc.Array:
@@ -343,13 +347,15 @@ def Tdg() -> pc.Array:
 
     gate tdg() a
     {
-       Rz(-pi/4) a;
+       TDG a;
     }.
+
+    Exactly, Tdg = exp(-i*pi/8) RZ(-pi/4).
     """
     return pc.diag(pc.array([1, pc.exp(-i * pi / 4)], dtype=pc.dtypes.complex128))
 
 
-assert eqv2phase(Tdg(), RZ(-pi / 4))
+assert pc.isclose(Tdg(), pc.exp(-i * pi / 8) * RZ(-pi / 4)).all()
 assert not eqv2phase(Tdg(), T())
 
 # // --- Standard rotations ---
@@ -363,7 +369,7 @@ def RX(theta: float) -> pc.Array:
        U1q(theta, 0) a;
     }.
     """
-    return pc.exp(i * (theta / 2)) * pc.linalg.expm(-i * (theta / 2) * X)
+    return pc.linalg.expm(-i * (theta / 2) * X)
 
 
 # try 5 random attempts to equivocate to gate definition
@@ -380,7 +386,7 @@ def RY(theta: float) -> pc.Array:
        U1q(theta, pi/2) a;
     }.
     """
-    return pc.exp(i * (theta / 2)) * pc.linalg.expm(-i * (theta / 2) * Y)
+    return pc.linalg.expm(-i * (theta / 2) * Y)
 
 
 # try 5 random attempts to equivocate to gate definition
@@ -485,17 +491,13 @@ assert eqv2phase(CH(), ch_def)
 def CRZ(theta: float) -> pc.Array:
     """Controlled-RZ(theta) gate. Convention: block-diag(I, RZ(theta)).
 
-    Decomposition (2q-minimal: 1 RZZ + 2 single-qubit RZ):
-        CRZ(theta) = (RZ(theta/2) o RZ(theta/2)) . RZZ(-theta/2)
-    Works because PECOS_RZ and PECOS_RZZ share the same e^{i.t/2}
-    global-phase convention. RZ on control absorbs the c=1-only phase
-    that the bare RZZ-based form would leave (it would otherwise be
-    a *relative* phase, not a global one, and thus observable).
+    Decomposition (2q-minimal: 1 RZZ + 1 single-qubit RZ):
+        CRZ(theta) = (I o RZ(theta/2)) . RZZ(-theta/2)
     """
     return oporder_multiply(
         [
             RZZ(-theta / 2),
-            (RZ(theta / 2), RZ(theta / 2)),
+            (I, RZ(theta / 2)),
         ],
     )
 

--- a/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.qubit.sq_noncliffords.T.qasm
+++ b/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.qubit.sq_noncliffords.T.qasm
@@ -1,1 +1,1 @@
-rz(pi/4) q_test[1];
+t q_test[1];

--- a/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.qubit.sq_noncliffords.Tdg.qasm
+++ b/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.qubit.sq_noncliffords.Tdg.qasm
@@ -1,1 +1,1 @@
-rz(-pi/4) q_test[1];
+tdg q_test[1];

--- a/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.steane.preps.t_plus_state.PrepEncodeTDagPlusNonFT.qasm
+++ b/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.steane.preps.t_plus_state.PrepEncodeTDagPlusNonFT.qasm
@@ -4,7 +4,7 @@ include "hqslib1.inc";
 // =============================
 reset q_test[6];
 h q_test[6];
-rz(-pi/4) q_test[6];
+tdg q_test[6];
 //
 // Encoding circuit
 // ---------------

--- a/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.steane.preps.t_plus_state.PrepEncodeTPlusNonFT.qasm
+++ b/python/quantum-pecos/tests/pecos/regression/test_qasm/regression_qasm/pecos.slr.qeclib.steane.preps.t_plus_state.PrepEncodeTPlusNonFT.qasm
@@ -4,7 +4,7 @@ include "hqslib1.inc";
 // =============================
 reset q_test[6];
 h q_test[6];
-rz(pi/4) q_test[6];
+t q_test[6];
 //
 // Encoding circuit
 // ---------------

--- a/python/quantum-pecos/tests/pecos/slr/ast_tests/test_ast_codegen_qasm.py
+++ b/python/quantum-pecos/tests/pecos/slr/ast_tests/test_ast_codegen_qasm.py
@@ -15,6 +15,7 @@ import pytest
 from pecos.slr import Barrier, CReg, If, Main, QReg, Repeat
 from pecos.slr.ast import AstToQasm, ast_to_qasm, slr_to_ast
 from pecos.slr.qeclib import qubit as qb
+from pecos_rslib import qasm_to_phir_json_py
 
 
 class TestAstToQasmBasic:
@@ -337,9 +338,15 @@ class TestAstToQasmFullPipeline:
         ast = slr_to_ast(prog)
         code = ast_to_qasm(ast)
 
-        # The QASM lowering uses RZ forms equivalent up to global phase.
-        assert "rz(pi/4) q[0];" in code
-        assert "rz(-pi/4) q[0];" in code
+        assert "t q[0];" in code
+        assert "tdg q[0];" in code
+        assert "rz(pi/4) q[0];" not in code
+        assert "rz(-pi/4) q[0];" not in code
+
+        # Reparse through the production QASM-to-PHIR lowering. Named gates
+        # must remain named instead of silently becoming symmetric rotations.
+        phir = qasm_to_phir_json_py(code)
+        assert [op["qop"] for op in phir["ops"] if "qop" in op] == ["T", "Tdg"]
 
     def test_barrier_operation(self) -> None:
         """Test barrier generation."""


### PR DESCRIPTION
## Summary

An independent review of #601 found the T/Tdg convention migration sound in the simulators, PHIR/HUGR, byte-message, GPU, and tensor-network paths, but incomplete in five places that still treated `T` and `RZ(pi/4)` as interchangeable. This PR completes the migration. It targets the `t-matrix-convention` branch so the fixes land with the convention change itself.

## Fixes

**Python QASM generators emitted the rotation for named gates.** Both the active AST generator and the deprecated generator lowered `GateKind.T`/`Tdg` to `rz(+/-pi/4)`, while `hqslib1.inc` now defines native `t`/`tdg` and the reparser deliberately distinguishes the two, so a named T round-tripped into an RZ and silently lost the convention. Both generators now emit `t`/`tdg`, the tests reject the rotation form for named gates, four regression fixtures were regenerated, and a generate-then-reparse test confirms a named T survives as a named T.

**Transformations silently exchanged the two matrices.** The `RZ(+/-pi/4) -> T/Tdg` rewrites in `clifford_simplify`, the `SimplifyRotations` pass, and the Neo canonicalizer replaced a gate with a different matrix. They were valid only while the two coincided and are removed rather than patched with a compensating phase. Neo's adaptor, whose trait promises an equivalent sequence, now rejects T/Tdg when the target has no global-phase operation instead of silently discarding the phase; its phase-inexact CCX lowering is removed on the same grounds.

**The foreign interface executed the old matrix.** The default T implementation applies RZ then a global-phase hook, but the hook defaulted to a no-op, so foreign simulators executed `RZ(pi/4)` while the rest of the codebase executed conventional T. The Rust foreign interface now panics before mutation on exact T/Tdg or global-phase requests, with the projective/measurement-only restriction documented at the trait, matching the restriction already documented on the Python side. Native T/Tdg callbacks in the next foreign-protocol version are the better long-term fix and can be filed as follow-up work.

**Tests named for exact identities could not detect their violation.** `verify_t_eighth_power` checked only MZ/MX outcomes, which the old `T^8 = -I` satisfies, and the density-matrix comparison is satisfied by both conventions because channels quotient global phase. These are renamed as projective checks, and exact componentwise identities are tested across six amplitude-exposing CPU simulators. Mutation-verified by restoring the old rotation-form T: the exact-identity test fails with `lhs = 0.35355 - 0.35355i` against `rhs = 0.5`, and passes on all six backends with the correct implementation.

**Documentation stated the old equality.** The gate-naming guide, the SLR gate class docstrings, and the Python matrix reference now state `T = exp(i*pi/8) RZ(pi/4)`; the reference rotation family is normalized to `exp(-i*theta*P/2)`.

`crates/pecos-core/src/unitary_rep.rs` is deliberately untouched: the stacked #612 fixes its named-gate constructors and parser, and touching it here would conflict.

## Verification

- Debug and release suites, all features, for the five touched crates.
- quantum-pecos Python suite via uv: 4726 passed, 57 skipped, 23 xfailed.
- Clippy `--all-targets --all-features -D warnings`; `cargo fmt --check`; pre-commit all files; `git diff --check`.
- Mutation evidence as above.
