### PR TITLE
Make rust check and clippy --include-ffi actually cover pecos-rslib-cuda

### DIFF
--- a/crates/pecos-cli/src/cli.rs
+++ b/crates/pecos-cli/src/cli.rs
@@ -60,9 +60,10 @@ pub enum RustCommands {
         #[arg(long, value_enum, default_value = "dev")]
         profile: BuildProfile,
 
-        /// Also test FFI crates (pecos-rslib, pecos-rslib-cuda,
-        /// pecos-julia-ffi). Same external-toolchain caveats as `rust check
-        /// --include-ffi`.
+        /// Also run pecos-rslib's Rust tests. It is the only excluded FFI
+        /// crate with Rust tests of its own, so the others are not added back
+        /// here even with this flag -- unlike `rust check`/`rust clippy`,
+        /// which do cover them.
         #[arg(long)]
         include_ffi: bool,
     },

--- a/crates/pecos-cli/src/cli/rust_cmd.rs
+++ b/crates/pecos-cli/src/cli/rust_cmd.rs
@@ -19,7 +19,9 @@ use std::process::Command;
 /// - pecos-julia-ffi needs Julia.
 ///
 /// All three are excluded from the default workspace check / clippy / test
-/// invocations and only touched when the caller opts in with `--include-ffi`.
+/// invocations. `--include-ffi` adds them back for check and clippy, each
+/// behind the toolchain it needs. For `test` it adds back only pecos-rslib,
+/// the one crate here with Rust tests of its own.
 const FFI_CRATES: &[&str] = &["pecos-rslib", "pecos-rslib-cuda", "pecos-julia-ffi"];
 
 /// Extra pyo3 cdylib crates excluded only from `cargo test --workspace`.
@@ -349,6 +351,25 @@ fn run_check(include_ffi: bool) -> Result<()> {
             ));
         }
 
+        // Gated on a CUDA toolkit being present: without one there is nothing
+        // for pecos-cuquantum's build script to build against. `find_cuda()` is
+        // the same resolver those build scripts use, so this agrees with what a
+        // real pecos-rslib-cuda build would see.
+        if pecos_build::cuda::find_cuda().is_some() {
+            println!("Checking pecos-rslib-cuda...");
+            if !run_cargo_command(&[
+                "check",
+                "-p",
+                "pecos-rslib-cuda",
+                "--all-targets",
+                "--all-features",
+            ]) {
+                return Err(Error::Config(
+                    "cargo check (pecos-rslib-cuda) failed".to_string(),
+                ));
+            }
+        }
+
         if is_tool_available("julia") {
             println!("Checking pecos-julia-ffi...");
             if !run_cargo_command(&[
@@ -426,6 +447,25 @@ fn run_clippy(include_ffi: bool, fix: bool) -> Result<()> {
             return Err(Error::Config(
                 "cargo clippy (pecos-rslib) failed".to_string(),
             ));
+        }
+
+        // See the CUDA gate in run_check for why this is conditional.
+        if pecos_build::cuda::find_cuda().is_some() {
+            println!("Running clippy on pecos-rslib-cuda...");
+            let mut args: Vec<&str> = vec![
+                "clippy",
+                "-p",
+                "pecos-rslib-cuda",
+                "--all-targets",
+                "--all-features",
+            ];
+            args.extend(&fix_args);
+            args.extend(&["--", "-D", "warnings"]);
+            if !run_cargo_command(&args) {
+                return Err(Error::Config(
+                    "cargo clippy (pecos-rslib-cuda) failed".to_string(),
+                ));
+            }
         }
 
         if is_tool_available("julia") {


### PR DESCRIPTION
`pecos rust check|clippy|test --include-ffi` documented that it opts in to the FFI crates excluded from the default lanes, but `pecos-rslib-cuda` appeared **only** in `FFI_CRATES` (the exclude list) and in an explanatory comment. No arm ever added it back. The crate was therefore never checked or linted by anything: no workflow and no Justfile recipe passes `--include-ffi`, so it is a hand-run developer flag and the gap was silent.

The rationale comment stated the intent plainly (`rust_cmd.rs:14-17`):

> `pecos-rslib-cuda` ... build.rs calls `ensure_cutensor()` on Linux -- that will silently download cuTensor over the network ... which we don't want a routine `cargo check` to do. Dedicated CUDA workflows can **opt in via `--include-ffi`** or by setting up the cache first.

The design was right; only the opt-in half was missing. This implements it rather than trimming the doc to match the bug, which would have deleted the only way to check that crate through the standard tool.

## Changes

- `run_check` and `run_clippy` gain a `pecos-rslib-cuda` arm gated on `pecos_build::cuda::find_cuda().is_some()`, mirroring the existing `is_tool_available("julia")` gate. No new helper: `find_cuda()` is already `pub` and used across pecos-cli, and it is the same resolver the `pecos-cuquantum` build scripts use, so the gate agrees with what a real build would see. Placed before the julia arm to match `FFI_CRATES` order.
- `run_test` behavior is deliberately **unchanged**. `pecos-rslib-cuda` and `pecos-julia-ffi` have 0 Rust test markers; `pecos-rslib` has 135. There is nothing to run, so the `Test` help was corrected instead of adding an empty arm.
- The blanket sentence on `FFI_CRATES` ("only touched when the caller opts in") was true of neither subcommand as written; it now states what check/clippy and test each actually do.

## Verification

All run locally on a CUDA box (RTX 4090, CUDA 13.3 at `/usr/local/cuda`, cuTensor already cached in `~/.pecos/deps/` so no network fetch):

- Negative proof on `dev`: `pecos-rslib-cuda` occurs only at `rust_cmd.rs:14` and `:23` -- never added back.
- `find_cuda()` resolves `/usr/local/cuda` here, so the gate fires.
- `cargo check -p pecos-rslib-cuda --all-targets --all-features` -- exit 0.
- `pecos rust check --include-ffi` -- emits `Checking pecos-rslib-cuda...`, exit 0.
- `pecos rust clippy --include-ffi` -- emits `Running clippy on pecos-rslib-cuda...`, exit 0.
- Cold clippy after touching `python/pecos-rslib-cuda/src/lib.rs` -- recompiles and exits 0, so the crate carries no latent lint debt from never having been linted.
- `cargo fmt --all -- --check` and `cargo clippy --locked -p pecos-cli --all-targets -- -D warnings` clean.

The julia arm does not appear in those runs because Julia is not installed on this machine -- the gate behaving correctly.

## Notes

Found by an independent review of #652 as a pre-existing defect, and kept out of that PR: whether `--include-ffi` *should* cover CUDA is a behavior decision, not a Go-removal one.

Incidental: `nvcc` is not on `PATH` and `CUDA_PATH` is unset on a machine that plainly has CUDA, so `command -v nvcc` is a false negative for CUDA presence. `find_cuda()` resolves `/usr/local/cuda` directly and is the reliable probe. Nothing in this diff depends on the `nvcc` check, but it is worth knowing before writing another one.