### PR TITLE
Cut ~20 min of wasted native builds from the Python CI lanes and make the PR-gate Rust caches restorable

### DIFF
--- a/.github/workflows/pr-core-gate.yml
+++ b/.github/workflows/pr-core-gate.yml
@@ -12,7 +12,11 @@ name: PR core gate
 #
 # The setup below mirrors the Linux legs of python-test.yml (python-core) and
 # rust-test.yml. Keep their action SHAs, uv/just/LLVM versions, and cache keys
-# in sync when editing either side. The change-detection rule lives in
+# in sync when editing either side. The Rust caches are shared with those two
+# jobs through `shared-key` (they save on dev pushes, this workflow only
+# restores); rust-cache hashes the RUSTFLAGS/CARGO_*/RUST_BACKTRACE values into
+# the key, so the `env:` block here must stay identical to theirs or every
+# restore silently misses. The change-detection rule lives in
 # scripts/ci/pr-core-changed.sh (single source of truth for both jobs).
 
 permissions:
@@ -121,9 +125,9 @@ jobs:
           cache-bin: false
           prefix-key: v1-rust-no-bin
           save-if: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
-          workspaces: |
-            python/pecos-rslib
-            python/pecos-rslib-llvm
+          # Read the cache the post-merge python-core job (python-test.yml)
+          # saves on dev pushes; this workflow never saves one (PR events).
+          shared-key: python-core
 
       - name: Cache LLVM ${{ env.LLVM_VERSION }}
         if: steps.detect.outputs.run == 'true'
@@ -224,9 +228,9 @@ jobs:
           cache-bin: false
           prefix-key: v1-rust-no-bin
           save-if: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
-          workspaces: |
-            python/pecos-rslib
-            python/pecos-rslib-llvm
+          # Read the cache the post-merge rust-test job (rust-test.yml) saves
+          # on dev pushes; this workflow never saves one (PR events).
+          shared-key: rust-test
 
       - name: Cache LLVM ${{ env.LLVM_VERSION }}
         if: steps.detect.outputs.run == 'true'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -203,9 +203,11 @@ jobs:
         cache-bin: false
         prefix-key: v1-rust-no-bin
         save-if: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
-        workspaces: |
-          python/pecos-rslib
-          python/pecos-rslib-llvm
+        # The cache saved here is what pr-core-python (pr-core-gate.yml)
+        # restores on every PR. The default (root) workspace is the right one:
+        # the rslib crates are members of the root Cargo workspace and build
+        # into the top-level target/.
+        shared-key: python-core
 
     - name: Cache LLVM ${{ env.LLVM_VERSION }}
       if: github.event_name != 'pull_request'
@@ -483,6 +485,8 @@ jobs:
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version-file: ".github/uv.toml"
+        enable-cache: true
+        save-cache: ${{ github.event_name == 'push' && contains(fromJSON('["main", "master", "development", "dev"]'), github.ref_name) }}
 
     - name: Set up Rust (Windows)
       if: runner.os == 'Windows' && matrix.include-llvm

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -9,6 +9,12 @@ env:
   RUST_BACKTRACE: 1
   LLVM_VERSION: "21.1"
   LLVM_RELEASE_VERSION: "21.1.8"
+  # Same cargo network settings as python-test.yml / pr-core-gate.yml. Beyond
+  # robustness, rust-cache hashes these values into its key, so the rust-test
+  # cache is only restorable by pr-core-rust if the sets match exactly.
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_NET_RETRY: "10"
 
 on:
   workflow_dispatch:
@@ -253,6 +259,9 @@ jobs:
           cache-bin: false
           prefix-key: v1-rust-no-bin
           save-if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'development' || github.ref_name == 'dev') }}
+          # The cache saved here is what pr-core-rust (pr-core-gate.yml)
+          # restores on every PR.
+          shared-key: rust-test
 
       - name: Cache LLVM ${{ env.LLVM_VERSION }}
         if: github.event_name != 'pull_request' || matrix.os == 'ubuntu-latest'

