### PR TITLE
Make the Rust-backed PauliProp wrapper execute every gate with sign-correct propagation and fix held gate-binding callables

### DIFF
--- a/crates/pecos-simulators/src/bitmask_pauli_prop.rs
+++ b/crates/pecos-simulators/src/bitmask_pauli_prop.rs
@@ -168,6 +168,22 @@ impl BitmaskPauliProp {
         self.set_x_component(q, x);
         self.set_z_component(q, z);
     }
+
+    fn clear_qubits(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.clear_qubit(q.index());
+        }
+        self
+    }
+
+    fn clear_qubits_after_measurement(
+        &mut self,
+        qubits: &[QubitId],
+        results: Vec<MeasurementResult>,
+    ) -> Vec<MeasurementResult> {
+        self.clear_qubits(qubits);
+        results
+    }
 }
 
 impl QuantumSimulator for BitmaskPauliProp {
@@ -370,6 +386,109 @@ impl CliffordGateable for BitmaskPauliProp {
     }
 
     #[inline]
+    fn px(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pnx(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn py(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pny(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pz(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pnz(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn mpx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mx(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpnx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mnx(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpy(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.my(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpny(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mny(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mz(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpnz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mnz(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        qubits
+            .iter()
+            .map(|&q| MeasurementResult {
+                outcome: self.contains_z(q.index()),
+                is_deterministic: true,
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn my(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        qubits
+            .iter()
+            .map(|&q| MeasurementResult {
+                outcome: self.contains_x(q.index()) ^ self.contains_z(q.index()),
+                is_deterministic: true,
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn mnx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.mx(qubits)
+    }
+
+    #[inline]
+    fn mny(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.my(qubits)
+    }
+
+    #[inline]
+    fn mnz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.mz(qubits)
+    }
+
+    #[inline]
     fn mz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
         qubits
             .iter()
@@ -444,6 +563,38 @@ mod tests {
                 bitmask.dense_string(),
                 sparse.dense_string(),
                 "{name}: {input}"
+            );
+        }
+    }
+
+    fn assert_measure_then_prep_matches_sparse<F, G>(
+        name: &str,
+        mut apply_sparse: F,
+        mut apply_bitmask: G,
+    ) where
+        F: FnMut(&mut PauliProp) -> Vec<MeasurementResult>,
+        G: FnMut(&mut BitmaskPauliProp) -> Vec<MeasurementResult>,
+    {
+        for input in all_paulis(1) {
+            let mut sparse = sparse_prop_from_dense(&input);
+            let mut bitmask = bitmask_prop_from_dense(&input);
+            let sparse_results = apply_sparse(&mut sparse);
+            let bitmask_results = apply_bitmask(&mut bitmask);
+            assert_eq!(
+                bitmask_results
+                    .iter()
+                    .map(|result| (result.outcome, result.is_deterministic))
+                    .collect::<Vec<_>>(),
+                sparse_results
+                    .iter()
+                    .map(|result| (result.outcome, result.is_deterministic))
+                    .collect::<Vec<_>>(),
+                "{name}: {input} results"
+            );
+            assert_eq!(
+                bitmask.dense_string(),
+                sparse.dense_string(),
+                "{name}: {input} frame"
             );
         }
     }
@@ -604,6 +755,50 @@ mod tests {
                 p.fdg(&[QubitId(0)]);
             },
         );
+    }
+
+    #[test]
+    fn preparations_match_sparse_pauli_prop() {
+        macro_rules! check_prep {
+            ($name:literal, $method:ident) => {
+                assert_matches_sparse_1q(
+                    $name,
+                    |prop| {
+                        prop.$method(&[QubitId(0)]);
+                    },
+                    |prop| {
+                        prop.$method(&[QubitId(0)]);
+                    },
+                );
+            };
+        }
+
+        check_prep!("PX", px);
+        check_prep!("PNX", pnx);
+        check_prep!("PY", py);
+        check_prep!("PNY", pny);
+        check_prep!("PZ", pz);
+        check_prep!("PNZ", pnz);
+    }
+
+    #[test]
+    fn measure_then_preparations_match_sparse_pauli_prop() {
+        macro_rules! check_measure_then_prep {
+            ($name:literal, $method:ident) => {
+                assert_measure_then_prep_matches_sparse(
+                    $name,
+                    |prop| prop.$method(&[QubitId(0)]),
+                    |prop| prop.$method(&[QubitId(0)]),
+                );
+            };
+        }
+
+        check_measure_then_prep!("MPX", mpx);
+        check_measure_then_prep!("MPNX", mpnx);
+        check_measure_then_prep!("MPY", mpy);
+        check_measure_then_prep!("MPNY", mpny);
+        check_measure_then_prep!("MPZ", mpz);
+        check_measure_then_prep!("MPNZ", mpnz);
     }
 
     #[test]

--- a/crates/pecos-simulators/src/clifford_gateable.rs
+++ b/crates/pecos-simulators/src/clifford_gateable.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The PECOS Developers
+// Copyright 2026 The PECOS Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.You may obtain a copy of the License at
@@ -229,8 +229,8 @@ pub trait CliffordGateable: QuantumSimulator {
     /// # Pauli Transformation
     /// ```text
     /// X → X
-    /// Y → -Z
-    /// Z → Y
+    /// Y → Z
+    /// Z → -Y
     /// ```
     ///
     /// # Matrix Representation
@@ -257,8 +257,8 @@ pub trait CliffordGateable: QuantumSimulator {
     /// # Pauli Transformation
     /// ```text
     /// X → X
-    /// Y → Z
-    /// Z → -Y
+    /// Y → -Z
+    /// Z → Y
     /// ```
     ///
     /// # Matrix Representation

--- a/crates/pecos-simulators/src/pauli_prop.rs
+++ b/crates/pecos-simulators/src/pauli_prop.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The PECOS Developers
+// Copyright 2026 The PECOS Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.You may obtain a copy of the License at
@@ -563,6 +563,41 @@ impl PauliProp {
         self.set_x_component(q, x);
         self.set_z_component(q, z);
     }
+
+    #[inline]
+    /// The sign mask uses base-4 Pauli-pair indices in `I, X, Y, Z` order.
+    fn update_two_qubit_sign(&mut self, sign_mask: u16, q1: (bool, bool), q2: (bool, bool)) {
+        if self.sign.is_none() {
+            return;
+        }
+
+        let pauli_index = |(x, z)| match (x, z) {
+            (false, false) => 0,
+            (true, false) => 1,
+            (true, true) => 2,
+            (false, true) => 3,
+        };
+        let index = 4 * pauli_index(q1) + pauli_index(q2);
+        if sign_mask & (1 << index) != 0 {
+            self.flip_sign();
+        }
+    }
+
+    fn clear_qubits(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            self.clear_qubit(q.index());
+        }
+        self
+    }
+
+    fn clear_qubits_after_measurement(
+        &mut self,
+        qubits: &[QubitId],
+        results: Vec<MeasurementResult>,
+    ) -> Vec<MeasurementResult> {
+        self.clear_qubits(qubits);
+        results
+    }
 }
 
 impl fmt::Display for PauliProp {
@@ -572,6 +607,37 @@ impl fmt::Display for PauliProp {
 }
 
 impl CliffordGateable for PauliProp {
+    #[inline]
+    fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            if self.contains_z(q.index()) {
+                self.flip_sign();
+            }
+        }
+        self
+    }
+
+    #[inline]
+    fn y(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            let qu = q.index();
+            if self.contains_x(qu) ^ self.contains_z(qu) {
+                self.flip_sign();
+            }
+        }
+        self
+    }
+
+    #[inline]
+    fn z(&mut self, qubits: &[QubitId]) -> &mut Self {
+        for &q in qubits {
+            if self.contains_x(q.index()) {
+                self.flip_sign();
+            }
+        }
+        self
+    }
+
     /// Applies the square root of Z gate (SZ or S gate) to the specified qubits.
     ///
     /// The SZ gate transforms Pauli operators as follows:
@@ -592,7 +658,12 @@ impl CliffordGateable for PauliProp {
     fn sz(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             let qu = q.index();
-            if self.contains_x(qu) {
+            let x = self.contains_x(qu);
+            let z = self.contains_z(qu);
+            if x && z {
+                self.flip_sign();
+            }
+            if x {
                 self.track_z(&[qu]);
             }
         }
@@ -607,7 +678,12 @@ impl CliffordGateable for PauliProp {
     fn szdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             let qu = q.index();
-            if self.contains_x(qu) {
+            let x = self.contains_x(qu);
+            let z = self.contains_z(qu);
+            if x && !z {
+                self.flip_sign();
+            }
+            if x {
                 self.track_z(&[qu]);
             }
         }
@@ -641,6 +717,7 @@ impl CliffordGateable for PauliProp {
             let in_zs = self.contains_z(qu);
 
             if in_xs && in_zs {
+                self.flip_sign();
             } else if in_xs {
                 self.xs.remove(&qu);
                 self.zs.insert(qu);
@@ -659,7 +736,12 @@ impl CliffordGateable for PauliProp {
     fn sx(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             let qu = q.index();
-            if self.contains_z(qu) {
+            let x = self.contains_x(qu);
+            let z = self.contains_z(qu);
+            if !x && z {
+                self.flip_sign();
+            }
+            if z {
                 self.track_x(&[qu]);
             }
         }
@@ -673,7 +755,12 @@ impl CliffordGateable for PauliProp {
     fn sxdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             let qu = q.index();
-            if self.contains_z(qu) {
+            let x = self.contains_x(qu);
+            let z = self.contains_z(qu);
+            if x && z {
+                self.flip_sign();
+            }
+            if z {
                 self.track_x(&[qu]);
             }
         }
@@ -689,6 +776,9 @@ impl CliffordGateable for PauliProp {
             let qu = q.index();
             let x = self.contains_x(qu);
             let z = self.contains_z(qu);
+            if x && !z {
+                self.flip_sign();
+            }
             self.set_components(qu, z, x);
         }
         self
@@ -703,6 +793,9 @@ impl CliffordGateable for PauliProp {
             let qu = q.index();
             let x = self.contains_x(qu);
             let z = self.contains_z(qu);
+            if !x && z {
+                self.flip_sign();
+            }
             self.set_components(qu, z, x);
         }
         self
@@ -732,6 +825,9 @@ impl CliffordGateable for PauliProp {
         for &(q1, q2) in pairs {
             let q1 = q1.index();
             let q2 = q2.index();
+            let components1 = (self.contains_x(q1), self.contains_z(q1));
+            let components2 = (self.contains_x(q2), self.contains_z(q2));
+            self.update_two_qubit_sign(0x0480, components1, components2);
             if self.contains_x(q1) {
                 self.track_x(&[q2]);
             }
@@ -752,6 +848,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x0820, (x1, z1), (x2, z2));
             self.set_components(q1, x1, z1 ^ x2 ^ z2);
             self.set_components(q2, x2 ^ x1, z2 ^ x1);
         }
@@ -768,6 +865,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x0240, (x1, z1), (x2, z2));
             self.set_components(q1, x1, z1 ^ x2);
             self.set_components(q2, x2, z2 ^ x1);
         }
@@ -784,6 +882,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x3088, (x1, z1), (x2, z2));
             let affected = z1 ^ z2;
             self.set_components(q1, x1 ^ affected, z1);
             self.set_components(q2, x2 ^ affected, z2);
@@ -803,6 +902,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x0344, (x1, z1), (x2, z2));
             let affected = z1 ^ z2;
             self.set_components(q1, x1 ^ affected, z1);
             self.set_components(q2, x2 ^ affected, z2);
@@ -820,6 +920,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x0252, (x1, z1), (x2, z2));
             self.set_components(q1, x2 ^ z1 ^ z2, x1 ^ x2 ^ z2);
             self.set_components(q2, x1 ^ z1 ^ z2, x1 ^ x2 ^ z1);
         }
@@ -838,6 +939,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x5808, (x1, z1), (x2, z2));
             self.set_components(q1, x2 ^ z1 ^ z2, x1 ^ x2 ^ z2);
             self.set_components(q2, x1 ^ z1 ^ z2, x1 ^ x2 ^ z1);
         }
@@ -854,6 +956,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x4904, (x1, z1), (x2, z2));
             let affected = x1 ^ x2;
             self.set_components(q1, x1, z1 ^ affected);
             self.set_components(q2, x2, z2 ^ affected);
@@ -873,6 +976,7 @@ impl CliffordGateable for PauliProp {
             let z1 = self.contains_z(q1);
             let x2 = self.contains_x(q2);
             let z2 = self.contains_z(q2);
+            self.update_two_qubit_sign(0x2092, (x1, z1), (x2, z2));
             let affected = x1 ^ x2;
             self.set_components(q1, x1, z1 ^ affected);
             self.set_components(q2, x2, z2 ^ affected);
@@ -894,6 +998,112 @@ impl CliffordGateable for PauliProp {
             self.set_components(q2, x1, z1);
         }
         self
+    }
+
+    #[inline]
+    fn px(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pnx(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn py(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pny(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pz(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn pnz(&mut self, qubits: &[QubitId]) -> &mut Self {
+        self.clear_qubits(qubits)
+    }
+
+    #[inline]
+    fn mpx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mx(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpnx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mnx(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpy(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.my(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpny(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mny(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mz(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mpnz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        let results = self.mnz(qubits);
+        self.clear_qubits_after_measurement(qubits, results)
+    }
+
+    #[inline]
+    fn mx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        qubits
+            .iter()
+            .map(|&q| MeasurementResult {
+                outcome: self.contains_z(q.index()),
+                is_deterministic: true,
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn my(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        qubits
+            .iter()
+            .map(|&q| {
+                let qu = q.index();
+                MeasurementResult {
+                    outcome: self.contains_x(qu) ^ self.contains_z(qu),
+                    is_deterministic: true,
+                }
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn mnx(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.mx(qubits)
+    }
+
+    #[inline]
+    fn mny(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.my(qubits)
+    }
+
+    #[inline]
+    fn mnz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+        self.mz(qubits)
     }
 
     /// Performs a Z-basis measurement on the specified qubits.
@@ -932,10 +1142,22 @@ impl CliffordGateable for PauliProp {
 mod tests {
     use super::*;
     use crate::clifford_matrix_oracle::{CliffordMatrixGate, all_pauli_strings, conjugate_pauli};
+    use pecos_core::{Pauli, PauliString, QuarterPhase, clifford_rep::CliffordRep};
     use std::collections::BTreeMap;
 
     fn prop_from_dense(input: &str) -> PauliProp {
         let mut prop = PauliProp::with_sign_tracking(input.len());
+        seed_prop_from_dense(&mut prop, input);
+        prop
+    }
+
+    fn untracked_prop_from_dense(input: &str) -> PauliProp {
+        let mut prop = PauliProp::new();
+        seed_prop_from_dense(&mut prop, input);
+        prop
+    }
+
+    fn seed_prop_from_dense(prop: &mut PauliProp, input: &str) {
         for (q, p) in input.chars().enumerate() {
             match p {
                 'I' => {}
@@ -945,7 +1167,71 @@ mod tests {
                 _ => panic!("invalid Pauli label {p}"),
             }
         }
-        prop
+    }
+
+    fn assert_prop_supports_match(prop: &PauliProp, expected: &PauliString, num_qubits: usize) {
+        for q in 0..num_qubits {
+            let (x, z) = match expected.get(q) {
+                Pauli::I => (false, false),
+                Pauli::X => (true, false),
+                Pauli::Y => (true, true),
+                Pauli::Z => (false, true),
+            };
+            assert_eq!(prop.contains_x(q), x, "qubit {q} X support");
+            assert_eq!(prop.contains_z(q), z, "qubit {q} Z support");
+        }
+    }
+
+    fn assert_single_gate_matches_clifford_rep<F>(name: &str, rep: &CliffordRep, mut apply: F)
+    where
+        F: FnMut(&mut PauliProp, &[QubitId]),
+    {
+        let qubits = [QubitId(0)];
+        for input in ["II", "XI", "YI", "ZI"] {
+            let input_pauli = PauliString::from_dense_str(input).unwrap();
+            let expected = rep.apply(&input_pauli);
+
+            let mut tracked = prop_from_dense(input);
+            apply(&mut tracked, &qubits);
+            assert_prop_supports_match(&tracked, &expected, 2);
+            assert_eq!(
+                tracked.get_sign(),
+                expected.phase() == QuarterPhase::MinusOne,
+                "{name}: {input} sign"
+            );
+            assert_eq!(tracked.get_img(), 0, "{name}: {input} imaginary phase");
+
+            let mut untracked = untracked_prop_from_dense(input);
+            apply(&mut untracked, &qubits);
+            assert_prop_supports_match(&untracked, &expected, 2);
+            assert_eq!(untracked.sign, None, "{name}: {input} untracked sign");
+        }
+    }
+
+    fn assert_two_qubit_gate_matches_clifford_rep<F>(name: &str, rep: &CliffordRep, mut apply: F)
+    where
+        F: FnMut(&mut PauliProp, &[(QubitId, QubitId)]),
+    {
+        let pairs = [(QubitId(0), QubitId(1))];
+        for input in all_pauli_strings(2) {
+            let input_pauli = PauliString::from_dense_str(&input).unwrap();
+            let expected = rep.apply(&input_pauli);
+
+            let mut tracked = prop_from_dense(&input);
+            apply(&mut tracked, &pairs);
+            assert_prop_supports_match(&tracked, &expected, 2);
+            assert_eq!(
+                tracked.get_sign(),
+                expected.phase() == QuarterPhase::MinusOne,
+                "{name}: {input} sign"
+            );
+            assert_eq!(tracked.get_img(), 0, "{name}: {input} imaginary phase");
+
+            let mut untracked = untracked_prop_from_dense(&input);
+            apply(&mut untracked, &pairs);
+            assert_prop_supports_match(&untracked, &expected, 2);
+            assert_eq!(untracked.sign, None, "{name}: {input} untracked sign");
+        }
     }
 
     fn assert_gate_table<F>(name: &str, table: &[(&str, &str)], mut apply: F)
@@ -1024,8 +1310,8 @@ mod tests {
             apply(&mut sequential, &pairs[1..2]);
 
             assert_eq!(
-                batched.dense_string(),
-                sequential.dense_string(),
+                batched.to_dense_string(),
+                sequential.to_dense_string(),
                 "{name} batched: {input}"
             );
         }
@@ -1394,5 +1680,201 @@ mod tests {
         assert_two_pair_batch_matches_sequential("SWAP", |prop, pairs| {
             prop.swap(pairs);
         });
+    }
+
+    #[test]
+    fn all_named_single_qubit_cliffords_match_clifford_rep() {
+        macro_rules! check {
+            ($name:literal, $rep:expr, $method:ident) => {
+                assert_single_gate_matches_clifford_rep($name, &$rep, |prop, qubits| {
+                    prop.$method(qubits);
+                });
+            };
+        }
+
+        check!("X", CliffordRep::x(0), x);
+        check!("Y", CliffordRep::y(0), y);
+        check!("Z", CliffordRep::z(0), z);
+        check!("SX", CliffordRep::sx(0), sx);
+        check!("SXdg", CliffordRep::sxdg(0), sxdg);
+        check!("SY", CliffordRep::sy(0), sy);
+        check!("SYdg", CliffordRep::sydg(0), sydg);
+        check!("SZ", CliffordRep::sz(0), sz);
+        check!("SZdg", CliffordRep::szdg(0), szdg);
+        check!("H", CliffordRep::h(0), h);
+        check!("H2", CliffordRep::h2(0), h2);
+        check!("H3", CliffordRep::h3(0), h3);
+        check!("H4", CliffordRep::h4(0), h4);
+        check!("H5", CliffordRep::h5(0), h5);
+        check!("H6", CliffordRep::h6(0), h6);
+        check!("F", CliffordRep::f(0), f);
+        check!("Fdg", CliffordRep::fdg(0), fdg);
+        check!("F2", CliffordRep::f2(0), f2);
+        check!("F2dg", CliffordRep::f2dg(0), f2dg);
+        check!("F3", CliffordRep::f3(0), f3);
+        check!("F3dg", CliffordRep::f3dg(0), f3dg);
+        check!("F4", CliffordRep::f4(0), f4);
+        check!("F4dg", CliffordRep::f4dg(0), f4dg);
+    }
+
+    #[test]
+    fn all_named_two_qubit_cliffords_match_clifford_rep() {
+        macro_rules! check {
+            ($name:literal, $rep:expr, $method:ident) => {
+                assert_two_qubit_gate_matches_clifford_rep($name, &$rep, |prop, pairs| {
+                    prop.$method(pairs);
+                });
+            };
+        }
+
+        check!("CX", CliffordRep::cx(0, 1), cx);
+        check!("CY", CliffordRep::cy(0, 1), cy);
+        check!("CZ", CliffordRep::cz(0, 1), cz);
+        check!("SXX", CliffordRep::sxx(0, 1), sxx);
+        check!("SXXdg", CliffordRep::sxxdg(0, 1), sxxdg);
+        check!("SYY", CliffordRep::syy(0, 1), syy);
+        check!("SYYdg", CliffordRep::syydg(0, 1), syydg);
+        check!("SZZ", CliffordRep::szz(0, 1), szz);
+        check!("SZZdg", CliffordRep::szzdg(0, 1), szzdg);
+        check!("SWAP", CliffordRep::swap(0, 1), swap);
+        check!("G", CliffordRep::g(0, 1), g);
+        check!("Gdg", CliffordRep::gdg(0, 1), gdg);
+        check!("ISWAP", CliffordRep::iswap(0, 1), iswap);
+        check!("ISWAPdg", CliffordRep::iswapdg(0, 1), iswapdg);
+    }
+
+    #[test]
+    fn preparations_clear_only_the_target_and_preserve_phase() {
+        let target = [QubitId(0)];
+        let labels = ['I', 'X', 'Y', 'Z'];
+
+        macro_rules! check_prep {
+            ($name:literal, $method:ident) => {
+                for target_label in labels {
+                    for neighbor_label in labels {
+                        let input = format!("{target_label}{neighbor_label}");
+                        let mut prop = prop_from_dense(&input);
+                        prop.flip_sign();
+                        prop.$method(&target);
+                        assert!(!prop.contains_x(0), "{}: {input} target X", $name);
+                        assert!(!prop.contains_z(0), "{}: {input} target Z", $name);
+                        assert_eq!(
+                            (prop.contains_x(1), prop.contains_z(1)),
+                            match neighbor_label {
+                                'I' => (false, false),
+                                'X' => (true, false),
+                                'Y' => (true, true),
+                                'Z' => (false, true),
+                                _ => unreachable!(),
+                            },
+                            "{}: {input} neighbor",
+                            $name
+                        );
+                        assert!(prop.get_sign(), "{}: {input} sign", $name);
+                        assert_eq!(prop.get_img(), 0, "{}: {input} phase", $name);
+                    }
+                }
+            };
+        }
+
+        check_prep!("PX", px);
+        check_prep!("PNX", pnx);
+        check_prep!("PY", py);
+        check_prep!("PNY", pny);
+        check_prep!("PZ", pz);
+        check_prep!("PNZ", pnz);
+    }
+
+    #[test]
+    fn measure_then_prepare_variants_report_then_clear() {
+        let target = [QubitId(0)];
+
+        macro_rules! check_prep {
+            ($name:literal, $method:ident, $outcomes:expr) => {
+                for (input, expected_outcome) in ["II", "XI", "YI", "ZI"].into_iter().zip($outcomes)
+                {
+                    let mut prop = prop_from_dense(input);
+                    prop.flip_sign();
+                    let results = prop.$method(&target);
+                    assert_eq!(results.len(), 1, "{}: {input} result count", $name);
+                    assert_eq!(
+                        results[0].outcome, expected_outcome,
+                        "{}: {input} outcome",
+                        $name
+                    );
+                    assert!(
+                        results[0].is_deterministic,
+                        "{}: {input} determinism",
+                        $name
+                    );
+                    assert!(prop.is_identity(), "{}: {input} frame", $name);
+                    assert!(prop.get_sign(), "{}: {input} sign", $name);
+                }
+            };
+        }
+
+        check_prep!("MPX", mpx, [false, false, true, true]);
+        check_prep!("MPNX", mpnx, [false, false, true, true]);
+        check_prep!("MPY", mpy, [false, true, false, true]);
+        check_prep!("MPNY", mpny, [false, true, false, true]);
+        check_prep!("MPZ", mpz, [false, true, true, false]);
+        check_prep!("MPNZ", mpnz, [false, true, true, false]);
+    }
+
+    #[test]
+    fn measurements_report_frame_flips_without_mutation() {
+        let target = [QubitId(0)];
+        for track_sign in [true, false] {
+            for (input, mx, my, mz) in [
+                ("II", false, false, false),
+                ("XI", false, true, true),
+                ("YI", true, false, true),
+                ("ZI", true, true, false),
+            ] {
+                let mut prop = if track_sign {
+                    prop_from_dense(input)
+                } else {
+                    untracked_prop_from_dense(input)
+                };
+                prop.flip_sign();
+                let before = prop.to_dense_string();
+                let before_sign = prop.sign;
+                let before_img = prop.img;
+
+                macro_rules! check_measurement {
+                    ($name:literal, $method:ident, $outcome:expr) => {
+                        assert_eq!(
+                            prop.$method(&target)[0].outcome,
+                            $outcome,
+                            "{}: {input}, track_sign={track_sign}",
+                            $name
+                        );
+                        assert_eq!(
+                            prop.to_dense_string(),
+                            before,
+                            "{} frame: {input}, track_sign={track_sign}",
+                            $name
+                        );
+                        assert_eq!(
+                            prop.sign, before_sign,
+                            "{} sign: {input}, track_sign={track_sign}",
+                            $name
+                        );
+                        assert_eq!(
+                            prop.img, before_img,
+                            "{} phase: {input}, track_sign={track_sign}",
+                            $name
+                        );
+                    };
+                }
+
+                check_measurement!("MX", mx, mx);
+                check_measurement!("MNX", mnx, mx);
+                check_measurement!("MY", my, my);
+                check_measurement!("MNY", mny, my);
+                check_measurement!("MZ", mz, mz);
+                check_measurement!("MNZ", mnz, mz);
+            }
+        }
     }
 }

--- a/python/pecos-rslib/src/pauli_prop_bindings.rs
+++ b/python/pecos-rslib/src/pauli_prop_bindings.rs
@@ -1,5 +1,6 @@
-// Copyright 2025 The PECOS Developers
+// Copyright 2026 The PECOS Developers
 use crate::prelude::*;
+use crate::simulator_utils::{extract_angle, extract_angles};
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.You may obtain a copy of the License at
@@ -11,8 +12,10 @@ use crate::prelude::*;
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+use pecos_simulators::clifford_rotation::CliffordRotation;
+use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PySet};
+use pyo3::types::{PyAny, PyDict, PySet, PyTuple};
 use std::collections::BTreeMap;
 
 /// Python wrapper for the Rust `PauliProp` simulator
@@ -99,6 +102,370 @@ impl PyPauliProp {
     /// Reset the simulator state
     pub fn reset(&mut self) {
         self.inner.reset();
+    }
+
+    #[expect(clippy::too_many_lines)]
+    #[pyo3(signature = (symbol, location, params=None))]
+    fn run_1q_gate(
+        &mut self,
+        symbol: &str,
+        location: usize,
+        params: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<u8>> {
+        let q = &[QubitId(location)];
+        match symbol {
+            "I" => Ok(None),
+            "X" => {
+                self.inner.x(q);
+                Ok(None)
+            }
+            "Y" => {
+                self.inner.y(q);
+                Ok(None)
+            }
+            "Z" => {
+                self.inner.z(q);
+                Ok(None)
+            }
+            "H" | "H1" | "H+z+x" => {
+                self.inner.h(q);
+                Ok(None)
+            }
+            "H2" | "H-z-x" => {
+                self.inner.h2(q);
+                Ok(None)
+            }
+            "H3" | "H+y-z" => {
+                self.inner.h3(q);
+                Ok(None)
+            }
+            "H4" | "H-y-z" => {
+                self.inner.h4(q);
+                Ok(None)
+            }
+            "H5" | "H-x+y" => {
+                self.inner.h5(q);
+                Ok(None)
+            }
+            "H6" | "H-x-y" => {
+                self.inner.h6(q);
+                Ok(None)
+            }
+            "F" | "F1" => {
+                self.inner.f(q);
+                Ok(None)
+            }
+            "Fdg" | "F1d" | "F1dg" => {
+                self.inner.fdg(q);
+                Ok(None)
+            }
+            "F2" => {
+                self.inner.f2(q);
+                Ok(None)
+            }
+            "F2dg" | "F2d" => {
+                self.inner.f2dg(q);
+                Ok(None)
+            }
+            "F3" => {
+                self.inner.f3(q);
+                Ok(None)
+            }
+            "F3dg" | "F3d" => {
+                self.inner.f3dg(q);
+                Ok(None)
+            }
+            "F4" => {
+                self.inner.f4(q);
+                Ok(None)
+            }
+            "F4dg" | "F4d" => {
+                self.inner.f4dg(q);
+                Ok(None)
+            }
+            "Q" | "SX" | "SqrtX" => {
+                self.inner.sx(q);
+                Ok(None)
+            }
+            "Qd" | "SXdg" | "SqrtXd" | "SqrtXdg" => {
+                self.inner.sxdg(q);
+                Ok(None)
+            }
+            "R" | "SY" | "SqrtY" => {
+                self.inner.sy(q);
+                Ok(None)
+            }
+            "Rd" | "SYdg" | "SqrtYd" | "SqrtYdg" => {
+                self.inner.sydg(q);
+                Ok(None)
+            }
+            "S" | "SZ" | "SqrtZ" => {
+                self.inner.sz(q);
+                Ok(None)
+            }
+            "Sd" | "SZdg" | "SqrtZd" | "SqrtZdg" => {
+                self.inner.szdg(q);
+                Ok(None)
+            }
+            "RX" => {
+                let angle = extract_angle(params, "RX")?;
+                self.inner
+                    .try_rx(angle, q)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RY" => {
+                let angle = extract_angle(params, "RY")?;
+                self.inner
+                    .try_ry(angle, q)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RZ" => {
+                let angle = extract_angle(params, "RZ")?;
+                self.inner
+                    .try_rz(angle, q)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RXY1Q" | "R1XY" => {
+                let angles = extract_angles(params, "RXY1Q", 2)?;
+                self.inner
+                    .try_rxy1q(angles[0], angles[1], q)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "U" => {
+                let angles = extract_angles(params, "U", 3)?;
+                self.inner
+                    .try_u(angles[0], angles[1], angles[2], q)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "PZ" | "PZForced" | "Init" | "Init +Z" | "init |0>" | "leak" | "leak |0>"
+            | "unleak |0>" => {
+                self.inner.pz(q);
+                Ok(None)
+            }
+            "PNZ" | "Init -Z" | "init |1>" | "leak |1>" | "unleak |1>" => {
+                self.inner.pnz(q);
+                Ok(None)
+            }
+            "PX" | "Init +X" | "init |+>" => {
+                self.inner.px(q);
+                Ok(None)
+            }
+            "PNX" | "Init -X" | "init |->" => {
+                self.inner.pnx(q);
+                Ok(None)
+            }
+            "PY" | "Init +Y" | "init |+i>" => {
+                self.inner.py(q);
+                Ok(None)
+            }
+            "PNY" | "Init -Y" | "init |-i>" => {
+                self.inner.pny(q);
+                Ok(None)
+            }
+            "MZ" | "MZForced" | "Measure" | "measure Z" | "Measure +Z" => {
+                Ok(Some(u8::from(self.inner.mz(q)[0].outcome)))
+            }
+            "MX" | "Measure +X" | "measure X" => Ok(Some(u8::from(self.inner.mx(q)[0].outcome))),
+            "MY" | "Measure +Y" | "measure Y" => Ok(Some(u8::from(self.inner.my(q)[0].outcome))),
+            _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Unsupported single-qubit gate",
+            )),
+        }
+    }
+
+    #[pyo3(signature = (symbol, location, params=None))]
+    fn run_2q_gate(
+        &mut self,
+        symbol: &str,
+        location: &Bound<'_, PyTuple>,
+        params: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<u8>> {
+        if location.len() != 2 {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Two-qubit gate requires exactly 2 qubit locations",
+            ));
+        }
+
+        let q1: usize = location.get_item(0)?.extract()?;
+        let q2: usize = location.get_item(1)?.extract()?;
+        let pair = &[(QubitId(q1), QubitId(q2))];
+
+        match symbol {
+            "CX" | "CNOT" => {
+                self.inner.cx(pair);
+                Ok(None)
+            }
+            "CY" => {
+                self.inner.cy(pair);
+                Ok(None)
+            }
+            "CZ" => {
+                self.inner.cz(pair);
+                Ok(None)
+            }
+            "SXX" | "SqrtXX" | "MS" | "MSXX" => {
+                self.inner.sxx(pair);
+                Ok(None)
+            }
+            "SXXdg" | "SqrtXXd" | "SqrtXXdg" => {
+                self.inner.sxxdg(pair);
+                Ok(None)
+            }
+            "SYY" | "SqrtYY" => {
+                self.inner.syy(pair);
+                Ok(None)
+            }
+            "SYYdg" | "SqrtYYd" | "SqrtYYdg" => {
+                self.inner.syydg(pair);
+                Ok(None)
+            }
+            "SZZ" | "SqrtZZ" => {
+                self.inner.szz(pair);
+                Ok(None)
+            }
+            "SZZdg" | "SqrtZZd" | "SqrtZZdg" => {
+                self.inner.szzdg(pair);
+                Ok(None)
+            }
+            "SWAP" => {
+                self.inner.swap(pair);
+                Ok(None)
+            }
+            "G" | "G2" => {
+                self.inner.g(pair);
+                Ok(None)
+            }
+            "Gdg" => {
+                self.inner.gdg(pair);
+                Ok(None)
+            }
+            "ISWAP" => {
+                self.inner.iswap(pair);
+                Ok(None)
+            }
+            "ISWAPdg" => {
+                self.inner.iswapdg(pair);
+                Ok(None)
+            }
+            "RXX" => {
+                let angle = extract_angle(params, "RXX")?;
+                self.inner
+                    .try_rxx(angle, pair)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RYY" => {
+                let angle = extract_angle(params, "RYY")?;
+                self.inner
+                    .try_ryy(angle, pair)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RZZ" => {
+                let angle = extract_angle(params, "RZZ")?;
+                self.inner
+                    .try_rzz(angle, pair)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "RXXRYYRZZ" | "RZZRYYRXX" | "R2XXYYZZ" | "RXXYYZZ" => {
+                let angles = extract_angles(params, "RXXRYYRZZ", 3)?;
+                self.inner
+                    .try_rxxryyrzz(angles[0], angles[1], angles[2], pair)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Ok(None)
+            }
+            "II" => Ok(None),
+            _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Unsupported two-qubit gate",
+            )),
+        }
+    }
+
+    #[pyo3(signature = (symbol, location, params=None))]
+    fn run_gate_internal(
+        &mut self,
+        symbol: &str,
+        location: &Bound<'_, PyTuple>,
+        params: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<u8>> {
+        match location.len() {
+            1 => self.run_1q_gate(symbol, location.get_item(0)?.extract()?, params),
+            2 => self.run_2q_gate(symbol, location, params),
+            _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Gate location must be specified for either 1 or 2 qubits",
+            )),
+        }
+    }
+
+    #[pyo3(signature = (symbol, locations, **params))]
+    fn run_gate(
+        &mut self,
+        symbol: &str,
+        locations: &Bound<'_, PyAny>,
+        params: Option<&Bound<'_, PyDict>>,
+        py: Python<'_>,
+    ) -> PyResult<Py<PyDict>> {
+        self.run_gate_highlevel(symbol, locations, params, py)
+    }
+
+    #[pyo3(signature = (symbol, locations, **params))]
+    fn run_gate_highlevel(
+        &mut self,
+        symbol: &str,
+        locations: &Bound<'_, PyAny>,
+        params: Option<&Bound<'_, PyDict>>,
+        py: Python<'_>,
+    ) -> PyResult<Py<PyDict>> {
+        let output = PyDict::new(py);
+
+        if matches!(symbol, "force output" | "check" | "measure") {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Unsupported gate",
+            ));
+        }
+
+        if let Some(p) = params
+            && let Ok(Some(simulate_gate)) = p.get_item("simulate_gate")
+            && let Ok(false) = simulate_gate.extract::<bool>()
+        {
+            return Ok(output.into());
+        }
+
+        let locations_set: Bound<PySet> = locations.clone().cast_into()?;
+        if locations_set.is_empty() {
+            return Ok(output.into());
+        }
+
+        let has_special_params = params.is_some_and(|p| !p.is_empty());
+        if !has_special_params
+            && let Some(result) = crate::simulator_utils::try_clifford_batch_dispatch(
+                &mut self.inner,
+                symbol,
+                &locations_set,
+                py,
+            )?
+        {
+            return Ok(result);
+        }
+
+        for location in locations_set.iter() {
+            let loc_tuple: Bound<'_, PyTuple> = if location.is_instance_of::<PyTuple>() {
+                location.clone().cast_into()?
+            } else {
+                PyTuple::new(py, std::slice::from_ref(&location))?
+            };
+            if let Some(value) = self.run_gate_internal(symbol, &loc_tuple, params)? {
+                output.set_item(location, value)?;
+            }
+        }
+
+        Ok(output.into())
     }
 
     /// Check if a qubit has an X operator
@@ -374,6 +741,13 @@ impl PyPauliProp {
             obj.inner.flip_img(img as usize);
         }
         Ok(obj)
+    }
+
+    #[getter]
+    fn bindings(slf: PyRef<'_, Self>) -> PyResult<crate::simulator_utils::GateBindingsDict> {
+        let py = slf.py();
+        let sim_obj: Py<PyAny> = slf.into_bound_py_any(py)?.unbind();
+        Ok(crate::simulator_utils::GateBindingsDict::new(sim_obj))
     }
 
     /// String representation

--- a/python/pecos-rslib/src/simulator_utils.rs
+++ b/python/pecos-rslib/src/simulator_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 The PECOS Developers
+// Copyright 2026 The PECOS Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyDict, PyModule};
 use std::collections::HashMap;
 
@@ -43,6 +44,8 @@ pub struct GateBindingsDict {
     cache: HashMap<String, Py<PyAny>>,
 }
 
+static GATE_LAMBDA_FACTORY: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
 impl GateBindingsDict {
     /// Create a new `GateBindingsDict` from Rust code.
     pub fn new(sim: Py<PyAny>) -> Self {
@@ -66,46 +69,44 @@ impl GateBindingsDict {
             return Ok(cached.clone_ref(py));
         }
 
-        // Create a closure that calls run_gate
-        let sim = self.sim.clone_ref(py);
         let gate_name = key.to_string();
 
-        // Create a Python function that wraps the gate call
-        let locals = PyDict::new(py);
-        locals.set_item("sim", sim)?;
-        locals.set_item("gate_name", &gate_name)?;
+        let factory = GATE_LAMBDA_FACTORY.get_or_try_init(py, || {
+            let code = c_str!(
+                r#"
+def make_gate_lambda(sim, gate_name):
+    def gate_lambda(simulator, location, **params):
+        if isinstance(location, int):
+            loc_tuple = (location,)
+        elif isinstance(location, list):
+            loc_tuple = tuple(location)
+        else:
+            loc_tuple = location
 
-        // Define a wrapper function in Python using PyModule::from_code
-        let code = c_str!(
-            r#"
-def gate_lambda(simulator, location, **params):
-    # Convert location to tuple
-    if isinstance(location, int):
-        loc_tuple = (location,)
-    elif isinstance(location, list):
-        loc_tuple = tuple(location)
-    else:
-        loc_tuple = location
+        loc_set = {loc_tuple}
+        result_dict = sim.run_gate(gate_name, loc_set, **params)
 
-    # Wrap in a set (run_gate expects a set of locations)
-    loc_set = {loc_tuple}
+        if result_dict:
+            if isinstance(location, int) and location in result_dict:
+                return result_dict[location]
+            return result_dict.get(loc_tuple)
+        return None
 
-    # Call run_gate
-    result_dict = sim.run_gate(gate_name, loc_set, **params)
-
-    # Extract the result for this specific location
-    if result_dict:
-        return result_dict.get(location) or result_dict.get(loc_tuple)
-    return None
+    return gate_lambda
 "#
-        );
-
-        // Create a module with the code and inject the sim and gate_name
-        let module =
-            PyModule::from_code(py, code, c_str!("gate_bindings"), c_str!("gate_bindings"))?;
-        module.setattr("sim", self.sim.clone_ref(py))?;
-        module.setattr("gate_name", &gate_name)?;
-        let gate_lambda = module.getattr("gate_lambda")?.unbind();
+            );
+            let module = PyModule::from_code(
+                py,
+                code,
+                c_str!("_pecos_gate_bindings"),
+                c_str!("_pecos_gate_bindings"),
+            )?;
+            Ok::<_, PyErr>(module.getattr("make_gate_lambda")?.unbind())
+        })?;
+        let gate_lambda = factory
+            .bind(py)
+            .call1((self.sim.clone_ref(py), &gate_name))?
+            .unbind();
 
         // Cache the lambda
         self.cache
@@ -477,7 +478,7 @@ pub fn try_clifford_batch_dispatch<S: CliffordGateable>(
         // Two-qubit Clifford gates (no return value)
         "CX" | "CNOT" | "CY" | "CZ" | "SZZ" | "SZZdg" | "SXX" | "SXXdg" | "SYY" | "SYYdg"
         | "SqrtZZ" | "SqrtZZd" | "SqrtXX" | "SqrtXXd" | "SqrtYY" | "SqrtYYd" | "SWAP" | "G"
-        | "G2" => {
+        | "G2" | "Gdg" | "ISWAP" | "ISWAPdg" => {
             let pairs = collect_pairs(locations)?;
             match symbol {
                 "CX" | "CNOT" => {
@@ -512,6 +513,15 @@ pub fn try_clifford_batch_dispatch<S: CliffordGateable>(
                 }
                 "G" | "G2" => {
                     sim.g(&pairs);
+                }
+                "Gdg" => {
+                    sim.gdg(&pairs);
+                }
+                "ISWAP" => {
+                    sim.iswap(&pairs);
+                }
+                "ISWAPdg" => {
+                    sim.iswapdg(&pairs);
                 }
                 _ => unreachable!(),
             }

--- a/python/pecos-rslib/src/sparse_stab_bindings.rs
+++ b/python/pecos-rslib/src/sparse_stab_bindings.rs
@@ -404,6 +404,18 @@ impl PySparseStab {
                 self.inner.g(pair);
                 Ok(None)
             }
+            "Gdg" => {
+                self.inner.gdg(pair);
+                Ok(None)
+            }
+            "ISWAP" => {
+                self.inner.iswap(pair);
+                Ok(None)
+            }
+            "ISWAPdg" => {
+                self.inner.iswapdg(pair);
+                Ok(None)
+            }
             "RXX" => {
                 let angle = extract_angle(params, "RXX")?;
                 self.inner

--- a/python/pecos-rslib/src/stab_bindings.rs
+++ b/python/pecos-rslib/src/stab_bindings.rs
@@ -406,6 +406,18 @@ impl PyStabilizer {
                 self.inner.g(pair);
                 Ok(None)
             }
+            "Gdg" => {
+                self.inner.gdg(pair);
+                Ok(None)
+            }
+            "ISWAP" => {
+                self.inner.iswap(pair);
+                Ok(None)
+            }
+            "ISWAPdg" => {
+                self.inner.iswapdg(pair);
+                Ok(None)
+            }
             "RXX" => {
                 let angle = extract_angle(params, "RXX")?;
                 self.inner

--- a/python/pecos-rslib/src/stab_vec_bindings.rs
+++ b/python/pecos-rslib/src/stab_vec_bindings.rs
@@ -319,6 +319,18 @@ impl PyStabVec {
                 self.inner.g(pair);
                 Ok(None)
             }
+            "Gdg" => {
+                self.inner.gdg(pair);
+                Ok(None)
+            }
+            "ISWAP" => {
+                self.inner.iswap(pair);
+                Ok(None)
+            }
+            "ISWAPdg" => {
+                self.inner.iswapdg(pair);
+                Ok(None)
+            }
             "II" => Ok(None),
 
             // Two-qubit rotation gates

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/bindings.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/bindings.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -9,7 +9,10 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-"""Specifies the symbol and function for each gate."""
+"""Specify legacy gate bindings not used by ``PauliProp``.
+
+This module is a legacy reference implementation and is not used by ``PauliProp``.
+"""
 
 from pecos.simulators.pauliprop import (
     gates_init,

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_init.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_init.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -13,6 +13,8 @@
 
 This module provides quantum state initialization operations for the Pauli fault propagation simulator, including
 functions to initialize qubits to computational basis states using efficient Pauli frame tracking.
+
+This module is a legacy reference implementation and is not used by ``PauliProp``.
 """
 
 from __future__ import annotations

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_meas.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_meas.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -13,6 +13,8 @@
 
 This module provides quantum measurement operations for the Pauli fault propagation simulator, including projective
 measurements with efficient Pauli frame updates and fault propagation tracking through measurement operations.
+
+This module is a legacy reference implementation and is not used by ``PauliProp``.
 """
 
 from __future__ import annotations

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_one_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_one_qubit.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -13,6 +13,8 @@
 
 This module provides single-qubit quantum gate operations for the Pauli fault propagation simulator, including
 Clifford gates and their effect on Pauli frame propagation for efficient stabilizer circuit simulation.
+
+This module is a legacy reference implementation and is not used by ``PauliProp``.
 """
 
 from __future__ import annotations
@@ -319,7 +321,7 @@ def H2(state: PauliProp, qubit: int, **_params: SimulatorGateParams) -> None:
     Returns: None
 
     """
-    if state.track_sign:
+    if state.track_sign and any(qubit in faults for faults in state.faults.values()):
         state.flip_sign()
 
     switch(
@@ -373,7 +375,7 @@ def H4(state: PauliProp, qubit: int, **_params: SimulatorGateParams) -> None:
     Returns: None
 
     """
-    if state.track_sign:
+    if state.track_sign and any(qubit in faults for faults in state.faults.values()):
         state.flip_sign()
 
     switch(
@@ -427,7 +429,7 @@ def H6(state: PauliProp, qubit: int, **_params: SimulatorGateParams) -> None:
     Returns: None
 
     """
-    if state.track_sign:
+    if state.track_sign and any(qubit in faults for faults in state.faults.values()):
         state.flip_sign()
 
     switch(

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_two_qubit.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/gates_two_qubit.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -13,6 +13,8 @@
 
 This module provides two-qubit quantum gate operations for the Pauli fault propagation simulator, including Clifford
 gates and their effect on Pauli frame propagation for efficient stabilizer circuit simulation with entangling gates.
+
+This module is a legacy reference implementation and is not used by ``PauliProp``.
 """
 
 from __future__ import annotations
@@ -154,21 +156,21 @@ def CY(state: PauliProp, qubits: tuple[int, int]) -> None:
     """Applies the controlled-Y gate.
 
     II -> II
-    XI -> XZ
+    XI -> XY
     ZI -> ZI
-    YI -> YZ
+    YI -> YY
     IX -> ZX
-    IZ -> IZ
-    IY -> ZY
-    XX -> YY
-    XZ -> XI
-    XY -> -YX
+    IZ -> ZZ
+    IY -> IY
+    XX -> -YZ
+    XZ -> YX
+    XY -> XI
     ZX -> IX
-    ZZ -> ZZ
-    ZY -> IY
-    YX -> -XY
-    YZ -> YI
-    YY -> XX
+    ZZ -> IZ
+    ZY -> ZY
+    YX -> XZ
+    YZ -> -XX
+    YY -> YI
 
     state (SparseStabPy): Instance representing the stabilizer state.
     qubit (int): Integer that indexes the qubit being acted on.
@@ -176,7 +178,7 @@ def CY(state: PauliProp, qubits: tuple[int, int]) -> None:
     Returns: None
 
     """
-    SZ(state, qubits[1])
+    SZdg(state, qubits[1])
     CX(state, qubits)
     SZ(state, qubits[1])
 

--- a/python/quantum-pecos/src/pecos/simulators/pauliprop/state.py
+++ b/python/quantum-pecos/src/pecos/simulators/pauliprop/state.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The PECOS Developers
+# Copyright 2026 The PECOS Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License.You may obtain a copy of the License at
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING
 from pecos_rslib.simulators import PauliProp as PauliPropRs
 
 from pecos.simulators.gate_syms import alt_symbols
-from pecos.simulators.pauliprop import bindings
 from pecos.simulators.pauliprop.logical_sign import find_logical_signs
 from pecos.simulators.sim_class_types import PauliPropagation
 
@@ -65,59 +64,33 @@ class PauliProp(PauliPropagation):
         # Use Rust backend
         self._backend = PauliPropRs(num_qubits, track_sign=track_sign)
 
-        # Set up optimized bindings for gates available in Rust backend
-        self._setup_optimized_bindings()
-
-        # Fall back to Python implementations for gates not in Rust
-        for gate, func in bindings.gate_dict.items():
-            if gate not in self.bindings:
-                self.bindings[gate] = func
-
-        # Add alternative symbols
+        self.bindings = self._backend.bindings
         for k, v in alt_symbols.items():
             if v in self.bindings:
                 self.bindings[k] = self.bindings[v]
 
-    def _setup_optimized_bindings(self) -> None:
-        """Set up direct bindings to Rust backend for supported gates."""
-        self.bindings = {}
-        backend = self._backend  # Local reference to avoid attribute lookup
+    def __getstate__(self) -> tuple[PauliPropRs]:
+        """Serialize only the backend; bindings are reconstructed after unpickling."""
+        return (self._backend,)
 
-        # Single-qubit gates - location is always an int
-        self.bindings["H"] = lambda _s, q, **_p: backend.h(q)
-        self.bindings["SX"] = lambda _s, q, **_p: backend.sx(q)
-        self.bindings["SY"] = lambda _s, q, **_p: backend.sy(q)
-        self.bindings["SZ"] = lambda _s, q, **_p: backend.sz(q)
-
-        # Two-qubit gates - location is always a tuple
-        self.bindings["CX"] = lambda _s, qs, **_p: backend.cx(
-            qs[0],
-            qs[1],
-        )
-        self.bindings["CY"] = lambda _s, qs, **_p: backend.cy(
-            qs[0],
-            qs[1],
-        )
-        self.bindings["CZ"] = lambda _s, qs, **_p: backend.cz(
-            qs[0],
-            qs[1],
-        )
-        self.bindings["SWAP"] = lambda _s, qs, **_p: backend.swap(
-            qs[0],
-            qs[1],
-        )
-
-        # Note: X, Y, Z are Pauli operators, not gates to apply to the state,
-        # so they should still use the Python implementations
+    def __setstate__(self, state: tuple[PauliPropRs]) -> None:
+        """Restore the backend and reconstruct the dynamic binding surface."""
+        (self._backend,) = state
+        self.num_qubits = self._backend.num_qubits
+        self.track_sign = self._backend.track_sign
+        self.bindings = self._backend.bindings
+        for k, v in alt_symbols.items():
+            if v in self.bindings:
+                self.bindings[k] = self.bindings[v]
 
     @property
     def faults(self) -> dict:
-        """Get the current faults dictionary."""
+        """Return a snapshot of the frame; mutate through the setter or ``add_faults``."""
         return self._backend.faults
 
     @faults.setter
     def faults(self, value: dict) -> None:
-        """Set the faults dictionary."""
+        """Replace the frame and reset its sign and imaginary phase."""
         self._backend.set_faults(value)
 
     @property

--- a/python/quantum-pecos/tests/pecos/test_gate_bindings_dict.py
+++ b/python/quantum-pecos/tests/pecos/test_gate_bindings_dict.py
@@ -1,0 +1,61 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License.You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+"""Callables handed out by a Rust-backed simulator's ``bindings`` must stay bound to their gate and simulator.
+
+The bindings dictionary builds one Python callable per gate symbol. Each callable must capture its own gate
+name and simulator instance: fetching another symbol, or the same symbol on another simulator, must not
+redirect a callable that was fetched earlier.
+"""
+
+from __future__ import annotations
+
+from pecos.simulators import SparseStab
+
+
+def _tableau_after(gate: str, location: int | tuple[int, int]) -> tuple[str, str]:
+    state = SparseStab(2)
+    state.bindings[gate](state, location)
+    return state.stab_tableau(), state.destab_tableau()
+
+
+def test_held_callable_keeps_its_gate_after_another_symbol_is_fetched() -> None:
+    state = SparseStab(2)
+    apply_h = state.bindings["H"]
+    state.bindings["CX"]
+    apply_h(state, 0)
+    assert (state.stab_tableau(), state.destab_tableau()) == _tableau_after("H", 0)
+
+
+def test_held_callable_keeps_its_simulator_after_another_instance_fetches_the_symbol() -> None:
+    first = SparseStab(2)
+    second = SparseStab(2)
+    apply_h_first = first.bindings["H"]
+    second.bindings["H"]
+    apply_h_first(first, 0)
+    untouched = SparseStab(2)
+    assert (first.stab_tableau(), first.destab_tableau()) == _tableau_after("H", 0)
+    assert (second.stab_tableau(), second.destab_tableau()) == (
+        untouched.stab_tableau(),
+        untouched.destab_tableau(),
+    )
+
+
+def test_alias_assignment_does_not_redirect_existing_callables() -> None:
+    state = SparseStab(2)
+    apply_h = state.bindings["H"]
+    state.bindings["CNOT"] = state.bindings["CX"]
+    apply_h(state, 0)
+    assert (state.stab_tableau(), state.destab_tableau()) == _tableau_after("H", 0)
+    aliased = SparseStab(2)
+    aliased.bindings["CNOT"] = aliased.bindings["CX"]
+    aliased.bindings["CNOT"](aliased, (0, 1))
+    assert (aliased.stab_tableau(), aliased.destab_tableau()) == _tableau_after("CX", (0, 1))

--- a/python/quantum-pecos/tests/pecos/test_pauli_prop_bindings.py
+++ b/python/quantum-pecos/tests/pecos/test_pauli_prop_bindings.py
@@ -1,0 +1,302 @@
+# Copyright 2026 The PECOS Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""End-to-end tests for the Rust-backed PauliProp gate binding surface."""
+
+from __future__ import annotations
+
+import itertools
+import math
+import pickle
+from dataclasses import dataclass, field
+
+import pytest
+from pecos.circuits import QuantumCircuit
+from pecos.engines.hybrid_engine_old import HybridEngine
+from pecos.simulators import PauliProp
+from pecos.simulators.pauliprop import bindings as legacy_bindings
+from pecos.simulators.pauliprop import gates_meas, gates_one_qubit, gates_two_qubit
+from pecos_rslib import CliffordRep, StabVec
+from pecos_rslib import PauliProp as RustPauliProp
+from pecos_rslib.simulators import SparseStab, Stabilizer
+
+
+@dataclass
+class LegacyOracle:
+    """Minimal mutable state accepted by the legacy Pauli propagation functions."""
+
+    track_sign: bool
+    faults: dict[str, set[int]] = field(
+        default_factory=lambda: {"X": set(), "Y": set(), "Z": set()},
+    )
+    sign: int = 0
+
+    def flip_sign(self) -> None:
+        """Toggle the tracked conjugation sign."""
+        if self.track_sign:
+            self.sign ^= 1
+
+
+def _faults_for_labels(labels: tuple[str, ...]) -> dict[str, set[int]]:
+    faults = {"X": set(), "Y": set(), "Z": set()}
+    for qubit, label in enumerate(labels):
+        if label != "I":
+            faults[label].add(qubit)
+    return faults
+
+
+def _seeded_states(labels: tuple[str, ...], *, track_sign: bool) -> tuple[PauliProp, LegacyOracle]:
+    faults = _faults_for_labels(labels)
+    state = PauliProp(num_qubits=3, track_sign=track_sign)
+    state.faults = faults
+    oracle = LegacyOracle(track_sign=track_sign, faults={key: set(value) for key, value in faults.items()})
+    return state, oracle
+
+
+def _fault_circuit(symbol: str, qubit: int) -> QuantumCircuit:
+    circuit = QuantumCircuit()
+    circuit.append(symbol, {qubit})
+    return circuit
+
+
+def _sparse_stab_tableau_image(image: object, num_qubits: int) -> str:
+    dense = image.to_dense_str(num_qubits)
+    if dense.startswith(("+i", "-i")):
+        prefix, paulis = dense[:2], dense[2:]
+    else:
+        prefix, paulis = dense[0], dense[1:]
+    phase = {"+": 0, "+i": 1, "-": 2, "-i": 3}[prefix]
+    phase = (phase + paulis.count("Y")) % 4
+    return f"{['+', '+i', '-', '-i'][phase]}{paulis}"
+
+
+def _stab_vec_amplitudes(state: StabVec) -> list[complex]:
+    return [complex(real, imaginary) for real, imaginary in state.state_vector()]
+
+
+def _state_vectors_are_equivalent(left: list[complex], right: list[complex]) -> bool:
+    pivot = next(index for index, amplitude in enumerate(right) if abs(amplitude) > 1e-12)
+    if abs(left[pivot]) <= 1e-12:
+        return False
+    phase = left[pivot] / right[pivot]
+    return left == pytest.approx([phase * amplitude for amplitude in right], abs=1e-9)
+
+
+def _pauli_expectation(amplitudes: list[complex], image: object, num_qubits: int) -> complex:
+    dense = image.to_dense_str(num_qubits)
+    if dense.startswith(("+i", "-i")):
+        prefix, paulis = dense[:2], dense[2:]
+    else:
+        prefix, paulis = dense[0], dense[1:]
+    phase = {"+": 1, "+i": 1j, "-": -1, "-i": -1j}[prefix]
+    expectation = 0j
+    for source, amplitude in enumerate(amplitudes):
+        target = source
+        coefficient = phase
+        for qubit, pauli in enumerate(paulis):
+            bit = (source >> qubit) & 1
+            if pauli == "X":
+                target ^= 1 << qubit
+            elif pauli == "Y":
+                coefficient *= -1j if bit else 1j
+                target ^= 1 << qubit
+            elif pauli == "Z" and bit:
+                coefficient *= -1
+        expectation += amplitudes[target].conjugate() * coefficient * amplitude
+    return expectation
+
+
+SUPPORTED_LEGACY_SYMBOLS = tuple(
+    symbol for symbol in legacy_bindings.gate_dict if symbol not in {"force output", "check", "measure"}
+)
+
+
+@pytest.mark.parametrize("track_sign", [True, False])
+@pytest.mark.parametrize("symbol", SUPPORTED_LEGACY_SYMBOLS)
+def test_every_legacy_symbol_dispatches_like_the_fixed_reference(symbol: str, track_sign: bool) -> None:
+    """Every formerly exposed legacy gate has matching frame, sign, and measurement behavior."""
+    legacy_gate = legacy_bindings.gate_dict[symbol]
+    is_two_qubit = legacy_gate.__module__.endswith("gates_two_qubit")
+    configurations = itertools.product("IXYZ", repeat=2 if is_two_qubit else 1)
+    location: int | tuple[int, int] = (0, 1) if is_two_qubit else 0
+
+    for labels in configurations:
+        state, oracle = _seeded_states(labels, track_sign=track_sign)
+        rust_result = state.bindings[symbol](state, location)
+        legacy_result = legacy_gate(oracle, location)
+
+        assert state.faults == oracle.faults, (symbol, labels, track_sign)
+        assert state.sign == oracle.sign, (symbol, labels, track_sign)
+        if legacy_gate.__module__.endswith("gates_meas"):
+            # Batch false outcomes are None while per-location false outcomes are 0.
+            assert (rust_result or 0) == (legacy_result or 0), (symbol, labels, track_sign)
+
+
+def test_zero_measurement_output_convention_depends_on_dispatch_path() -> None:
+    """Record the existing batch-versus-per-location zero-outcome convention."""
+    state = RustPauliProp(1)
+    assert state.bindings["measure Z"](state, 0) is None
+    assert state.bindings["measure X"](state, 0) == 0
+
+
+@pytest.mark.parametrize("symbol", ["force output", "check", "measure"])
+def test_legacy_symbols_without_rust_meaning_are_rejected(symbol: str) -> None:
+    """Legacy operations with no frame-propagation meaning never silently succeed."""
+    state = PauliProp(num_qubits=2)
+    with pytest.raises(ValueError, match="Unsupported gate"):
+        state.bindings[symbol](state, 0)
+    with pytest.raises(ValueError, match="Unsupported gate"):
+        state.bindings[symbol](state, 0, simulate_gate=False)
+
+
+def test_clifford_rotations_lower_through_bindings() -> None:
+    """Parameterized bindings use the Rust Clifford-rotation lowering path."""
+    cases = [
+        ("RZ", {"angle": -math.pi / 2}, "SZdg", 0),
+        ("RX", {"angle": math.pi}, "X", 0),
+        ("RZZ", {"angle": math.pi / 2}, "SZZ", (0, 1)),
+    ]
+    for rotation, params, named_gate, location in cases:
+        rotated, _ = _seeded_states(("Y", "X"), track_sign=True)
+        named, _ = _seeded_states(("Y", "X"), track_sign=True)
+        rotated.bindings[rotation](rotated, location, **params)
+        named.bindings[named_gate](named, location)
+        assert rotated.faults == named.faults
+        assert rotated.sign == named.sign
+
+    state, _ = _seeded_states(("Y",), track_sign=True)
+    with pytest.raises(ValueError, match="is not a Clifford rotation"):
+        state.bindings["RZ"](state, 0, angle=0.5)
+
+
+def test_forced_outcome_parameters_do_not_change_frame_semantics() -> None:
+    """Pauli-frame preparations clear and measurements report the frame regardless of forced outcomes."""
+    state, _ = _seeded_states(("Y", "Z"), track_sign=True)
+    state.flip_sign()
+    state.bindings["init |0>"](state, 0, forced_outcome=1)
+    assert state.faults == {"X": set(), "Y": set(), "Z": {1}}
+    assert state.sign == 1
+
+    state.faults = {"X": {0}, "Y": set(), "Z": set()}
+    result = state.bindings["measure Z"](state, 0, forced_outcome=0)
+    assert result == 1
+    assert state.faults == {"X": {0}, "Y": set(), "Z": set()}
+
+
+def test_hybrid_engine_user_scenario_matches_legacy_reference() -> None:
+    """The legacy engine drives H, CX, SZdg, and measure Z through Rust bindings."""
+    state, oracle = _seeded_states(("X", "I"), track_sign=True)
+    circuit = QuantumCircuit(cvar_spec={"m": 1}, num_qubits=2)
+    circuit.append("H", {0})
+    circuit.append("CX", {(0, 1)})
+    circuit.append("SZdg", {1})
+    circuit.append("measure Z", {1}, var_output={1: ("m", 0)})
+
+    output, _ = HybridEngine().run(state, circuit, shot_id=0)
+
+    gates_one_qubit.H(oracle, 0)
+    gates_two_qubit.CX(oracle, (0, 1))
+    gates_one_qubit.SZdg(oracle, 1)
+    expected_outcome = gates_meas.meas_z(oracle, 1)
+    assert state.faults == oracle.faults
+    assert state.sign == oracle.sign
+    assert output["m"][0] == expected_outcome
+
+
+def test_faults_property_is_a_snapshot_and_assignment_resets_phase() -> None:
+    """Fault replacement is the mutation boundary and resets sign and imaginary phase."""
+    state = PauliProp(num_qubits=2, track_sign=True)
+    state.add_faults(_fault_circuit("X", 0))
+    state.add_faults(_fault_circuit("Z", 0))
+    assert (state.sign, state.img) == (1, 1)
+
+    snapshot = state.faults
+    snapshot["X"].add(1)
+    assert state.faults == {"X": set(), "Y": {0}, "Z": set()}
+
+    state.faults = {"Z": {1}}
+    assert state.faults == {"X": set(), "Y": set(), "Z": {1}}
+    assert (state.sign, state.img) == (0, 0)
+
+
+def test_wrapper_pickle_round_trip_restores_bindings() -> None:
+    """Wrapper state and its dynamic binding surface survive pickling."""
+    state, _ = _seeded_states(("Y", "Z"), track_sign=True)
+    state.flip_sign()
+    restored = pickle.loads(pickle.dumps(state))
+
+    assert restored.faults == state.faults
+    assert (restored.sign, restored.img) == (state.sign, state.img)
+    restored.bindings["H"](restored, 0)
+    state.bindings["H"](state, 0)
+    assert restored.faults == state.faults
+    assert restored.sign == state.sign
+
+
+@pytest.mark.parametrize(
+    ("symbol", "rep"),
+    [
+        ("ISWAP", CliffordRep.iswap(0, 1)),
+        ("ISWAPdg", CliffordRep.iswap(0, 1).inverse()),
+        ("Gdg", CliffordRep.g(0, 1)),
+    ],
+)
+@pytest.mark.parametrize("simulator", [SparseStab, Stabilizer])
+def test_shared_dispatch_arms_match_clifford_rep_on_tableau_simulators(
+    symbol: str,
+    rep: CliffordRep,
+    simulator: type,
+) -> None:
+    """Batch and parameterized paths produce the exact CliffordRep tableau images."""
+    z_state = simulator(2)
+    z_parameterized = simulator(2)
+    z_state.bindings[symbol](z_state, (0, 1))
+    z_parameterized.bindings[symbol](z_parameterized, (0, 1), simulate_gate=True)
+    expected_z_images = "".join(f"{_sparse_stab_tableau_image(rep.z_image(q), 2)}\n" for q in range(2))
+    assert z_state.stab_tableau() == expected_z_images
+    assert z_parameterized.stab_tableau() == expected_z_images
+
+    x_state = simulator(2)
+    x_parameterized = simulator(2)
+    x_state.bindings["H"](x_state, 0)
+    x_state.bindings["H"](x_state, 1)
+    x_parameterized.bindings["H"](x_parameterized, 0)
+    x_parameterized.bindings["H"](x_parameterized, 1)
+    x_state.bindings[symbol](x_state, (0, 1))
+    x_parameterized.bindings[symbol](x_parameterized, (0, 1), simulate_gate=True)
+    expected_x_images = "".join(f"{_sparse_stab_tableau_image(rep.x_image(q), 2)}\n" for q in range(2))
+    assert x_state.stab_tableau() == expected_x_images
+    assert x_parameterized.stab_tableau() == expected_x_images
+
+
+@pytest.mark.parametrize(
+    ("symbol", "rep"),
+    [
+        ("ISWAP", CliffordRep.iswap(0, 1)),
+        ("ISWAPdg", CliffordRep.iswap(0, 1).inverse()),
+        ("Gdg", CliffordRep.g(0, 1)),
+    ],
+)
+def test_shared_dispatch_arms_match_clifford_rep_on_stab_vec(symbol: str, rep: CliffordRep) -> None:
+    """StabVec batch and parameterized paths agree and satisfy transformed stabilizers."""
+    batch = StabVec(2)
+    parameterized = StabVec(2)
+    batch.bindings["H"](batch, 0)
+    parameterized.bindings["H"](parameterized, 0)
+    batch.bindings[symbol](batch, (0, 1))
+    parameterized.bindings[symbol](parameterized, (0, 1), simulate_gate=True)
+
+    batch_amplitudes = _stab_vec_amplitudes(batch)
+    parameterized_amplitudes = _stab_vec_amplitudes(parameterized)
+    assert _state_vectors_are_equivalent(batch_amplitudes, parameterized_amplitudes)
+    assert _pauli_expectation(batch_amplitudes, rep.x_image(0), 2) == pytest.approx(1, abs=1e-9)
+    assert _pauli_expectation(batch_amplitudes, rep.z_image(1), 2) == pytest.approx(1, abs=1e-9)


### PR DESCRIPTION
## Summary

Closes #625. The Rust-backed Python `PauliProp` wrapper (`pecos.simulators.PauliProp`, alias `PauliFaultProp`) now executes every gate correctly through `state.bindings[symbol](...)`, which is how the engines drive simulators. On `dev`:

- the Rust-bound gates (`H`, `SX`, `SY`, `SZ`, `CX`, `CY`, `CZ`, `SWAP`) raised `TypeError` (scalar operands passed to list-taking pyo3 methods);
- every other Clifford fell back to the pure-Python gate functions, which mutate a `faults` dict that the wrapper rebuilds from the backend on every access, so support changes were discarded while `flip_sign()` calls still landed -- a corrupt partial result;
- the Rust `PauliProp` never updated the conjugation sign under `with_sign_tracking`, so the public `sign` was wrong after any Clifford gate.

## Changes

- `crates/pecos-simulators/src/pauli_prop.rs`: sign-correct propagation (`C P C^dagger = +/- P'`) for every named Clifford in `CliffordGateable` when sign tracking is on, inert when off; preparations clear the tracked Pauli on the qubit (no measure-and-correct); `mx`/`my`/`mz` (and the negative-basis variants) report whether an anticommuting Pauli is present without mutating the frame; `mp*` report that outcome and then clear. `BitmaskPauliProp` gets the same preparation semantics so the two Pauli-frame backends stay equivalent, and the cross-check tests now cover preparations. Pinned exhaustively against `pecos_core::CliffordRep` for every gate and every input Pauli (4 single-qubit, 16 two-qubit), with and without sign tracking. The `PauliProp::new()` consumers in `pecos-qec` are unaffected (they never call the preparation or `mx`/`my` defaults and the sign branch is inert without sign tracking).
- `python/pecos-rslib/src/pauli_prop_bindings.rs`: the same dispatch surface the other Rust-backed simulators have (`run_gate`, `run_1q_gate`, `run_2q_gate`, `bindings`) through the shared `try_clifford_batch_dispatch`, including the Clifford rotation arms (`RZ RX RY RXY1Q U`, `RXX RYY RZZ RXXRYYRZZ`; not `CRZ`, see #626). Legacy `force output`, `check`, and general-Pauli `measure` raise the unsupported-gate error instead of doing nothing.
- `python/pecos-rslib/src/simulator_utils.rs`: `Gdg`, `ISWAP`, `ISWAPdg` arms added to the shared batch dispatcher and to the per-location arms of `SparseStab`, `Stabilizer`, and `StabVec` (trait methods every simulator has; both paths verified against `CliffordRep`); the gate-callable factory is compiled once into a private module instead of re-executed into `sys.modules["gate_bindings"]` on every lookup; `GateBindingsDict` builds each gate callable through a closure factory instead of module globals. This fixes a pre-existing defect affecting every Rust-backed simulator: the old implementation stored `sim` and `gate_name` as globals of one shared module, so any callable a caller HELD was silently redirected by the next `bindings[...]` lookup -- to a different gate (reproduced on `dev`: fetch `H`, fetch `CX`, call the held `H` -> `CX` executes) or to a different simulator instance (fetch `H` on `sim1`, fetch `H` on `sim2`, call the held `sim1` callable -> it acts on `sim2`). The engines' fetch-then-call-immediately pattern was unaffected, which is why the suite never saw it; anything that caches or aliases bindings was. Pinned by `tests/pecos/test_gate_bindings_dict.py`. The callable's return extraction also changed for every simulator: an integer location is looked up explicitly (an int-keyed `0` outcome now returns `0` instead of falling through the old `get(location) or get(loc_tuple)` to `None`), and a list location no longer risks `TypeError` from `dict.get([...])`.
- `pecos/simulators/pauliprop/state.py`: `bindings` is the backend's `GateBindingsDict` plus `alt_symbols`, as `SparseStabPy` does; the pure-Python fallback merge and `_setup_optimized_bindings` are gone; `faults` is documented as a snapshot (assigning it resets sign/img, pinned by a test); pickling round-trips the wrapper.
- Legacy pure-Python gate modules (`gates_one_qubit.py`, `gates_two_qubit.py`, `gates_init.py`, `gates_meas.py`, `bindings.py`) stay as a documented reference implementation, with four sign bugs fixed: `H2`/`H4`/`H6` flipped the sign on identity; `CY` was `SZ; CX; SZ` where PECOS's is `SZdg; CX; SZ`. They are no longer used by `PauliProp`.
- Doc fix: the `SX`/`SXdg` prose tables on `CliffordGateable` had their signs reversed relative to the code.
- Tests: `tests/pecos/test_pauli_prop_bindings.py` (99 tests) runs every legacy `gate_dict` symbol through `bindings` on the wrapper against the fixed legacy functions on a mutable oracle object, for every Pauli configuration on the involved qubits, sign tracking on and off; rotations through `bindings`; the legacy `HybridEngine` scenario; setter and pickle. The Rust exhaustive test against `CliffordRep` is the tiebreaker; there is no residual disagreement.

## Not in this PR

- Measurement outcomes of 0 come back as `None` from the batch dispatch path and `0` from the per-location path on every Rust-backed simulator (pre-existing; the engines normalize). Pinned as current behavior by a test here; filed separately.

- `run_circuit` still ignores its `_apply_faults` argument (pre-existing; separate).
- Removing the legacy pure-Python modules (a separate decision; they are exported as `pecos.simulators.pauliprop.bindings`).

## Verification

Cold in a fresh worktree: `cargo test -p pecos-simulators -p pecos-core -p pecos-engines -p pecos-qec`, clippy `-D warnings` on the five touched crates (files touched first), `cargo fmt --check`, the fast Python lane, the new module, `pecos-rslib` tests, `pre-commit run --all-files`. Reviewed by a read-only pass of the task packet against the tree (which caught that the legacy Python functions were not a valid oracle), hunk review, and a fresh-context review of the finished tree.
