### PR TITLE
Restore the zluppy test suite to current zlup syntax and give it a CI lane

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,6 +23,8 @@ on:
       - 'python/**'
       - 'examples/**'
       - 'crates/**'
+      - 'exp/zlup/**'
+      - 'exp/zluppy/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
@@ -40,6 +42,8 @@ on:
       - 'python/**'
       - 'examples/**'
       - 'crates/**'
+      - 'exp/zlup/**'
+      - 'exp/zluppy/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
@@ -228,7 +232,9 @@ jobs:
 
     - name: Validate Python lockfile (PR fast path)
       if: github.event_name == 'pull_request'
-      run: uv lock --check --project .
+      run: |
+        uv lock --check --project .
+        uv lock --check --project exp/zluppy
 
   python-compat-smoke-build:
     runs-on: ${{ matrix.os }}
@@ -669,6 +675,87 @@ jobs:
 
     - name: Run slow Python tests
       run: just pytest-slow
+
+  zluppy-postmerge:
+    if: (github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name)) || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PECOS_BUILD_MWPF: "1"
+    steps:
+    - name: Harden the runner (egress audit)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        tool-cache: false
+        swap-storage: true
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: "3.14"
+
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version-file: ".github/uv.toml"
+        enable-cache: true
+        save-cache: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
+
+    - name: Set up Rust
+      run: |
+        bash scripts/ci/ensure-rust.sh stable minimal
+        export PATH="$HOME/.cargo/bin:$PATH"
+        rustup show
+
+    - name: Verify cmake is available (MWPF decoder build)
+      run: cmake --version
+
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+    - name: Cache Rust
+      uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+      with:
+        cache-bin: false
+        prefix-key: v1-rust-no-bin
+        save-if: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
+        workspaces: |
+          python/pecos-rslib
+          python/pecos-rslib-llvm
+
+    - name: Cache LLVM ${{ env.LLVM_VERSION }}
+      id: cache-llvm-zluppy
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.pecos/deps/llvm-21.1
+        key: llvm-${{ env.LLVM_RELEASE_VERSION }}-${{ runner.os }}-${{ runner.arch }}-v3
+
+    - name: Ensure LLVM ${{ env.LLVM_VERSION }}
+      run: just ci-env
+
+    - name: Save LLVM ${{ env.LLVM_VERSION }} cache
+      if: steps.cache-llvm-zluppy.outputs.cache-hit != 'true' && github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name)
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.pecos/deps/llvm-21.1
+        key: ${{ steps.cache-llvm-zluppy.outputs.cache-primary-key }}
+
+    - name: Run zluppy Python tests
+      run: just pytest-zluppy
 
   windows-vanilla-cargo:
     name: Windows vanilla cargo (crates.io consumer contract)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,27 +1058,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
+checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
+checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
+checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
+checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
+checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
+checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1141,24 +1141,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
+checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
+checksum = "e61dfa0766c0eadf42b3febd145a35f81f31086e207f534e5fb406fc3d08fc47"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
+checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
+checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1181,15 +1181,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
+checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
+checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
+checksum = "4b3f161aa81ee5dd8d7b0eb8828988f57baf2f78d288e62b6b3714b37aa6d6a1"
 
 [[package]]
 name = "crc32fast"
@@ -5405,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
+checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5417,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
+checksum = "3e902032e329008b189b67498b1be7784d5849276f32402eca17441df08a6bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7897,9 +7897,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
+checksum = "d39226663bd765601279a79b88645a7c4a4d3c2fe73040afdc27bead02ee6659"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
+checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7967,15 +7967,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
+checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
+checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -7984,9 +7984,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
+checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -8011,9 +8011,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
+checksum = "a000d1124dd40417ce8433d07de1063ecc9be7cac21745c8de7f9cf7684c3ead"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8026,9 +8026,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
+checksum = "a7439956e78ba68e2cd766f34c3f056d625fad9a055eafb0c4569ac91c09e6b4"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -8036,9 +8036,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
+checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8048,9 +8048,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
+checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -8061,9 +8061,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
+checksum = "51e06f9fabbe647e5c2ed186e6920ab1fb48174688d7d3fdadbda537b8499b51"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Justfile
+++ b/Justfile
@@ -312,6 +312,12 @@ pytest-ci-core:
     uv run --frozen pytest -n auto python/quantum-pecos/tests -m "not optional_dependency and not slow"
     uv run --frozen pytest -n auto python/pecos-rslib-exp/tests
 
+# Run the experimental zluppy package's independent Python test project.
+[group('test')]
+pytest-zluppy:
+    uv sync --project exp/zluppy --frozen
+    uv run --project exp/zluppy --frozen pytest exp/zluppy/tests
+
 # Build and import the core Python packages on a target platform/interpreter.
 [group('test')]
 python-ci-smoke profile="debug": (validate-profile "python-ci-smoke" profile) (python-ci-build profile)

--- a/exp/zlup/src/ast.rs
+++ b/exp/zlup/src/ast.rs
@@ -636,65 +636,85 @@ pub struct GateOp {
     pub location: Option<SourceLocation>,
 }
 
