### PR TITLE
Preserve controlled-rotation source angles through PHIR emission

### DIFF
--- a/python/quantum-pecos/src/pecos/circuits/qc2phir.py
+++ b/python/quantum-pecos/src/pecos/circuits/qc2phir.py
@@ -320,13 +320,21 @@ def to_phir_dict(qc: pecos.QuantumCircuit) -> dict:
             )
 
             angles = None
-            if "angle" in metadata:
+            if "angles" in metadata:
+                angles = list(metadata["angles"])
+            elif "angle" in metadata:
                 angles = [metadata["angle"]]
-            elif "angles" in metadata:
-                angles = metadata["angles"]
+            elif "theta" in metadata:
+                angles = [metadata["theta"]]
+                if "phi" in metadata:
+                    angles.append(metadata["phi"])
+                if "lambda" in metadata:
+                    angles.append(metadata["lambda"])
+                elif "lambda_" in metadata:
+                    angles.append(metadata["lambda_"])
 
             if angles:
-                op["angles"] = angles
+                op["angles"] = [angles, "rad"]
 
             if sym.startswith("measure"):
                 # Getting return values:

--- a/python/quantum-pecos/src/pecos/circuits/quantum_circuit.py
+++ b/python/quantum-pecos/src/pecos/circuits/quantum_circuit.py
@@ -448,7 +448,11 @@ class QuantumCircuit(MutableSequence):
                 if len(angle_parts) >= 3:
                     params["angles"] = [float(a) for a in angle_parts[:3]]
             elif hasattr(gate, "angles"):
-                angles = gate.angles
+                # The serialized parameters are the source values supplied to
+                # the generic API.  Prefer them to the gate's Angle64 values:
+                # controlled rotations must be halved before reduction, and
+                # that sheet information cannot be reconstructed afterward.
+                angles = self._extract_angles_full(params) or gate.angles
                 if angles:
                     if len(angles) == 1:
                         # Single angle gates (RX, RY, RZ, RXX, RYY, RZZ)

--- a/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
+++ b/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
@@ -35,6 +35,7 @@ from pecos.simulators import (
 )
 from pecos.simulators.custatevec._cuquantum_compat import custatevec_available
 from pecos.testing import assert_allclose
