### PR TITLE
Constrain the Selene plugins CI install to the locked dependency versions

### DIFF
--- a/.github/workflows/selene-plugins.yml
+++ b/.github/workflows/selene-plugins.yml
@@ -92,6 +92,16 @@ jobs:
           prefix-key: v1-rust-no-bin
           save-if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'development' || github.ref_name == 'dev') }}
 
+      # `uv pip install` re-resolves from PyPI and does NOT read uv.lock, so the
+      # plugins' test extras drifted to whatever PyPI offered. Exporting the lock
+      # as a constraints file keeps this lane on the same versions as every other
+      # recipe. Reproducibility comes from uv.lock, not from tightening the
+      # sub-packages' requires-dist -- those ship to PyPI and must stay installable.
+      - name: Export locked versions as pip constraints
+        run: |
+          uv export --frozen --no-hashes --all-packages --no-emit-workspace \
+            -o "${{ runner.temp }}/uv-constraints.txt"
+
       - name: Build and install Selene plugins (Unix)
         if: runner.os != 'Windows'
         run: |
@@ -115,7 +125,7 @@ jobs:
             DEST="python/selene-plugins/$PLUGIN/python/${LIB_NAME}/_dist/lib"
             mkdir -p "$DEST"
             cp "target/release/lib${LIB_NAME}.$EXT" "$DEST/"
-            uv pip install --system -e "${DIR}[test]"
+            uv pip install --system -c "${{ runner.temp }}/uv-constraints.txt" -e "${DIR}[test]"
           done
 
       - name: Build and install Selene plugins (Windows)
@@ -134,7 +144,7 @@ jobs:
           }
 
           foreach ($pluginDir in (Get-ChildItem -Directory python/selene-plugins/pecos-selene-*)) {
-            uv pip install --system -e "$($pluginDir.FullName)[test]"
+            uv pip install --system -c "$env:RUNNER_TEMP/uv-constraints.txt" -e "$($pluginDir.FullName)[test]"
           }
 
       - name: Run tests

--- a/python/selene-plugins/pecos-selene-general-noise/tests/conftest.py
+++ b/python/selene-plugins/pecos-selene-general-noise/tests/conftest.py
@@ -128,7 +128,17 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     collection order, so a test asserting on executed coverage would only ever see the
     channels from files sorted before it.
     """
-    if not session.config.getoption("--require-full-noise-coverage"):
+    # The option is registered by the pytest_addoption above, but pytest only honours
+    # pytest_addoption for conftests between the rootdir and the command-line anchor.
+    # This plugin's pyproject.toml carries [tool.pytest.ini_options], so pointing pytest
+    # at these tests makes this directory the rootdir and the option registers; pointing
+    # it at python/selene-plugins/ makes the repo root the rootdir, leaving this conftest
+    # below the cutoff -- its hooks still run, but the option was never added. An absent
+    # option means the gate was not requested, which is exactly the fast lane's intent.
+    # The gated run (selene-general-noise-semantics.yml) is scoped to this directory and
+    # passes the flag explicitly, so a misconfiguration there fails loudly as an unknown
+    # option rather than silently skipping the check.
+    if not session.config.getoption("--require-full-noise-coverage", default=False):
         return
     passed = session.config.stash.get(PASSED_KEY, {})
     unexecuted = sorted(channel for channel in REQUIRED_CHANNELS if not passed.get(channel))


### PR DESCRIPTION
The Selene Plugins workflow has failed on `dev` on **all four platforms** since roughly 2026-08-31. Nothing in PECOS caused it; a transitive dependency moved on PyPI.

## Root cause

The lane installed its test dependencies with

```
uv pip install --system -e "${DIR}[test]"
```

`uv pip install` re-resolves from PyPI and does **not** read `uv.lock`. The plugin declares `guppylang~=1.0.1`, which admits 1.0.3, and that pulled newer `hugr` and `tket` than the lock:

| package | uv.lock | installed in CI |
|---|---|---|
| guppylang | 1.0.1 | 1.0.3 |
| hugr | 0.18.3 | **0.18.6** |
| tket | 0.15.6 | 0.15.7 |

Collection of `test_qutrit_conformance.py` then aborted the whole session, since the guppy program is compiled at module scope:

```
RuntimeError: Could not read CompilationState from bytes
  arithmetic.float.fdiv in Node(49) requires extension arithmetic.float,
  but it could not be found in the extension list used during resolution.
```

## Which dependency is actually at fault

Bisected locally by pinning one package at a time and re-running the failing test:

| guppylang | hugr | tket | result |
|---|---|---|---|
| 1.0.1 | 0.18.3 | 0.15.6 | pass |
| 1.0.3 | 0.18.3 | 0.15.7 | pass |
| 1.0.3 | 0.18.4 | 0.15.7 | pass |
| 1.0.3 | 0.18.5 | 0.15.7 | pass |
| 1.0.3 | **0.18.6** | 0.15.7 | **fail** |

`hugr 0.18.6` is the first bad version. **guppylang 1.0.3 is not the problem** and is compatible with everything else here.

The incompatibility is upstream: `tket 0.15.7` declares `hugr~=0.18.3` (i.e. `>=0.18.3, <0.19`), so hugr 0.18.6 satisfies its constraint while being incompatible with the extension registry compiled into tket.

## The fix

Export the lock as a pip constraints file and pass it to the install:

```
uv export --frozen --no-hashes --all-packages --no-emit-workspace -o "$RUNNER_TEMP/uv-constraints.txt"
uv pip install --system -c "$RUNNER_TEMP/uv-constraints.txt" -e "${DIR}[test]"
```

Applied to both the Unix and Windows install steps.

This keeps `uv.lock` as the single source of truth, which is the repo's stated policy — the root `pyproject.toml` says reproducibility comes from `uv.lock` rather than from tightening the sub-packages' `requires-dist`, because those packages ship to PyPI and must stay installable for downstream users. Accordingly this change adds **no** version pin to any plugin's metadata; a `hugr < 0.18.6` bound belongs to `tket`, not to us.

The lighter constraints approach was chosen over `uv sync --frozen --all-packages` because a full workspace sync builds `pecos-rslib` from source, which took over ten minutes locally and would be paid on all four platforms.

## Verification

Reproduced the failure and the fix locally rather than relying on CI.

- Locked versions, failing test: **11 passed**.
- guppylang 1.0.3 + hugr 0.18.6: reproduces the exact CI error.
- Simulated the fixed lane in a clean venv (`uv pip install -c <exported constraints> -e "<plugin>[test]"`): resolved to guppylang 1.0.1 / hugr 0.18.3 / tket 0.15.6, and the full plugin suite ran **99 passed, 2 skipped**.
- `pre-commit run --files .github/workflows/selene-plugins.yml`: exit 0, nothing reformatted.

## Not changed

`uv pip install --system build` in the `build-wheels` job is left unconstrained. It installs only the packaging tool, is not a drift source for these tests, and constraining it would require duplicating the export step into that job.

## Follow-up worth deciding separately

guppylang 1.0.3 and tket 0.15.7 are verified compatible with hugr <= 0.18.5, so the lock could be bumped to them. That is a deliberate dependency upgrade rather than part of this fix, and it should stay separate from restoring the lane.
