### PR TITLE
Keep HUGR rotation addition unreduced so controlled rotations retain their winding

### DIFF
--- a/crates/pecos-hugr/src/engine/handlers/quantum.rs
+++ b/crates/pecos-hugr/src/engine/handlers/quantum.rs
@@ -202,7 +202,10 @@ impl HugrEngine {
             }
             "radd" => {
                 // radd: (Rotation, Rotation) -> Rotation
-                // Add two rotations
+                // Keep the sum unreduced. Controlled rotations need the source
+                // angle's winding so they can halve it before constructing an
+                // Angle64; reducing here would make CRz 2π-periodic instead of
+                // 4π-periodic.
                 let a = self
                     .get_input_value(hugr, node, 0)
                     .and_then(|v| v.as_rotation());
@@ -214,8 +217,7 @@ impl HugrEngine {
                     return HandlerOutcome::Defer;
                 };
 
-                // Rotation addition, normalized to [0, 2) half-turns
-                let sum = (a + b).rem_euclid(2.0);
+                let sum = a + b;
 
                 self.wire_state
                     .classical_values

--- a/crates/pecos-hugr/tests/crz_boundary.rs
+++ b/crates/pecos-hugr/tests/crz_boundary.rs
@@ -12,12 +12,15 @@
 
 use pecos_engines::Engine;
 use pecos_engines::byte_message::builder::ByteMessageBuilder;
-use pecos_engines::quantum::StateVecEngine;
+use pecos_engines::hybrid::HybridEngineBuilder;
+use pecos_engines::quantum::{DenseStateVecEngine, StateVecEngine};
+use pecos_hugr::HugrEngine;
 use pecos_quantum::hugr_convert::hugr_to_dag_circuit;
 use tket::TketOp;
-use tket::extension::rotation::ConstRotation;
+use tket::extension::rotation::{ConstRotation, RotationOp, RotationOpBuilder};
 use tket::hugr::Hugr;
 use tket::hugr::builder::{DFGBuilder, Dataflow, DataflowHugr};
+use tket::hugr::std_extensions::arithmetic::float_types::ConstF64;
 use tket::hugr::types::Signature;
 
 fn crz_hugr(theta: f64, basis: usize) -> Hugr {
@@ -89,6 +92,109 @@ fn execute(theta: f64, basis: usize) -> Vec<(f64, f64)> {
         .iter()
         .map(|amplitude| (amplitude.re, amplitude.im))
         .collect()
+}
+
+fn dynamic_radd_crz_hugr() -> Hugr {
+    let mut builder = DFGBuilder::new(Signature::new(vec![], vec![])).expect("create HUGR");
+    let target = builder
+        .add_dataflow_op(TketOp::QAlloc, vec![])
+        .expect("allocate target")
+        .out_wire(0);
+    let control = builder
+        .add_dataflow_op(TketOp::QAlloc, vec![])
+        .expect("allocate control")
+        .out_wire(0);
+    let control = builder
+        .add_dataflow_op(TketOp::H, [control])
+        .expect("prepare superposed control")
+        .out_wire(0);
+
+    let halfturns_a = builder.add_load_value(ConstF64::new(1.5));
+    let halfturns_b = builder.add_load_value(ConstF64::new(1.5));
+    let rotation_a = builder
+        .add_from_halfturns_unchecked(halfturns_a)
+        .expect("construct first rotation");
+    let rotation_b = builder
+        .add_from_halfturns_unchecked(halfturns_b)
+        .expect("construct second rotation");
+    let rotation_sum = builder
+        .add_dataflow_op(RotationOp::radd, [rotation_a, rotation_b])
+        .expect("add rotations")
+        .out_wire(0);
+
+    let crz = builder
+        .add_dataflow_op(TketOp::CRz, [control, target, rotation_sum])
+        .expect("apply CRz");
+    builder
+        .add_dataflow_op(TketOp::QFree, [crz.out_wire(1)])
+        .expect("free target");
+    builder
+        .add_dataflow_op(TketOp::QFree, [crz.out_wire(0)])
+        .expect("free control");
+    builder
+        .finish_hugr_with_outputs(vec![])
+        .expect("finish HUGR")
+}
+
+fn execute_dynamic_radd_crz() -> Vec<(f64, f64)> {
+    let hugr_engine = HugrEngine::from_hugr(dynamic_radd_crz_hugr());
+    let mut hybrid = HybridEngineBuilder::new()
+        .with_classical_engine(Box::new(hugr_engine))
+        .with_quantum_engine(Box::new(DenseStateVecEngine::new(2)))
+        .build();
+    hybrid.run_shot().expect("execute dynamic CRz HUGR");
+
+    let state_vector = hybrid
+        .quantum_system
+        .quantum_engine_mut()
+        .as_any_mut()
+        .downcast_mut::<DenseStateVecEngine>()
+        .expect("dense state-vector engine")
+        .simulator_mut()
+        .state();
+    state_vector
+        .iter()
+        .map(|amplitude| (amplitude.re, amplitude.im))
+        .collect()
+}
+
+fn expected_superposed_control(theta: f64) -> [(f64, f64); 4] {
+    let amplitude = std::f64::consts::FRAC_1_SQRT_2;
+    let controlled_amplitude = (
+        amplitude * (-theta / 2.0).cos(),
+        amplitude * (-theta / 2.0).sin(),
+    );
+    [
+        (amplitude, 0.0),
+        (0.0, 0.0),
+        controlled_amplitude,
+        (0.0, 0.0),
+    ]
+}
+
+fn state_matches_up_to_global_phase(actual: &[(f64, f64)], expected: &[(f64, f64)]) -> bool {
+    let reference = std::f64::consts::FRAC_1_SQRT_2;
+    let phase = (actual[0].0 / reference, actual[0].1 / reference);
+    actual.iter().zip(expected).all(|(&(re, im), expected)| {
+        let normalized = (re * phase.0 + im * phase.1, im * phase.0 - re * phase.1);
+        (normalized.0 - expected.0).abs() < 1e-12 && (normalized.1 - expected.1).abs() < 1e-12
+    })
+}
+
+#[test]
+fn dynamic_radd_preserves_crz_winding() {
+    let actual = execute_dynamic_radd_crz();
+    let expected_three_pi = expected_superposed_control(3.0 * std::f64::consts::PI);
+    let wrong_pi = expected_superposed_control(std::f64::consts::PI);
+
+    assert!(
+        state_matches_up_to_global_phase(&actual, &expected_three_pi),
+        "dynamic CRz state {actual:?} did not match CRz(3π) on |+0>"
+    );
+    assert!(
+        !state_matches_up_to_global_phase(&actual, &wrong_pi),
+        "dynamic CRz state {actual:?} incorrectly matched CRz(π) on |+0>"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #688.

## The defect

`pecos-hugr`'s `tket.rotation.radd` handler reduced the sum modulo one full turn:

```rust
// Rotation addition, normalized to [0, 2) half-turns
let sum = (a + b).rem_euclid(2.0);
```

Rotations in this runtime are raw `f64` half-turns, and `lower_crz` is designed to receive the **unreduced** source angle so it can halve before any `Angle64` exists. Reducing in the arithmetic destroyed the winding first: `1.5 + 1.5` half-turns (`3*pi`) became `1.0` (`pi`), so a dynamically computed `CRZ(3*pi)` executed as `CRZ(pi)`. Those differ by a `Z` on the **control** — observable, not a global phase. Same class as #626 and #689.

Constants and `from_halfturns` preserved their values correctly; only the addition path collapsed. The locked LLVM implementation (`tket-0.21.2`, `src/llvm/rotation.rs`) performs ordinary floating-point addition, so the direct `HugrEngine` and the compiled QIS/LLVM route disagreed on the same program. The compiled route was right.

## The fix

`radd` keeps the raw sum. The single reduction now happens where it is safe — inside `lower_crz`, after halving.

## Reduction audit

Every rotation-value reduction in the crate was checked, not just the failing one:

- Constants, `symbolic_angle`, `from_halfturns`, `to_halfturns`, static tracing, propagation, and `resolve_rotation_angle` all preserve unreduced values.
- `RX`/`RY`/`RZ` construct an `Angle64` only at their native gate-consumer boundary.
- The remaining `rem_euclid(2.0)` accumulates `tket.global_phase`. That one is legitimate: global phase is genuinely 2pi-periodic and does not feed rotation lowering.
- The two `% PERIOD` sites in `engine/types.rs` are RNG jump-period arithmetic, unrelated to rotations.

## Regression test

`crz_boundary.rs` builds the angle **dynamically** through `radd` (not as a constant) and applies `CRz` with the control prepared in `|+>`. The superposed control is essential: with a definite control the two cases are indistinguishable, which is why nothing caught this. The test asserts the result matches `CRZ(3*pi)` and explicitly rejects `CRZ(pi)`.

Mutation-verified: reinstating `rem_euclid(2.0)` fails the test with the `CRZ(pi)` relative phase; restoring `a + b` passes.

## Verification

Debug and release: 88 unit + 2 integration + 6 doctests each. Clippy `--all-targets -D warnings`; `cargo fmt --check`; `git diff --check`.

Background: `~/Repos/pecos-docs/design/angle-representation-and-controlled-rotations.md`.
