### PR TITLE
Update chacha20 to 0.10.2 to clear the yanked-crate advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
cargo-deny now fails every CI run with `error[yanked]: detected yanked crate` because chacha20 0.10.1 was yanked upstream. This bumps the lockfile entry to 0.10.2 (patch release, no manifest change). Verified locally: `cargo deny check advisories` passes and the workspace builds. This unblocks the cargo-deny gate on all open PRs, which pick it up by merging dev.