### PR TITLE
Guard the StabVec reset fix, make u2/u3 phase-exact, and remove dead is_diagonal branches

### DIFF
--- a/crates/pecos-qasm/includes/qelib1.inc
+++ b/crates/pecos-qasm/includes/qelib1.inc
@@ -154,20 +154,10 @@ gate u(theta, phi, lambda) q { U(theta, phi, lambda) q; }
 gate u1(lambda) a { U(0, 0, lambda) a; }
 
 // Two-parameter rotation
-gate u2(phi, lambda) a {
-  rz(phi) a;
-  rx(pi/2) a;
-  rz(lambda) a;
-}
+gate u2(phi, lambda) a { U(pi/2, phi, lambda) a; }
 
 // Three-parameter general rotation
-gate u3(theta, phi, lambda) a {
-  rz(phi) a;
-  rx(-pi/2) a;
-  rz(theta) a;
-  rx(pi/2) a;
-  rz(lambda) a;
-}
+gate u3(theta, phi, lambda) a { U(theta, phi, lambda) a; }
 
 // Controlled gates
 gate cu1(lambda) a,b {

--- a/crates/pecos-qasm/tests/core/preprocessor_tests.rs
+++ b/crates/pecos-qasm/tests/core/preprocessor_tests.rs
@@ -1,5 +1,6 @@
-use pecos_qasm::Preprocessor;
+use pecos_core::prelude::GateType;
 use pecos_qasm::parser::QASMParser;
+use pecos_qasm::{Operation, Preprocessor};
 use std::fs;
 use tempfile::TempDir;
 
@@ -39,8 +40,15 @@ fn test_simple_include() {
 
     // Check that the gate definition was loaded
     assert!(program.gate_definitions.contains_key("hadamard"));
-    // After expansion, we'll have more than 2 operations due to gate expansion
-    assert!(program.operations.len() > 2);
+    // Each hadamard invocation lowers through qelib1's u2 to one native U.
+    assert_eq!(program.operations.len(), 2);
+    assert!(program.operations.iter().all(|operation| matches!(
+        operation,
+        Operation::Gate { name, .. } if name == "U"
+    ) || matches!(
+        operation,
+        Operation::NativeGate(gate) if gate.gate_type == GateType::U
+    )));
 }
 
 #[test]

--- a/crates/pecos-qasm/tests/features/virtual_includes_test.rs
+++ b/crates/pecos-qasm/tests/features/virtual_includes_test.rs
@@ -1,5 +1,6 @@
+use pecos_core::prelude::GateType;
 use pecos_qasm::parser::{ParseConfig, QASMParser};
-use pecos_qasm::{Preprocessor, QASMEngine};
+use pecos_qasm::{Operation, Preprocessor, QASMEngine};
 
 #[test]
 fn test_virtual_include_single() {
@@ -34,8 +35,17 @@ fn test_virtual_include_single() {
 
     // Verify the gate was loaded
     assert!(program.gate_definitions.contains_key("my_h"));
-    // After expansion, my_h expands to u2, which expands to more operations
-    assert!(program.operations.len() > 1);
+    // my_h lowers through qelib1's u2 to one native U.
+    assert_eq!(program.operations.len(), 1);
+    assert!(
+        matches!(
+            &program.operations[0],
+            Operation::Gate { name, .. } if name == "U"
+        ) || matches!(
+            &program.operations[0],
+            Operation::NativeGate(gate) if gate.gate_type == GateType::U
+        )
+    );
 }
 
 #[test]

--- a/crates/pecos-qasm/tests/integration/phase_exactness_test.rs
+++ b/crates/pecos-qasm/tests/integration/phase_exactness_test.rs
@@ -107,14 +107,102 @@ fn apply_expanded_operation(sim: &mut StateVecSoA32, operation: &Operation) {
         Operation::Gate { name, qubits, .. } if name == "CX" => {
             sim.cx(&[(QubitId(qubits[0]), QubitId(qubits[1]))]);
         }
+        Operation::Gate { name, qubits, .. } if name == "H" => {
+            sim.h(&[QubitId(qubits[0])]);
+        }
+        Operation::Gate {
+            name,
+            parameters,
+            qubits,
+        } if name == "RX" => {
+            sim.rx(Angle64::from_radians(parameters[0]), &[QubitId(qubits[0])]);
+        }
+        Operation::Gate {
+            name,
+            parameters,
+            qubits,
+        } if name == "RZ" => {
+            sim.rz(Angle64::from_radians(parameters[0]), &[QubitId(qubits[0])]);
+        }
+        Operation::Gate {
+            name,
+            parameters,
+            qubits,
+        } if name == "R1XY" => {
+            sim.r1xy(
+                Angle64::from_radians(parameters[0]),
+                Angle64::from_radians(parameters[1]),
+                &[QubitId(qubits[0])],
+            );
+        }
         Operation::NativeGate(gate) if gate.gate_type == GateType::U => {
             sim.u(gate.angles[0], gate.angles[1], gate.angles[2], &gate.qubits);
         }
         Operation::NativeGate(gate) if gate.gate_type == GateType::CX => {
             sim.cx(&[(gate.qubits[0], gate.qubits[1])]);
         }
-        operation => panic!("unexpected controlled-phase operation {operation:?}"),
+        Operation::NativeGate(gate) if gate.gate_type == GateType::H => {
+            sim.h(&gate.qubits);
+        }
+        Operation::NativeGate(gate) if gate.gate_type == GateType::RX => {
+            sim.rx(gate.angles[0], &gate.qubits);
+        }
+        Operation::NativeGate(gate) if gate.gate_type == GateType::RZ => {
+            sim.rz(gate.angles[0], &gate.qubits);
+        }
+        Operation::NativeGate(gate) if gate.gate_type == GateType::R1XY => {
+            sim.r1xy(gate.angles[0], gate.angles[1], &gate.qubits);
+        }
+        operation => panic!("unexpected expanded operation {operation:?}"),
     }
+}
+
+fn single_qubit_columns(invocation: &str) -> [[Complex64; 2]; 2] {
+    let qasm = format!("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\n{invocation} q[0];");
+    let program = QASMParser::parse_str(&qasm).expect("single-qubit gate must parse");
+    let mut columns = [[Complex64::new(0.0, 0.0); 2]; 2];
+
+    for (basis, column) in columns.iter_mut().enumerate() {
+        let mut sim = StateVecSoA32::new(1);
+        if basis == 1 {
+            sim.x(&[QubitId(0)]);
+        }
+        for operation in &program.operations {
+            apply_expanded_operation(&mut sim, operation);
+        }
+        *column = [
+            complex64(sim.get_amplitude(0)),
+            complex64(sim.get_amplitude(1)),
+        ];
+    }
+
+    columns
+}
+
+fn assert_columns_equal(label: &str, actual: &[[Complex64; 2]; 2], expected: &[[Complex64; 2]; 2]) {
+    for (column, (actual_column, expected_column)) in actual.iter().zip(expected).enumerate() {
+        for (row, (actual, expected)) in actual_column.iter().zip(expected_column).enumerate() {
+            let error = (actual - expected).norm();
+            assert!(
+                error < TOLERANCE,
+                "{label}, column {column}, row {row}: actual={actual}, expected={expected}, error={error:e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn qelib1_u3_zero_theta_matches_u1_phase_exactly() {
+    let u3 = single_qubit_columns("u3(0, 0, 0.7)");
+    let u1 = single_qubit_columns("u1(0.7)");
+    assert_columns_equal("u3(0,0,lambda) versus u1(lambda)", &u3, &u1);
+}
+
+#[test]
+fn qelib1_u2_matches_native_u_phase_exactly() {
+    let u2 = single_qubit_columns("u2(0.4, 0.8)");
+    let native_u = single_qubit_columns("U(pi/2, 0.4, 0.8)");
+    assert_columns_equal("u2(phi,lambda) versus U(pi/2,phi,lambda)", &u2, &native_u);
 }
 
 fn assert_controlled_phase(include: &str, spelling: &str) {

--- a/crates/pecos-simulators/src/clifford_frame.rs
+++ b/crates/pecos-simulators/src/clifford_frame.rs
@@ -765,7 +765,7 @@ impl CliffordFrame {
 
     /// Whether this Clifford is diagonal in the computational basis.
     ///
-    /// A Clifford is diagonal iff its Z-image axis is Z (maps Z to +/-Z).
+    /// A Clifford is diagonal iff its Z image is +Z.
     /// The four diagonal Cliffords are: I, Z, S, Sdg.
     #[inline]
     #[must_use]

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -637,15 +637,13 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         // Z-basis measurement on qubit q.
         // Frames and pending_rz on OTHER qubits commute with Z_q -- no flush needed.
         // Only qubit q's frame matters:
-        // - Diagonal frame (Z→±Z): just flips the outcome. Discard frame.
+        // - Diagonal frame (Z→+Z): discard frame.
         // - Non-diagonal frame: must flush (changes measurement basis).
         // Pending_rz on q is diagonal: doesn't affect Z measurement. Discard after.
-        // Pending_rz on q is diagonal: doesn't affect Z measurement. Discard after.
-        let mut flip_outcome = false;
         let cf_q = self.cliff_frame[q];
         if !cf_q.is_identity() {
             if cf_q.is_diagonal() {
-                flip_outcome = !cf_q.z_image().positive; // Z->-Z flips outcome
+                // is_diagonal() guarantees Z→+Z, so this cannot flip the outcome.
                 self.cliff_frame[q] = CliffordFrame::IDENTITY;
             } else {
                 // Non-diagonal: flush this qubit's frame (needs pending_rz flushed first).
@@ -828,25 +826,19 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             } // end non-deterministic
         };
 
-        // Adjust probability for frame flip (Z→-Z swaps |0⟩ and |1⟩ probabilities).
-        let actual_prob0 = if flip_outcome { 1.0 - prob0 } else { prob0 };
-
-        // Determine outcome from user's perspective (actual state).
+        // Determine the outcome.
         let outcome = if let Some(forced_val) = forced {
             forced_val
-        } else if (actual_prob0 - 1.0).abs() < 1e-10 {
+        } else if (prob0 - 1.0).abs() < 1e-10 {
             false // deterministic |0>
-        } else if actual_prob0 < 1e-10 {
+        } else if prob0 < 1e-10 {
             true // deterministic |1>
         } else {
             let r: f64 = self.rng.random();
-            r >= actual_prob0
+            r >= prob0
         };
 
-        let is_deterministic = (actual_prob0 - 1.0).abs() < 1e-10 || actual_prob0 < 1e-10;
-
-        // Projection uses stored-state outcome (flip back if frame flipped).
-        let stored_outcome = outcome ^ flip_outcome;
+        let is_deterministic = (prob0 - 1.0).abs() < 1e-10 || prob0 < 1e-10;
 
         // Project: measure each CH-form term, keep only compatible terms.
         // After measurement, the state should be projected onto the outcome subspace.
@@ -875,7 +867,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             // Apply mz_forced once, compute deltas, propagate to others.
             let gamma_before = self.terms[0].1.gamma().to_vec();
             let omega_before = self.terms[0].1.omega_exact();
-            self.terms[0].1.mz_forced(q, stored_outcome);
+            self.terms[0].1.mz_forced(q, outcome);
             let omega_after = self.terms[0].1.omega_exact();
             let mut gamma_delta = vec![0u8; self.num_qubits];
             for p in 0..self.num_qubits {
@@ -899,7 +891,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             }
         } else {
             for (_coeff, ch) in &mut self.terms {
-                ch.mz_forced(q, stored_outcome);
+                ch.mz_forced(q, outcome);
             }
         }
 
@@ -927,16 +919,6 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
                     *coeff *= inv_norm;
                 }
             }
-        }
-
-        // The frame's flip was reported in the outcome, but the projection
-        // collapsed the stored (unflipped) eigenstate and the frame is gone.
-        // Re-align the state with the report: collapse projects, it does not
-        // reset, so a repeated measurement must read this outcome again.
-        if flip_outcome {
-            self.apply_clifford(|ch| {
-                ch.x(&[QubitId(q)]);
-            });
         }
 
         MeasurementResult {
@@ -1395,13 +1377,8 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> ArbitraryRotationGateabl
                 // Non-diagonal frame doesn't commute with RZ. Flush.
                 self.flush_cliff_frame(qi);
             }
-            // If frame anticommutes with Z (X or Y component), negate the angle.
-            // Frame C: C†ZC = ±Z. If -Z, then C*RZ(θ) = RZ(-θ)*C.
-            if !cf.is_identity() && cf.is_diagonal() && !cf.z_image().positive {
-                self.apply_rz(-theta, qi);
-            } else {
-                self.apply_rz(theta, qi);
-            }
+            // is_diagonal() guarantees Z→+Z, so a retained frame cannot negate theta.
+            self.apply_rz(theta, qi);
         }
         self
     }
