### PR TITLE
Bump setup-uv to v10.0.1 to tolerate transient manifest fetch failures

### DIFF
--- a/.github/workflows/dependency-integrity-check.yml
+++ b/.github/workflows/dependency-integrity-check.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true

--- a/.github/workflows/julia-version-consistency.yml
+++ b/.github/workflows/julia-version-consistency.yml
@@ -42,7 +42,7 @@ jobs:
         python-version: "3.12"
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
 

--- a/.github/workflows/pr-core-gate.yml
+++ b/.github/workflows/pr-core-gate.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install the latest version of uv
         if: steps.detect.outputs.run == 'true'
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true
@@ -196,7 +196,7 @@ jobs:
 
       - name: Install the latest version of uv
         if: steps.detect.outputs.run == 'true'
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -134,7 +134,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true
@@ -228,7 +228,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
 
@@ -543,7 +543,7 @@ jobs:
 
       - name: Install uv for Linux wheel verification
         if: runner.os == 'Linux'
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -81,7 +81,7 @@ jobs:
         python-version: "3.12"
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
         enable-cache: true
@@ -171,7 +171,7 @@ jobs:
         python-version: "3.12"
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
         enable-cache: true
@@ -302,7 +302,7 @@ jobs:
         persist-credentials: false
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
         enable-cache: true
@@ -474,7 +474,7 @@ jobs:
         persist-credentials: false
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
 
@@ -611,7 +611,7 @@ jobs:
         python-version: "3.14"
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
         enable-cache: true

--- a/.github/workflows/python-version-consistency.yml
+++ b/.github/workflows/python-version-consistency.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
       - name: Harden apt against mirror flakiness

--- a/.github/workflows/rust-version-consistency.yml
+++ b/.github/workflows/rust-version-consistency.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
 

--- a/.github/workflows/selene-plugins.yml
+++ b/.github/workflows/selene-plugins.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true
@@ -164,7 +164,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true

--- a/.github/workflows/test-docs-examples.yml
+++ b/.github/workflows/test-docs-examples.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: ".github/uv.toml"
           enable-cache: true


### PR DESCRIPTION
PR #612's `pr-core-python` job failed in the setup-uv step with `##[error]fetch failed` while retrieving the uv version manifest from raw.githubusercontent.com, before any repository code ran. The pinned v7 action treats one failed manifest fetch as fatal.

Upstream fixed this failure class in v10.0.1 ("Tolerate transient manifest timeouts", astral-sh/setup-uv#1016). This bumps all 18 pinned usages across 10 workflow files from the v7 SHA to the v10.0.1 SHA.

Breaking changes between v7 and v10, checked against our usage:

- v8 removed the deprecated `manifest-file` format; we use `version-file` (.github/uv.toml), unaffected.
- v8 stopped publishing major/minor tags; we pin full SHAs already.
- v9 changed `prune-cache` default to false; we never set it, and the new default matches upstream's PyPI-load reasoning.
- v10 disables caching under `enable-cache: auto` for `pull_request_target`, `workflow_run`, and `release` events as cache-poisoning protection. Our PR/test workflows set `enable-cache: true` explicitly; the only usage affected is one step in python-release.yml, which loses caching on release events. That is accepted as intended hardening rather than overridden.

Verified: zero v7 pins remain; every usage was audited for its cache setting and trigger events.