+from pecos_rslib.simulators import StateVec as StateVecRs
 
 str_to_sim = {
     "StateVec": StateVec,
@@ -406,6 +407,38 @@ def test_controlled_rotations_statevec() -> None:
             expected = reference(symbol, theta)
             assert_one_phase(binding_columns, expected, theta)
             assert_one_phase(circuit_columns, expected, theta)
+
+
+def _run_crz_angle_circuit(simulator: StateVec | StateVecRs, theta: float) -> list[complex]:
+    circuit = QuantumCircuit()
+    circuit.append("H", {0})
+    circuit.append("CRZ", {(0, 1)}, angle=theta)
+    simulator.run_circuit(circuit)
+    vector = [complex(value) for value in simulator.vector]
+    if isinstance(simulator, StateVecRs):
+        vector = [vector[index] for index in (0, 2, 1, 3)]
+    return vector
+
+
+def _assert_three_pi_differs_by_control_z(pi_state: list[complex], three_pi_state: list[complex]) -> None:
+    expected = [pi_state[0], pi_state[1], -pi_state[2], -pi_state[3]]
+    assert all(abs(actual - wanted) < 1e-12 for actual, wanted in zip(three_pi_state, expected, strict=True))
+
+
+def test_quantum_circuit_angle_preserves_controlled_rotation_sheet() -> None:
+    """The Python StateVec route must halve CRZ's unreduced source angle."""
+    pi_state = _run_crz_angle_circuit(StateVec(2), pc.f64.pi)
+    three_pi_state = _run_crz_angle_circuit(StateVec(2), 3 * pc.f64.pi)
+
+    _assert_three_pi_differs_by_control_z(pi_state, three_pi_state)
+
+
+def test_statevecrs_run_circuit_preserves_controlled_rotation_sheet() -> None:
+    """The direct Rust runner must receive CRZ's unreduced source angle."""
+    pi_state = _run_crz_angle_circuit(StateVecRs(2), pc.f64.pi)
+    three_pi_state = _run_crz_angle_circuit(StateVecRs(2), 3 * pc.f64.pi)
+
+    _assert_three_pi_differs_by_control_z(pi_state, three_pi_state)
 
 
 @pytest.mark.parametrize(

--- a/python/quantum-pecos/tests/pecos/integration/test_quantum_circuits.py
+++ b/python/quantum-pecos/tests/pecos/integration/test_quantum_circuits.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 
 from pecos.circuits import QuantumCircuit
 
@@ -911,6 +912,17 @@ def test_json_str_is_valid_json() -> None:
     parsed = json.loads(json_str)
     assert parsed["prog_type"] == "PECOS.QuantumCircuit"
     assert "gates" in parsed
+
+
+def test_to_phir_dict_preserves_controlled_rotation_source_angle() -> None:
+    """PHIR angles retain the CRZ sheet and include their unit."""
+    qc = QuantumCircuit()
+    qc.append("CRZ", {(0, 1)}, angle=3 * math.pi)
+
+    phir = qc.to_phir_dict()
+
+    crz_op = next(op for op in phir["ops"] if op.get("qop") == "CRZ")
+    assert crz_op["angles"] == [[3 * math.pi], "rad"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #689.

## The defect

Building a controlled rotation through the generic Python `QuantumCircuit` API lost the rotation's sheet. `append("CRZ", ..., angle=3*pi)` reached lowering as `pi`.

`GateType::from_str` has no `CRX`/`CRY`/`CRZ` case, so a generic append falls through to `custom_gate`, which converts radians to `Angle64` immediately. That reduction is modulo one turn and happens before anything halves. `CRZ(3*pi)` and `CRZ(pi)` differ by a `Z` on the control, which is observable rather than a global phase.

A second defect sat alongside it: `to_phir_dict`/`to_phir_json` reconstructed `angle` from the reduced stored value and preferred it over any raw `angles` sidecar, and emitted a flat list where PHIR expects `[[values], unit]`.

## Approach

Of the two options weighed in the issue, this takes the second: keep the unreduced source parameters authoritative through iteration and emission rather than overwriting them from the stored `Angle64`.

`QuantumCircuit` now prefers the serialized source parameters to the gate's `Angle64` values when both are present, because a controlled rotation must be halved before reduction and that sheet cannot be reconstructed afterwards. The PHIR emitter reads `angles`, then `angle`, then the `theta`/`phi`/`lambda` spelling, and emits the `[[values], "rad"]` shape.

This leaves the boundary rule intact rather than working around it: `pecos_core::controlled_rotations` still takes `theta_radians: f64`, so it remains structurally impossible to hand it a pre-reduced angle.

## Tests

Three regressions, written to the constraints the issue specified.

- Both simulator tests use the `angle=` spelling, not the `angles=` tuple that happened to work already, and both put the control in superposition with an `H` first. Without a superposed control the difference is invisible, so a definite-input test would have passed against the broken code.
- They assert the concrete relationship rather than a norm: `CRZ(3*pi)` must equal `CRZ(pi)` with the sign of the two control-set amplitudes flipped.
- Coverage spans the Python `StateVec` route, `StateVecRs.run_circuit` (which bypasses the Python wrapper's incidental repair entirely), and the PHIR emission shape.

## Verification

`pytest python/quantum-pecos/tests -m "not optional_dependency and not slow"`: 5493 passed, 0 failed.

`pre-commit run --all-files`: exit 0, no files modified by any hook.

Note on running this locally: use `python -m pytest`. Console scripts inside a copied worktree venv can carry a shebang pointing at another checkout's interpreter, in which case `pytest` silently runs a different tree's source and these tests appear to fail with pre-change values.
