### PR TITLE
Run the PR gate's workspace Rust tests through cargo-nextest

### DIFF
--- a/.github/workflows/pr-core-gate.yml
+++ b/.github/workflows/pr-core-gate.yml
@@ -228,6 +228,10 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           rustup show
 
+      - name: Install cargo-nextest
+        if: steps.detect.outputs.run == 'true'
+        run: bash scripts/ci/ensure-nextest.sh
+
       - name: Verify cmake is available (MWPF decoder build)
         if: steps.detect.outputs.run == 'true'
         run: cmake --version
@@ -262,8 +266,9 @@ jobs:
       - name: Run core Rust tests
         if: steps.detect.outputs.run == 'true'
         # debug profile keeps this sentinel fast; the full release matrix runs
-        # post-merge on push via rust-test.yml.
-        run: just rstest debug
+        # post-merge on push via rust-test.yml. nextest runs the ~320 workspace
+        # test binaries in parallel (cargo test runs them one after another).
+        run: just rstest debug nextest
 
       - name: Core Rust gate passed (no core-relevant changes)
         if: steps.detect.outputs.run != 'true'

--- a/Justfile
+++ b/Justfile
@@ -363,13 +363,26 @@ pytest-zluppy:
 python-ci-smoke profile="debug": (validate-profile "python-ci-smoke" profile) (python-ci-build profile)
     uv run --frozen python -c "from importlib.metadata import version; import pecos, pecos_rslib, pecos_rslib_llvm; print({'pecos': pecos.__version__, 'pecos_rslib': pecos_rslib.__version__, 'pecos_rslib_llvm': version('pecos-rslib-llvm')})"
 
-# Run Rust tests (CUDA-aware; mode: dev/debug, release, native)
+# Run Rust tests (CUDA-aware; mode: dev/debug, release, native; runner: cargo
+# or nextest -- nextest runs the workspace test binaries in parallel and needs
+# cargo-nextest on PATH, see scripts/ci/ensure-nextest.sh)
 [group('test')]
-rstest mode="release": _msvc-bootstrap (validate-test-mode "rstest" mode)
+rstest mode="release" runner="cargo": _msvc-bootstrap (validate-test-mode "rstest" mode)
     #!/usr/bin/env bash
     set -euo pipefail
     MODE="{{mode}}"
-    {{pecos}} rust test --profile "$MODE"
+    case "{{runner}}" in
+        cargo)
+            {{pecos}} rust test --profile "$MODE"
+            ;;
+        nextest)
+            {{pecos}} rust test --profile "$MODE" --nextest
+            ;;
+        *)
+            echo "Invalid runner: {{runner}} (expected cargo or nextest)" >&2
+            exit 2
+            ;;
+    esac
 
 # Run all tests (Rust + Python + Julia if available; mode: dev/debug, release, native)
 [group('test')]

--- a/crates/pecos-cli/src/cli.rs
+++ b/crates/pecos-cli/src/cli.rs
@@ -65,6 +65,13 @@ pub enum RustCommands {
         /// --include-ffi`.
         #[arg(long)]
         include_ffi: bool,
+
+        /// Run the workspace test binaries with cargo-nextest, which runs
+        /// them in parallel instead of one binary after another. Doctests
+        /// still run through `cargo test --doc` with the same selection.
+        /// Requires cargo-nextest on PATH (CI: scripts/ci/ensure-nextest.sh).
+        #[arg(long)]
+        nextest: bool,
     },
 }
 

--- a/crates/pecos-cli/src/cli/rust_cmd.rs
+++ b/crates/pecos-cli/src/cli/rust_cmd.rs
@@ -139,7 +139,8 @@ pub fn run(command: &super::RustCommands) -> Result<()> {
         super::RustCommands::Test {
             profile,
             include_ffi,
-        } => run_test(*profile, *include_ffi),
+            nextest,
+        } => run_test(*profile, *include_ffi, *nextest),
     }
 }
 
@@ -452,8 +453,57 @@ fn run_clippy(include_ffi: bool, fix: bool) -> Result<()> {
     Ok(())
 }
 