@@ -1838,6 +1815,34 @@ mod tests {
         assert_eq!(crz.num_terms(), 1);
         let sv = crz.state_vector();
         assert!((sv[0] - Complex64::new(1.0, 0.0)).norm() < EPS);
+    }
+
+    #[test]
+    fn stab_vec_reset_clears_frame_state() {
+        let mut reset_sim = StabVec::new_with_seed(2, 17);
+        let mut fresh_sim = StabVec::new_with_seed(2, 17);
+        let q0 = qid(0);
+        let q1 = qid(1);
+
+        // Leave both non-zero rotations pending while accumulating X/Y frames.
+        // The extra Z composition also leaves a non-trivial global frame phase.
+        reset_sim
+            .rz(Angle64::from_radians(0.37), &q0)
+            .y(&q0)
+            .z(&q0)
+            .rz(Angle64::from_radians(-0.91), &q1)
+            .y(&q1);
+        assert_eq!(reset_sim.cliff_frame[0], CliffordFrame::X);
+        assert_eq!(reset_sim.cliff_frame[1], CliffordFrame::Y);
+        assert_ne!(reset_sim.pending_rz[0], Angle64::ZERO);
+        assert_ne!(reset_sim.pending_rz[1], Angle64::ZERO);
+        assert_ne!(reset_sim.frame_phase, 0);
+
+        reset_sim.reset();
+        reset_sim.h(&[QubitId(0), QubitId(1)]);
+        fresh_sim.h(&[QubitId(0), QubitId(1)]);
+
+        assert_eq!(reset_sim.state_vector(), fresh_sim.state_vector());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A post-merge adversarial review of #616 confirmed its headline claims by execution -- including that the StabMps/Mast exact-U paths are not the wrong-layer scalar construction #612 had to revert -- and returned three findings. This PR closes all three.

## Fixes

**The StabVec reset fix was unguarded.** #616 corrected `reset()` to clear frame state, but no test covered it: reverting the fix left the entire tracked suite green while a post-reset gate deviated by up to 1.0 in amplitude (a stale frame applied to a fresh state). A regression test now locks the behavior. Mutation-verified: with the frame-clearing lines removed, the test fails with stale amplitudes `[-0.5, +0.5, +0.5, -0.5]` against the correct `[+0.5; 4]`; restored, it passes.

**`u2`/`u3` were left phase-inexact while `u1`/`p`/`u` became exact.** OpenQASM 2 defines `u3` as `U` and `u1(lambda)` as `u3(0,0,lambda)`, but qelib1.inc lowered `u3` through a projective rotation chain, so `u3(0,0,lambda)` and `u1(lambda)` differed by `exp(i*lambda/2)` after #616 -- and the include contradicted the PHIR mapping, which already sends `u3` to native `U`. Both gates now lower directly to native `U`, with phase-sensitive column tests. Mutation-verified: restoring the rotation chains fails the new tests with deviations 0.348 (`u3`) and 0.418 (`u2`). hqslib1.inc defines neither gate, so no counterpart change was needed.

**Dead branches removed.** The corrected `is_diagonal` criterion implies the Z image is positive, making the measurement outcome-flip and RZ angle-negation branches provably unreachable. They are removed, with the `is_diagonal() => Z -> +Z` invariant documented at both sites. The existing mutation-killing tests for `is_diagonal` still pass.

Two include-expansion tests that encoded the old multi-operation `u2` lowering were updated to the native form.

## Verification

Full debug and release suites for `pecos-simulators` and `pecos-qasm` (including doc tests); clippy `--all-targets -D warnings` on both; `cargo fmt --check`; `git diff --check`. All mutation evidence above was produced by execution and each mutation was restored before the final green run.