-/// Gate types (matches SLR GateKind).
-/// Note: Gate names like SXX, RZZ use uppercase for clarity with quantum conventions.
-#[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum GateKind {
+macro_rules! gate_kinds {
+    ($($variant:ident => $keyword:literal),+ $(,)?) => {
+        /// Gate types (matches SLR GateKind).
+        /// Note: Gate names like SXX, RZZ use uppercase for clarity with quantum conventions.
+        #[allow(clippy::upper_case_acronyms)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        pub enum GateKind {
+            $($variant),+
+        }
+
+        impl GateKind {
+            /// Every variant in declaration order.
+            pub const ALL: &[GateKind] = &[$(GateKind::$variant),+];
+
+            /// Canonical zlup source keyword for this gate.
+            pub fn keyword(&self) -> &'static str {
+                match self {
+                    $(GateKind::$variant => $keyword),+
+                }
+            }
+        }
+    };
+}
+
+gate_kinds! {
     // Single-qubit Paulis
-    X,
-    Y,
-    Z,
+    X => "x",
+    Y => "y",
+    Z => "z",
 
     // Hadamard
-    H,
+    H => "h",
 
     // T gates (fourth root of Z)
-    T,
-    Tdg,
+    T => "t",
+    Tdg => "tdg",
 
     // Square root gates (SZ is the S gate / sqrt(Z))
-    SX,
-    SY,
-    SZ,
-    SXdg,
-    SYdg,
-    SZdg,
+    SX => "sx",
+    SY => "sy",
+    SZ => "sz",
+    SXdg => "sxdg",
+    SYdg => "sydg",
+    SZdg => "szdg",
 
     // Rotation gates (parameterized)
-    RX,
-    RY,
-    RZ,
+    RX => "rx",
+    RY => "ry",
+    RZ => "rz",
 
     // Two-qubit gates
-    CX,
-    CY,
-    CZ,
-    CH,
-    SWAP,
-    ISWAP,
+    CX => "cx",
+    CY => "cy",
+    CZ => "cz",
+    CH => "ch",
+    SWAP => "swap",
+    ISWAP => "iswap",
 
     // Two-qubit rotation gates
-    SXX,
-    SYY,
-    SZZ,
-    SXXdg,
-    SYYdg,
-    SZZdg,
-    CRZ,
-    RZZ,
+    SXX => "sxx",
+    SYY => "syy",
+    SZZ => "szz",
+    SXXdg => "sxxdg",
+    SYYdg => "syydg",
+    SZZdg => "szzdg",
+    CRZ => "crz",
+    RZZ => "rzz",
 
     // Three-qubit gates
-    CCX, // Toffoli gate
+    CCX => "ccx", // Toffoli gate
 
     // Face rotations
-    F,
-    Fdg,
-    F4,
-    F4dg,
+    F => "f",
+    Fdg => "fdg",
+    F4 => "f4",
+    F4dg => "f4dg",
 
     // Prepare/reset operations (pz = prepare Z, reset to |0⟩)
-    PZ,
+    PZ => "pz",
 }
 
 impl GateKind {

--- a/exp/zlup/src/codegen/hugr.rs
+++ b/exp/zlup/src/codegen/hugr.rs
@@ -48,6 +48,9 @@ pub enum HugrError {
     #[error("unknown gate '{name}'")]
     UnknownGate { name: String },
 
+    #[error("HUGR codegen supports only gate calls; call to '{name}' is unsupported")]
+    UnsupportedCall { name: String },
+
     #[error("undefined qubit '{name}'")]
     UndefinedQubit { name: String },
 
@@ -153,8 +156,6 @@ enum GateMapping {
     F4,
     /// F4 dagger
     F4dg,
-    /// Mid-circuit measurement (returns classical bit, keeps qubit)
-    MidMeasure,
 }
 
 /// Maps Zluppy gate names to gate operations.
@@ -167,11 +168,10 @@ enum GateMapping {
 /// - Square root: sx, sxdg, sy, sydg, sz, szdg (sqrt of X, Y, and Z)
 /// - T gates: t, tdg (fourth root of Z)
 /// - F gates: f, fdg, f4, f4dg (Clifford face rotations)
-/// - Rotation: rx, ry, rz (single-qubit), crz, rzz (two-qubit)
+/// - Rotation: rx, ry, rz (single-qubit), rzz (two-qubit)
 /// - Two-qubit: cx, cy, cz, ch, swap, iswap
 /// - Two-qubit Ising: sxx, syy, szz, sxxdg, syydg, szzdg
 /// - Three-qubit: ccx
-/// - Measurement: mz (Z-basis measurement)
 /// - State preparation: pz (prepare +Z eigenstate)
 ///
 /// Composite gates (decomposed):
@@ -239,9 +239,6 @@ fn gate_name_to_mapping(name: &str) -> Option<GateMapping> {
         "fdg" => Some(GateMapping::Fdg),
         "f4" => Some(GateMapping::F4),
         "f4dg" => Some(GateMapping::F4dg),
-
-        // Mid-circuit measurement in Z basis (keeps qubit alive)
-        "mz" => Some(GateMapping::MidMeasure),
 
         // Prepare +Z eigenstate (reset)
         "pz" => Some(GateMapping::Direct(TketOp::Reset)),
@@ -691,6 +688,8 @@ impl HugrCodegen {
         match stmt {
             Stmt::Binding(binding) => self.collect_binding(binding)?,
             Stmt::Expr(expr_stmt) => self.collect_expr(&expr_stmt.expr)?,
+            Stmt::Gate(gate) => self.collect_gate_op(gate)?,
+            Stmt::Prepare(prepare) => self.collect_prepare_op(prepare)?,
             // Tick blocks - flatten operations (HUGR doesn't have native parallel blocks)
             Stmt::Tick(tick_stmt) => {
                 for inner_stmt in &tick_stmt.body {
@@ -788,7 +787,10 @@ impl HugrCodegen {
 
     fn collect_expr(&mut self, expr: &Expr) -> HugrResult<()> {
         match expr {
-            Expr::Call(call) => self.collect_call(call)?,
+            // HUGR lowering does not yet represent ordinary function calls.
+            // Reject them so user code cannot silently disappear from the circuit.
+            Expr::Call(call) => self.reject_unsupported_call(call)?,
+            Expr::Gate(gate) => self.collect_gate_expr(gate)?,
             Expr::Binary(binary) => {
                 self.collect_expr(&binary.left)?;
                 self.collect_expr(&binary.right)?;
@@ -798,14 +800,100 @@ impl HugrCodegen {
         Ok(())
     }
 
+    fn collect_gate_expr(&mut self, gate: &crate::ast::GateExpr) -> HugrResult<()> {
+        if gate.kind == crate::ast::GateKind::PZ
+            && let Expr::Ident(ident) = &gate.target
+        {
+            let allocator =
+                self.allocators
+                    .get(&ident.name)
+                    .ok_or_else(|| HugrError::AllocatorNotFound {
+                        name: ident.name.clone(),
+                    })?;
+            for index in 0..allocator.capacity {
+                self.operations.push(GateOp::Direct {
+                    op: TketOp::Reset,
+                    qubits: vec![QubitRef::new(&ident.name, index)],
+                    angle: None,
+                });
+            }
+            return Ok(());
+        }
+
+        let targets = match &gate.target {
+            Expr::Tuple(tuple) => tuple.elements.clone(),
+            target => vec![target.clone()],
+        };
+        self.collect_named_gate(gate.kind.keyword(), &gate.params, targets)
+    }
+
+    fn collect_gate_op(&mut self, gate: &crate::ast::GateOp) -> HugrResult<()> {
+        let targets = gate
+            .targets
+            .iter()
+            .cloned()
+            .map(|target| Expr::SlotRef(Box::new(target)))
+            .collect();
+        self.collect_named_gate(gate.kind.keyword(), &gate.params, targets)
+    }
+
+    fn collect_named_gate(
+        &mut self,
+        name: &str,
+        params: &[Expr],
+        targets: Vec<Expr>,
+    ) -> HugrResult<()> {
+        let mut args = params.to_vec();
+        args.extend(targets);
+        self.collect_call(&CallExpr {
+            callee: Expr::Ident(crate::ast::Ident {
+                name: name.to_string(),
+                location: None,
+            }),
+            args,
+            location: None,
+        })
+    }
+
+    fn reject_unsupported_call(&self, call: &CallExpr) -> HugrResult<()> {
+        let name = self.extract_call_name(&call.callee)?;
+        Err(HugrError::UnsupportedCall { name })
+    }
+
+    fn collect_prepare_op(&mut self, prepare: &crate::ast::PrepareOp) -> HugrResult<()> {
+        let allocator = self.allocators.get(&prepare.allocator).ok_or_else(|| {
+            HugrError::AllocatorNotFound {
+                name: prepare.allocator.clone(),
+            }
+        })?;
+        let slots = prepare
+            .slots
+            .clone()
+            .unwrap_or_else(|| (0..allocator.capacity as u32).collect());
+        for index in slots {
+            let index = index as usize;
+            if index >= allocator.capacity {
+                return Err(HugrError::QubitIndexOutOfBounds {
+                    index,
+                    capacity: allocator.capacity,
+                });
+            }
+            self.operations.push(GateOp::Direct {
+                op: TketOp::Reset,
+                qubits: vec![QubitRef::new(&prepare.allocator, index)],
+                angle: None,
+            });
+        }
+        Ok(())
+    }
+
     fn collect_call(&mut self, call: &CallExpr) -> HugrResult<()> {
         // Check if this is a gate call
         let name = self.extract_call_name(&call.callee)?;
 
-        // Skip non-gate calls
+        // Named-gate lowering must resolve through the canonical HUGR mapping.
         let Some(mapping) = gate_name_to_mapping(&name) else {
-            // Could be a method call like child()
-            return Ok(());
+            return Err(HugrError::UnknownGate { name });
         };
 
         match mapping {
@@ -1374,33 +1462,6 @@ impl HugrCodegen {
                     angle: Some(-std::f64::consts::FRAC_PI_4),
                 });
             }
-
-            GateMapping::MidMeasure => {
-                // Typed measurement: mz(type, target) or mz(type, &[targets])
-                // Also supports legacy mz(qubit)
-                if call.args.len() == 2 {
-                    // New typed syntax: mz(type, target)
-                    let target_arg = &call.args[1];
-                    let qubits = self.extract_measurement_targets(target_arg)?;
-                    for qubit in qubits {
-                        let result_var = format!("__measure_{}", self.operations.len());
-                        self.operations
-                            .push(GateOp::MidMeasure { qubit, result_var });
-                    }
-                } else if call.args.len() == 1 {
-                    // Legacy syntax: mz(qubit)
-                    let qubit = self.extract_qubit_ref(&call.args[0])?;
-                    let result_var = format!("__measure_{}", self.operations.len());
-                    self.operations
-                        .push(GateOp::MidMeasure { qubit, result_var });
-                } else {
-                    return Err(HugrError::WrongArgumentCount {
-                        gate: name,
-                        expected: 2,
-                        got: call.args.len(),
-                    });
-                }
-            }
         }
 
         Ok(())
@@ -1459,6 +1520,21 @@ impl HugrCodegen {
     fn extract_qubit_ref(&self, expr: &Expr) -> HugrResult<QubitRef> {
         match expr {
             Expr::Index(index_expr) => self.extract_qubit_from_index(index_expr),
+            Expr::SlotRef(slot_ref) => {
+                let index = self.extract_integer(&slot_ref.index)?;
+                let allocator = self.allocators.get(&slot_ref.allocator).ok_or_else(|| {
+                    HugrError::AllocatorNotFound {
+                        name: slot_ref.allocator.clone(),
+                    }
+                })?;
+                if index >= allocator.capacity {
+                    return Err(HugrError::QubitIndexOutOfBounds {
+                        index,
+                        capacity: allocator.capacity,
+                    });
+                }
+                Ok(QubitRef::new(&slot_ref.allocator, index))
+            }
             _ => Err(HugrError::UnsupportedExpression),
         }
     }
@@ -1499,6 +1575,13 @@ impl HugrCodegen {
         match expr {
             Expr::IntLit(lit) => Ok(lit.value as f64),
             Expr::FloatLit(lit) => Ok(lit.value),
+            Expr::AngleLit(angle) => {
+                let value = self.extract_angle(&angle.value)?;
+                match angle.unit {
+                    crate::ast::AngleUnit::Turns => Ok(value * std::f64::consts::TAU),
+                    crate::ast::AngleUnit::Rad => Ok(value),
+                }
+            }
             // Handle expressions like PI / 4
             Expr::Binary(binary) => {
                 let left = self.extract_angle(&binary.left)?;
@@ -2130,6 +2213,62 @@ mod tests {
         codegen.compile(&program)
     }
 
+    fn collect_operations(source: &str) -> Vec<GateOp> {
+        let program = parse(source).expect("parse failed");
+        let mut codegen = HugrCodegen::new();
+        codegen
+            .collect_program(&program)
+            .expect("collection failed");
+        codegen.operations
+    }
+
+    fn assert_direct_operation(
+        operation: &GateOp,
+        expected_op: TketOp,
+        expected_qubits: &[QubitRef],
+        expected_angle: Option<f64>,
+    ) {
+        let GateOp::Direct { op, qubits, angle } = operation else {
+            panic!("expected direct operation, got {operation:?}");
+        };
+        assert_eq!(*op, expected_op);
+        assert_eq!(qubits, expected_qubits);
+        match (angle, expected_angle) {
+            (Some(actual), Some(expected)) => {
+                assert!((actual - expected).abs() < f64::EPSILON);
+            }
+            (None, None) => {}
+            _ => panic!("expected angle {expected_angle:?}, got {angle:?}"),
+        }
+    }
+
+    fn slot_ref(allocator: &str, index: i128) -> crate::ast::SlotRef {
+        crate::ast::SlotRef {
+            allocator: allocator.to_string(),
+            index: Box::new(Expr::IntLit(crate::ast::IntLit {
+                value: index,
+                suffix: None,
+                location: None,
+            })),
+            location: None,
+        }
+    }
+
+    fn insert_builder_statements(program: &mut Program, statements: Vec<Stmt>) {
+        let main = program
+            .declarations
+            .iter_mut()
+            .find_map(|decl| match decl {
+                TopLevelDecl::Fn(function) if function.name == "main" => Some(function),
+                _ => None,
+            })
+            .expect("main function");
+        let insertion_index = main.body.statements.len() - 1;
+        main.body
+            .statements
+            .splice(insertion_index..insertion_index, statements);
+    }
+
     #[test]
     fn test_empty_program() {
         let hugr = compile_to_hugr("").unwrap();
@@ -2138,14 +2277,36 @@ mod tests {
 
     #[test]
     fn test_single_qubit_gate() {
-        let source = r#"
+        let mut program = parse(
+            r#"
             pub fn main() -> unit {
                 mut q := qalloc(1);
-                h q[0];
+                return unit;
             }
-        "#;
+        "#,
+        )
+        .expect("parse failed");
+        insert_builder_statements(
+            &mut program,
+            vec![Stmt::Gate(crate::ast::GateOp {
+                kind: crate::ast::GateKind::H,
+                targets: vec![slot_ref("q", 0)],
+                params: Vec::new(),
+                attrs: Vec::new(),
+                location: None,
+            })],
+        );
+        let mut codegen = HugrCodegen::new();
+        codegen.collect_program(&program).unwrap();
+        assert_eq!(codegen.operations.len(), 1);
+        assert_direct_operation(
+            &codegen.operations[0],
+            TketOp::H,
+            &[QubitRef::new("q", 0)],
+            None,
+        );
 
-        let hugr = compile_to_hugr(source).unwrap();
+        let hugr = codegen.build_hugr().unwrap();
         // Should have input, h gate, output nodes
         assert!(hugr.num_nodes() >= 3);
     }
@@ -2160,6 +2321,16 @@ mod tests {
             }
         "#;
 
+        let operations = collect_operations(source);
+        assert_eq!(operations.len(), 2);
+        assert_direct_operation(&operations[0], TketOp::H, &[QubitRef::new("q", 0)], None);
+        assert_direct_operation(
+            &operations[1],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+
         let hugr = compile_to_hugr(source).unwrap();
         // Should have input, h, cx, output nodes
         assert!(hugr.num_nodes() >= 4);
@@ -2170,7 +2341,7 @@ mod tests {
         let source = r#"
             pub fn main() -> unit {
                 mut q := qalloc(1);
-                rz(1.57, q[0]);
+                rz(1.57) q[0];
             }
         "#;
 
@@ -2201,6 +2372,19 @@ mod tests {
                 ccx (q[0], q[1], q[2]);
             }
         "#;
+
+        let operations = collect_operations(source);
+        assert_eq!(operations.len(), 1);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::Toffoli,
+            &[
+                QubitRef::new("q", 0),
+                QubitRef::new("q", 1),
+                QubitRef::new("q", 2),
+            ],
+            None,
+        );
 
         let hugr = compile_to_hugr(source).unwrap();
         assert!(hugr.num_nodes() >= 3);
@@ -2332,16 +2516,24 @@ mod tests {
     }
 
     #[test]
-    fn test_controlled_rotation() {
+    fn test_crz_lowers_to_tket_crz() {
         let source = r#"
             pub fn main() -> unit {
                 mut q := qalloc(2);
-                crz(1.57, q[0], q[1]);
+                crz(1.57) (q[0], q[1]);
             }
         "#;
 
-        let hugr = compile_to_hugr(source).unwrap();
-        assert!(hugr.num_nodes() >= 3);
+        // `crz` is its own GateKind (PR #638); the HUGR backend emits tket's own
+        // CRz spelling rather than a decomposition, since Guppy/tket own that name.
+        let operations = collect_operations(source);
+        assert_eq!(operations.len(), 1);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::CRz,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            Some(1.57),
+        );
     }
 
     #[test]
@@ -2349,10 +2541,20 @@ mod tests {
         let source = r#"
             pub fn main() -> unit {
                 mut q := qalloc(1);
-                x(q[0]);
-                reset(q[0]);
+                x q[0];
+                pz q[0];
             }
         "#;
+
+        let operations = collect_operations(source);
+        assert_eq!(operations.len(), 2);
+        assert_direct_operation(&operations[0], TketOp::X, &[QubitRef::new("q", 0)], None);
+        assert_direct_operation(
+            &operations[1],
+            TketOp::Reset,
+            &[QubitRef::new("q", 0)],
+            None,
+        );
 
         let hugr = compile_to_hugr(source).unwrap();
         assert!(hugr.num_nodes() >= 3);
@@ -2458,13 +2660,317 @@ mod tests {
         let source = r#"
             pub fn main() -> unit {
                 mut q := qalloc(2);
-                rzz(1.57, q[0], q[1]);
+                rzz(0.25 turns) (q[0], q[1]);
             }
         "#;
 
-        // RZZ decomposes to CX Rz CX
+        let operations = collect_operations(source);
+        assert_eq!(operations.len(), 3);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+        assert_direct_operation(
+            &operations[1],
+            TketOp::Rz,
+            &[QubitRef::new("q", 1)],
+            Some(std::f64::consts::FRAC_PI_2),
+        );
+        assert_direct_operation(
+            &operations[2],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+
         let hugr = compile_to_hugr(source).unwrap();
         assert!(hugr.num_nodes() >= 4);
+    }
+
+    #[test]
+    fn test_rzz_gate_with_radian_literal() {
+        let operations = collect_operations(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(2);
+                    rzz(1.25 rad) (q[0], q[1]);
+                }
+            "#,
+        );
+
+        assert_eq!(operations.len(), 3);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+        assert_direct_operation(
+            &operations[1],
+            TketOp::Rz,
+            &[QubitRef::new("q", 1)],
+            Some(1.25),
+        );
+        assert_direct_operation(
+            &operations[2],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+    }
+
+    #[test]
+    fn test_prepare_whole_allocator() {
+        let operations = collect_operations(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(2);
+                    pz q;
+                }
+            "#,
+        );
+
+        assert_eq!(operations.len(), 2);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::Reset,
+            &[QubitRef::new("q", 0)],
+            None,
+        );
+        assert_direct_operation(
+            &operations[1],
+            TketOp::Reset,
+            &[QubitRef::new("q", 1)],
+            None,
+        );
+    }
+
+    #[test]
+    fn test_prepare_explicit_slot() {
+        let operations = collect_operations(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(2);
+                    pz q[1];
+                }
+            "#,
+        );
+
+        assert_eq!(operations.len(), 1);
+        assert_direct_operation(
+            &operations[0],
+            TketOp::Reset,
+            &[QubitRef::new("q", 1)],
+            None,
+        );
+    }
+
+    #[test]
+    fn test_builder_shaped_gate_and_prepare_statements() {
+        let mut program = parse(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(2);
+                    return unit;
+                }
+            "#,
+        )
+        .expect("parse failed");
+        insert_builder_statements(
+            &mut program,
+            vec![
+                Stmt::Gate(crate::ast::GateOp {
+                    kind: crate::ast::GateKind::X,
+                    targets: vec![slot_ref("q", 0)],
+                    params: Vec::new(),
+                    attrs: Vec::new(),
+                    location: None,
+                }),
+                Stmt::Prepare(crate::ast::PrepareOp {
+                    allocator: "q".to_string(),
+                    slots: Some(vec![1]),
+                    location: None,
+                }),
+            ],
+        );
+
+        let mut codegen = HugrCodegen::new();
+        codegen
+            .collect_program(&program)
+            .expect("collection failed");
+        assert_eq!(codegen.operations.len(), 2);
+        assert_direct_operation(
+            &codegen.operations[0],
+            TketOp::X,
+            &[QubitRef::new("q", 0)],
+            None,
+        );
+        assert_direct_operation(
+            &codegen.operations[1],
+            TketOp::Reset,
+            &[QubitRef::new("q", 1)],
+            None,
+        );
+    }
+
+    #[test]
+    fn test_builder_shaped_multi_qubit_gate_target_order() {
+        let mut program = parse(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(3);
+                    return unit;
+                }
+            "#,
+        )
+        .expect("parse failed");
+        insert_builder_statements(
+            &mut program,
+            vec![
+                Stmt::Gate(crate::ast::GateOp {
+                    kind: crate::ast::GateKind::CX,
+                    targets: vec![slot_ref("q", 0), slot_ref("q", 1)],
+                    params: Vec::new(),
+                    attrs: Vec::new(),
+                    location: None,
+                }),
+                Stmt::Gate(crate::ast::GateOp {
+                    kind: crate::ast::GateKind::CCX,
+                    targets: vec![slot_ref("q", 0), slot_ref("q", 1), slot_ref("q", 2)],
+                    params: Vec::new(),
+                    attrs: Vec::new(),
+                    location: None,
+                }),
+            ],
+        );
+
+        let mut codegen = HugrCodegen::new();
+        codegen
+            .collect_program(&program)
+            .expect("collection failed");
+        assert_eq!(codegen.operations.len(), 2);
+        assert_direct_operation(
+            &codegen.operations[0],
+            TketOp::CX,
+            &[QubitRef::new("q", 0), QubitRef::new("q", 1)],
+            None,
+        );
+        assert_direct_operation(
+            &codegen.operations[1],
+            TketOp::Toffoli,
+            &[
+                QubitRef::new("q", 0),
+                QubitRef::new("q", 1),
+                QubitRef::new("q", 2),
+            ],
+            None,
+        );
+    }
+
+    #[test]
+    fn test_builder_prepare_whole_allocator() {
+        let mut program = parse(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(3);
+                    return unit;
+                }
+            "#,
+        )
+        .expect("parse failed");
+        insert_builder_statements(
+            &mut program,
+            vec![Stmt::Prepare(crate::ast::PrepareOp {
+                allocator: "q".to_string(),
+                slots: None,
+                location: None,
+            })],
+        );
+
+        let mut codegen = HugrCodegen::new();
+        codegen
+            .collect_program(&program)
+            .expect("collection failed");
+        assert_eq!(codegen.operations.len(), 3);
+        for (index, operation) in codegen.operations.iter().enumerate() {
+            assert_direct_operation(operation, TketOp::Reset, &[QubitRef::new("q", index)], None);
+        }
+    }
+
+    #[test]
+    fn test_builder_prepare_rejects_out_of_bounds_slot() {
+        let mut program = parse(
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(2);
+                    return unit;
+                }
+            "#,
+        )
+        .expect("parse failed");
+        insert_builder_statements(
+            &mut program,
+            vec![Stmt::Prepare(crate::ast::PrepareOp {
+                allocator: "q".to_string(),
+                slots: Some(vec![2]),
+                location: None,
+            })],
+        );
+
+        let mut codegen = HugrCodegen::new();
+        assert!(matches!(
+            codegen.collect_program(&program),
+            Err(HugrError::QubitIndexOutOfBounds {
+                index: 2,
+                capacity: 2
+            })
+        ));
+        assert!(codegen.operations.is_empty());
+    }
+
+    #[test]
+    fn test_all_gate_kinds_have_hugr_mappings() {
+        for kind in crate::ast::GateKind::ALL {
+            assert!(
+                gate_name_to_mapping(kind.keyword()).is_some(),
+                "missing HUGR mapping for {}",
+                kind.keyword()
+            );
+        }
+    }
+
+    #[test]
+    fn test_ordinary_function_call_is_an_error() {
+        let program = parse(
+            r#"
+                fn helper() -> unit {
+                    return unit;
+                }
+
+                pub fn main() -> unit {
+                    helper();
+                }
+            "#,
+        )
+        .expect("parse failed");
+        let mut codegen = HugrCodegen::new();
+
+        assert!(matches!(
+            codegen.collect_program(&program),
+            Err(HugrError::UnsupportedCall { name }) if name == "helper"
+        ));
+    }
+
+    #[test]
+    fn test_missing_named_gate_mapping_is_an_error() {
+        let mut codegen = HugrCodegen::new();
+
+        assert!(matches!(
+            codegen.collect_named_gate("unmapped_gate", &[], Vec::new()),
+            Err(HugrError::UnknownGate { name }) if name == "unmapped_gate"
+        ));
     }
 
     #[test]

--- a/exp/zlup/src/codegen/slr.rs
+++ b/exp/zlup/src/codegen/slr.rs
@@ -1993,34 +1993,57 @@ impl SlrCodegen {
                                     .with_attrs(attrs.clone()),
                             ));
                         }
-                        // Tuple for two-qubit gates: (q[0], q[1])
-                        (2, Expr::Tuple(tuple)) if tuple.elements.len() == 2 => {
-                            let control = self.extract_slot_ref(&tuple.elements[0])?;
-                            let target = self.extract_slot_ref(&tuple.elements[1])?;
+                        // Tuple for multi-qubit gates: (q[0], q[1], ...)
+                        (expected, Expr::Tuple(tuple)) if tuple.elements.len() == expected => {
+                            let targets = tuple
+                                .elements
+                                .iter()
+                                .map(|element| self.extract_slot_ref(element))
+                                .collect::<SlrResult<Vec<_>>>()?;
                             statements.push(SlrStatement::Gate(
-                                SlrGateOp::new(gate_name, vec![control, target])
+                                SlrGateOp::new(gate_name, targets)
                                     .with_params(params.clone())
                                     .with_attrs(attrs.clone()),
                             ));
                         }
-                        // Wrong arity: single qubit for 2-qubit gate or vice versa
-                        (expected, _) => {
+                        // Wrong arity: single qubit for a multi-qubit gate
+                        (expected, Expr::Index(_)) => {
                             return Err(SlrError::WrongArgumentCount {
                                 gate: gate_name.to_string(),
                                 expected,
-                                got: if matches!(elem, Expr::Index(_)) { 1 } else { 2 },
+                                got: 1,
                             });
                         }
+                        // Wrong arity: tuple has the wrong number of qubits
+                        (expected, Expr::Tuple(tuple)) => {
+                            return Err(SlrError::WrongArgumentCount {
+                                gate: gate_name.to_string(),
+                                expected,
+                                got: tuple.elements.len(),
+                            });
+                        }
+                        (_, _) => return Err(SlrError::UnsupportedExpression),
                     }
                 }
                 Ok(statements)
             }
-            // Two-qubit gate with tuple: (q[0], q[1])
-            Expr::Tuple(tuple) if tuple.elements.len() == 2 => {
-                let control = self.extract_slot_ref(&tuple.elements[0])?;
-                let target = self.extract_slot_ref(&tuple.elements[1])?;
+            // Multi-qubit gate with tuple: (q[0], q[1], ...)
+            Expr::Tuple(tuple) => {
+                let expected = gate_kind_arity(&gate.kind);
+                if tuple.elements.len() != expected {
+                    return Err(SlrError::WrongArgumentCount {
+                        gate: gate_name.to_string(),
+                        expected,
+                        got: tuple.elements.len(),
+                    });
+                }
+                let targets = tuple
+                    .elements
+                    .iter()
+                    .map(|element| self.extract_slot_ref(element))
+                    .collect::<SlrResult<Vec<_>>>()?;
                 Ok(vec![SlrStatement::Gate(
-                    SlrGateOp::new(gate_name, vec![control, target])
+                    SlrGateOp::new(gate_name, targets)
                         .with_params(params)
                         .with_attrs(attrs),
                 )])
@@ -2039,22 +2062,33 @@ impl SlrCodegen {
                                     .with_attrs(attrs.clone()),
                             ));
                         }
-                        (2, Expr::Tuple(tuple)) if tuple.elements.len() == 2 => {
-                            let control = self.extract_slot_ref(&tuple.elements[0])?;
-                            let target = self.extract_slot_ref(&tuple.elements[1])?;
+                        (expected, Expr::Tuple(tuple)) if tuple.elements.len() == expected => {
+                            let targets = tuple
+                                .elements
+                                .iter()
+                                .map(|element| self.extract_slot_ref(element))
+                                .collect::<SlrResult<Vec<_>>>()?;
                             statements.push(SlrStatement::Gate(
-                                SlrGateOp::new(gate_name, vec![control, target])
+                                SlrGateOp::new(gate_name, targets)
                                     .with_params(params.clone())
                                     .with_attrs(attrs.clone()),
                             ));
                         }
-                        (expected, _) => {
+                        (expected, Expr::Index(_)) => {
                             return Err(SlrError::WrongArgumentCount {
                                 gate: gate_name.to_string(),
                                 expected,
-                                got: if matches!(elem, Expr::Index(_)) { 1 } else { 2 },
+                                got: 1,
                             });
                         }
+                        (expected, Expr::Tuple(tuple)) => {
+                            return Err(SlrError::WrongArgumentCount {
+                                gate: gate_name.to_string(),
+                                expected,
+                                got: tuple.elements.len(),
+                            });
+                        }
+                        (_, _) => return Err(SlrError::UnsupportedExpression),
                     }
                 }
                 Ok(statements)
@@ -3207,6 +3241,7 @@ fn extract_pi_fraction(left: &Expr, right: &Expr) -> Option<(i64, i64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::GateKind;
     use crate::parse;
 
     fn compile_to_slr(source: &str) -> SlrResult<SlrProgram> {
@@ -3220,6 +3255,27 @@ mod tests {
         let mut codegen = SlrCodegen::new();
         let slr = codegen.compile(&program).expect("compile failed");
         codegen.to_json(&slr).expect("json failed")
+    }
+
+    #[test]
+    fn test_gate_info_covers_every_lowered_gate_kind() {
+        for kind in GateKind::ALL {
+            if *kind == GateKind::PZ {
+                // PZ becomes an SLR Prepare statement before the gate-info lookup.
+                assert!(get_gate_info(kind.keyword()).is_none());
+                continue;
+            }
+
+            let info = get_gate_info(kind.keyword())
+                .unwrap_or_else(|| panic!("missing SLR gate info for {}", kind.keyword()));
+            assert_eq!(info.arity, kind.arity(), "gate: {}", kind.keyword());
+            assert_eq!(
+                info.parameterized,
+                kind.is_parameterized(),
+                "gate: {}",
+                kind.keyword()
+            );
+        }
     }
 
     #[test]
@@ -3278,6 +3334,24 @@ mod tests {
         } else {
             panic!("Expected CX gate");
         }
+    }
+
+    #[test]
+    fn test_three_qubit_gate() {
+        let source = r#"
+            pub fn main() -> unit {
+                q := qalloc(3);
+                ccx (q[0], q[1], q[2]);
+                return unit;
+            }
+        "#;
+
+        let slr = compile_to_slr(source).unwrap();
+        let SlrStatement::Gate(gate) = &slr.body[0] else {
+            panic!("Expected CCX gate operation");
+        };
+        assert_eq!(gate.gate, "CCX");
+        assert_eq!(gate.targets.len(), 3);
     }
 
     #[test]
@@ -3439,6 +3513,29 @@ mod tests {
 
         let result = compile_to_slr(source);
         assert!(matches!(result, Err(SlrError::WrongArgumentCount { .. })));
+    }
+
+    #[test]
+    fn test_batch_gate_rejects_non_qubit_elements_without_fake_arity() {
+        for source in [
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(1);
+                    h {q[0], 42};
+                }
+            "#,
+            r#"
+                pub fn main() -> unit {
+                    mut q := qalloc(1);
+                    h [q[0], 42];
+                }
+            "#,
+        ] {
+            assert!(matches!(
+                compile_to_slr(source),
+                Err(SlrError::UnsupportedExpression)
+            ));
+        }
     }
 
     #[test]

--- a/exp/zlup/src/parser.rs
+++ b/exp/zlup/src/parser.rs
@@ -3911,75 +3911,25 @@ impl<'a> ParserState<'a> {
 
     /// Parse gate keyword to GateKind.
     fn parse_gate_keyword(&self, s: &str) -> ParseResult<GateKind> {
-        use GateKind::*;
-        match s {
-            // Single-qubit Pauli gates
-            "x" => Ok(X),
-            "y" => Ok(Y),
-            "z" => Ok(Z),
-            // Hadamard
-            "h" => Ok(H),
-            // T gates (fourth root of Z)
-            "t" => Ok(T),
-            "tdg" => Ok(Tdg),
-            // Square root gates
-            "sx" => Ok(SX),
-            "sy" => Ok(SY),
-            "sz" => Ok(SZ),
-            "sxdg" => Ok(SXdg),
-            "sydg" => Ok(SYdg),
-            "szdg" => Ok(SZdg),
-            // Rotation gates
-            "rx" => Ok(RX),
-            "ry" => Ok(RY),
-            "rz" => Ok(RZ),
-            // Two-qubit gates
-            "cx" => Ok(CX),
-            "cy" => Ok(CY),
-            "cz" => Ok(CZ),
-            "ch" => Ok(CH),
-            // Two-qubit rotation gates
-            "sxx" => Ok(SXX),
-            "syy" => Ok(SYY),
-            "szz" => Ok(SZZ),
-            "sxxdg" => Ok(SXXdg),
-            "syydg" => Ok(SYYdg),
-            "szzdg" => Ok(SZZdg),
-            "rzz" => Ok(RZZ),
-            "crz" => Ok(CRZ),
-            // Swap gates
-            "swap" => Ok(SWAP),
-            "iswap" => Ok(ISWAP),
-            // Three-qubit gates
-            "ccx" => Ok(CCX), // Toffoli gate
-            // Face rotations
-            "f" => Ok(F),
-            "fdg" => Ok(Fdg),
-            "f4" => Ok(F4),
-            "f4dg" => Ok(F4dg),
-            // Prepare operation
-            "pz" => Ok(PZ),
-            other => {
-                let suggestion = suggest_gate_name(other);
-                let message = match suggestion {
-                    Some(name) => format!("unknown gate '{}', did you mean '{}'?", other, name),
-                    None => format!("unknown gate '{}'", other),
-                };
-                Err(ParseError {
-                    message,
-                    location: SourceLocation::default(),
-                })
-            }
+        if let Some(kind) = GateKind::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.keyword() == s)
+        {
+            return Ok(kind);
         }
+
+        let suggestion = suggest_gate_name(s);
+        let message = match suggestion {
+            Some(name) => format!("unknown gate '{}', did you mean '{}'?", s, name),
+            None => format!("unknown gate '{}'", s),
+        };
+        Err(ParseError {
+            message,
+            location: SourceLocation::default(),
+        })
     }
 }
-
-/// Known gate names for suggestions.
-const KNOWN_GATE_NAMES: &[&str] = &[
-    "x", "y", "z", "h", "t", "tdg", "sx", "sy", "sz", "sxdg", "sydg", "szdg", "rx", "ry", "rz",
-    "cx", "cy", "cz", "ch", "sxx", "syy", "szz", "sxxdg", "syydg", "szzdg", "rzz", "crz", "swap",
-    "iswap", "ccx", "f", "fdg", "f4", "f4dg", "pz",
-];
 
 /// Deprecated gate name mappings.
 const DEPRECATED_GATES: &[(&str, &str)] = &[("s", "sz"), ("sdg", "szdg")];
@@ -3995,7 +3945,11 @@ pub fn suggest_gate_name(unknown: &str) -> Option<&'static str> {
 
     // Find closest match by edit distance
     let mut best: Option<(&str, usize)> = None;
-    for &name in KNOWN_GATE_NAMES {
+    for name in GateKind::ALL
+        .iter()
+        .map(GateKind::keyword)
+        .chain(std::iter::once("crz"))
+    {
         let dist = edit_distance(unknown, name);
         if dist <= 2 {
             match best {
@@ -4105,6 +4059,45 @@ mod tests {
         let parser = ParserState::new("");
         assert_eq!(parser.parse_gate_keyword("crz").unwrap(), GateKind::CRZ);
         assert_eq!(parser.parse_gate_keyword("rzz").unwrap(), GateKind::RZZ);
+    }
+
+    #[test]
+    fn test_gate_kind_keywords_round_trip() {
+        let parser = ParserState::new("");
+        let mut keywords = std::collections::HashSet::new();
+        for kind in GateKind::ALL {
+            let keyword = kind.keyword();
+            assert!(
+                keywords.insert(keyword),
+                "duplicate canonical gate keyword: {}",
+                keyword
+            );
+
+            let grammar_rule = if kind.is_parameterized() {
+                Rule::param_gate_keyword
+            } else {
+                Rule::simple_gate_keyword
+            };
+            let mut grammar_pairs =
+                ZluppyParser::parse(grammar_rule, keyword).unwrap_or_else(|error| {
+                    panic!("grammar rejected gate keyword '{keyword}': {error}")
+                });
+            let grammar_pair = grammar_pairs
+                .next()
+                .expect("successful grammar parse should produce a pair");
+            assert_eq!(grammar_pair.as_span().start(), 0, "keyword: {keyword}");
+            assert_eq!(
+                grammar_pair.as_span().end(),
+                keyword.len(),
+                "grammar did not consume the whole keyword: {keyword}"
+            );
+            assert!(grammar_pairs.next().is_none(), "keyword: {keyword}");
+
+            let parsed = parser
+                .parse_gate_keyword(keyword)
+                .expect("canonical gate keyword should parse");
+            assert_eq!(parsed, *kind, "keyword: {keyword}");
+        }
     }
 
     #[test]

--- a/exp/zlup/src/pretty.rs
+++ b/exp/zlup/src/pretty.rs
@@ -811,7 +811,7 @@ impl PrettyPrinter {
     // =========================================================================
 
     fn print_gate_op(&mut self, g: &GateOp) {
-        self.write(&format!("{:?}", g.kind).to_lowercase());
+        self.write(g.kind.keyword());
 
         if !g.params.is_empty() {
             self.write("(");
@@ -1218,7 +1218,7 @@ impl PrettyPrinter {
                 self.print_expr(&m.targets);
             }
             Expr::Gate(g) => {
-                self.write(&format!("{:?}", g.kind).to_lowercase());
+                self.write(g.kind.keyword());
                 if !g.params.is_empty() {
                     self.write("(");
                     for (i, param) in g.params.iter().enumerate() {

--- a/exp/zlup/src/semantic.rs
+++ b/exp/zlup/src/semantic.rs
@@ -6033,12 +6033,28 @@ fn float_suffix_to_type(suffix: &str) -> Type {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::GateKind;
     use crate::parse;
 
     fn analyze(source: &str) -> SemanticResult<()> {
         let program = parse(source).expect("parse failed");
         let mut analyzer = SemanticAnalyzer::new();
         analyzer.analyze(&program)
+    }
+
+    #[test]
+    fn test_gate_info_covers_every_gate_kind() {
+        for kind in GateKind::ALL {
+            let info = get_gate_info(kind.keyword())
+                .unwrap_or_else(|| panic!("missing semantic gate info for {}", kind.keyword()));
+            assert_eq!(info.arity, kind.arity(), "gate: {}", kind.keyword());
+            assert_eq!(
+                info.parameterized,
+                kind.is_parameterized(),
+                "gate: {}",
+                kind.keyword()
+            );
+        }
     }
 
     #[test]

--- a/exp/zluppy/Cargo.toml
+++ b/exp/zluppy/Cargo.toml
@@ -19,12 +19,19 @@ doctest = false
 # Skip unit tests - all testing should be done through Python
 test = false
 
+[features]
+extension-module = [
+    "pyo3/extension-module",
+    "pyo3/abi3-py312",
+    "pyo3/generate-import-lib",
+]
+
 [dependencies]
 # The zlup library crate (with HUGR support for compilation to HUGR)
 zlup = { path = "../zlup", features = ["hugr"] }
 
 # PyO3 for Python bindings
-pyo3 = { workspace = true, features = ["extension-module", "abi3-py312"] }
+pyo3.workspace = true
 
 # Serialization
 serde_json.workspace = true

--- a/exp/zluppy/pyproject.toml
+++ b/exp/zluppy/pyproject.toml
@@ -34,6 +34,14 @@ build-backend = "maturin"
 [tool.maturin]
 module-name = "zluppy._zluppy"
 python-source = "python"
+features = ["extension-module"]
+
+[tool.uv]
+reinstall-package = [
+    "pecos-rslib",
+    "pecos-rslib-llvm",
+    "zluppy",
+]
 
 [dependency-groups]
 dev = [

--- a/exp/zluppy/src/lib.rs
+++ b/exp/zluppy/src/lib.rs
@@ -7,10 +7,11 @@
 //!
 //! # Compile to SLR-AST (returns dict)
 //! ast = zluppy.compile_to_slr("""
-//!     fn main() -> void {
-//!         var q = qalloc(2);
-//!         H(q[0]);
-//!         CX(q[0], q[1]);
+//!     pub fn main() -> unit {
+//!         q := qalloc(2);
+//!         h q[0];
+//!         cx (q[0], q[1]);
+//!         return;
 //!     }
 //! """)
 //!
@@ -667,7 +668,7 @@ impl ZlupProgram {
     /// Returns:
     ///     self: For method chaining
     fn add_allocator(&mut self, name: &str, capacity: usize) -> Self {
-        // Build: var {name} = qalloc({capacity});
+        // Build: mut {name} := qalloc({capacity});
         let alloc_call = ::zlup::ast::Expr::Call(Box::new(::zlup::ast::CallExpr {
             callee: ::zlup::ast::Expr::Ident(::zlup::ast::Ident {
                 name: "qalloc".to_string(),
@@ -1008,7 +1009,14 @@ impl ZlupProgram {
 impl ZlupProgram {
     /// Build the Zlup AST Program.
     fn build_ast(&self) -> ::zlup::ast::Program {
-        // Create main function with all statements
+        let mut statements = self.statements.clone();
+        statements.push(::zlup::ast::Stmt::Return(::zlup::ast::ReturnStmt {
+            value: Some(::zlup::ast::Expr::Unit(::zlup::ast::UnitLit {
+                location: None,
+            })),
+            location: None,
+        }));
+
         let main_fn = ::zlup::ast::FnDecl {
             name: self.name.clone(),
             params: Vec::new(),
@@ -1016,7 +1024,7 @@ impl ZlupProgram {
             body: ::zlup::ast::Block {
                 label: None,
                 attrs: Vec::new(),
-                statements: self.statements.clone(),
+                statements,
                 trailing_expr: None,
                 location: None,
             },
@@ -1047,10 +1055,11 @@ impl ZlupProgram {
 /// Example:
 ///     ```python
 ///     result = zluppy.ZluppyEngine().source('''
-///         fn main() -> void {
-///             var q = qalloc(2);
-///             H(q[0]);
-///             CX(q[0], q[1]);
+///         pub fn main() -> unit {
+///             q := qalloc(2);
+///             h q[0];
+///             cx (q[0], q[1]);
+///             return;
 ///         }
 ///     ''').run(shots=100)
 ///     print(result.to_dict())

--- a/exp/zluppy/tests/test_zluppy.py
+++ b/exp/zluppy/tests/test_zluppy.py
@@ -8,6 +8,12 @@ import pytest
 import zluppy
 from pecos.simulators import StateVec
 
+
+def operation_signature(program):
+    """Return the exact ordered SLR operation types and gate kinds."""
+    return [(statement["type"], statement.get("gate")) for statement in program["body"]]
+
+
 # =============================================================================
 # Version Tests
 # =============================================================================
@@ -28,10 +34,11 @@ def test_version():
 
 def test_compile_to_slr_bell_state():
     """Test compiling a Bell state program to SLR-AST dict."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
-        cx(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        h q[0];
+        cx (q[0], q[1]);
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr(source)
@@ -50,9 +57,10 @@ def test_compile_to_slr_bell_state():
 
 def test_compile_to_slr_rotation_gate():
     """Test compiling a rotation gate program."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        rz(q[0], 1.57);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        rz(1.57) q[0];
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr(source)
@@ -65,10 +73,11 @@ def test_compile_to_slr_rotation_gate():
 
 def test_compile_to_slr_child_allocator():
     """Test compiling with child allocator."""
-    source = """fn main() -> void {
-        var base = qalloc(4);
-        var q = base.child(2);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        mut base := qalloc(4);
+        q := base.child(2);
+        h q[0];
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr(source)
@@ -80,9 +89,11 @@ def test_compile_to_slr_child_allocator():
 
 def test_compile_to_slr_strict_mode():
     """Test compiling with strict mode enabled."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        pz q;
+        h q[0];
+        return unit;
     }"""
 
     # Strict mode should still compile valid code
@@ -92,7 +103,7 @@ def test_compile_to_slr_strict_mode():
 
 def test_compile_to_slr_parse_error():
     """Test that parse errors raise ZluppyError."""
-    source = "fn main() -> void { h(q[0] }"  # Missing closing paren
+    source = "pub fn main() -> unit { h q[0 }"  # Missing closing bracket
 
     with pytest.raises(zluppy.ZluppyError) as exc_info:
         zluppy.compile_to_slr(source)
@@ -102,8 +113,9 @@ def test_compile_to_slr_parse_error():
 
 def test_compile_to_slr_semantic_error():
     """Test that semantic errors raise ZluppyError."""
-    source = """fn main() -> void {
-        h(undefined_var[0]);
+    source = """pub fn main() -> unit {
+        h undefined_var[0];
+        return unit;
     }"""
 
     with pytest.raises(zluppy.ZluppyError) as exc_info:
@@ -119,9 +131,10 @@ def test_compile_to_slr_semantic_error():
 
 def test_compile_to_slr_json_pretty():
     """Test compiling to pretty-printed JSON string."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        h q[0];
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr_json(source)
@@ -137,9 +150,10 @@ def test_compile_to_slr_json_pretty():
 
 def test_compile_to_slr_json_compact():
     """Test compiling to compact JSON string."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        h q[0];
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr_json(source, compact=True)
@@ -155,9 +169,11 @@ def test_compile_to_slr_json_compact():
 
 def test_compile_to_slr_json_strict():
     """Test compiling to JSON with strict mode."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        x(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        pz q;
+        x q[0];
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr_json(source, strict=True)
@@ -172,10 +188,11 @@ def test_compile_to_slr_json_strict():
 
 def test_check_valid_program():
     """Test checking a valid program."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
-        cx(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        h q[0];
+        cx (q[0], q[1]);
+        return unit;
     }"""
 
     # Should not raise
@@ -184,9 +201,11 @@ def test_check_valid_program():
 
 def test_check_strict_mode():
     """Test checking in strict mode."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        pz q;
+        h q[0];
+        return unit;
     }"""
 
     # Should not raise for valid code
@@ -195,7 +214,7 @@ def test_check_strict_mode():
 
 def test_check_parse_error():
     """Test that check raises on parse error."""
-    source = "fn main( void { }"  # Missing closing paren
+    source = "pub fn main( -> unit { }"  # Missing closing paren
 
     with pytest.raises(zluppy.ZluppyError):
         zluppy.check(source)
@@ -203,8 +222,9 @@ def test_check_parse_error():
 
 def test_check_semantic_error():
     """Test that check raises on semantic error."""
-    source = """fn main() -> void {
+    source = """pub fn main() -> unit {
         UnknownGate(q[0]);
+        return unit;
     }"""
 
     with pytest.raises(zluppy.ZluppyError):
@@ -218,7 +238,7 @@ def test_check_semantic_error():
 
 def test_parse_debug():
     """Test getting debug AST string."""
-    source = "fn main() -> void { var q = qalloc(1); }"
+    source = "pub fn main() -> unit { q := qalloc(1); return unit; }"
 
     result = zluppy.parse_debug(source)
 
@@ -230,7 +250,7 @@ def test_parse_debug():
 def test_parse_debug_error():
     """Test that parse_debug raises on parse error."""
     with pytest.raises(zluppy.ZluppyError):
-        zluppy.parse_debug("fn main( void { }")
+        zluppy.parse_debug("pub fn main( -> unit { }")
 
 
 # =============================================================================
@@ -354,10 +374,11 @@ def test_slr_program_unknown_gate():
 
 def test_roundtrip_compile_and_build():
     """Test that compiled and built programs produce similar structure."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
-        cx(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        h q[0];
+        cx (q[0], q[1]);
+        return unit;
     }"""
 
     # Compile from source
@@ -462,10 +483,11 @@ def test_lowercase_gate_aliases():
 
 def test_zluppy_engine_source():
     """Test ZluppyEngine with source code."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
-        cx(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        h q[0];
+        cx (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
@@ -473,15 +495,17 @@ def test_zluppy_engine_source():
 
     assert isinstance(hugr_bytes, bytes)
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [("GateOp", "H"), ("GateOp", "CX")]
 
 
 def test_zluppy_engine_file(tmp_path):
     """Test ZluppyEngine with file input."""
     # Create a temporary .zlp file
     zlp_file = tmp_path / "test.zlp"
-    zlp_file.write_text("""fn main() -> void {
-        var q = qalloc(1);
-        h(q[0]);
+    zlp_file.write_text("""pub fn main() -> unit {
+        q := qalloc(1);
+        h q[0];
+        return unit;
     }""")
 
     engine = zluppy.ZluppyEngine().file(str(zlp_file))
@@ -489,34 +513,38 @@ def test_zluppy_engine_file(tmp_path):
 
     assert isinstance(hugr_bytes, bytes)
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_file(str(zlp_file))) == [("GateOp", "H")]
 
 
 def test_zluppy_engine_run():
     """Test ZluppyEngine.run() executes through simulator."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
-        cx(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        h q[0];
+        cx (q[0], q[1]);
+        return unit;
     }"""
 
-    result = zluppy.ZluppyEngine().source(source).run(shots=10)
+    result = zluppy.ZluppyEngine().source(source).run(shots=100)
 
     # Check we got results
     assert result is not None
     result_dict = result.to_dict()
     assert "measurements" in result_dict
-    assert len(result_dict["measurements"]) == 10
+    assert len(result_dict["measurements"]) == 100
 
     # Verify Bell state correlations (q0 == q1 for each shot)
     for shot in result_dict["measurements"]:
         assert shot[0] == shot[1], f"Bell state violation: {shot}"
+    assert {tuple(shot) for shot in result_dict["measurements"]} == {(0, 0), (1, 1)}
 
 
 def test_zluppy_engine_run_single_qubit():
     """Test ZluppyEngine with single qubit circuit."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        x(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        x q[0];
+        return unit;
     }"""
 
     result = zluppy.ZluppyEngine().source(source).run(shots=5)
@@ -539,7 +567,7 @@ def test_zluppy_engine_no_source_error():
 
 def test_zluppy_engine_parse_error():
     """Test that ZluppyEngine raises on parse error."""
-    source = "fn main() -> void { h(q[0] }"  # Missing closing paren
+    source = "pub fn main() -> unit { h q[0 }"  # Missing closing bracket
 
     with pytest.raises(zluppy.ZluppyError):
         zluppy.ZluppyEngine().source(source)
@@ -547,8 +575,9 @@ def test_zluppy_engine_parse_error():
 
 def test_zluppy_engine_semantic_error():
     """Test that ZluppyEngine raises on semantic error."""
-    source = """fn main() -> void {
-        h(undefined_var[0]);
+    source = """pub fn main() -> unit {
+        h undefined_var[0];
+        return unit;
     }"""
 
     with pytest.raises(zluppy.ZluppyError):
@@ -557,9 +586,11 @@ def test_zluppy_engine_semantic_error():
 
 def test_zluppy_engine_strict_mode():
     """Test ZluppyEngine with strict mode."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        pz q;
+        h q[0];
+        return unit;
     }"""
 
     # Strict mode should work for valid code
@@ -567,18 +598,23 @@ def test_zluppy_engine_strict_mode():
     hugr_bytes = engine.to_hugr_bytes()
 
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source, strict=True)) == [
+        ("PrepareOp", None),
+        ("GateOp", "H"),
+    ]
 
 
 def test_zluppy_engine_chaining():
     """Test that ZluppyEngine methods return self for chaining."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        h(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        x q[0];
+        return unit;
     }"""
 
     # All methods should be chainable
     result = zluppy.ZluppyEngine().source(source).run(shots=1)
-    assert result is not None
+    assert result.to_dict()["measurements"] == [[1]]
 
 
 def test_zluppy_engine_repr():
@@ -586,7 +622,7 @@ def test_zluppy_engine_repr():
     engine = zluppy.ZluppyEngine()
     assert "not compiled" in repr(engine)
 
-    engine.source("fn main() -> void { var q = qalloc(1); }")
+    engine.source("pub fn main() -> unit { q := qalloc(1); return unit; }")
     assert "compiled" in repr(engine)
 
 
@@ -603,122 +639,150 @@ def test_zluppy_engine_file_not_found():
 
 def test_engine_ch_gate():
     """Test CH (controlled Hadamard) gate compiles to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        ch(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        ch (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [("GateOp", "CH")]
 
 
 def test_engine_ising_gates():
     """Test Ising gates (SXX, SYY, SZZ) compile to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        sxx(q[0], q[1]);
-        syy(q[0], q[1]);
-        szz(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        sxx (q[0], q[1]);
+        syy (q[0], q[1]);
+        szz (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [
+        ("GateOp", "SXX"),
+        ("GateOp", "SYY"),
+        ("GateOp", "SZZ"),
+    ]
 
 
 def test_engine_ising_dagger_gates():
     """Test Ising dagger gates compile to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        sxxdg(q[0], q[1]);
-        syydg(q[0], q[1]);
-        szzdg(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        sxxdg (q[0], q[1]);
+        syydg (q[0], q[1]);
+        szzdg (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [
+        ("GateOp", "SXXdg"),
+        ("GateOp", "SYYdg"),
+        ("GateOp", "SZZdg"),
+    ]
 
 
 def test_engine_rzz_gate():
     """Test RZZ (ZZ rotation) gate compiles to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        rzz(q[0], q[1], 1.57);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        rzz(1.57) (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [("GateOp", "RZZ")]
 
 
 def test_engine_f_gates():
     """Test F gates (Clifford face rotation) compile to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(1);
-        f(q[0]);
-        fdg(q[0]);
-        f4(q[0]);
-        f4dg(q[0]);
+    source = """pub fn main() -> unit {
+        q := qalloc(1);
+        f q[0];
+        fdg q[0];
+        f4 q[0];
+        f4dg q[0];
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [
+        ("GateOp", "F"),
+        ("GateOp", "Fdg"),
+        ("GateOp", "F4"),
+        ("GateOp", "F4dg"),
+    ]
 
 
 def test_engine_ccx_gate():
     """Test CCX (Toffoli) gate compiles to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(3);
-        ccx(q[0], q[1], q[2]);
+    source = """pub fn main() -> unit {
+        q := qalloc(3);
+        ccx (q[0], q[1], q[2]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [("GateOp", "CCX")]
 
 
 def test_engine_swap_gates():
     """Test SWAP and iSWAP gates compile to HUGR."""
-    source = """fn main() -> void {
-        var q = qalloc(2);
-        swap(q[0], q[1]);
-        iswap(q[0], q[1]);
+    source = """pub fn main() -> unit {
+        q := qalloc(2);
+        swap (q[0], q[1]);
+        iswap (q[0], q[1]);
+        return unit;
     }"""
 
     engine = zluppy.ZluppyEngine().source(source)
     hugr_bytes = engine.to_hugr_bytes()
     assert len(hugr_bytes) > 0
+    assert operation_signature(zluppy.compile_to_slr(source)) == [("GateOp", "SWAP"), ("GateOp", "ISWAP")]
 
 
 def test_compile_all_new_gates():
     """Test compiling a program with all new gates to SLR."""
-    source = """fn main() -> void {
-        var q = qalloc(3);
+    source = """pub fn main() -> unit {
+        q := qalloc(3);
         // F gates
-        f(q[0]);
-        fdg(q[0]);
-        f4(q[0]);
-        f4dg(q[0]);
+        f q[0];
+        fdg q[0];
+        f4 q[0];
+        f4dg q[0];
         // Two-qubit controlled
-        ch(q[0], q[1]);
+        ch (q[0], q[1]);
         // Ising gates
-        sxx(q[0], q[1]);
-        syy(q[0], q[1]);
-        szz(q[0], q[1]);
-        sxxdg(q[0], q[1]);
-        syydg(q[0], q[1]);
-        szzdg(q[0], q[1]);
+        sxx (q[0], q[1]);
+        syy (q[0], q[1]);
+        szz (q[0], q[1]);
+        sxxdg (q[0], q[1]);
+        syydg (q[0], q[1]);
+        szzdg (q[0], q[1]);
         // Swap gates
-        swap(q[0], q[1]);
-        iswap(q[0], q[1]);
+        swap (q[0], q[1]);
+        iswap (q[0], q[1]);
         // Rotation
-        rzz(q[0], q[1], 0.5);
-        crz(q[0], q[1], 0.5);
+        rzz(0.5) (q[0], q[1]);
+        crz(0.5) (q[0], q[1]);
         // Three-qubit
-        ccx(q[0], q[1], q[2]);
+        ccx (q[0], q[1], q[2]);
+        return unit;
     }"""
 
     result = zluppy.compile_to_slr(source)
@@ -815,7 +879,8 @@ def test_zlup_program_add_allocator():
     prog.add_allocator("q", 2)
 
     source = prog.to_source()
-    assert "var q = qalloc(2);" in source
+    assert "mut q := qalloc(2);" in source
+    assert source.endswith("    return;\n}\n")
 
 
 def test_zlup_program_add_gate():
@@ -826,8 +891,8 @@ def test_zlup_program_add_gate():
     prog.add_gate("cx", [("q", 0), ("q", 1)])
 
     source = prog.to_source()
-    assert "h(q[0]);" in source
-    assert "cx(q[0], q[1]);" in source
+    assert "h q[0];" in source
+    assert "cx (q[0], q[1]);" in source
 
 
 def test_zlup_program_add_rotation_gate():
@@ -837,7 +902,7 @@ def test_zlup_program_add_rotation_gate():
     prog.add_gate("rz", [("q", 0)], params=[1.57])
 
     source = prog.to_source()
-    assert "rz(q[0], 1.57);" in source
+    assert "rz(1.57) q[0];" in source
 
 
 def test_zlup_program_compile_to_slr():
@@ -880,6 +945,7 @@ def test_zlup_program_compile_to_hugr():
 
     assert isinstance(hugr_bytes, bytes)
     assert len(hugr_bytes) > 0
+    assert operation_signature(json.loads(prog.compile_to_slr())) == [("GateOp", "H"), ("GateOp", "CX")]
 
 
 def test_zlup_program_method_chaining():
@@ -889,9 +955,9 @@ def test_zlup_program_method_chaining():
     )
 
     source = prog.to_source()
-    assert "var q = qalloc(2);" in source
-    assert "h(q[0]);" in source
-    assert "cx(q[0], q[1]);" in source
+    assert "mut q := qalloc(2);" in source
+    assert "h q[0];" in source
+    assert "cx (q[0], q[1]);" in source
 
 
 def test_zlup_program_all_single_qubit_gates():
@@ -943,7 +1009,7 @@ def test_zlup_program_prepare():
     prog.add_gate("h", [("q", 0)])
 
     source = prog.to_source()
-    assert "q.prepare_all();" in source
+    assert "pz q;" in source
 
 
 def test_zlup_program_measure():
@@ -986,10 +1052,11 @@ def test_zlup_program_save(tmp_path):
 
     # Verify file contents
     content = path.read_text()
-    assert "fn main() -> void {" in content
-    assert "var q = qalloc(2);" in content
-    assert "h(q[0]);" in content
-    assert "cx(q[0], q[1]);" in content
+    assert "fn main() -> unit {" in content
+    assert "mut q := qalloc(2);" in content
+    assert "h q[0];" in content
+    assert "cx (q[0], q[1]);" in content
+    assert content.endswith("    return;\n}\n")
 
     # Verify the saved file can be compiled
     result = zluppy.compile_file(str(path))
@@ -1029,6 +1096,10 @@ def test_zlup_program_compile_via_source_to_hugr():
 
     assert isinstance(hugr_bytes, bytes)
     assert len(hugr_bytes) > 0
+    assert operation_signature(json.loads(prog.compile_via_source_to_slr())) == [
+        ("GateOp", "H"),
+        ("GateOp", "CX"),
+    ]
 
 
 def test_zlup_program_roundtrip_all_gates():


### PR DESCRIPTION
## Summary

The `zluppy` Python test suite (`exp/zluppy/tests/test_zluppy.py`) was 41 failed / 29 passed on `dev`, and nothing ran it: no workflow or Justfile recipe invokes it (the Python workflow's path filters do not include `exp/**`), so the suite rotted as the zlup language moved on. This PR brings it back to green and gives it a post-merge CI lane.

## What was wrong

- 26 tests wrote zlup source in a syntax the language no longer accepts (`var q = qalloc(2); h(q[0]); cx(q[0], q[1]);`). Current zlup uses `q := qalloc(2);`, DSL gate statements (`h q[0];`, `cx (q[0], q[1]);`), `pz q;`, `result: u1 = mz(u1) q[0];`, and `pub fn main() -> unit { ...; return unit; }` (see `exp/zlup/examples/bell_state.zlp`).
- 6 tests asserted the old rendering of `ZlupProgram.to_source()`; the pretty-printer has rendered current syntax for a long time.
- 9 tests failed on a real binding bug: `ZlupProgram.build_ast()` emitted `main` with a `unit` return type and no return statement, which zlup's semantic analysis rejects (`missing return statement in function 'main'`).

Reviving the tests then exposed two `zlup` backend bugs that the old syntax had hidden: the HUGR backend did not lower current-syntax gate statements (`h q[0];`, `pz q;`) at all, so such programs compiled to identity, and the SLR backend only accepted two-element qubit tuples, so the documented `ccx (q[0], q[1], q[2]);` failed.

The HUGR backend now also fails loudly on a gate it has no mapping for instead of dropping it; the remaining forms it does not lower (allocator broadcast for non-`pz` gates, bracket-array batches, named comptime angle constants -- which is why `exp/zlup/examples/qft_3qubit.zlp` fails HUGR codegen) are tracked in #636.

## Changes

- `exp/zlup/src/codegen/hugr.rs`: `Stmt::Gate`, `Stmt::Prepare`, slot references, and angle literals lower through the existing named-gate path, with codegen tests asserting the emitted operation list for each form (byte-length checks on the HUGR blob cannot tell a lowered circuit from an empty one); `GateKind::keyword()`/`GateKind::ALL` are the one canonical spelling shared by parser, pretty-printer, suggestions, and HUGR codegen, with a round-trip test; `exp/zlup/src/codegen/slr.rs`: tuple lowering generalized to the gate's arity.
- `exp/zluppy/Cargo.toml` / `pyproject.toml`: pyo3 extension-module linking moved behind a maturin-enabled feature (the `pecos-rslib` pattern) so plain `cargo test` works for the crate's unit tests.
- `exp/zluppy/src/lib.rs`: the builder appends the explicit unit return that zlup requires, using the AST the parser produces for `return unit;` (the pretty-printer keeps rendering it as the `return;` shorthand); Rust test on the builder path.
- `exp/zluppy/tests/test_zluppy.py`: sources rewritten in current zlup; rendering expectations updated to the pretty-printer's output; assertions kept as specific as before.
- `Justfile`: `pytest-zluppy` recipe (syncs the `exp/zluppy` project env and runs its suite).
- `.github/workflows/python-test.yml`: `zluppy-postmerge` job patterned on `python-slow-postmerge` (post-merge push and `workflow_dispatch`), `exp/zlup/**` and `exp/zluppy/**` added to the path filters, and `uv lock --check --project exp/zluppy` on the PR fast path.

Judgment call: `zluppy` is its own uv project on its own version train, so its environment rebuilds `quantum-pecos` and the Rust extensions. Running that only post-merge (with a dispatch escape hatch) matches how the slow lane is treated and keeps the PR path unchanged; making it a PR blocker would be a separate decision.

## Merge order

This branch and the CRZ boundary-lowering branch (#626) both touch `exp/zlup/src/{ast.rs,parser.rs,codegen/slr.rs}` and this package. They do not conflict semantically, but whichever lands second needs a rebase. If #626 lands first, this branch adds its `GateKind::CRZ` to `ALL`/`keyword()` (`"crz"`)/`ordinal()` and drops the `crz -> RZZ` alias special case here; the mapping-drift guard still passes because `gate_name_to_mapping("crz")` already returns `TketOp::CRz`.

## Verification

Full zluppy suite green; `cargo test`/`clippy -D warnings`/`fmt` on `zluppy` and `zlup`; `uv lock --check --project exp/zluppy`; `pre-commit run --all-files`.


## Also included: wasmtime 46.0.2 -> 46.0.3

RUSTSEC-2026-0268 and RUSTSEC-2026-0269 (Wasmtime) were published on 2026-08-31, after `dev`'s last clean `cargo-deny` run, and both require `>=46.0.3`. They are not caused by this PR, but this PR touches `exp/zluppy/Cargo.toml`, so `cargo-deny` gates it -- and the repo's policy is to fix a pre-existing advisory on the current PR only when it blocks that PR's checks. `dev` is affected identically and will need this bump regardless.

`wasmtime` is reached only through `crates/pecos-wasm`. The plain `cargo update` also re-normalized 25 unrelated dependency edges among duplicate versions (`windows-sys`, `unicode-width`, `hashbrown`, `indexmap`), so the lockfile change here was rebuilt as version+checksum substitutions only -- zero non-version lines differ. Verified: `cargo tree --locked` resolves, `cargo check --locked -p pecos-wasm` builds, and `just cargo-deny` reports advisories, bans, and sources all ok.