--- a/Justfile
+++ b/Justfile
@@ -266,7 +266,9 @@ python-ci-build-docs profile="debug": _msvc-bootstrap (validate-profile "python-
     set -euo pipefail
     PROFILE="{{profile}}"
     PECOS_BUILD_MWPF=0 {{pecos}} python build --profile "$PROFILE" --no-cuda
-    uv run --frozen --package pecos-rslib-exp maturin develop --uv --locked --manifest-path python/pecos-rslib-exp/Cargo.toml
+    # --no-sync: a package-scoped `uv run` otherwise syncs pecos-rslib-exp into the
+    # environment first, i.e. builds the release wheel this very command replaces.
+    uv run --frozen --no-sync --package pecos-rslib-exp maturin develop --uv --locked --manifest-path python/pecos-rslib-exp/Cargo.toml
 
 # Build the extra experimental bindings exercised by the fast Python core test lane.
 [group('build')]
@@ -275,7 +277,9 @@ python-ci-build-test profile="debug": _msvc-bootstrap (validate-profile "python-
     set -euo pipefail
     PROFILE="{{profile}}"
     {{pecos}} python build --profile "$PROFILE" --no-cuda
-    uv run --frozen --package pecos-rslib-exp maturin develop --uv --locked --manifest-path python/pecos-rslib-exp/Cargo.toml
+    # --no-sync: a package-scoped `uv run` otherwise syncs pecos-rslib-exp into the
+    # environment first, i.e. builds the release wheel this very command replaces.
+    uv run --frozen --no-sync --package pecos-rslib-exp maturin develop --uv --locked --manifest-path python/pecos-rslib-exp/Cargo.toml
 
 # =============================================================================
 # Testing

--- a/Justfile
+++ b/Justfile
@@ -961,6 +961,12 @@ sync-deps:
     fi
     uv sync "${SYNC_ARGS[@]}"
 
+# The python-ci-sync* recipes install the pure-Python side of the workspace
+# only. The native packages are listed with `--package` so their dependencies
+# land in the environment, but are excluded from installation with
+# `--no-install-package`: otherwise uv builds release wheels of each one
+# (~20 min on a 4-core runner) that the following `pecos python build` /
+# `maturin develop` step immediately replaces with a debug build.
 [group('setup')]
 python-ci-sync:
     #!/usr/bin/env bash
@@ -970,7 +976,9 @@ python-ci-sync:
       --group test \
       --package pecos-rslib \
       --package pecos-rslib-llvm \
-      --package quantum-pecos
+      --package quantum-pecos \
+      --no-install-package pecos-rslib \
+      --no-install-package pecos-rslib-llvm
 
 [group('setup')]
 python-ci-sync-test:
@@ -982,7 +990,10 @@ python-ci-sync-test:
       --package pecos-rslib \
       --package pecos-rslib-exp \
       --package pecos-rslib-llvm \
-      --package quantum-pecos
+      --package quantum-pecos \
+      --no-install-package pecos-rslib \
+      --no-install-package pecos-rslib-exp \
+      --no-install-package pecos-rslib-llvm
 
 [group('setup')]
 python-ci-sync-docs:

--- a/scripts/ci/ensure-rust.sh
+++ b/scripts/ci/ensure-rust.sh
@@ -4,8 +4,27 @@ set -euo pipefail
 toolchain="${1:-stable}"
 profile="${2:-minimal}"
 
+# Every network step below talks to static.rust-lang.org, which resets
+# connections from GitHub runners now and then (two PR gate failures within
+# an hour on 2026-09-03, both `Connection reset by peer` on the channel
+# manifest). Retry each one a few times with a growing pause before giving up.
+retry() {
+    local attempts=3 attempt
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+        if "$@"; then
+            return 0
+        fi
+        if ((attempt < attempts)); then
+            echo "ensure-rust: attempt $attempt/$attempts failed: $*; retrying in $((attempt * 15))s" >&2
+            sleep $((attempt * 15))
+        fi
+    done
+    echo "ensure-rust: giving up after $attempts attempts: $*" >&2
+    return 1
+}
+
 if command -v rustup >/dev/null 2>&1; then
-    rustup toolchain install "$toolchain" --profile "$profile"
+    retry rustup toolchain install "$toolchain" --profile "$profile"
 else
     case "$(uname -s)-$(uname -m)" in
         Linux-x86_64)
@@ -30,8 +49,8 @@ else
     trap 'rm -rf "$tmp_dir"' EXIT
 
     base_url="https://static.rust-lang.org/rustup/dist/${target}"
-    curl --proto '=https' --tlsv1.2 -fsSLo "$tmp_dir/rustup-init" "$base_url/rustup-init"
-    curl --proto '=https' --tlsv1.2 -fsSLo "$tmp_dir/rustup-init.sha256" "$base_url/rustup-init.sha256"
+    retry curl --proto '=https' --tlsv1.2 -fsSLo "$tmp_dir/rustup-init" "$base_url/rustup-init"
+    retry curl --proto '=https' --tlsv1.2 -fsSLo "$tmp_dir/rustup-init.sha256" "$base_url/rustup-init.sha256"
 
     if command -v sha256sum >/dev/null 2>&1; then
         (cd "$tmp_dir" && sha256sum -c rustup-init.sha256)
@@ -40,7 +59,7 @@ else
     fi
 
     chmod +x "$tmp_dir/rustup-init"
-    "$tmp_dir/rustup-init" -y --profile "$profile" --default-toolchain "$toolchain" --no-modify-path
+    retry "$tmp_dir/rustup-init" -y --profile "$profile" --default-toolchain "$toolchain" --no-modify-path
 fi
 
 if [[ -n "${GITHUB_PATH:-}" ]]; then


### PR DESCRIPTION
## Why

`pr-core-python` takes ~48 min and `pr-core-rust` ~30 min on every PR. Step logs of a green run (33689125045) show most of the Python time is spent on work that is thrown away, and that neither job has ever restored a Rust cache.

**Double native build (20 min).** `python-ci-sync-test` / `python-ci-sync` run `uv sync --package pecos-rslib --package pecos-rslib-llvm ...`, so uv builds release wheels of the native packages through the maturin build backend (`Prepared 40 packages in 19m 52s` on 4 cores). `pecos python build --profile debug` then rebuilds all of them in debug mode and replaces the installs. The post-merge `python-core` lane pays the same 19 min.

**Rust cache never hits.** Both `Cache Rust` steps log `No cache found.`:
- the key embeds the job name (`v1-rust-no-bin-pr-core-python-...`) while the only jobs that save (dev pushes) are named `python-core` / `rust-test`, and this workflow never saves on PR events;
- `workspaces:` pointed at `python/pecos-rslib` and `python/pecos-rslib-llvm`, so the cache paths were `python/pecos-rslib/target`, which does not exist (those crates are members of the root Cargo workspace and build into the top-level `target/`). The dev-push `python-core` save is 179 MB of registry only.

## What

- `Justfile`: the `python-ci-sync*` recipes keep the native packages in `--package` (their dependencies still install) but add `--no-install-package` for each, so uv no longer builds them. Verified locally: the recipe drops from ~20 min to about 1 s, the pure-Python deps and `maturin` still land in the environment, and the later `uv run --frozen pytest` does not try to build them (the root `pecos-workspace` project has no dependency on them).
- `pr-core-gate.yml`: drop the wrong `workspaces:` (default is the root workspace) and set `shared-key: python-core` / `shared-key: rust-test` so the PR jobs restore what the dev-push jobs save.
- `python-test.yml`: same fix for the `python-core` job (the saver), plus `enable-cache`/`save-cache` on the compat-smoke uv setup, which was saving a 459 MB uv cache per Python version on every PR merge ref. The repo is at 10.57 GB of the 10 GB cache budget, so those PR-ref entries were evicting the caches that matter.
- `rust-test.yml`: `shared-key: rust-test` on the saver, and the same three `CARGO_*` network vars as the other two workflows. rust-cache hashes those values into the key, so the sets must match for the PR job to restore.

The remaining `workspaces:` blocks with the same stale paths (python-lint, python-compat-smoke-build, python-slow-postmerge, zluppy-postmerge, docs-ci, julia-test, python-release) are left alone on purpose: fixing them would make each save a 1-2 GB root target cache on dev pushes and blow the budget. They only lose the target cache, not correctness.

## Expected effect

| job | before | after this PR |
|---|---|---|
| pr-core-python | ~48 min | ~25 min (build ~5 min once the cache warms after the next dev push) |
| pr-core-rust | ~30 min | ~25 min after the next dev push warms the cache |

A follow-up PR shards the Python lane into three matrix jobs (test time is ~20 min of the remaining ~25).

## Verification

- `uvx pre-commit run --files` on the four changed files: pass.
- `just -n python-ci-sync-test` shows the intended command; running it against a scratch `UV_PROJECT_ENVIRONMENT` finished in 1.0 s with no `pecos_rslib*` installed and `maturin`/`pytest`/`numpy`/`guppylang` present.
- The cache-key half can only be proven by CI: this PR's `Cache Rust` steps will still miss (nothing saved under the new keys yet); the first dev push after merge saves them and the next PR should log `Cache restored`.

## Review

An independent correctness review of the diff found one real gap, confirmed by execution and fixed in the second commit: the `uv run --frozen --package pecos-rslib-exp maturin develop ...` line in `python-ci-build-test` / `python-ci-build-docs` performs a package-scoped sync before running maturin, so with pecos-rslib-exp no longer pre-installed uv would build its release wheel first (the pre-change log already shows uv's isolated build environment rebuilding `target/release/libpecos_rslib_exp.so` in that step). `--no-sync` removes that; verified locally that the line then runs the environment's maturin in 0.1 s with no build. The review agreed with the other claims (dependency coverage of the new sync, cache key pairing and env hash, smoke-job uv cache expression).


A re-review of the `--no-sync` fix raised that `.venv/bin/maturin` might no longer be provisioned, since neither the old nor the new sync installs it (the `--group dev` flags resolve against the `--package` members, whose dev groups hold only patchelf). Checked by execution: it is installed by `pecos python build` itself, whose availability check runs a bare `uv run python --version` that syncs the root project's default `dev`/`test` groups (57 packages, maturin included) before any maturin call. That is the pre-existing mechanism on `dev` as well, unchanged here; the `--no-sync` line runs after it and resolves the venv copy first on PATH.


## Also: retry in `scripts/ci/ensure-rust.sh`

Two gate jobs on this PR died in `Set up Rust` within an hour of each other with `Connection reset by peer` from static.rust-lang.org while rustup fetched the channel manifest, before any PECOS code ran. The script now wraps `rustup toolchain install`, the two `rustup-init` curl downloads, and the `rustup-init` run in a three-attempt retry with a 15 s then 30 s pause; the final failure still propagates. The helper was exercised with stub commands (succeeds on attempt three; gives up after three and returns non-zero). The Windows legs call `rustup toolchain install` directly from pwsh steps (rust-test.yml, python-test.yml) and are not covered by this bash helper.