+/// The cargo invocations for the workspace test phase.
+///
+/// With `cargo test` this is one command. With nextest it is two: `cargo
+/// nextest run` for the test binaries (nextest schedules tests across all
+/// binaries at once, where `cargo test` runs one binary after another) and
+/// `cargo test --doc` for the doctests, which nextest does not run. Both use
+/// the same package selection and features. nextest's own `--profile` selects
+/// a nextest profile, so the cargo profile goes through `--release` /
+/// `--cargo-profile`.
+fn workspace_test_commands<'a>(
+    nextest: bool,
+    profile: super::BuildProfile,
+    excludes: &[&'a str],
+) -> Vec<Vec<&'a str>> {
+    let selection = ["--workspace", "--features=runtime,hugr,neo"];
+    let cargo_profile_args: &[&str] = match profile {
+        super::BuildProfile::Dev | super::BuildProfile::Debug => &[],
+        super::BuildProfile::Release => &["--release"],
+        super::BuildProfile::Native => &["--profile", "native"],
+    };
+    let nextest_profile_args: &[&str] = match profile {
+        super::BuildProfile::Dev | super::BuildProfile::Debug => &[],
+        super::BuildProfile::Release => &["--release"],
+        super::BuildProfile::Native => &["--cargo-profile", "native"],
+    };
+    let mut commands = Vec::new();
+    if nextest {
+        // `--locked` is placed explicitly: run_cargo_command_with_rustflags
+        // only inserts it for the plain cargo subcommands.
+        let mut run_args = vec!["nextest", "run", "--locked"];
+        run_args.extend(selection);
+        run_args.extend(excludes);
+        run_args.extend(nextest_profile_args);
+        commands.push(run_args);
+        let mut doc_args = vec!["test", "--doc"];
+        doc_args.extend(selection);
+        doc_args.extend(excludes);
+        doc_args.extend(cargo_profile_args);
+        commands.push(doc_args);
+    } else {
+        let mut args = vec!["test"];
+        args.extend(selection);
+        args.extend(excludes);
+        args.extend(cargo_profile_args);
+        commands.push(args);
+    }
+    commands
+}
+
 /// Run cargo test with GPU-aware feature handling
