### PR TITLE
Fix four wrong gate conversions in qelib1.inc and add an include-gate conformance test

### DIFF
--- a/crates/pecos-qasm/includes/qelib1.inc
+++ b/crates/pecos-qasm/includes/qelib1.inc
@@ -26,20 +26,11 @@ gate sdg a { SDG a; }
 gate t a { T a; }
 gate tdg a { TDG a; }
 
-// X-axis rotation using decomposition
-// Note: H · RZ(θ) · H = RX(θ)
-gate rx(theta) a {
-  h a;
-  rz(theta) a;
-  h a;
-}
+// RXY1Q(theta, 0) = RX(theta)
+gate rx(theta) a { RXY1Q(theta, 0) a; }
 
-// Y-axis rotation
-gate ry(theta) a {
-  rx(-pi/2) a;
-  rz(theta) a;
-  rx(pi/2) a;
-}
+// RXY1Q(theta, pi/2) = RY(theta)
+gate ry(theta) a { RXY1Q(theta, pi/2) a; }
 
 // sqrt(X) gates (native)
 gate sx a { SX a; }
@@ -65,8 +56,11 @@ gate cy a,b {
 }
 
 // Controlled-SX
+// H · S · H = SX on the target
 gate csx a,b {
-  cx a,b;  // Simplified version
+  h b;
+  cu1(pi/2) a,b;
+  h b;
 }
 
 // SWAP gate
@@ -91,12 +85,11 @@ gate crz(theta) a,b {
 }
 
 // Controlled RX
+// H · RZ(theta) · H = RX(theta) on the target
 gate crx(theta) a,b {
-  ry(pi/2) b;
-  cx a,b;
-  ry(theta) b;
-  cx a,b;
-  ry(-pi/2) b;
+  h b;
+  crz(theta) a,b;
+  h b;
 }
 
 // Controlled RY

