### PR TITLE
Halve the signed angle when building dense rotation matrices

### DIFF
--- a/crates/pecos-quantum/src/unitary_matrix.rs
+++ b/crates/pecos-quantum/src/unitary_matrix.rs
@@ -1598,8 +1598,7 @@ fn rotation_to_matrix(
     qubits: &[usize],
     num_qubits: usize,
 ) -> DMatrix<Complex64> {
-    let half = angle / 2u64;
-    let (sin_half, cos_half) = half.sin_cos();
+    let (sin_half, cos_half) = angle.half_angle_sin_cos();
     let cos_half = Complex64::new(cos_half, 0.0);
     let sin_half = Complex64::new(sin_half, 0.0);
     let neg_i = Complex64::new(0.0, -1.0);
@@ -1629,7 +1628,7 @@ fn rotation_to_matrix(
             embed_single_qubit_gate(&gate, qubits[0], num_qubits)
         }
         RotationType::RXX | RotationType::RYY | RotationType::RZZ => {
-            // For two-qubit rotations, use matrix exponential: exp(-i * θ/2 * PP)
+            // exp(-i * θ/2 * PP) = cos(θ/2) I - i sin(θ/2) PP
             let generator = match rotation_type {
                 RotationType::RXX => {
                     two_qubit_pauli_matrix(Pauli::X, Pauli::X, qubits[0], qubits[1], num_qubits)
@@ -1642,8 +1641,8 @@ fn rotation_to_matrix(
                 }
                 _ => unreachable!("outer match already filtered for RXX/RYY/RZZ"),
             };
-            let scaled = generator * Complex64::new(0.0, -half.to_radians());
-            pecos_num::matrix_exp(&scaled)
+            DMatrix::identity(generator.nrows(), generator.ncols()) * cos_half
+                + generator * (neg_i * sin_half)
         }
     }
 }