-fn run_test(profile: super::BuildProfile, include_ffi: bool) -> Result<()> {
+fn run_test(profile: super::BuildProfile, include_ffi: bool, nextest: bool) -> Result<()> {
     // Warn about any C++ dependency version differences across crates
     check_dep_consistency();
 
@@ -495,14 +545,12 @@ fn run_test(profile: super::BuildProfile, include_ffi: bool) -> Result<()> {
     // neo = sim() routing to the pecos-neo stack (contract tests)
     // pecos-cli is excluded here and tested separately below with --features=runtime
     // to ensure the pecos binary has PHIR/QIS support for integration tests.
-    let mut args: Vec<&str> = vec!["test", "--workspace", "--features=runtime,hugr,neo"];
-
+    let mut excludes: Vec<&str> = Vec::new();
     for crate_name in FFI_CRATES.iter().chain(PYO3_CDYLIB_TEST_EXCLUDES) {
-        args.push("--exclude");
-        args.push(*crate_name);
+        excludes.push("--exclude");
+        excludes.push(*crate_name);
     }
-
-    args.extend(&[
+    excludes.extend(&[
         "--exclude",
         "pecos-cuquantum", // Requires cuQuantum SDK, test separately if available
         "--exclude",
@@ -513,11 +561,15 @@ fn run_test(profile: super::BuildProfile, include_ffi: bool) -> Result<()> {
         "pecos-gpu-sims", // Always exclude from workspace test, test separately if GPU available
     ]);
 
-    args.extend(profile_args);
     reject_static_llvm_workspace_test()?;
 
-    if !run(&args) {
-        return Err(Error::Config("cargo test (workspace) failed".to_string()));
+    for args in workspace_test_commands(nextest, profile, &excludes) {
+        if !run(&args) {
+            return Err(Error::Config(format!(
+                "cargo {} (workspace) failed",
+                args.first().copied().unwrap_or("test")
+            )));
+        }
     }
 
     // Test pecos-cli separately with --features=runtime.
@@ -604,6 +656,63 @@ fn run_test(profile: super::BuildProfile, include_ffi: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspace_test_commands_cargo_test_is_one_command_with_excludes() {
+        let excludes = ["--exclude", "pecos-cli"];
+        let commands =
+            workspace_test_commands(false, super::super::BuildProfile::Native, &excludes);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0],
+            vec![
+                "test",
+                "--workspace",
+                "--features=runtime,hugr,neo",
+                "--exclude",
+                "pecos-cli",
+                "--profile",
+                "native"
+            ]
+        );
+    }
+
+    #[test]
+    fn workspace_test_commands_nextest_adds_doctests_and_maps_the_cargo_profile() {
+        let excludes = ["--exclude", "pecos-cli"];
+        let commands = workspace_test_commands(true, super::super::BuildProfile::Native, &excludes);
+        assert_eq!(commands.len(), 2);
+        assert_eq!(
+            commands[0],
+            vec![
+                "nextest",
+                "run",
+                "--locked",
+                "--workspace",
+                "--features=runtime,hugr,neo",
+                "--exclude",
+                "pecos-cli",
+                "--cargo-profile",
+                "native"
+            ]
+        );
+        assert_eq!(
+            commands[1],
+            vec![
+                "test",
+                "--doc",
+                "--workspace",
+                "--features=runtime,hugr,neo",
+                "--exclude",
+                "pecos-cli",
+                "--profile",
+                "native"
+            ]
+        );
+        let debug = workspace_test_commands(true, super::super::BuildProfile::Debug, &excludes);
+        assert!(!debug[0].contains(&"--cargo-profile"));
+        assert!(!debug[1].contains(&"--profile"));
+    }
 
     #[test]
     fn llvm_link_mode_parses_llvm_config_output() {

--- a/scripts/ci/ensure-nextest.sh
+++ b/scripts/ci/ensure-nextest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install the pinned cargo-nextest release into the cargo bin directory so
+# `pecos rust test --nextest` (the PR gate's `just rstest debug nextest`) can
+# run the workspace test binaries in parallel instead of one after another.
+# Prebuilt release, verified against the sha256 nextest publishes next to it;
+# a `cargo install` would spend minutes compiling on every run.
+#
+# Usage: scripts/ci/ensure-nextest.sh
+set -euo pipefail
+
+version="0.9.143"
+target="x86_64-unknown-linux-gnu"
+sha256="66786b9abe23920d022a182d1416b1bbc8130dd4872a9553d76985a1708dcd1e"
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) ;;
+    *)
+        echo "ensure-nextest: only ${target} is pinned; got $(uname -s)-$(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+dest="${CARGO_HOME:-$HOME/.cargo}/bin"
+if [[ -x "$dest/cargo-nextest" ]] && "$dest/cargo-nextest" --version | grep -q "^cargo-nextest ${version} "; then
+    echo "cargo-nextest ${version} already installed at $dest"
+    exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+archive="cargo-nextest-${version}-${target}.tar.gz"
+curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-all-errors \
+    -o "$tmp_dir/$archive" \
+    "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/${archive}"
+echo "${sha256}  ${tmp_dir}/${archive}" | sha256sum -c -
+mkdir -p "$dest"
+tar -xzf "$tmp_dir/$archive" -C "$dest" cargo-nextest
+"$dest/cargo-nextest" --version

--- a/scripts/ci/ensure-nextest.sh
+++ b/scripts/ci/ensure-nextest.sh
@@ -23,16 +23,22 @@ esac
 dest="${CARGO_HOME:-$HOME/.cargo}/bin"
 if [[ -x "$dest/cargo-nextest" ]] && "$dest/cargo-nextest" --version | grep -q "^cargo-nextest ${version} "; then
     echo "cargo-nextest ${version} already installed at $dest"
-    exit 0
+else
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    archive="cargo-nextest-${version}-${target}.tar.gz"
+    curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-all-errors \
+        -o "$tmp_dir/$archive" \
+        "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/${archive}"
+    echo "${sha256}  ${tmp_dir}/${archive}" | sha256sum -c -
+    mkdir -p "$dest"
+    tar -xzf "$tmp_dir/$archive" -C "$dest" cargo-nextest
 fi
-
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
-archive="cargo-nextest-${version}-${target}.tar.gz"
-curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-all-errors \
-    -o "$tmp_dir/$archive" \
-    "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/${archive}"
-echo "${sha256}  ${tmp_dir}/${archive}" | sha256sum -c -
-mkdir -p "$dest"
-tar -xzf "$tmp_dir/$archive" -C "$dest" cargo-nextest
 "$dest/cargo-nextest" --version
+
+# `cargo nextest` is resolved through PATH by cargo, so expose the install
+# directory to later workflow steps (a custom CARGO_HOME is not the directory
+# ensure-rust.sh adds).
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$dest" >>"$GITHUB_PATH"
+fi


### PR DESCRIPTION
Draft until the local full-lane run and the CI timing are in.

## Why

After #683/#684 the Python side of the PR gate finishes in ~14 min and `pr-core-rust` (~30 min) is the critical path. Inside that job the workspace test phase is 11 min, and the per-binary times from a green run add up to 656 s across 323 test binaries with the longest at 314 s: `cargo test` runs the binaries one after another, so the phase is serial regardless of how many cores the runner has. nextest schedules tests from all binaries at once, so on the 4-core runner the phase is bounded by the longest single test (~5 min) instead of the sum.

## What

- `scripts/ci/ensure-nextest.sh`: installs the pinned cargo-nextest 0.9.143 prebuilt release for x86_64 Linux into the cargo bin directory, verified against the sha256 nextest publishes with the release, idempotent, curl retries. Any other platform fails loudly. A `cargo install` would spend minutes compiling on every run and `cache-bin: false` keeps it out of the Rust cache.
- `pecos rust test --nextest`: new flag. The workspace phase runs `cargo nextest run` followed by `cargo test --doc`, both with exactly the same package selection and features (nextest does not run doctests). The three follow-up phases (pecos-cli with runtime, zlup with cli, pecos-decoders) are unchanged. The invocation list is built by a small pure function with unit tests pinning the nextest/cargo profile mapping: nextest's own `--profile` selects a nextest profile, so the cargo profile goes through `--release` / `--cargo-profile native`.
- `just rstest <mode> <runner>`: `runner` is `cargo` (default, unchanged) or `nextest`. Local use is untouched.
- `pr-core-gate.yml`: installs nextest after Rust and runs `just rstest debug nextest`.

## Verification

- `cargo clippy -p pecos-cli --all-targets -- -D warnings`, `cargo fmt --check`, the two new unit tests, pre-commit on all changed files: clean.
- `scripts/ci/ensure-nextest.sh`: fresh install into an empty `CARGO_HOME` succeeds and prints the version; a second run is a no-op; a copy with a wrong pinned checksum fails at `sha256sum -c` and installs nothing.
- Full `just rstest debug nextest` on a cold worktree (14 cores, RTX 4090 present): workspace phase `Starting 10352 tests across 270 binaries (60 tests skipped)` -> `10352 passed, 60 skipped` in 524 s, then `cargo test --doc` over the same 51 doc-test binaries, 818 doctests passed; the pecos-cli, zlup and pecos-decoders phases passed. The only failure was in the GPU-only `pecos-gpu-sims` phase, which this machine runs because it has a GPU and CI skips (`GPU not detected`): `gpu_density_matrix_two_qubit_roots_preserve_rotation_channels` fails on the untouched `dev` base too (`GpuDensityMatrix64 SXX: max density-matrix error 1.5e-7 exceeds 1e-12`), and that phase still runs through plain `cargo test`. Unrelated to this change; reported separately.
- CI timing of `pr-core-rust` on this PR (run 33841091323, warm Rust cache): 25 min total; compile 9m02, nextest phase `Summary [626.409s] 10352 tests run: 10352 passed, 60 skipped`, doctests 7 s, follow-up phases 3 min.

## Result: no gain, recommend closing

The serial `cargo test` phase was 656 s; nextest is 626 s. The per-test times nextest reports add up to 2486 CPU-seconds, which on a 4-core runner is 10.4 min regardless of scheduling, and `neo_surface_ler_test` alone takes 560 s while everything else runs alongside it (314 s when it had the machine to itself). `cargo test` was already saturating the cores because tests within each binary run on all threads, so running binaries one after another cost nothing. The workspace test phase is CPU-bound, not scheduling-bound, and the ~5 min the job did lose came from the now-warm Rust cache (#683), not from nextest. Adding a pinned tool and an install step for a 30 s difference is not worth carrying; the levers that would move this job are the CPU cost of the debug-profile simulators under test (e.g. `[profile.test] opt-level`) or sharding the job. Left as a draft for the record.

## Review

Independent correctness review of the first commit: no blocker. It confirmed the workspace selection is identical between `cargo test` and `cargo nextest run` + `cargo test --doc` (ignored tests stay ignored, no non-libtest harness targets in the selection, required-feature targets keep cargo's selection, the later pecos-cli phase stays authoritative for the `pecos` binary), that `--locked` / `--release` / `--cargo-profile native` are valid for nextest 0.9.143 and that `--cargo-profile native` lands in `target/native/` like the doctest command after it, and that the default `cargo` runner is unchanged. One robustness finding, fixed in the second commit: the installer wrote to `${CARGO_HOME}/bin` but only `ensure-rust.sh` put a cargo bin directory on PATH, and that one is `$HOME/.cargo/bin` regardless of `CARGO_HOME`; the installer now appends its own directory to `GITHUB_PATH` on both the fresh and already-installed paths (verified with a scratch `CARGO_HOME` and `GITHUB_PATH`).