--- a/crates/pecos-qasm/tests/gates/custom_gates.rs
+++ b/crates/pecos-qasm/tests/gates/custom_gates.rs
@@ -77,7 +77,7 @@ fn test_custom_gate_with_defined_params() {
     // After expansion, we should have operations from mygate
     // mygate expands to: anrz(theta) a; cx b, a; rx(phi) b;
     // anrz expands to: rz(p) a;
-    // So final expansion: rz(theta), cx, rx (plus any expansions of rx)
+    // So final expansion is RZ(theta), CX, and RXY1Q(phi, 0).
 
     assert!(
         !program.operations.is_empty(),
@@ -94,7 +94,7 @@ fn test_custom_gate_with_defined_params() {
             match name.to_uppercase().as_str() {
                 "RZ" => found_rz = true,
                 "CX" => found_cx = true,
-                "H" => found_rx_expansion = true, // rx expands to H-RZ-H
+                "RXY1Q" => found_rx_expansion = true,
                 _ => {}
             }
         }
@@ -103,8 +103,8 @@ fn test_custom_gate_with_defined_params() {
     assert!(found_rz, "Should have RZ gate from anrz expansion");
     assert!(found_cx, "Should have CX gate from mygate");
     assert!(
-        found_rx_expansion || program.operations.len() > 3,
-        "Should have rx expansion"
+        found_rx_expansion,
+        "Should have native RXY1Q from rx expansion"
     );
 }
 

--- a/crates/pecos-qasm/tests/gates/expansion.rs
+++ b/crates/pecos-qasm/tests/gates/expansion.rs
@@ -71,67 +71,27 @@ fn test_gate_expansion_rx() {
 
     let program = QASMParser::parse_str(qasm).unwrap();
 
-    // The rx gate should be expanded to h; rz; h
-    assert_eq!(program.operations.len(), 3);
+    // The rx gate should lower directly to RXY1Q(pi/2, 0).
+    assert_eq!(program.operations.len(), 1);
 
-    // Check first operation is h
     match &program.operations[0] {
-        Operation::Gate { name, qubits, .. } => {
-            assert_eq!(name, "H");
-            assert_eq!(qubits, &[0]);
-        }
         Operation::NativeGate(gate) => {
-            assert_eq!(gate.gate_type, pecos_core::gate_type::GateType::H);
+            assert_eq!(gate.gate_type, GateType::RXY1Q);
             assert_eq!(gate.qubits.len(), 1);
             assert_eq!({ gate.qubits[0].0 }, 0);
-        }
-        _ => panic!("Expected h gate"),
-    }
-
-    // Check second operation is rz
-    match &program.operations[1] {
-        Operation::Gate {
-            name,
-            qubits,
-            parameters,
-            ..
-        } => {
-            assert_eq!(name, "RZ");
-            assert_eq!(qubits, &[0]);
-            assert_eq!(parameters.len(), 1);
-            assert!(
-                (parameters[0] - std::f64::consts::FRAC_PI_2).abs() < 1e-6,
-                "Expected parameter PI/2, got {}",
-                parameters[0]
-            );
-        }
-        Operation::NativeGate(gate) => {
-            assert_eq!(gate.gate_type, pecos_core::gate_type::GateType::RZ);
-            assert_eq!(gate.qubits.len(), 1);
-            assert_eq!({ gate.qubits[0].0 }, 0);
-            // Rotation gate angles are now stored in gate.angles as Angle64
-            assert_eq!(gate.angles.len(), 1);
+            assert_eq!(gate.angles.len(), 2);
             assert!(
                 (gate.angles[0].to_radians() - std::f64::consts::FRAC_PI_2).abs() < 1e-6,
-                "Expected angle PI/2, got {}",
+                "Expected theta PI/2, got {}",
                 gate.angles[0].to_radians()
             );
+            assert!(
+                gate.angles[1].to_radians().abs() < 1e-6,
+                "Expected phi 0, got {}",
+                gate.angles[1].to_radians()
+            );
         }
-        _ => panic!("Expected rz gate"),
-    }
-
-    // Check third operation is h
-    match &program.operations[2] {
-        Operation::Gate { name, qubits, .. } => {
-            assert_eq!(name, "H");
-            assert_eq!(qubits, &[0]);
-        }
-        Operation::NativeGate(gate) => {
-            assert_eq!(gate.gate_type, pecos_core::gate_type::GateType::H);
-            assert_eq!(gate.qubits.len(), 1);
-            assert_eq!({ gate.qubits[0].0 }, 0);
-        }
-        _ => panic!("Expected h gate"),
+        operation => panic!("Expected native RXY1Q gate, got {operation:?}"),
     }
 }
 

--- a/crates/pecos-qasm/tests/gates/mixed_gates_test.rs
+++ b/crates/pecos-qasm/tests/gates/mixed_gates_test.rs
@@ -55,7 +55,7 @@ fn test_mixed_gates_circuit() {
 
     // These gates will be expanded
     // rz stays as rz (or RZ)
-    // rx expands to H-RZ-H
+    // rx lowers to RXY1Q(theta, 0)
     // cx stays as cx (or CX)
     // cz expands to H-CX-H
 
@@ -101,8 +101,9 @@ fn test_angle_precision() {
 
     let program = QASMParser::parse_str(qasm).expect("Failed to parse angle precision test");
 
-    // Track the RZ gates and their angles after expansion
+    // Track the RZ and RX-family gates and their angles after expansion.
     let mut rz_angles = Vec::new();
+    let mut rx_angles = Vec::new();
 
     for op in &program.operations {
         match op {
@@ -121,6 +122,13 @@ fn test_angle_precision() {
                     rz_angles.push(angle.to_radians());
                 }
             }
+            Operation::NativeGate(gate)
+                if matches!(gate.gate_type, pecos_core::gate_type::GateType::RXY1Q) =>
+            {
+                if let Some(angle) = gate.angles.first() {
+                    rx_angles.push(angle.to_radians());
+                }
+            }
             _ => {}
         }
     }
@@ -134,20 +142,27 @@ fn test_angle_precision() {
     // Check that angles are preserved with reasonable precision
     // Note: Angle64 normalizes angles to [0, 2π), so 2.25*pi becomes 0.25*pi
     let pi = std::f64::consts::PI;
-    let expected_angles = vec![
+    let expected_rz_angles = [
         1.5 * pi, // rz(1.5*pi)
         0.5 * pi, // rz(0.5*pi)
-        // rx gates will contribute their angles too
+    ];
+    let expected_rx_angles = [
         0.085 * pi, // from rx(0.085*pi)
         0.25 * pi,  // from rx(2.25*pi) - normalized: 2.25*pi mod 2*pi = 0.25*pi
     ];
 
     // The angles might not be in the same order after expansion
-    for expected in &expected_angles {
+    for expected in &expected_rz_angles {
         let found = rz_angles
             .iter()
             .any(|&angle| (angle - expected).abs() < 1e-6); // Relaxed tolerance for angle normalization
         assert!(found, "Expected angle {expected} not found in RZ gates");
+    }
+    for expected in &expected_rx_angles {
+        let found = rx_angles
+            .iter()
+            .any(|&angle| (angle - expected).abs() < 1e-6);
+        assert!(found, "Expected angle {expected} not found in RXY1Q gates");
     }
 }
 

--- a/crates/pecos-qasm/tests/gates/rotation_gates.rs
+++ b/crates/pecos-qasm/tests/gates/rotation_gates.rs
@@ -76,15 +76,11 @@ fn test_controlled_rotation_gates() {
                 "Expected 6 CX gates from 3 controlled rotations"
             );
 
-            // crz contributes 2 RZ gates, crx uses ry which expands to rx (h-rz-h),
-            // and cry uses ry gates
-            assert!(
-                rz_count > 2,
-                "Expected multiple RZ gates from controlled rotations"
-            );
+            // crz and crx each contribute two RZ gates.
+            assert_eq!(rz_count, 4, "Expected 4 RZ gates from crz and crx");
 
-            // The rx gates expand to h-rz-h patterns
-            assert!(h_count > 0, "Expected H gates from the expansions");
+            // crx conjugates crz by H on the target.
+            assert_eq!(h_count, 2, "Expected 2 H gates from crx");
         }
         Err(e) => {
             panic!("Failed to parse controlled rotation gates: {e}");
@@ -225,8 +221,7 @@ fn test_crx_expansion() {
                 program.operations.len()
             );
 
-            // crx expands to a controlled version of rx
-            // It should include CX gates and rotations
+            // crx is H on the target, crz, then H on the target.
             let cx_count = program
                 .operations
                 .iter()
@@ -243,16 +238,15 @@ fn test_crx_expansion() {
 
             println!("CRX gate sequence: {gate_types:?}");
 
-            // crx uses ry gates which expand to rx (h-rz-h) patterns
             assert!(
                 gate_types
                     .iter()
                     .any(|name| name.to_uppercase() == "H" || name.to_uppercase() == "HADAMARD"),
-                "CRX should contain H gates from RY expansion"
+                "CRX should contain H gates from H-RZ-H conjugation"
             );
             assert!(
                 gate_types.iter().any(|name| name.to_uppercase() == "RZ"),
-                "CRX should contain RZ gates from RY expansion"
+                "CRX should contain RZ gates from crz"
             );
             assert!(
                 gate_types
@@ -286,13 +280,11 @@ fn test_cry_expansion() {
                 program.operations.len()
             );
 
-            // cry uses ry gates which expand to rx (h-rz-h) patterns
-            // Each ry expands to: rx(-pi/2); rz(theta); rx(pi/2)
-            // And each rx expands to: h; rz(angle); h
-            // So we expect more than 4 operations due to expansions
-            assert!(
-                program.operations.len() > 4,
-                "CRY should expand to more than 4 operations due to ry expansion"
+            // cry contains two native RXY1Q rotations and two CX gates.
+            assert_eq!(
+                program.operations.len(),
+                4,
+                "CRY should expand to 4 operations"
             );
 
             // Count gate types
@@ -301,25 +293,18 @@ fn test_cry_expansion() {
                 .iter()
                 .filter(|op| is_gate_with_name(op, "CX"))
                 .count();
-            let h_count = program
+            let rxy_count = program
                 .operations
                 .iter()
-                .filter(|op| is_gate_with_name(op, "H"))
-                .count();
-            let rz_count = program
-                .operations
-                .iter()
-                .filter(|op| is_gate_with_name(op, "RZ"))
+                .filter(|op| is_gate_with_name(op, "RXY1Q"))
                 .count();
 
-            println!("CRY gate counts - CX: {cx_count}, H: {h_count}, RZ: {rz_count}");
+            println!("CRY gate counts - CX: {cx_count}, RXY1Q: {rxy_count}");
 
             // Should have 2 CX gates from the original cry structure
             assert_eq!(cx_count, 2, "CRY should have 2 CX gates");
 
-            // Should have multiple H and RZ gates from ry expansion
-            assert!(h_count > 0, "CRY should have H gates from ry expansion");
-            assert!(rz_count > 0, "CRY should have RZ gates from ry expansion");
+            assert_eq!(rxy_count, 2, "CRY should have 2 RXY1Q gates from ry");
         }
         Err(e) => {
             panic!("Failed to parse cry gate: {e}");

--- a/crates/pecos-qasm/tests/integration.rs
+++ b/crates/pecos-qasm/tests/integration.rs
@@ -43,3 +43,6 @@ pub mod clifford_rotation_simulation_test;
 
 #[path = "integration/phase_exactness_test.rs"]
 pub mod phase_exactness_test;
+
+#[path = "integration/include_gate_conformance_test.rs"]
+pub mod include_gate_conformance_test;

--- a/crates/pecos-qasm/tests/integration/clifford_rotation_simulation_test.rs
+++ b/crates/pecos-qasm/tests/integration/clifford_rotation_simulation_test.rs
@@ -227,9 +227,9 @@ fn qasm_rzz_pi_over_2_entangles_qubits() {
 }
 
 #[test]
-fn qasm_rx_pi_via_decomposition_acts_as_x() {
-    // In qelib1.inc, rx(theta) decomposes to h; rz(theta); h.
-    // rx(pi) = H*Z*H = X. So |0> -> |1>.
+fn qasm_rx_pi_via_rxy1q_acts_as_x() {
+    // In qelib1.inc, rx(theta) maps to RXY1Q(theta, 0).
+    // RXY1Q(pi, 0) = X up to global phase. So |0> -> |1>.
     let qasm = r#"
         OPENQASM 2.0;
         include "qelib1.inc";

--- a/crates/pecos-qasm/tests/integration/include_gate_conformance_test.rs
+++ b/crates/pecos-qasm/tests/integration/include_gate_conformance_test.rs
@@ -1,0 +1,546 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! This is a PROJECTIVE check: each gate is compared to its reference up to one
+//! shared global phase, because a boundary conversion is only required to be exact
+//! up to an unobservable global phase. It therefore does NOT pin phase exactness --
+//! `phase_exactness_test.rs` is the test that does. Every RELATIVE phase, including
+//! the control-side phase that distinguishes a controlled rotation from a controlled
+//! phase, is compared exactly.
+
+use num_complex::Complex64;
+use pecos_engines::{ClassicalEngine, DenseStateVecEngine, Engine};
+use pecos_qasm::{QASMEngine, ast::GateDefinition};
+use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_3, FRAC_PI_4, PI, TAU};
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+const TOLERANCE: f64 = 1e-9;
+
+type Matrix = Vec<Vec<Complex64>>;
+
+fn complex(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+fn cis(angle: f64) -> Complex64 {
+    Complex64::from_polar(1.0, angle)
+}
+
+fn matrix<const N: usize>(rows: [[Complex64; N]; N]) -> Matrix {
+    rows.into_iter().map(Vec::from).collect()
+}
+
+fn identity(dimension: usize) -> Matrix {
+    let mut result = vec![vec![complex(0.0, 0.0); dimension]; dimension];
+    for (index, row) in result.iter_mut().enumerate() {
+        row[index] = complex(1.0, 0.0);
+    }
+    result
+}
+
+fn h_matrix() -> Matrix {
+    matrix([
+        [complex(FRAC_1_SQRT_2, 0.0), complex(FRAC_1_SQRT_2, 0.0)],
+        [complex(FRAC_1_SQRT_2, 0.0), complex(-FRAC_1_SQRT_2, 0.0)],
+    ])
+}
+
+fn x_matrix() -> Matrix {
+    matrix([
+        [complex(0.0, 0.0), complex(1.0, 0.0)],
+        [complex(1.0, 0.0), complex(0.0, 0.0)],
+    ])
+}
+
+fn y_matrix() -> Matrix {
+    matrix([
+        [complex(0.0, 0.0), complex(0.0, -1.0)],
+        [complex(0.0, 1.0), complex(0.0, 0.0)],
+    ])
+}
+
+fn z_matrix() -> Matrix {
+    matrix([
+        [complex(1.0, 0.0), complex(0.0, 0.0)],
+        [complex(0.0, 0.0), complex(-1.0, 0.0)],
+    ])
+}
+
+fn phase_matrix(angle: f64) -> Matrix {
+    matrix([
+        [complex(1.0, 0.0), complex(0.0, 0.0)],
+        [complex(0.0, 0.0), cis(angle)],
+    ])
+}
+
+fn rx_matrix(theta: f64) -> Matrix {
+    let cosine = (theta / 2.0).cos();
+    let sine = (theta / 2.0).sin();
+    matrix([
+        [complex(cosine, 0.0), complex(0.0, -sine)],
+        [complex(0.0, -sine), complex(cosine, 0.0)],
+    ])
+}
+
+fn ry_matrix(theta: f64) -> Matrix {
+    let cosine = (theta / 2.0).cos();
+    let sine = (theta / 2.0).sin();
+    matrix([
+        [complex(cosine, 0.0), complex(-sine, 0.0)],
+        [complex(sine, 0.0), complex(cosine, 0.0)],
+    ])
+}
+
+fn rz_matrix(theta: f64) -> Matrix {
+    matrix([
+        [cis(-theta / 2.0), complex(0.0, 0.0)],
+        [complex(0.0, 0.0), cis(theta / 2.0)],
+    ])
+}
+
+fn u_matrix(theta: f64, phi: f64, lambda: f64) -> Matrix {
+    let cosine = (theta / 2.0).cos();
+    let sine = (theta / 2.0).sin();
+    matrix([
+        [complex(cosine, 0.0), -cis(lambda) * sine],
+        [cis(phi) * sine, cis(phi + lambda) * cosine],
+    ])
+}
+
+fn rxy_matrix(theta: f64, phi: f64) -> Matrix {
+    let cosine = (theta / 2.0).cos();
+    let sine = (theta / 2.0).sin();
+    let minus_i = complex(0.0, -1.0);
+    matrix([
+        [complex(cosine, 0.0), minus_i * cis(-phi) * sine],
+        [minus_i * cis(phi) * sine, complex(cosine, 0.0)],
+    ])
+}
+
+fn sx_matrix() -> Matrix {
+    matrix([
+        [complex(0.5, 0.5), complex(0.5, -0.5)],
+        [complex(0.5, -0.5), complex(0.5, 0.5)],
+    ])
+}
+
+fn sxdg_matrix() -> Matrix {
+    matrix([
+        [complex(0.5, -0.5), complex(0.5, 0.5)],
+        [complex(0.5, 0.5), complex(0.5, -0.5)],
+    ])
+}
+
+fn controlled(target: &Matrix) -> Matrix {
+    let mut result = identity(4);
+    for target_row in 0..2 {
+        for target_column in 0..2 {
+            result[2 + target_row][2 + target_column] = target[target_row][target_column];
+        }
+    }
+    result
+}
+
+fn swap_matrix() -> Matrix {
+    matrix([
+        [
+            complex(1.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(1.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(1.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(1.0, 0.0),
+        ],
+    ])
+}
+
+fn rzz_matrix(theta: f64) -> Matrix {
+    let same = cis(-theta / 2.0);
+    let different = cis(theta / 2.0);
+    matrix([
+        [
+            same,
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            different,
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            different,
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            same,
+        ],
+    ])
+}
+
+fn rxx_matrix(theta: f64) -> Matrix {
+    let cosine = complex((theta / 2.0).cos(), 0.0);
+    let coupling = complex(0.0, -(theta / 2.0).sin());
+    matrix([
+        [cosine, complex(0.0, 0.0), complex(0.0, 0.0), coupling],
+        [complex(0.0, 0.0), cosine, coupling, complex(0.0, 0.0)],
+        [complex(0.0, 0.0), coupling, cosine, complex(0.0, 0.0)],
+        [coupling, complex(0.0, 0.0), complex(0.0, 0.0), cosine],
+    ])
+}
+
+fn szz_matrix() -> Matrix {
+    matrix([
+        [
+            complex(1.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 1.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 1.0),
+            complex(0.0, 0.0),
+        ],
+        [
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(0.0, 0.0),
+            complex(1.0, 0.0),
+        ],
+    ])
+}
+
+fn toffoli_matrix() -> Matrix {
+    let mut result = identity(8);
+    result[6][6] = complex(0.0, 0.0);
+    result[7][7] = complex(0.0, 0.0);
+    result[6][7] = complex(1.0, 0.0);
+    result[7][6] = complex(1.0, 0.0);
+    result
+}
+
+fn reference_matrix(name: &str, parameters: &[f64]) -> Matrix {
+    match name {
+        "h" => h_matrix(),
+        "x" => x_matrix(),
+        "y" => y_matrix(),
+        "z" => z_matrix(),
+        "id" => identity(2),
+        "s" => phase_matrix(PI / 2.0),
+        "sdg" | "Sdg" => phase_matrix(-PI / 2.0),
+        "t" => phase_matrix(FRAC_PI_4),
+        "tdg" | "Tdg" => phase_matrix(-FRAC_PI_4),
+        "sx" => sx_matrix(),
+        "sxdg" => sxdg_matrix(),
+        "rx" | "RX" => rx_matrix(parameters[0]),
+        "ry" | "RY" => ry_matrix(parameters[0]),
+        "rz" | "Rz" => rz_matrix(parameters[0]),
+        "phase" | "p" | "u1" => phase_matrix(parameters[0]),
+        "u" | "u3" => u_matrix(parameters[0], parameters[1], parameters[2]),
+        "u2" => u_matrix(PI / 2.0, parameters[0], parameters[1]),
+        "U1q" | "rxy1q" | "r1xy" => rxy_matrix(parameters[0], parameters[1]),
+        "cx" | "cnot" | "CNOT" => controlled(&x_matrix()),
+        "cy" => controlled(&y_matrix()),
+        "cz" | "cphase180" => controlled(&z_matrix()),
+        "swap" => swap_matrix(),
+        "csx" => controlled(&sx_matrix()),
+        "crz" => controlled(&rz_matrix(parameters[0])),
+        "crx" => controlled(&rx_matrix(parameters[0])),
+        "cry" => controlled(&ry_matrix(parameters[0])),
+        "cphase" | "cu1" | "cp" => controlled(&phase_matrix(parameters[0])),
+        "cphase90" => controlled(&phase_matrix(PI / 2.0)),
+        "rzz" => rzz_matrix(parameters[0]),
+        "rxx" => rxx_matrix(parameters[0]),
+        "szz" | "ZZ" => szz_matrix(),
+        "ccx" => toffoli_matrix(),
+        _ => panic!("gate '{name}' has no textbook reference"),
+    }
+}
+
+fn has_non_periodic_theta(name: &str) -> bool {
+    matches!(
+        name,
+        "rx" | "RX"
+            | "ry"
+            | "RY"
+            | "rz"
+            | "Rz"
+            | "crx"
+            | "cry"
+            | "crz"
+            | "rxx"
+            | "rzz"
+            | "u"
+            | "u3"
+            | "U1q"
+            | "rxy1q"
+            | "r1xy"
+    )
+}
+
+fn parameter_cases(definition: &GateDefinition) -> Vec<Vec<f64>> {
+    if definition.params.is_empty() {
+        return vec![Vec::new()];
+    }
+
+    let baseline = [0.23, -0.41, 0.59];
+    let mut cases = Vec::new();
+    for parameter_index in 0..definition.params.len() {
+        for probe in [0.7, FRAC_PI_3] {
+            let mut parameters = baseline[..definition.params.len()].to_vec();
+            parameters[parameter_index] = probe;
+            cases.push(parameters);
+        }
+    }
+
+    if has_non_periodic_theta(&definition.name) {
+        for probe in [TAU, 3.0 * PI] {
+            let mut parameters = baseline[..definition.params.len()].to_vec();
+            parameters[0] = probe;
+            cases.push(parameters);
+        }
+    }
+    cases
+}
+
+fn gate_invocation(definition: &GateDefinition, parameters: &[f64]) -> String {
+    let mut invocation = definition.name.clone();
+    if !parameters.is_empty() {
+        invocation.push('(');
+        for (index, parameter) in parameters.iter().enumerate() {
+            if index > 0 {
+                invocation.push_str(", ");
+            }
+            write!(invocation, "{parameter:.17}").expect("writing to String cannot fail");
+        }
+        invocation.push(')');
+    }
+    invocation.push(' ');
+    for index in 0..definition.qargs.len() {
+        if index > 0 {
+            invocation.push_str(", ");
+        }
+        write!(invocation, "q[{index}]").expect("writing to String cannot fail");
+    }
+    invocation.push(';');
+    invocation
+}
+
+fn compile_gate(
+    include_name: &str,
+    definition: &GateDefinition,
+    parameters: &[f64],
+) -> Vec<pecos_engines::ByteMessage> {
+    let invocation = gate_invocation(definition, parameters);
+    let qasm = format!(
+        "OPENQASM 2.0;\ninclude \"{include_name}\";\nqreg q[{}];\n{invocation}",
+        definition.qargs.len()
+    );
+    let mut engine = QASMEngine::from_str(&qasm).unwrap_or_else(|error| {
+        panic!(
+            "{include_name} {}{parameters:?} failed to parse: {error}",
+            definition.name
+        )
+    });
+    let mut messages = Vec::new();
+    loop {
+        let message = engine.generate_commands().unwrap_or_else(|error| {
+            panic!(
+                "{include_name} {}{parameters:?} failed to lower: {error}",
+                definition.name
+            )
+        });
+        let native_gates = message.quantum_ops().unwrap_or_else(|error| {
+            panic!(
+                "{include_name} {}{parameters:?} produced invalid native gates: {error}",
+                definition.name
+            )
+        });
+        if native_gates.is_empty() {
+            break;
+        }
+        messages.push(message);
+    }
+    messages
+}
+
+fn logical_to_simulator_basis(logical_basis: usize, qubit_count: usize) -> usize {
+    let mut simulator_basis = 0;
+    for logical_qubit in 0..qubit_count {
+        let logical_bit = (logical_basis >> (qubit_count - logical_qubit - 1)) & 1;
+        simulator_basis |= logical_bit << logical_qubit;
+    }
+    simulator_basis
+}
+
+fn executed_matrix(include_name: &str, definition: &GateDefinition, parameters: &[f64]) -> Matrix {
+    let messages = compile_gate(include_name, definition, parameters);
+    let qubit_count = definition.qargs.len();
+    let dimension = 1 << qubit_count;
+    let mut result = vec![vec![complex(0.0, 0.0); dimension]; dimension];
+
+    for logical_input in 0..dimension {
+        let simulator_input = logical_to_simulator_basis(logical_input, qubit_count);
+        let mut executor = DenseStateVecEngine::new(qubit_count);
+        if simulator_input != 0 {
+            executor.simulator_mut().set_amplitude(0, complex(0.0, 0.0));
+            executor
+                .simulator_mut()
+                .set_amplitude(simulator_input, complex(1.0, 0.0));
+        }
+        for message in &messages {
+            executor.process(message.clone()).unwrap_or_else(|error| {
+                panic!(
+                    "{include_name} {}{parameters:?} failed to execute: {error}",
+                    definition.name
+                )
+            });
+        }
+        let state = executor.simulator_mut().state();
+        for (logical_output, row) in result.iter_mut().enumerate() {
+            let simulator_output = logical_to_simulator_basis(logical_output, qubit_count);
+            row[logical_input] = state[simulator_output];
+        }
+    }
+    result
+}
+
+fn assert_matrix_matches(
+    include_name: &str,
+    gate_name: &str,
+    parameters: &[f64],
+    actual: &Matrix,
+    expected: &Matrix,
+) {
+    assert_eq!(actual.len(), expected.len());
+    let (pivot_row, pivot_column, _) = expected
+        .iter()
+        .enumerate()
+        .flat_map(|(row, entries)| {
+            entries
+                .iter()
+                .enumerate()
+                .map(move |(column, value)| (row, column, value.norm()))
+        })
+        .max_by(|left, right| left.2.total_cmp(&right.2))
+        .expect("a unitary matrix is nonempty");
+    let phase_ratio = actual[pivot_row][pivot_column] / expected[pivot_row][pivot_column];
+    let phase = phase_ratio / phase_ratio.norm();
+
+    for (row_index, (actual_row, expected_row)) in actual.iter().zip(expected).enumerate() {
+        for (column_index, (&actual_entry, &expected_entry)) in
+            actual_row.iter().zip(expected_row).enumerate()
+        {
+            let phase_adjusted = actual_entry / phase;
+            let error = (phase_adjusted - expected_entry).norm();
+            assert!(
+                error <= TOLERANCE,
+                "{include_name} {gate_name}{parameters:?} differs at [{row_index},{column_index}]: \
+                 actual={actual_entry}, shared_phase={phase}, adjusted={phase_adjusted}, \
+                 expected={expected_entry}, error={error}"
+            );
+        }
+    }
+}
+
+fn include_paths() -> Vec<PathBuf> {
+    let include_directory = Path::new(env!("CARGO_MANIFEST_DIR")).join("includes");
+    let mut paths: Vec<_> = fs::read_dir(&include_directory)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", include_directory.display()))
+        .map(|entry| {
+            entry
+                .expect("include directory entry must be readable")
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "inc"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn gate_definitions(include_name: &str) -> Vec<GateDefinition> {
+    let qasm = format!("OPENQASM 2.0;\ninclude \"{include_name}\";\nqreg q[1];");
+    let engine = QASMEngine::from_str(&qasm)
+        .unwrap_or_else(|error| panic!("failed to parse {include_name}: {error}"));
+    engine
+        .gate_definitions()
+        .expect("the engine has a loaded program")
+        .values()
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn every_include_gate_matches_its_textbook_unitary() {
+    let paths = include_paths();
+    assert!(
+        !paths.is_empty(),
+        "the standard includes directory is empty"
+    );
+
+    for path in paths {
+        let include_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("include filename must be valid UTF-8");
+        let definitions = gate_definitions(include_name);
+        assert!(!definitions.is_empty(), "{include_name} defines no gates");
+
+        for definition in definitions {
+            for parameters in parameter_cases(&definition) {
+                let expected = reference_matrix(&definition.name, &parameters);
+                let actual = executed_matrix(include_name, &definition, &parameters);
+                assert_matrix_matches(
+                    include_name,
+                    &definition.name,
+                    &parameters,
+                    &actual,
+                    &expected,
+                );
+            }
+        }
+    }
+}

--- a/crates/pecos-qasm/tests/integration/nine_qubit_circuit_test.rs
+++ b/crates/pecos-qasm/tests/integration/nine_qubit_circuit_test.rs
@@ -473,6 +473,7 @@ fn test_nine_qubit_quantum_circuit() {
     // Count the types of gates after expansion
     let mut h_count = 0;
     let mut cx_count = 0; // CZ expands to H-CX-H
+    let mut rxy_count = 0;
     let mut total_operations = 0;
 
     for op in &program.operations {
@@ -481,6 +482,8 @@ fn test_nine_qubit_quantum_circuit() {
             h_count += 1;
         } else if is_gate_type(op, "CX") {
             cx_count += 1;
+        } else if is_gate_type(op, "RXY1Q") {
+            rxy_count += 1;
         }
     }
 
@@ -500,11 +503,7 @@ fn test_nine_qubit_quantum_circuit() {
         "Should have more than 80 CX gates, got {cx_count}"
     );
 
-    // RX gates may also be expanded
-    assert!(
-        total_operations - h_count - cx_count > 100,
-        "Should have many other operations"
-    );
+    assert!(rxy_count > 100, "Should have many RXY1Q gates from RX");
 
     // Check that all operations are on valid qubits
     for op in &program.operations {
@@ -577,25 +576,19 @@ fn test_rx_half_pi_gates() {
 
     let program = QASMParser::parse_str(qasm).expect("Failed to parse RX gates");
 
-    // RX expands to H-RZ-H, so we look for the pattern
+    // RX lowers directly to RXY1Q(theta, 0).
     let mut total_ops = 0;
-    let mut h_count = 0;
-    let mut rz_count = 0;
+    let mut rxy_count = 0;
 
     for op in &program.operations {
         total_ops += 1;
-        if is_gate_type(op, "H") {
-            h_count += 1;
-        } else if is_gate_type(op, "RZ") {
-            rz_count += 1;
+        if is_gate_type(op, "RXY1Q") {
+            rxy_count += 1;
         }
     }
 
-    // Each RX expands to 3 gates (H-RZ-H)
-    // We have 5 RX gates, so expect 15 total operations
-    assert_eq!(total_ops, 15, "Should have 15 operations after expansion");
-    assert_eq!(h_count, 10, "Should have 10 H gates (2 per RX)");
-    assert_eq!(rz_count, 5, "Should have 5 RZ gates (1 per RX)");
+    assert_eq!(total_ops, 5, "Should have one native operation per RX");
+    assert_eq!(rxy_count, 5, "Should have 5 RXY1Q gates");
 }
 
 #[test]
@@ -627,15 +620,15 @@ fn test_circuit_patterns() {
     // After expansion, count the gate types
     let mut h_gates = 0;
     let mut cx_gates = 0;
-    let mut rz_gates = 0;
+    let mut rxy_gates = 0;
 
     for op in &program.operations {
         if is_gate_type(op, "H") {
             h_gates += 1;
         } else if is_gate_type(op, "CX") {
             cx_gates += 1;
-        } else if is_gate_type(op, "RZ") {
-            rz_gates += 1;
+        } else if is_gate_type(op, "RXY1Q") {
+            rxy_gates += 1;
         }
     }
 
@@ -645,8 +638,8 @@ fn test_circuit_patterns() {
     //   Pattern 1: rx q[0], rx q[1]
     //   Pattern 2: rx q[2], rx q[3]
     //   Pattern 3: rx q[1], rx q[2]
-    // Each RX expands to H-RZ-H = 12H + 6RZ
+    // Each RX lowers to one RXY1Q gate.
     assert_eq!(cx_gates, 4, "Should have 4 CX gates from CZ expansions");
-    assert_eq!(rz_gates, 6, "Should have 6 RZ gates from RX expansions");
-    assert_eq!(h_gates, 20, "Should have 20 H gates total");
+    assert_eq!(rxy_gates, 6, "Should have 6 RXY1Q gates from RX expansions");
+    assert_eq!(h_gates, 8, "Should have 8 H gates from CZ expansions");
 }

--- a/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_fault_tolerance.rs
+++ b/python/quantum-pecos/tests/docs/rust_crate/tests/user_guide_fault_tolerance.rs
@@ -198,7 +198,7 @@ let dem = DemBuilder::new(&influence_map)
     .with_noise(0.01, 0.01, 0.01, 0.01)  // p1, p2, p_meas, p_prep
     .with_detectors_json(detectors_json)?
     .with_observables_json(observables_json)?
-    .build()?;
+    .build();
 
 println!("DEM has {} detectors, {} contributions",
     dem.num_detectors(), dem.num_contributions());


### PR DESCRIPTION
## Summary

Closes #637. Four gate conversions in `crates/pecos-qasm/includes/qelib1.inc` computed the wrong unitary, and adds a conformance test covering every gate in every QASM include so this class of defect cannot recur silently.

`.inc` files are boundary translation tables: they express foreign QASM gate sets in PECOS natives. PECOS keeps a selective, QEC-focused native gate set and converts at the boundary, so a boundary conversion has to be exact — an approximate one is worse than a missing one, because a missing gate fails loud while a wrong gate silently computes something else. Every fix here uses natives that already exist; no native gate was added.

## The defects

Lowercase gate names are never native (`parser/native_gates.rs:3-4`), so user QASM always reaches these macros.

| Gate | Body | Computed |
|---|---|---|
| `ry(theta)` | `rx(-pi/2); rz(theta); rx(pi/2)` | `RY(-theta)` — the two `rx` calls are swapped |
| `cry(theta)` | standard body over `ry` | `CRY(-theta)` — inherited |
| `crx(theta)` | `ry(pi/2); cx; ry(theta); cx; ry(-pi/2)` | not a controlled gate at all: the `cx` pair cancels on the control=0 block, leaving a rotation there |
| `csx` | `cx a,b;  // Simplified version` | plain `CX` |

This was reachable in practice, not theoretical: the SLR QASM codegen emits `ry(pi/2)`/`ry(-pi/2)` for `SY`/`SYdg` (`slr/ast/codegen/qasm.py:87,90`), so SLR-generated QASM run against `qelib1.inc` silently computed `SYdg` where `SY` was written.

## The fixes

```
gate rx(theta) a { RXY1Q(theta, 0) a; }
gate ry(theta) a { RXY1Q(theta, pi/2) a; }
gate crx(theta) a,b { h b; crz(theta) a,b; h b; }
gate csx a,b { h b; cu1(pi/2) a,b; h b; }
```

`RXY1Q(theta, phi) = exp(-i(cos(phi) X + sin(phi) Y) theta/2)`, so `phi = 0` is `RX` and `phi = pi/2` is `RY` — matching `hqslib1.inc`, whose `rx`/`ry` already used the native and were correct. `rx`'s previous `h; rz; h` body was exact but indirect; it is the decomposition style that got `ry` wrong. `crx` conjugates the exact `crz` by `H` (`H Z H = X`). `csx` conjugates controlled-`S` by `H`, and `H diag(1,i) H` is exactly PECOS's phase-fixed `SX = e^{i pi/4} RX(pi/2)`, so `csx` stays supported with a real conversion rather than an approximation. `cry`'s body is unchanged — it becomes correct once `ry` is.

## The conformance test

`crates/pecos-qasm/tests/integration/include_gate_conformance_test.rs` enumerates every gate in every `.inc` under `includes/` via `QASMEngine::gate_definitions()` — the parser's own list, not a copy — and for each builds the unitary by executing it through the real QASM path on a generic dense state-vector engine across all computational basis inputs, comparing against a reference matrix under one shared global phase at non-Clifford angles (0.7 and pi/3, plus 2pi and 3pi where the reference is not 2pi-periodic). 78 gates, 171 matrices.

Properties that matter, each verified by mutation rather than asserted:

- A gate with no reference **fails** (`gate '<name>' has no textbook reference`) instead of being skipped — silent skipping is how these four survived. Verified by appending a gate to `pecos.inc`, and by dropping in a new `.inc` file.
- An unparseable include fails the test rather than covering fewer gates.
- Endianness is pinned, not self-cancelling: mutating `gate cx c,t` to `CX t,c` fails, as do control/target swaps inside `crx`, `csx`, and `ccx`.
- Reverting each of the four fixes fails, naming the gate, the matrix entry, and the error.
- The comparison is projective by design (a boundary conversion need only be exact up to an unobservable global phase); the file header says so explicitly, so it is not later mistaken for a phase-exactness guard — `phase_exactness_test.rs` remains that test. Every *relative* phase, including the control-side phase separating a controlled rotation from a controlled phase, is compared exactly.

Before writing any of this, all 78 gates across the three includes were checked against an independent reference table: `qelib1.inc` had exactly these four defects and `hqslib1.inc` (32 gates) and `pecos.inc` (9 gates) were exact throughout, so the other 74 are confirmed correct rather than merely unexamined.

## Existing tests updated

`rx` now expands to one native op instead of three, and `crx`/`cry` expand differently, so six test files were updated. Each expectation was tightened rather than merely made to pass: `custom_gates.rs` dropped an `|| operations.len() > 3` escape hatch; `expansion.rs` now pins `RXY1Q` with both `theta` and `phi == 0`; `rotation_gates.rs` replaced `rz_count > 2` / `h_count > 0` / `len > 4` with exact equalities; `nine_qubit_circuit_test.rs` replaced residual arithmetic with a direct count. No test function was removed. `clifford_rotation_simulation_test.rs` exercised `ry` through `hqslib1.inc`, which was already correct — which is why the broken `qelib1` definition was never caught.

Also included: one regenerated doc-test file (`tests/docs/rust_crate/tests/user_guide_fault_tolerance.rs`), where the committed copy was stale relative to `docs/user-guide/fault-tolerance.md`; re-running the generator reproduces it byte-identically.

## Follow-up filed

#646 — the SLR QASM codegen emits `crx`/`cry`/`crz` but defaults to an include that does not define them. Pre-existing and separate; it means these `crx`/`cry` fixes take effect for callers who include `qelib1.inc`.

## Verification

Cold: `cargo test -p pecos-qasm` (464), `cargo test` over pecos-core/quantum/simulators/engines (3,904), workspace clippy `-D warnings`, `cargo fmt --check`, the fast Python lane (2,831), `just docs-test` (306), `pre-commit` — all exit 0. Reviewed by an independent adversarial pass that re-derived all 78 reference matrices in its own oracle and ran 13 mutations (10 killed; the 3 survivors are true equivalences — a symmetric controlled-phase argument swap, commuting gates on disjoint qubits, and global-phase-only substitutions that the projective contract tolerates).
