### PR TITLE
Sample density measurements from normalized branch weights

### DIFF
--- a/crates/pecos-gpu-sims/src/gpu_density_matrix.rs
+++ b/crates/pecos-gpu-sims/src/gpu_density_matrix.rs
@@ -860,22 +860,33 @@ impl<SV: GpuStateVecBackend> CliffordGateable for GpuDensityMatrix<SV> {
             let qubit = q.index();
             let state = self.state_vector.state_f64();
 
-            // P(qubit = 1) = sum_k rho_{k,k} over k with bit_q(k) = 1.
-            // In the purification convention, rho_{k,k} = sum_i |psi[(k<<n)|i]|^2,
-            // so we sum over every Choi index whose system-row has bit_q set.
+            // In the purification convention, each branch weight is the sum of
+            // |psi[(k<<n)|i]|^2 over physical rows in that branch. Normalize the weights before
+            // applying probability-scale thresholds or sampling because f32 gate arithmetic can
+            // make the total drift slightly from one without changing the represented state.
             let qubit_mask = 1usize << qubit;
-            let prob_one: f64 = state
-                .iter()
-                .enumerate()
-                .filter(|(idx, _)| ((idx >> n) & qubit_mask) != 0)
-                .map(|(_, [re, im])| re * re + im * im)
-                .sum();
+            let (zero_weight, one_weight) = state.iter().enumerate().fold(
+                (0.0, 0.0),
+                |(zero_weight, one_weight), (idx, [re, im])| {
+                    let weight = re * re + im * im;
+                    if ((idx >> n) & qubit_mask) == 0 {
+                        (zero_weight + weight, one_weight)
+                    } else {
+                        (zero_weight, one_weight + weight)
+                    }
+                },
+            );
+            let total_weight = zero_weight + one_weight;
+            let prob_one = one_weight / total_weight;
 
             let is_deterministic = !(1e-10..=1.0 - 1e-10).contains(&prob_one);
+            // Keep RNG advancement transactional with the projected-state write. If the
+            // invariant below fails, a caught panic must not perturb seeded replay.
+            let mut next_rng = self.rng.clone();
             let outcome = if is_deterministic {
                 prob_one > 0.5
             } else {
-                self.rng.random_range(0.0..1.0) < prob_one
+                next_rng.random_range(0.0..1.0) < prob_one
             };
 
             let target_bit = if outcome { qubit_mask } else { 0 };
@@ -893,7 +904,11 @@ impl<SV: GpuStateVecBackend> CliffordGateable for GpuDensityMatrix<SV> {
 
             assert!(
                 norm_sq > 1e-15,
-                "projected outcome has zero weight; sampler and projector disagree"
+                "GPU density-matrix measurement projected to zero norm; sampler and projector \
+                 disagree: qubit={qubit}, outcome={}, projected_weight={norm_sq:.17e}, \
+                 zero_weight={zero_weight:.17e}, one_weight={one_weight:.17e}, \
+                 total_norm={total_weight:.17e}",
+                u8::from(outcome)
             );
             let norm = norm_sq.sqrt();
             for amp in &mut new_state {
@@ -902,6 +917,7 @@ impl<SV: GpuStateVecBackend> CliffordGateable for GpuDensityMatrix<SV> {
             }
 
             self.state_vector.write_state_f64(&new_state);
+            self.rng = next_rng;
 
             results.push(MeasurementResult {
                 outcome,
@@ -1038,11 +1054,169 @@ mod tests {
         fn sync_backend(&mut self) {}
     }
 
+    /// CPU-backed adapter that uses the GPU's f32 Hadamard coefficients. It exercises the real
+    /// generic density-wrapper logic on hosts where a hardware GPU is unavailable while retaining
+    /// the norm drift that exposed the f32 measurement bug.
+    struct RoundedF32StateVec(StateVecSoA);
+
+    impl QuantumSimulator for RoundedF32StateVec {
+        fn reset(&mut self) -> &mut Self {
+            self.0.reset();
+            self
+        }
+
+        fn num_qubits(&self) -> usize {
+            self.0.num_qubits()
+        }
+    }
+
+    impl CliffordGateable for RoundedF32StateVec {
+        fn x(&mut self, qubits: &[QubitId]) -> &mut Self {
+            self.0.x(qubits);
+            self
+        }
+
+        fn sz(&mut self, qubits: &[QubitId]) -> &mut Self {
+            self.0.sz(qubits);
+            self
+        }
+
+        fn h(&mut self, qubits: &[QubitId]) -> &mut Self {
+            let gate = crate::gates::H;
+            for &qubit in qubits {
+                self.0.single_qubit_unitary(
+                    qubit.index(),
+                    Complex64::new(f64::from(gate[0]), f64::from(gate[1])),
+                    Complex64::new(f64::from(gate[2]), f64::from(gate[3])),
+                    Complex64::new(f64::from(gate[4]), f64::from(gate[5])),
+                    Complex64::new(f64::from(gate[6]), f64::from(gate[7])),
+                );
+            }
+            self
+        }
+
+        fn cx(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
+            self.0.cx(pairs);
+            self
+        }
+
+        fn mz(&mut self, qubits: &[QubitId]) -> Vec<MeasurementResult> {
+            self.0.mz(qubits)
+        }
+    }
+
+    impl ArbitraryRotationGateable for RoundedF32StateVec {
+        fn rx(&mut self, theta: Angle64, qubits: &[QubitId]) -> &mut Self {
+            self.0.rx(theta, qubits);
+            self
+        }
+
+        fn rz(&mut self, theta: Angle64, qubits: &[QubitId]) -> &mut Self {
+            self.0.rz(theta, qubits);
+            self
+        }
+
+        fn rzz(&mut self, theta: Angle64, pairs: &[(QubitId, QubitId)]) -> &mut Self {
+            self.0.rzz(theta, pairs);
+            self
+        }
+    }
+
+    impl GpuStateVecBackend for RoundedF32StateVec {
+        fn new_backend(num_qubits: u32) -> Result<Self, GpuError> {
+            let mut state = StateVecSoA::new(
+                usize::try_from(num_qubits).expect("u32 qubit count must fit usize"),
+            );
+            state.set_fusion(false);
+            Ok(Self(state))
+        }
+
+        fn state_f64(&mut self) -> Vec<[f64; 2]> {
+            self.0
+                .state()
+                .into_iter()
+                .map(|amplitude| [amplitude.re, amplitude.im])
+                .collect()
+        }
+
+        fn write_state_f64(&mut self, amplitudes: &[[f64; 2]]) {
+            let amplitudes: Vec<Complex64> = amplitudes
+                .iter()
+                .map(|[re, im]| Complex64::new(*re, *im))
+                .collect();
+            let rng = self.0.rng().clone();
+            self.0 = StateVecSoA::from_state(&amplitudes, rng);
+            self.0.set_fusion(false);
+        }
+
+        fn sync_backend(&mut self) {}
+    }
+
     // Primary tests run on the f32 backend (GpuDensityMatrix32), because the
     // f64 backend has pre-existing shader bugs in RZZ/RXX/RYY we haven't
     // fixed yet. Tolerance ~1e-3 reflects f32 precision for f64 comparisons.
     const TOL: f64 = 1e-3;
     const CONJUGATION_TOLERANCE: f64 = 1e-12;
+    const UPPER_TAIL_SEED: u64 = 6_327_882;
+
+    fn check_rounded_deterministic_measurement<SV: GpuStateVecBackend>() -> Result<(), GpuError> {
+        let q0 = QubitId(0);
+        let mut density = GpuDensityMatrix::<SV>::with_seed(1, UPPER_TAIL_SEED)?;
+        density.x(&[q0]).h(&[q0]).h(&[q0]);
+
+        let state = density.state_vector.state_f64();
+        let (zero_weight, one_weight) = state.iter().enumerate().fold(
+            (0.0, 0.0),
+            |(zero_weight, one_weight), (idx, [re, im])| {
+                let weight = re * re + im * im;
+                if (idx >> 1) & 1 == 0 {
+                    (zero_weight + weight, one_weight)
+                } else {
+                    (zero_weight, one_weight + weight)
+                }
+            },
+        );
+        assert!(
+            (1e-10..=1.0 - 1e-10).contains(&one_weight),
+            "the rounded deterministic branch weight must expose the old absolute-threshold bug: \
+             {one_weight:.17e}"
+        );
+        assert!(zero_weight <= 1e-15);
+
+        let initial_rng = PecosRng::seed_from_u64(UPPER_TAIL_SEED);
+        let mut preview_rng = initial_rng.clone();
+        let upper_tail_draw = preview_rng.random_range(0.0..1.0);
+        assert!(
+            upper_tail_draw > one_weight,
+            "the forced draw {upper_tail_draw:.17e} must exceed the raw one-branch weight \
+             {one_weight:.17e}"
+        );
+        density.set_rng(initial_rng.clone());
+
+        let result = density.mz(&[q0]);
+        assert!(result[0].outcome);
+        assert!(result[0].is_deterministic);
+        assert_eq!(
+            density.rng(),
+            &initial_rng,
+            "deterministic measurement drew RNG"
+        );
+        assert!((density.probability(1) - 1.0).abs() < 1e-12);
+        assert!(density.probability(0) < 1e-15);
+        Ok(())
+    }
+
+    #[test]
+    fn rounded_f32_deterministic_measurement_ignores_upper_tail_draw() {
+        check_rounded_deterministic_measurement::<RoundedF32StateVec>().unwrap();
+    }
+
+    #[test]
+    fn gpu_f32_deterministic_measurement_ignores_upper_tail_draw() {
+        let Ok(()) = check_rounded_deterministic_measurement::<GpuStateVec32>() else {
+            return;
+        };
+    }
 
     fn assert_density_diagonal(rho: &[Vec<Complex64>], expected_diagonal: &[f64], tolerance: f64) {
         assert_eq!(rho.len(), expected_diagonal.len());

--- a/crates/pecos-simulators/src/density_matrix.rs
+++ b/crates/pecos-simulators/src/density_matrix.rs
@@ -1181,22 +1181,33 @@ where
             let state = self.state_vector.state();
             let qubit_mask = 1 << qubit;
 
-            // P(qubit = 1) is the norm on physical rows whose measured bit is set.
-            let prob_one: f64 = state
-                .iter()
-                .enumerate()
-                .filter(|(idx, _)| ((idx >> n) & qubit_mask) != 0)
-                .map(|(_, amplitude)| amplitude.norm_sqr())
-                .sum();
+            // Normalize the branch weights before applying probability-scale thresholds or
+            // sampling. The purification norm can drift slightly without changing the state.
+            let (zero_weight, one_weight) = state.iter().enumerate().fold(
+                (0.0, 0.0),
+                |(zero_weight, one_weight), (idx, amplitude)| {
+                    let weight = amplitude.norm_sqr();
+                    if ((idx >> n) & qubit_mask) == 0 {
+                        (zero_weight + weight, one_weight)
+                    } else {
+                        (zero_weight, one_weight + weight)
+                    }
+                },
+            );
+            let total_weight = zero_weight + one_weight;
+            let prob_one = one_weight / total_weight;
 
             // Determine if measurement is deterministic
             let is_deterministic = !(1e-10..=1.0 - 1e-10).contains(&prob_one);
 
             // Determine outcome
+            // Keep RNG advancement transactional with the projected-state write. If the
+            // invariant below fails, a caught panic must not perturb seeded replay.
+            let mut next_rng = self.state_vector.rng().clone();
             let outcome = if is_deterministic {
                 prob_one > 0.5
             } else {
-                self.state_vector.rng_mut().random_range(0.0..1.0) < prob_one
+                next_rng.random_range(0.0..1.0) < prob_one
             };
 
             // Apply the measurement projection to the physical/high register. The low index is a
@@ -1218,7 +1229,11 @@ where
 
             assert!(
                 norm_sq > 1e-15,
-                "projected outcome has zero weight; sampler and projector disagree"
+                "density-matrix measurement projected to zero norm; sampler and projector \
+                 disagree: qubit={qubit}, outcome={}, projected_weight={norm_sq:.17e}, \
+                 zero_weight={zero_weight:.17e}, one_weight={one_weight:.17e}, \
+                 total_norm={total_weight:.17e}",
+                u8::from(outcome)
             );
             let norm = norm_sq.sqrt();
             for amplitude in &mut new_state {
@@ -1226,7 +1241,7 @@ where
             }
 
             // Update the state vector
-            let new_sv = StateVec::from_state(&new_state, self.state_vector.rng().clone());
+            let new_sv = StateVec::from_state(&new_state, next_rng);
             *self.state_vector_mut() = new_sv;
 
             results.push(MeasurementResult {


### PR DESCRIPTION
Follow-up to #642, which merged before this fix was ready. Fixes a reachable liveness regression introduced by that PR's new zero-norm assertion.

## The defect

Measurement sampled against an **unnormalized** branch weight. `prob_one` was a raw sum of `norm_sqr()` over the physical rows with the measured bit set, and that raw value drove both the determinism band (`1e-10 ..= 1.0 - 1e-10`) and the draw (`random_range(0.0..1.0) < prob_one`). Those absolute f64-scale thresholds assume a total norm of exactly 1.

`GpuDensityMatrix32` is single precision: its f32 amplitudes are widened to f64 without renormalizing, so a total norm of `0.99999976` is normal there while its other tests allow 1e-3 error. The physically deterministic circuit `X; H; H` therefore lands inside the non-deterministic band, and an RNG draw above `prob_one` selects the outcome whose projected weight is at most 1e-15 -- tripping #642's new assertion. Measured on a live Vulkan backend: roughly a `2.4e-7` chance of aborting a valid circuit per such measurement.

## The fix

Both branch weights and their total are computed, and the determinism test and the draw both use `one_weight / total_weight`. Applied in the CPU path and in the GPU wrapper after the f32 widening. Normalizing makes the sampler robust to any legitimate norm drift, not only the f32 case.

The assertion is deliberately kept -- a genuinely zero-norm projection is still a real invariant violation and must fail loud -- and still precedes the state write. Its message now carries the qubit, the outcome, both branch weights, the projected weight, and the total norm, so a future trip is actionable rather than merely named.

Projection, physical-row selection, and normalization semantics are unchanged; #642's measurement change was reviewed and found sound.

## RNG ordering

Raised during review and resolved explicitly, since this repo depends on deterministic seeded replay: sampling is transactional. The stochastic draw uses a cloned RNG and the advance is committed only after branch validation and the state write. Deterministic measurements consume no RNG, successful stochastic measurements retain the prior seeded sequence, and a failed projection cannot advance the simulator's owned RNG.

## Regression evidence

A new upper-tail regression drives the generic GPU-density wrapper with f32 gate coefficients through `X; H; H`: raw one-weight `0.99999986308583988`, seeded draw `0.99999986599311885`, zero-weight at most 1e-15. Under the old comparison that draw selected the empty branch and panicked; it now yields deterministic outcome one, and the test additionally asserts the RNG was not consumed. A live-hardware `GpuStateVec32` variant compiles and runs where a device is available.

## Verification

`pecos-simulators` debug and release (762 library tests, all integration targets, 90 doc tests); `pecos-gpu-sims` debug and release (203 library tests including the analytic, seeded-oracle, mixed-state, and new upper-tail regressions); clippy `--all-targets -D warnings` on both crates; `cargo fmt --check`; `git diff --check`. Re-verified after rebasing onto `dev` post-#642-merge.