@@ -1655,10 +1654,8 @@ fn rxy1q_to_matrix(
     qubits: &[usize],
     num_qubits: usize,
 ) -> DMatrix<Complex64> {
-    let half_theta = (theta / 2u64).to_radians_signed();
+    let (sin_t, cos_t) = theta.half_angle_sin_cos();
     let phi_rad = phi.to_radians_signed();
-    let cos_t = half_theta.cos();
-    let sin_t = half_theta.sin();
     // RXY1Q: [[cos, r01], [r10, cos]]
     // r01 = -i*sin*e^{-i*phi}
     // r10 = -i*sin*e^{i*phi}
@@ -1679,11 +1676,9 @@ fn u3_to_matrix(
     qubits: &[usize],
     num_qubits: usize,
 ) -> DMatrix<Complex64> {
-    let t = (theta / 2u64).to_radians_signed();
+    let (sin_t, cos_t) = theta.half_angle_sin_cos();
     let p = phi.to_radians_signed();
     let l = lambda.to_radians_signed();
-    let cos_t = t.cos();
-    let sin_t = t.sin();
     let u00 = Complex64::new(cos_t, 0.0);
     let u01 = Complex64::new(-sin_t * l.cos(), -sin_t * l.sin());
     let u10 = Complex64::new(sin_t * p.cos(), sin_t * p.sin());

--- a/crates/pecos-quantum/tests/clifford_simplify_matrix_verification.rs
+++ b/crates/pecos-quantum/tests/clifford_simplify_matrix_verification.rs
@@ -273,7 +273,7 @@ fn ryy_pi_equiv_y_tensor_y() {
 
 /// Build CRZ(angle) as a composition: RZ(angle/2) on target, CX, RZ(-angle/2) on target, CX.
 fn crz_operator(angle: Angle64, control: usize, target: usize) -> UnitaryRep {
-    let half = angle / 2u64;
+    let half = Angle64::from_radians(angle.to_radians_signed() / 2.0);
     // CRZ(theta) = CX * RZ(-theta/2)_target * CX * RZ(theta/2)_target
     // Read right-to-left: first RZ(theta/2), then CX, then RZ(-theta/2), then CX
     RZ(half, target) * CX(control, target) * RZ(-half, target) * CX(control, target)

--- a/crates/pecos-quantum/tests/unitary_matrix_tests.rs
+++ b/crates/pecos-quantum/tests/unitary_matrix_tests.rs
@@ -453,6 +453,172 @@ fn to_matrix_unitary_rotation_at_various_angles() {
     }
 }
 
+fn assert_phase_exact_matrix(
+    label: &str,
+    actual: &UnitaryMatrix,
+    expected: &nalgebra::DMatrix<Complex64>,
+) {
+    let error = actual
+        .iter()
+        .zip(expected.iter())
+        .map(|(lhs, rhs)| (lhs - rhs).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        error < 1e-12,
+        "{label}: max entrywise error {error:e}; actual={actual:?}; expected={expected:?}"
+    );
+}
+
+#[test]
+fn negative_pauli_rotations_use_the_signed_principal_half_angle() {
+    use pecos_core::unitary_rep::{RX, RY, RZ, RZZ};
+    use std::f64::consts::FRAC_1_SQRT_2;
+
+    let negative_angle = -Angle64::QUARTER_TURN;
+    let aliased_angle = Angle64::THREE_QUARTERS_TURN;
+    assert_eq!(negative_angle, aliased_angle);
+
+    let c = FRAC_1_SQRT_2;
+    let zero = Complex64::new(0.0, 0.0);
+    let real = Complex64::new(c, 0.0);
+    let plus_i = Complex64::new(0.0, c);
+    let exp_plus_i = Complex64::new(c, c);
+    let exp_minus_i = Complex64::new(c, -c);
+
+    let cases = [
+        (
+            "RX(-pi/2)",
+            RX(negative_angle, 0),
+            RX(aliased_angle, 0),
+            nalgebra::DMatrix::from_row_slice(2, 2, &[real, plus_i, plus_i, real]),
+        ),
+        (
+            "RY(-pi/2)",
+            RY(negative_angle, 0),
+            RY(aliased_angle, 0),
+            nalgebra::DMatrix::from_row_slice(2, 2, &[real, real, -real, real]),
+        ),
+        (
+            "RZ(-pi/2)",
+            RZ(negative_angle, 0),
+            RZ(aliased_angle, 0),
+            nalgebra::DMatrix::from_row_slice(2, 2, &[exp_plus_i, zero, zero, exp_minus_i]),
+        ),
+    ];
+
+    for (label, negative, aliased, expected) in cases {
+        let negative = negative.to_matrix();
+        let aliased = aliased.to_matrix();
+        assert_phase_exact_matrix(label, &negative, &expected);
+        assert_phase_exact_matrix(
+            &format!("{label} three-quarter-turn alias"),
+            &aliased,
+            &expected,
+        );
+        assert_phase_exact_matrix(
+            &format!("{label} aliases agree"),
+            &aliased,
+            negative.inner(),
+        );
+    }
+
+    let expected_rzz = nalgebra::DMatrix::from_diagonal(&nalgebra::DVector::from_row_slice(&[
+        exp_plus_i,
+        exp_minus_i,
+        exp_minus_i,
+        exp_plus_i,
+    ]));
+    let negative_rzz = RZZ(negative_angle, 0, 1).to_matrix();
+    let aliased_rzz = RZZ(aliased_angle, 0, 1).to_matrix();
+    assert_phase_exact_matrix("RZZ(-pi/2)", &negative_rzz, &expected_rzz);
+    assert_phase_exact_matrix(
+        "RZZ(-pi/2) three-quarter-turn alias",
+        &aliased_rzz,
+        &expected_rzz,
+    );
+    assert_phase_exact_matrix(
+        "RZZ(-pi/2) aliases agree",
+        &aliased_rzz,
+        negative_rzz.inner(),
+    );
+}
+
+#[test]
+fn other_negative_half_angle_dense_gates_use_the_signed_principal_angle() {
+    use std::f64::consts::FRAC_1_SQRT_2;
+
+    let negative_angle = -Angle64::QUARTER_TURN;
+    let aliased_angle = Angle64::THREE_QUARTERS_TURN;
+    let c = FRAC_1_SQRT_2;
+    let expected_rxy1q = nalgebra::DMatrix::from_row_slice(
+        2,
+        2,
+        &[
+            Complex64::new(c, 0.0),
+            Complex64::new(0.0, c),
+            Complex64::new(0.0, c),
+            Complex64::new(c, 0.0),
+        ],
+    );
+    let expected_u3 = nalgebra::DMatrix::from_row_slice(
+        2,
+        2,
+        &[
+            Complex64::new(c, 0.0),
+            Complex64::new(c, 0.0),
+            Complex64::new(-c, 0.0),
+            Complex64::new(c, 0.0),
+        ],
+    );
+
+    for (label, negative, aliased, expected) in [
+        (
+            "RXY1Q(-pi/2, 0)",
+            Unitary::RXY1Q {
+                theta: negative_angle,
+                phi: Angle64::ZERO,
+            }
+            .on_qubit(0),
+            Unitary::RXY1Q {
+                theta: aliased_angle,
+                phi: Angle64::ZERO,
+            }
+            .on_qubit(0),
+            expected_rxy1q,
+        ),
+        (
+            "U3(-pi/2, 0, 0)",
+            Unitary::U3 {
+                theta: negative_angle,
+                phi: Angle64::ZERO,
+                lambda: Angle64::ZERO,
+            }
+            .on_qubit(0),
+            Unitary::U3 {
+                theta: aliased_angle,
+                phi: Angle64::ZERO,
+                lambda: Angle64::ZERO,
+            }
+            .on_qubit(0),
+            expected_u3,
+        ),
+    ] {
+        let negative = negative.to_matrix();
+        let aliased = aliased.to_matrix();
+        assert_phase_exact_matrix(label, &negative, &expected);
+        assert_phase_exact_matrix(
+            &format!("{label} three-quarter-turn alias"),
+            &aliased,
+            &expected,
+        );
+        assert_phase_exact_matrix(
+            &format!("{label} aliases agree"),
+            &aliased,
+            negative.inner(),
+        );
+    }
+}
+
 #[test]
 fn to_matrix_unitary_named_ccx_is_unitary() {
     use pecos_core::gate_type::GateType;
@@ -868,9 +1034,8 @@ fn rotation_adjoint_negates_angle_via_matrix() {
     let angle = Angle64::QUARTER_TURN;
     let neg_angle = Angle64::THREE_QUARTERS_TURN;
 
-    // R(-theta) = R(theta)^dagger up to global phase
-    // (THREE_QUARTERS_TURN and -QUARTER_TURN differ by 2pi but the half-angle
-    //  causes an overall -1 factor, so we check equiv_up_to_phase)
+    // Angle64's three-quarter turn is the signed principal -pi/2, so the
+    // phase-fixed matrices must be exact adjoints, not merely equivalent up to phase.
     for (make_rot, name) in [
         (RX as fn(Angle64, usize) -> pecos_core::UnitaryRep, "RX"),
         (RY as fn(Angle64, usize) -> pecos_core::UnitaryRep, "RY"),
@@ -880,9 +1045,10 @@ fn rotation_adjoint_negates_angle_via_matrix() {
         let mat_neg = make_rot(neg_angle, 0).to_matrix();
         let mat_adj = mat.adjoint();
 
+        let error = (&mat_neg - &mat_adj).norm();
         assert!(
-            mat_neg.equiv_up_to_phase(&mat_adj),
-            "{name}(-theta) should equal {name}(theta).adjoint() up to phase"
+            error < 1e-12,
+            "{name}(-theta) should exactly equal {name}(theta).adjoint(); error={error:e}"
         );
     }
 }

--- a/python/selene-plugins/pecos-selene-general-noise/src/lib.rs
+++ b/python/selene-plugins/pecos-selene-general-noise/src/lib.rs
@@ -1651,12 +1651,8 @@ mod tests {
     ///
     /// Three facts the pinned values record rather than hide:
     ///
-    /// - PECOS's `rotation_to_matrix` halves the unsigned `[0, 2pi)` representative of an
-    ///   angle, so for any angle in `(pi, 2pi)` -- every negative angle -- its dense matrix
-    ///   is `-1` times the signed textbook `exp(-i theta/2 P)`. Every negative-angle
-    ///   parameterized rotation therefore carries `pi` here. This is the 4pi-periodicity
-    ///   problem recorded in the CRZ parameter representation note; the bridge cannot fix
-    ///   it and this test does not pretend it is absent.
+    /// - PECOS's dense matrices and simulators both halve the signed angle representative,
+    ///   so negative-angle rotations agree with Selene's signed textbook definitions.
     /// - Selene's Rust `QuEST` simulator at the same revision scales `exp(i a/2)` out of
     ///   `RZZ`, differing from Selene's own reference definition above. Under that one
     ///   simulator the two-qubit arms carry an additional `-a/2` that the reference does
@@ -1859,8 +1855,7 @@ mod tests {
                 named(GateType::Tdg, &q1),
                 -PI / 8.0,
             ),
-            // Parameterised single-qubit rotations, positive and negative angles. The
-            // negative cases carry pi against PECOS's unsigned-halved dense matrix.
+            // Parameterised single-qubit rotations, positive and negative angles.
             arm(
                 "RX(+0.37)",
                 |b| {
@@ -1875,7 +1870,7 @@ mod tests {
                     b.rx(Angle64::from_radians(-0.37), &[0]);
                 },
                 rot(RotationType::RX, -0.37, &q1),
-                PI,
+                0.0,
             ),
             arm(
                 "RY(+0.37)",
@@ -1891,7 +1886,7 @@ mod tests {
                     b.ry(Angle64::from_radians(-0.37), &[0]);
                 },
                 rot(RotationType::RY, -0.37, &q1),
-                PI,
+                0.0,
             ),
             arm(
                 "RZ(+0.37)",
@@ -1907,7 +1902,7 @@ mod tests {
                     b.rz(Angle64::from_radians(-0.37), &[0]);
                 },
                 rot(RotationType::RZ, -0.37, &q1),
-                PI,
+                0.0,
             ),
             arm(
                 "RXY1Q(+0.37, -0.91)",
@@ -1958,7 +1953,7 @@ mod tests {
                     b.rzz(Angle64::from_radians(-0.37), &[(0, 1)]);
                 },
                 rot(RotationType::RZZ, -0.37, &q2),
-                PI,
+                0.0,
             ),
         ];
 


### PR DESCRIPTION
Closes #686.

## Summary

`rotation_to_matrix` halved the **unsigned** modular angle before taking trig:

```rust
let half = angle / 2u64;
let (sin_half, cos_half) = half.sin_cos();
```

`Angle64` wraps at `2*pi` while `exp(-i*theta*G/2)` has period `4*pi`, so for any stored value above `pi` — that is, every negative angle — the resulting dense matrix was **negated**. `Angle64`'s own documentation states that the signed principal form is essential for half-angle trig, and `Angle64::half_angle_sin_cos` was corrected to return the signed half in #604; this call site never adopted it.

The simulators implement the signed convention correctly, so the dense matrix API disagreed with execution. Global sign is unobservable for a bare gate, but this is a public API used for verification, controlled constructions, and comparison against named gates, where it is not.

## Fix

`RX`/`RY`/`RZ`/`RXX`/`RYY`/`RZZ` now use `half_angle_sin_cos`, so there is one implementation of the convention. The audit found the same defect in two more paths — `RXY1Q` and `U3` — both fixed, plus an indirect instance in the CRZ verification helper. Two-qubit rotations use the exact Pauli identity `cos(theta/2) I - i sin(theta/2) PP`.

A workspace-wide audit for "halve an `Angle` then take trig" found no remaining instances. Sites that already sign before halving or use the helper are listed in the commit discussion: the whole state-vector simulator family, the MPS paths, `arbitrary_rotation_gateable`, `stab_vec`, and the synthesis interval code (exact signed fractions). `exp/pecos-eeg/src/circuit.rs` divides unsigned radians as a propagated coefficient, not for trig, and is outside this family.

## Regression coverage

Phase-exact, independently constructed expectations for `RX`, `RY`, `RZ`, and `RZZ` at `-pi/2` — including the stored three-quarter-turn alias, which must produce the same matrix — plus audited `RXY1Q` and `U3` paths. An existing adjoint test was strengthened from global-phase equivalence to exact equality.

Mutation-verified: restoring the unsigned halving fails both new regressions with maximum entrywise error `1.4142135623730951`, and the actual matrices are exactly the negatives of the expected ones.

## Fallout

`residual_phase_per_arm` in the Selene general-noise plugin had encoded this defect: the four negative-angle rotation arms pinned `pi`, which was the negation, and now pin `0`. The explanatory comment is updated. The separate `SZZdg = -pi/4` convention entry is unaffected.

## How it stayed hidden

The matrix verification tests compared with `unitaries_equiv` (up to global phase), which cannot see a `-1`. It surfaced only during a review of #681, which strengthens those tests to pin exact phases: twelve of its expectations had been fitted to this defect and would have rejected this fix. #681 is held and will be corrected on top of this.

## Verification

Debug and release suites for `pecos-core`, `pecos-quantum`, `pecos-simulators`; the Selene plugin package (15/15); clippy `--all-targets -D warnings`; `cargo fmt --check`; `git diff --check`.
