### PR TITLE
Propagate every run-time failure in pecos-neo as an error instead of printing or panicking

### DIFF
--- a/crates/pecos/src/unified_sim.rs
+++ b/crates/pecos/src/unified_sim.rs
@@ -333,7 +333,7 @@ impl ProgrammedSimBuilder {
             builder = builder.noise(noise);
         }
 
-        let results = builder.run();
+        let results = builder.run()?;
         let shot_vec = results.shots.ok_or_else(|| {
             PecosError::Generic(
                 "The neo stack produced no register results for a classical-engine program; \

--- a/crates/pecos/tests/neo_emission_test.rs
+++ b/crates/pecos/tests/neo_emission_test.rs
@@ -114,7 +114,8 @@ fn neo_zero_count() -> u64 {
         .sampling(monte_carlo(SHOTS))
         .noise(noise)
         .seed(99) // independent of the engines seed; agreement must be physical
-        .run();
+        .run()
+        .expect("neo simulation should succeed");
     let shots = results.shots.expect("neo produced shots");
     rate_zero(&shots).0
 }
@@ -238,7 +239,8 @@ fn neo_2q_zero_count() -> u64 {
         .sampling(monte_carlo(SHOTS))
         .noise(noise)
         .seed(99)
-        .run();
+        .run()
+        .expect("neo simulation should succeed");
     let shots = results.shots.expect("neo produced shots");
     rate_zero(&shots).0
 }

--- a/exp/pecos-neo/examples/noise_cookbook.rs
+++ b/exp/pecos-neo/examples/noise_cookbook.rs
@@ -91,7 +91,8 @@ fn recipe_sim_neo_integration() {
         .sampling(monte_carlo(1000))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     let error_rate = results
         .outcomes
@@ -108,7 +109,8 @@ fn recipe_sim_neo_integration() {
         .sampling(monte_carlo(1000))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     let error_rate = results
         .outcomes
@@ -133,7 +135,8 @@ fn recipe_sim_neo_integration() {
         .sampling(monte_carlo(1000))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     let error_rate = results
         .outcomes
@@ -156,8 +159,8 @@ fn recipe_sim_neo_integration() {
         .build();
 
     // Run multiple times with different seeds
-    let results1 = sim.seed(100).run();
-    let results2 = sim.seed(200).run();
+    let results1 = sim.seed(100).run().expect("simulation should succeed");
+    let results2 = sim.seed(200).run().expect("simulation should succeed");
 
     let err1 = results1
         .outcomes

--- a/exp/pecos-neo/src/adapter.rs
+++ b/exp/pecos-neo/src/adapter.rs
@@ -59,13 +59,14 @@
 //! let mut runner = ProgramRunner::new(SparseStab::new(2))
 //!     .with_noise(noise);
 //!
-//! let result = runner.run_shot(&mut program);
+//! let result = runner.run_shot(&mut program).expect("shot should succeed");
 //! ```
 
 use crate::command::{CommandQueue, GateCommand, GateType as NeoGateType};
 use crate::outcome::{MeasurementOutcome, MeasurementOutcomes};
 use crate::program::{CommandSource, DynProgramRunner, ProgramResult};
 use pecos_core::QubitId;
+use pecos_core::errors::PecosError;
 use pecos_core::gate_type::GateType as CoreGateType;
 use pecos_core::gates::Gate;
 
@@ -285,38 +286,21 @@ impl<E> CommandSource for ClassicalEngineAdapter<E>
 where
     E: pecos_engines::ClassicalControlEngine,
 {
-    fn next_commands(&mut self, outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue> {
+    fn next_commands(
+        &mut self,
+        outcomes: Option<&MeasurementOutcomes>,
+    ) -> Result<Option<CommandQueue>, PecosError> {
         match self.state {
-            AdapterState::NotStarted => {
-                // Start the engine
-                match self.start_engine() {
-                    Ok(cmds) => cmds,
-                    Err(e) => {
-                        // Log error and complete
-                        eprintln!("ClassicalEngineAdapter: start error: {e}");
-                        self.state = AdapterState::Complete;
-                        None
-                    }
-                }
-            }
-            AdapterState::Running => {
-                // Continue with outcomes from previous batch
-                if let Some(outcomes) = outcomes {
-                    match self.continue_with_outcomes(outcomes) {
-                        Ok(cmds) => cmds,
-                        Err(e) => {
-                            eprintln!("ClassicalEngineAdapter: continue error: {e}");
-                            self.state = AdapterState::Complete;
-                            None
-                        }
-                    }
-                } else {
-                    // No outcomes but running - shouldn't happen in normal flow
-                    self.state = AdapterState::Complete;
-                    None
-                }
-            }
-            AdapterState::Complete => None,
+            AdapterState::NotStarted => self.start_engine(),
+            AdapterState::Running => match outcomes {
+                Some(outcomes) => self.continue_with_outcomes(outcomes),
+                None => Err(PecosError::Processing(
+                    "ClassicalEngineAdapter: continuation requested without the previous \
+                     batch's outcomes"
+                        .to_string(),
+                )),
+            },
+            AdapterState::Complete => Ok(None),
         }
     }
 
@@ -324,26 +308,21 @@ where
         self.state == AdapterState::Complete
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<(), PecosError> {
         // Reset both the adapter state and the underlying engine
         self.state = AdapterState::NotStarted;
         self.pending_commands = None;
         self.measurement_count = 0;
 
-        // Try to reset the engine (ignore errors - some engines don't need reset)
-        let _ = pecos_engines::ControlEngine::reset(&mut self.engine);
+        pecos_engines::ControlEngine::reset(&mut self.engine)
     }
 
     fn num_qubits(&self) -> usize {
         self.num_qubits
     }
 
-    fn shot_results(&self) -> Option<pecos_results::Shot> {
-        Some(
-            self.engine
-                .get_results()
-                .expect("classical engine failed to produce results for a completed shot"),
-        )
+    fn shot_results(&self) -> Result<Option<pecos_results::Shot>, PecosError> {
+        self.engine.get_results().map(Some)
     }
 }
 
@@ -417,17 +396,9 @@ impl QuantumEngineProgramRunner {
         Ok(outcomes)
     }
 }
-impl QuantumEngineProgramRunner {
-    /// Run a command source, reporting conversion and engine errors.
-    ///
-    /// # Errors
-    /// Returns an error if a command cannot be converted losslessly, the engine
-    /// rejects it, or measurement results do not match the requested measurements.
-    pub fn try_run_shot(
-        &mut self,
-        source: &mut dyn CommandSource,
-    ) -> Result<ProgramResult, pecos_core::errors::PecosError> {
-        source.reset();
+impl DynProgramRunner for QuantumEngineProgramRunner {
+    fn run_shot(&mut self, source: &mut dyn CommandSource) -> Result<ProgramResult, PecosError> {
+        source.reset()?;
         self.engine.reset()?;
 
         let mut all_outcomes = MeasurementOutcomes::new();
@@ -435,7 +406,7 @@ impl QuantumEngineProgramRunner {
         let mut last_outcomes: Option<MeasurementOutcomes> = None;
 
         loop {
-            let commands = source.next_commands(last_outcomes.as_ref());
+            let commands = source.next_commands(last_outcomes.as_ref())?;
 
             match commands {
                 Some(cmds) if !cmds.is_empty() => {
@@ -462,12 +433,6 @@ impl QuantumEngineProgramRunner {
             outcomes: all_outcomes,
             num_batches,
         })
-    }
-}
-impl DynProgramRunner for QuantumEngineProgramRunner {
-    fn run_shot(&mut self, source: &mut dyn CommandSource) -> ProgramResult {
-        self.try_run_shot(source)
-            .expect("quantum engine command source should execute")
     }
 
     fn set_full_seed(&mut self, seed: u64) {
@@ -655,7 +620,9 @@ mod tests {
         let mut runner = QuantumEngineProgramRunner::new(Box::new(
             pecos_engines::quantum::SparseStabEngine::with_seed(1, 17),
         ));
-        let result = runner.run_shot(&mut source);
+        let result = runner
+            .run_shot(&mut source)
+            .expect("valid commands should execute");
 
         assert_eq!(result.num_batches, 1);
         assert_eq!(result.outcomes.len(), 1);

--- a/exp/pecos-neo/src/command.rs
+++ b/exp/pecos-neo/src/command.rs
@@ -86,6 +86,69 @@ pub enum GateType {
     Idle,
 }
 
+macro_rules! declare_all_gate_types {
+    ($($variant:ident),+ $(,)?) => {
+        impl GateType {
+            /// Every built-in gate type.
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+        }
+
+        // Adding a `GateType` variant without listing it above makes this
+        // match non-exhaustive, so `ALL` cannot silently fall behind the enum.
+        const fn gate_type_all_is_exhaustive(gate: GateType) {
+            match gate {
+                $(GateType::$variant => {}),+
+            }
+        }
+
+        const _: () = gate_type_all_is_exhaustive(GateType::ALL[0]);
+    };
+}
+
+declare_all_gate_types!(
+    I,
+    X,
+    Y,
+    Z,
+    H,
+    F,
+    Fdg,
+    SX,
+    SXdg,
+    SY,
+    SYdg,
+    SZ,
+    SZdg,
+    T,
+    Tdg,
+    RX,
+    RY,
+    RZ,
+    U,
+    RXY1Q,
+    CX,
+    CY,
+    CZ,
+    SZZ,
+    SZZdg,
+    SXX,
+    SXXdg,
+    SYY,
+    SYYdg,
+    SWAP,
+    RXX,
+    RYY,
+    RZZ,
+    CCX,
+    MZ,
+    MeasureLeaked,
+    MeasureFree,
+    PZ,
+    QAlloc,
+    QFree,
+    Idle,
+);
+
 impl GateType {
     /// Returns the number of qubits this gate operates on.
     #[must_use]
@@ -286,6 +349,12 @@ pub struct GateCommand {
 }
 
 impl GateCommand {
+    /// Whether this command has complete qubit groups and the required angles.
+    #[must_use]
+    pub(crate) fn has_valid_shape(&self) -> bool {
+        !self.qubits.is_empty() && self.validate().is_ok()
+    }
+
     /// Create a new gate command.
     #[must_use]
     pub fn new(gate_type: GateType, qubits: impl Into<SmallVec<[QubitId; 4]>>) -> Self {

--- a/exp/pecos-neo/src/program.rs
+++ b/exp/pecos-neo/src/program.rs
@@ -31,6 +31,7 @@
 //! ```no_run
 //! use pecos_neo::program::{CommandSource, ProgramRunner};
 //! use pecos_neo::prelude::*;
+//! use pecos_core::errors::PecosError;
 //! use pecos_simulators::SparseStab;
 //!
 //! // A simple repeat-until-success program
@@ -41,36 +42,37 @@
 //! }
 //!
 //! impl CommandSource for RepeatUntilSuccess {
-//!     fn next_commands(&mut self, outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue> {
+//!     fn next_commands(&mut self, outcomes: Option<&MeasurementOutcomes>) -> Result<Option<CommandQueue>, PecosError> {
 //!         // Check if previous attempt succeeded
 //!         if let Some(outcomes) = outcomes {
 //!             if outcomes.get_bit(QubitId(0)) == Some(true) {
 //!                 self.succeeded = true;
-//!                 return None; // Done!
+//!                 return Ok(None); // Done!
 //!             }
 //!         }
 //!
 //!         if self.current_attempt >= self.max_attempts {
-//!             return None; // Give up
+//!             return Ok(None); // Give up
 //!         }
 //!
 //!         self.current_attempt += 1;
 //!
 //!         // Try again: prep, rotate, measure
-//!         Some(CommandBuilder::new()
+//!         Ok(Some(CommandBuilder::new()
 //!             .pz(&[0])
 //!             .h(&[0])
 //!             .mz(&[0])
-//!             .build())
+//!             .build()))
 //!     }
 //!
 //!     fn is_complete(&self) -> bool {
 //!         self.succeeded || self.current_attempt >= self.max_attempts
 //!     }
 //!
-//!     fn reset(&mut self) {
+//!     fn reset(&mut self) -> Result<(), PecosError> {
 //!         self.current_attempt = 0;
 //!         self.succeeded = false;
+//!         Ok(())
 //!     }
 //!
 //!     fn num_qubits(&self) -> usize { 1 }
@@ -82,6 +84,7 @@ use crate::extensible::GateDefinitions;
 use crate::noise::ComposableNoiseModel;
 use crate::outcome::MeasurementOutcomes;
 use crate::runner::{CircuitRunner, EventHandlers, GateOverrides};
+use pecos_core::errors::PecosError;
 use pecos_core::rng::RngManageable;
 use pecos_random::PecosRng;
 use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable};
@@ -100,13 +103,24 @@ pub trait CommandSource {
     /// # Returns
     /// * `Some(commands)` - The next batch of commands to execute
     /// * `None` - The program is complete
-    fn next_commands(&mut self, outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue>;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source cannot generate the next command batch.
+    fn next_commands(
+        &mut self,
+        outcomes: Option<&MeasurementOutcomes>,
+    ) -> Result<Option<CommandQueue>, PecosError>;
 
     /// Check if the program is complete.
     fn is_complete(&self) -> bool;
 
     /// Reset the program state for a new shot.
-    fn reset(&mut self);
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source cannot reset its state.
+    fn reset(&mut self) -> Result<(), PecosError>;
 
     /// Get the number of qubits required.
     fn num_qubits(&self) -> usize;
@@ -119,8 +133,12 @@ pub trait CommandSource {
     /// Sources without register data (static circuits, plain command
     /// queues) return `None`; their per-qubit bits live in
     /// `MeasurementOutcomes` instead.
-    fn shot_results(&self) -> Option<pecos_results::Shot> {
-        None
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source cannot retrieve its shot results.
+    fn shot_results(&self) -> Result<Option<pecos_results::Shot>, PecosError> {
+        Ok(None)
     }
 }
 
@@ -194,22 +212,15 @@ impl<S: CliffordGateable> ProgramRunner<S> {
     /// The simulator is reset to |0>^n at the start of each shot, ensuring
     /// clean state for programs that don't explicitly prepare qubits.
     ///
-    /// # Panics
-    /// Panics if gate execution fails. Use [`Self::try_run_shot`] to handle the error.
-    pub fn run_shot<P: CommandSource + ?Sized>(&mut self, program: &mut P) -> ProgramResult {
-        self.try_run_shot(program)
-            .expect("core gates should not fail")
-    }
-
-    /// Execute a shot, reporting malformed commands and execution failures.
-    ///
     /// # Errors
-    /// Returns the first error reported by [`CircuitRunner`].
-    pub fn try_run_shot<P: CommandSource + ?Sized>(
+    ///
+    /// Returns an error if the command source cannot reset or produce commands,
+    /// or if the simulator cannot execute a command batch.
+    pub fn run_shot<P: CommandSource + ?Sized>(
         &mut self,
         program: &mut P,
-    ) -> Result<ProgramResult, crate::runner::ExecutionError> {
-        program.reset();
+    ) -> Result<ProgramResult, PecosError> {
+        program.reset()?;
 
         // Reset simulator to |0>^n state at the start of each shot
         self.simulator.reset();
@@ -219,7 +230,7 @@ impl<S: CliffordGateable> ProgramRunner<S> {
         let mut last_outcomes: Option<MeasurementOutcomes> = None;
 
         loop {
-            let commands = program.next_commands(last_outcomes.as_ref());
+            let commands = program.next_commands(last_outcomes.as_ref())?;
 
             match commands {
                 Some(cmds) if !cmds.is_empty() => {
@@ -330,7 +341,11 @@ impl<S: CliffordGateable + ArbitraryRotationGateable> ProgramRunner<S> {
 /// the concrete simulator type at compile time.
 pub trait DynProgramRunner: Send + Sync {
     /// Execute a single shot of the program.
-    fn run_shot(&mut self, source: &mut dyn CommandSource) -> ProgramResult;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command source or simulator fails.
+    fn run_shot(&mut self, source: &mut dyn CommandSource) -> Result<ProgramResult, PecosError>;
 
     /// Set the full seed for deterministic execution.
     fn set_full_seed(&mut self, seed: u64);
@@ -340,7 +355,7 @@ impl<S> DynProgramRunner for ProgramRunner<S>
 where
     S: CliffordGateable + RngManageable<Rng = PecosRng> + Send + Sync,
 {
-    fn run_shot(&mut self, source: &mut dyn CommandSource) -> ProgramResult {
+    fn run_shot(&mut self, source: &mut dyn CommandSource) -> Result<ProgramResult, PecosError> {
         ProgramRunner::run_shot(self, source)
     }
 
@@ -376,12 +391,15 @@ impl StaticProgram {
 }
 
 impl CommandSource for StaticProgram {
-    fn next_commands(&mut self, _outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue> {
+    fn next_commands(
+        &mut self,
+        _outcomes: Option<&MeasurementOutcomes>,
+    ) -> Result<Option<CommandQueue>, PecosError> {
         if self.executed {
-            None
+            Ok(None)
         } else {
             self.executed = true;
-            Some(self.commands.clone())
+            Ok(Some(self.commands.clone()))
         }
     }
 
@@ -389,8 +407,9 @@ impl CommandSource for StaticProgram {
         self.executed
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<(), PecosError> {
         self.executed = false;
+        Ok(())
     }
 
     fn num_qubits(&self) -> usize {
@@ -425,21 +444,25 @@ impl RepeatedProgram {
 }
 
 impl CommandSource for RepeatedProgram {
-    fn next_commands(&mut self, _outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue> {
+    fn next_commands(
+        &mut self,
+        _outcomes: Option<&MeasurementOutcomes>,
+    ) -> Result<Option<CommandQueue>, PecosError> {
         if self.current_round >= self.num_rounds {
-            return None;
+            return Ok(None);
         }
 
         self.current_round += 1;
-        Some(self.round_commands.clone())
+        Ok(Some(self.round_commands.clone()))
     }
 
     fn is_complete(&self) -> bool {
         self.current_round >= self.num_rounds
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<(), PecosError> {
         self.current_round = 0;
+        Ok(())
     }
 
     fn num_qubits(&self) -> usize {
@@ -492,8 +515,11 @@ impl<F> CommandSource for ConditionalProgram<F>
 where
     F: Fn(&MeasurementOutcomes) -> Option<CommandQueue>,
 {
-    fn next_commands(&mut self, outcomes: Option<&MeasurementOutcomes>) -> Option<CommandQueue> {
-        match self.state {
+    fn next_commands(
+        &mut self,
+        outcomes: Option<&MeasurementOutcomes>,
+    ) -> Result<Option<CommandQueue>, PecosError> {
+        Ok(match self.state {
             ConditionalState::Initial => {
                 self.state = ConditionalState::Branching;
                 Some(self.initial_commands.clone())
@@ -503,15 +529,16 @@ where
                 outcomes.and_then(|o| (self.branch_fn)(o))
             }
             ConditionalState::Complete => None,
-        }
+        })
     }
 
     fn is_complete(&self) -> bool {
         self.state == ConditionalState::Complete
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<(), PecosError> {
         self.state = ConditionalState::Initial;
+        Ok(())
     }
 
     fn num_qubits(&self) -> usize {
@@ -533,7 +560,7 @@ mod tests {
         let mut program = StaticProgram::new(commands, 1);
         let mut runner = ProgramRunner::new(SparseStab::with_seed(1, 42)).with_seed(42);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).unwrap();
 
         assert_eq!(result.num_batches, 1);
         assert_eq!(result.outcomes.len(), 1);
@@ -547,7 +574,7 @@ mod tests {
         let mut program = RepeatedProgram::new(round_commands, 3, 1);
         let mut runner = ProgramRunner::new(SparseStab::with_seed(1, 42)).with_seed(42);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).unwrap();
 
         assert_eq!(result.num_batches, 3);
         // 3 measurements (one per round)
@@ -571,7 +598,7 @@ mod tests {
         let mut program = ConditionalProgram::new(initial, branch, 1);
         let mut runner = ProgramRunner::new(SparseStab::with_seed(1, 42)).with_seed(42);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).unwrap();
 
         // Either 1 or 2 batches depending on measurement outcome
         assert!(result.num_batches >= 1 && result.num_batches <= 2);
@@ -584,11 +611,11 @@ mod tests {
         let mut runner = ProgramRunner::new(SparseStab::with_seed(1, 42)).with_seed(42);
 
         // Run first shot
-        let result1 = runner.run_shot(&mut program);
+        let result1 = runner.run_shot(&mut program).unwrap();
         assert_eq!(result1.num_batches, 1);
 
         // Run second shot (program should reset)
-        let result2 = runner.run_shot(&mut program);
+        let result2 = runner.run_shot(&mut program).unwrap();
         assert_eq!(result2.num_batches, 1);
     }
 
@@ -606,7 +633,7 @@ mod tests {
         let mut program = StaticProgram::new(commands, 2);
         let mut runner = ProgramRunner::new(SparseStab::with_seed(2, 42)).with_seed(42);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).unwrap();
 
         // Bell state: both measurements should be correlated
         let o0 = result.outcomes.get_bit(QubitId(0));

--- a/exp/pecos-neo/src/runner.rs
+++ b/exp/pecos-neo/src/runner.rs
@@ -612,6 +612,12 @@ pub enum ExecutionError {
     },
     /// The command has invalid qubit support or payload.
     InvalidCommand(crate::command::GateCommandError),
+    /// A gate command carries an invalid number of target qubits.
+    QubitArity {
+        gate: GateType,
+        arity: usize,
+        got: usize,
+    },
     /// Maximum decomposition depth exceeded (possible infinite recursion).
     MaxDecompositionDepthExceeded,
 }
@@ -640,6 +646,11 @@ impl std::fmt::Display for ExecutionError {
                 "Gate {gate:?} expected {expected} angle parameters, got {got}"
             ),
             Self::InvalidCommand(error) => error.fmt(f),
+            Self::QubitArity { gate, arity, got } => write!(
+                f,
+                "Gate {gate:?} received {got} targets, which is not a nonzero multiple of its \
+                 qubit arity {arity}"
+            ),
             Self::MaxDecompositionDepthExceeded => {
                 write!(f, "Maximum decomposition depth exceeded")
             }
@@ -648,6 +659,12 @@ impl std::fmt::Display for ExecutionError {
 }
 
 impl std::error::Error for ExecutionError {}
+
+impl From<ExecutionError> for pecos_core::errors::PecosError {
+    fn from(error: ExecutionError) -> Self {
+        Self::Processing(error.to_string())
+    }
+}
 
 /// Outcome of the Clifford-rotation execution attempt.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1231,18 +1248,22 @@ impl<S: CliffordGateable> CircuitRunner<S> {
     /// and returns the response. Useful for idle noise between manually-applied
     /// gates, testing noise models, or custom execution loops.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if an undeclared noise mechanism injects a gate the runner cannot
+    /// Returns an error if the emitted response injects a gate the runner cannot
     /// execute. Declared requirements are rejected by [`Self::with_noise`].
-    pub fn apply_noise(&mut self, state: &mut S, event: &NoiseEvent<'_>) -> NoiseResponse {
+    pub fn apply_noise(
+        &mut self,
+        state: &mut S,
+        event: &NoiseEvent<'_>,
+    ) -> Result<NoiseResponse, ExecutionError> {
         let Some(ref mut noise) = self.noise else {
-            return NoiseResponse::None;
+            return Ok(NoiseResponse::None);
         };
 
         let response = noise.emit(event, &mut self.rng);
-        self.apply_noise_response(state, response.clone());
-        response
+        self.apply_noise_response(state, response.clone())?;
+        Ok(response)
     }
 
     /// Execute a single command from a `CommandQueue`.
@@ -1259,22 +1280,22 @@ impl<S: CliffordGateable> CircuitRunner<S> {
             // Preparation
             GateType::PZ | GateType::QAlloc => {
                 sim.pz(qubits);
-                self.dispatch_after_preparation(sim, command);
+                self.dispatch_after_preparation(sim, command)?;
             }
 
             // Measurement
             GateType::MZ | GateType::MeasureLeaked | GateType::MeasureFree => {
-                self.dispatch_before_measurement(sim, command);
+                self.dispatch_before_measurement(sim, command)?;
                 let results = sim.mz(qubits);
                 let outcomes: SmallVec<[bool; 4]> = results.iter().map(|r| r.outcome).collect();
                 self.record_measurements(command.gate_type, qubits, &results);
-                self.dispatch_after_measurement(sim, command, outcomes.as_slice());
+                self.dispatch_after_measurement(sim, command, outcomes.as_slice())?;
             }
 
             // Idle
             GateType::Idle => {
                 if let Some(duration) = command.get_idle_duration() {
-                    self.dispatch_idle(sim, command, duration);
+                    self.dispatch_idle(sim, command, duration)?;
                 }
             }
 
@@ -1287,7 +1308,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
                     command.gate_type,
                     qubits,
                     command.angles(),
-                );
+                )?;
                 if skip {
                     // Still emit after-gate for channels that want to inject errors
                     self.dispatch_after_gate_for_id(
@@ -1296,7 +1317,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
                         command.gate_type,
                         qubits,
                         command.angles(),
-                    );
+                    )?;
                     return Ok(());
                 }
 
@@ -1333,7 +1354,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
                     command.gate_type,
                     qubits,
                     command.angles(),
-                );
+                )?;
             }
         }
 
@@ -1363,12 +1384,12 @@ impl<S: CliffordGateable> CircuitRunner<S> {
 
         for (gate_idx, command) in commands.iter().enumerate() {
             #[allow(clippy::cast_possible_truncation)] // gate index fits in u32
-            self.dispatch_signals_at(sim, gate_idx as u32, store, &mut cursors);
+            self.dispatch_signals_at(sim, gate_idx as u32, store, &mut cursors)?;
             self.execute_queue_command(sim, command)?;
         }
         // Dispatch trailing signals (positioned after the last gate)
         #[allow(clippy::cast_possible_truncation)] // gate count fits in u32
-        self.dispatch_signals_at(sim, commands.len() as u32, store, &mut cursors);
+        self.dispatch_signals_at(sim, commands.len() as u32, store, &mut cursors)?;
         Ok(())
     }
 
@@ -1494,7 +1515,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
             validate_angle_arity(gate_type, angles)?;
         }
         // Emit before-gate noise event
-        let skip = self.emit_before_gate(sim, gate_id, qubits, angles);
+        let skip = self.emit_before_gate(sim, gate_id, qubits, angles)?;
         if skip {
             return Ok(());
         }
@@ -1522,7 +1543,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         }
 
         // Emit after-gate noise event
-        self.emit_after_gate(sim, gate_id, qubits, angles);
+        self.emit_after_gate(sim, gate_id, qubits, angles)?;
 
         Ok(())
     }
@@ -1858,7 +1879,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_type: GateType,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) -> bool {
+    ) -> Result<bool, ExecutionError> {
         // Fast path: no handlers registered, go directly to noise model
         if self.gate_handlers.before_gate.is_empty() {
             return self.emit_before_gate_noise_for_id(sim, gate_id, gate_type, qubits, angles);
@@ -1883,8 +1904,8 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         // 3. Combine
         let combined = user_response.combine(noise_response);
         let should_skip = combined.should_skip_gate();
-        self.apply_noise_response(sim, combined);
-        should_skip
+        self.apply_noise_response(sim, combined)?;
+        Ok(should_skip)
     }
 
     /// Dispatch after-gate event for a gate identified by `GateId`.
@@ -1895,11 +1916,10 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_type: GateType,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) {
+    ) -> Result<(), ExecutionError> {
         // Fast path
         if self.gate_handlers.after_gate.is_empty() {
-            self.emit_after_gate_noise_for_id(sim, gate_id, gate_type, qubits, angles);
-            return;
+            return self.emit_after_gate_noise_for_id(sim, gate_id, gate_type, qubits, angles);
         }
 
         // 1. Noise model AfterGate
@@ -1920,17 +1940,20 @@ impl<S: CliffordGateable> CircuitRunner<S> {
 
         // 3. Combine and apply
         let combined = noise_response.combine(user_response);
-        self.apply_noise_response(sim, combined);
+        self.apply_noise_response(sim, combined)
     }
 
     /// Dispatch before-measurement event.
-    fn dispatch_before_measurement(&mut self, sim: &mut S, command: &GateCommand) {
+    fn dispatch_before_measurement(
+        &mut self,
+        sim: &mut S,
+        command: &GateCommand,
+    ) -> Result<(), ExecutionError> {
         let qubits = command.qubits.as_slice();
 
         // Fast path
         if self.gate_handlers.before_measurement.is_empty() {
-            self.emit_before_measurement_noise(sim, qubits);
-            return;
+            return self.emit_before_measurement_noise(sim, qubits);
         }
 
         let ctx = self.gate_context(command);
@@ -1938,7 +1961,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
             GateEventHandlers::dispatch(&self.gate_handlers.before_measurement, &ctx);
         let noise_response = self.emit_before_measurement_noise_raw(qubits);
         let combined = user_response.combine(noise_response);
-        self.apply_noise_response(sim, combined);
+        self.apply_noise_response(sim, combined)
     }
 
     /// Dispatch after-measurement event.
@@ -1947,13 +1970,12 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         sim: &mut S,
         command: &GateCommand,
         outcomes: &[bool],
-    ) {
+    ) -> Result<(), ExecutionError> {
         let qubits = command.qubits.as_slice();
 
         // Fast path
         if self.gate_handlers.after_measurement.is_empty() {
-            self.emit_after_measurement_noise(sim, qubits, outcomes);
-            return;
+            return self.emit_after_measurement_noise(sim, qubits, outcomes);
         }
 
         let noise_response = self.emit_after_measurement_noise_raw(qubits, outcomes);
@@ -1969,17 +1991,20 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         let user_response =
             GateEventHandlers::dispatch(&self.gate_handlers.after_measurement, &ctx);
         let combined = noise_response.combine(user_response);
-        self.apply_noise_response(sim, combined);
+        self.apply_noise_response(sim, combined)
     }
 
     /// Dispatch after-preparation event.
-    fn dispatch_after_preparation(&mut self, sim: &mut S, command: &GateCommand) {
+    fn dispatch_after_preparation(
+        &mut self,
+        sim: &mut S,
+        command: &GateCommand,
+    ) -> Result<(), ExecutionError> {
         let qubits = command.qubits.as_slice();
 
         // Fast path
         if self.gate_handlers.after_preparation.is_empty() {
-            self.emit_after_preparation_noise(sim, qubits);
-            return;
+            return self.emit_after_preparation_noise(sim, qubits);
         }
 
         let noise_response = self.emit_after_preparation_noise_raw(qubits);
@@ -1987,17 +2012,21 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         let user_response =
             GateEventHandlers::dispatch(&self.gate_handlers.after_preparation, &ctx);
         let combined = noise_response.combine(user_response);
-        self.apply_noise_response(sim, combined);
+        self.apply_noise_response(sim, combined)
     }
 
     /// Dispatch idle event.
-    fn dispatch_idle(&mut self, sim: &mut S, command: &GateCommand, duration: TimeUnits) {
+    fn dispatch_idle(
+        &mut self,
+        sim: &mut S,
+        command: &GateCommand,
+        duration: TimeUnits,
+    ) -> Result<(), ExecutionError> {
         let qubits = command.qubits.as_slice();
 
         // Fast path
         if self.gate_handlers.idle.is_empty() {
-            self.emit_idle_noise(sim, qubits, duration);
-            return;
+            return self.emit_idle_noise(sim, qubits, duration);
         }
 
         let noise_response = self.emit_idle_noise_raw(qubits, duration);
@@ -2012,7 +2041,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         };
         let user_response = GateEventHandlers::dispatch(&self.gate_handlers.idle, &ctx);
         let combined = noise_response.combine(user_response);
-        self.apply_noise_response(sim, combined);
+        self.apply_noise_response(sim, combined)
     }
 
     // --- Noise emission (AdaptedSequence path) ---
@@ -2024,9 +2053,9 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_id: GateId,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) -> bool {
+    ) -> Result<bool, ExecutionError> {
         let Some(ref mut noise) = self.noise else {
-            return false;
+            return Ok(false);
         };
 
         let gate_type = gate_id.try_to_gate_type().unwrap_or(GateType::I);
@@ -2039,8 +2068,8 @@ impl<S: CliffordGateable> CircuitRunner<S> {
 
         let response = noise.emit(&event, &mut self.rng);
         let should_skip = response.should_skip_gate();
-        self.apply_noise_response(sim, response);
-        should_skip
+        self.apply_noise_response(sim, response)?;
+        Ok(should_skip)
     }
 
     /// Emit after-gate to noise model (`AdaptedSequence` path).
@@ -2050,9 +2079,9 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_id: GateId,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) {
+    ) -> Result<(), ExecutionError> {
         let Some(ref mut noise) = self.noise else {
-            return;
+            return Ok(());
         };
 
         let gate_type = gate_id.try_to_gate_type().unwrap_or(GateType::I);
@@ -2064,7 +2093,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         };
 
         let response = noise.emit(&event, &mut self.rng);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     // --- Noise emission (CommandQueue path) ---
@@ -2077,11 +2106,11 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_type: GateType,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) -> bool {
+    ) -> Result<bool, ExecutionError> {
         let response = self.emit_before_gate_noise_raw_for_id(gate_id, gate_type, qubits, angles);
         let should_skip = response.should_skip_gate();
-        self.apply_noise_response(sim, response);
-        should_skip
+        self.apply_noise_response(sim, response)?;
+        Ok(should_skip)
     }
 
     fn emit_before_gate_noise_raw_for_id(
@@ -2110,9 +2139,9 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         gate_type: GateType,
         qubits: &[QubitId],
         angles: &[Angle64],
-    ) {
+    ) -> Result<(), ExecutionError> {
         let response = self.emit_after_gate_noise_raw_for_id(gate_id, gate_type, qubits, angles);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     fn emit_after_gate_noise_raw_for_id(
@@ -2134,9 +2163,13 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         NoiseResponse::None
     }
 
-    fn emit_before_measurement_noise(&mut self, sim: &mut S, qubits: &[QubitId]) {
+    fn emit_before_measurement_noise(
+        &mut self,
+        sim: &mut S,
+        qubits: &[QubitId],
+    ) -> Result<(), ExecutionError> {
         let response = self.emit_before_measurement_noise_raw(qubits);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     fn emit_before_measurement_noise_raw(&mut self, qubits: &[QubitId]) -> NoiseResponse {
@@ -2147,9 +2180,14 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         NoiseResponse::None
     }
 
-    fn emit_after_measurement_noise(&mut self, sim: &mut S, qubits: &[QubitId], outcomes: &[bool]) {
+    fn emit_after_measurement_noise(
+        &mut self,
+        sim: &mut S,
+        qubits: &[QubitId],
+        outcomes: &[bool],
+    ) -> Result<(), ExecutionError> {
         let response = self.emit_after_measurement_noise_raw(qubits, outcomes);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     fn emit_after_measurement_noise_raw(
@@ -2164,9 +2202,13 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         NoiseResponse::None
     }
 
-    fn emit_after_preparation_noise(&mut self, sim: &mut S, qubits: &[QubitId]) {
+    fn emit_after_preparation_noise(
+        &mut self,
+        sim: &mut S,
+        qubits: &[QubitId],
+    ) -> Result<(), ExecutionError> {
         let response = self.emit_after_preparation_noise_raw(qubits);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     fn emit_after_preparation_noise_raw(&mut self, qubits: &[QubitId]) -> NoiseResponse {
@@ -2177,9 +2219,14 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         NoiseResponse::None
     }
 
-    fn emit_idle_noise(&mut self, sim: &mut S, qubits: &[QubitId], duration: TimeUnits) {
+    fn emit_idle_noise(
+        &mut self,
+        sim: &mut S,
+        qubits: &[QubitId],
+        duration: TimeUnits,
+    ) -> Result<(), ExecutionError> {
         let response = self.emit_idle_noise_raw(qubits, duration);
-        self.apply_noise_response(sim, response);
+        self.apply_noise_response(sim, response)
     }
 
     fn emit_idle_noise_raw(&mut self, qubits: &[QubitId], duration: TimeUnits) -> NoiseResponse {
@@ -2199,7 +2246,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
         pos: u32,
         store: &SignalStore,
         cursors: &mut [SignalCursor],
-    ) {
+    ) -> Result<(), ExecutionError> {
         let has_response_handlers = self.signal_handlers.has_response_handlers();
 
         for cursor in cursors.iter_mut() {
@@ -2226,25 +2273,32 @@ impl<S: CliffordGateable> CircuitRunner<S> {
                         .signal_handlers
                         .call_response(cursor.type_id, data, &ctx);
                     if !response.is_none() {
-                        self.apply_noise_response(sim, response);
+                        self.apply_noise_response(sim, response)?;
                     }
                 }
 
                 // 3. Emit to noise model
-                self.emit_signal_to_noise(sim, cursor.type_id, data);
+                self.emit_signal_to_noise(sim, cursor.type_id, data)?;
 
                 cursor.entry_idx += 1;
             }
         }
+        Ok(())
     }
 
     /// Emit a signal event to the noise model.
-    fn emit_signal_to_noise(&mut self, sim: &mut S, type_id: TypeId, data: &dyn Any) {
+    fn emit_signal_to_noise(
+        &mut self,
+        sim: &mut S,
+        type_id: TypeId,
+        data: &dyn Any,
+    ) -> Result<(), ExecutionError> {
         if let Some(ref mut noise) = self.noise {
             let event = NoiseEvent::Signal { type_id, data };
             let response = noise.emit(&event, &mut self.rng);
-            self.apply_noise_response(sim, response);
+            self.apply_noise_response(sim, response)?;
         }
+        Ok(())
     }
 
     // --- Measurement recording and noise response ---
@@ -2282,7 +2336,11 @@ impl<S: CliffordGateable> CircuitRunner<S> {
     }
 
     /// Apply a noise response (inject gates, flip outcomes, etc.).
-    fn apply_noise_response(&mut self, sim: &mut S, response: NoiseResponse) {
+    fn apply_noise_response(
+        &mut self,
+        sim: &mut S,
+        response: NoiseResponse,
+    ) -> Result<(), ExecutionError> {
         match response {
             NoiseResponse::None
             | NoiseResponse::SkipGate
@@ -2291,7 +2349,7 @@ impl<S: CliffordGateable> CircuitRunner<S> {
 
             NoiseResponse::InjectGates(gates) => {
                 for gate in gates.iter() {
-                    self.execute_noise_gate(sim, gate);
+                    self.execute_noise_gate(sim, gate)?;
                 }
             }
 
@@ -2315,49 +2373,51 @@ impl<S: CliffordGateable> CircuitRunner<S> {
 
             NoiseResponse::Multiple(responses) => {
                 for r in responses {
-                    self.apply_noise_response(sim, r);
+                    self.apply_noise_response(sim, r)?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Execute a noise gate (injected error).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if neither the Clifford simulator nor the configured rotation
-    /// executor can execute the injected gate, or if the gate carries the wrong
-    /// number of angles. Configuration validation should make this unreachable
-    /// for declared noise mechanisms.
-    fn execute_noise_gate(&self, sim: &mut S, gate: &GateCommand) {
-        if let Err(error) = validate_angle_arity(gate.gate_type, gate.angles()) {
-            panic!("CircuitRunner invariant violated: injected noise {error}");
-        }
+    /// Returns an error if the gate has invalid arity or neither the Clifford
+    /// simulator nor the configured rotation executor can execute it.
+    fn execute_noise_gate(&self, sim: &mut S, gate: &GateCommand) -> Result<(), ExecutionError> {
         let qubits = gate.qubits.as_slice();
+        validate_angle_arity(gate.gate_type, gate.angles())?;
         let arity = gate.gate_type.quantum_arity();
-        assert!(
-            !qubits.is_empty() && qubits.len().is_multiple_of(arity),
-            "CircuitRunner invariant violated: injected noise gate {:?} has {} target(s), which \
-             is not a nonzero multiple of its arity {arity}",
-            gate.gate_type,
-            qubits.len()
-        );
-        if let Err(error) = gate.validate() {
-            panic!("CircuitRunner invariant violated: injected noise {error}");
+        if qubits.is_empty() || !qubits.len().is_multiple_of(arity) {
+            return Err(ExecutionError::QubitArity {
+                gate: gate.gate_type,
+                arity,
+                got: qubits.len(),
+            });
         }
+        gate.validate().map_err(ExecutionError::InvalidCommand)?;
         let gate_id = GateId::from(gate.gate_type);
-        let executed = (gate.gate_type != GateType::Idle
+        let mut rotation_attempt = CliffordRotationAttempt::NotARotation;
+        let mut executed = (gate.gate_type != GateType::Idle
             && Self::try_execute_clifford(sim, gate_id, qubits))
             || self
                 .rotation_executor
                 .is_some_and(|executor| executor(sim, gate_id, gate.angles(), qubits));
-
-        assert!(
-            executed,
-            "CircuitRunner invariant violated: injected noise gate {:?} could not be executed; \
-             configuration validation should have rejected the emitting noise mechanism",
-            gate.gate_type
-        );
+        if !executed {
+            rotation_attempt =
+                Self::try_execute_clifford_rotation(sim, gate_id, qubits, gate.angles())?;
+            executed = rotation_attempt == CliffordRotationAttempt::Executed;
+        }
+        if executed {
+            Ok(())
+        } else {
+            Err(upgrade_rotation_error(
+                ExecutionError::NoDecomposition { gate_id },
+                rotation_attempt,
+            ))
+        }
     }
 }
 
@@ -2895,45 +2955,67 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "CircuitRunner invariant violated: injected noise gate PZ")]
-    fn unsupported_noise_gate_panics_in_circuit_runner() {
+    fn unsupported_noise_gate_errors_in_circuit_runner() {
         let mut state = SparseStab::with_seed(1, 42);
-        CircuitRunner::<SparseStab>::new()
-            .execute_noise_gate(&mut state, &GateCommand::pz(QubitId(0)));
+        let error = CircuitRunner::<SparseStab>::new()
+            .execute_noise_gate(&mut state, &GateCommand::pz(QubitId(0)))
+            .expect_err("PZ cannot be executed as an injected noise gate");
+        assert!(matches!(error, ExecutionError::NoDecomposition { .. }));
     }
 
     #[test]
-    #[should_panic(expected = "CircuitRunner invariant violated: injected noise gate PZ")]
-    fn unsupported_noise_gate_panics_with_rotation_executor() {
+    fn unsupported_noise_gate_errors_with_rotation_executor() {
         let mut state = StateVec::with_seed(1, 42);
-        CircuitRunner::<StateVec>::rotations()
-            .execute_noise_gate(&mut state, &GateCommand::pz(QubitId(0)));
+        let error = CircuitRunner::<StateVec>::rotations()
+            .execute_noise_gate(&mut state, &GateCommand::pz(QubitId(0)))
+            .expect_err("PZ cannot be executed as an injected noise gate");
+        assert!(matches!(error, ExecutionError::NoDecomposition { .. }));
     }
 
     #[test]
-    #[should_panic(expected = "CircuitRunner invariant violated: injected noise gate CX has 1")]
-    fn malformed_multi_qubit_noise_gate_panics_in_circuit_runner() {
+    fn malformed_multi_qubit_noise_gate_errors_in_circuit_runner() {
         let mut state = SparseStab::with_seed(1, 42);
-        CircuitRunner::<SparseStab>::new().execute_noise_gate(
-            &mut state,
-            &GateCommand::new(GateType::CX, smallvec::smallvec![QubitId(0)]),
+        let error = CircuitRunner::<SparseStab>::new()
+            .execute_noise_gate(
+                &mut state,
+                &GateCommand::new(GateType::CX, smallvec::smallvec![QubitId(0)]),
+            )
+            .expect_err("CX requires pairs of target qubits");
+        assert!(matches!(
+            error,
+            ExecutionError::QubitArity {
+                gate: GateType::CX,
+                arity: 2,
+                got: 1,
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Gate CX received 1 targets, which is not a nonzero multiple of its qubit arity 2"
         );
     }
 
     #[test]
-    #[should_panic(
-        expected = "CircuitRunner invariant violated: injected noise Gate H expected 0 angle parameters, got 1"
-    )]
-    fn surplus_fixed_gate_angle_panics_on_noise_injection() {
+    fn surplus_fixed_gate_angle_errors_on_noise_injection() {
         let mut state = SparseStab::with_seed(1, 42);
-        CircuitRunner::<SparseStab>::new().execute_noise_gate(
-            &mut state,
-            &GateCommand::with_angles(
-                GateType::H,
-                smallvec::smallvec![QubitId(0)],
-                smallvec::smallvec![Angle64::QUARTER_TURN],
-            ),
-        );
+        let error = CircuitRunner::<SparseStab>::new()
+            .execute_noise_gate(
+                &mut state,
+                &GateCommand::with_angles(
+                    GateType::H,
+                    smallvec::smallvec![QubitId(0)],
+                    smallvec::smallvec![Angle64::QUARTER_TURN],
+                ),
+            )
+            .expect_err("injected fixed gates must reject surplus angles");
+        assert!(matches!(
+            error,
+            ExecutionError::AngleArity {
+                gate: GateType::H,
+                expected: 0,
+                got: 1,
+            }
+        ));
     }
 
     #[test]
@@ -3756,11 +3838,16 @@ mod tests {
         }
     }
     #[test]
-    #[should_panic(expected = "only an Idle command can carry a duration payload")]
     fn injected_noise_rejects_duration_on_fixed_gate() {
         let mut gate = GateCommand::h(QubitId(0));
         gate.payload = crate::command::GatePayload::Duration(pecos_core::TimeUnits::new(23));
-        CircuitRunner::<SparseStab>::new()
-            .execute_noise_gate(&mut SparseStab::with_seed(1, 42), &gate);
+        let error = CircuitRunner::<SparseStab>::new()
+            .execute_noise_gate(&mut SparseStab::with_seed(1, 42), &gate)
+            .expect_err("fixed gates must reject duration payloads");
+        assert!(matches!(error, ExecutionError::InvalidCommand(_)));
+        assert_eq!(
+            error.to_string(),
+            "only an Idle command can carry a duration payload"
+        );
     }
 }

--- a/exp/pecos-neo/src/sampling/importance_runner.rs
+++ b/exp/pecos-neo/src/sampling/importance_runner.rs
@@ -205,6 +205,42 @@ pub struct ImportanceSamplingRunner<S: CliffordGateable> {
 }
 
 impl<S: CliffordGateable> ImportanceSamplingRunner<S> {
+    /// Whether this runner can execute a well-formed static circuit command.
+    pub(crate) fn supports(command: &GateCommand) -> bool {
+        command.has_valid_shape()
+            && matches!(
+                command.gate_type,
+                GateType::I
+                    | GateType::X
+                    | GateType::Y
+                    | GateType::Z
+                    | GateType::H
+                    | GateType::F
+                    | GateType::Fdg
+                    | GateType::SX
+                    | GateType::SXdg
+                    | GateType::SY
+                    | GateType::SYdg
+                    | GateType::SZ
+                    | GateType::SZdg
+                    | GateType::CX
+                    | GateType::CY
+                    | GateType::CZ
+                    | GateType::SZZ
+                    | GateType::SZZdg
+                    | GateType::SXX
+                    | GateType::SXXdg
+                    | GateType::SYY
+                    | GateType::SYYdg
+                    | GateType::SWAP
+                    | GateType::MZ
+                    | GateType::MeasureLeaked
+                    | GateType::MeasureFree
+                    | GateType::PZ
+                    | GateType::QAlloc
+            )
+    }
+
     /// Create a new importance sampling runner with the given simulator.
     pub fn new(simulator: S) -> Self {
         Self {
@@ -1114,6 +1150,60 @@ mod tests {
                 ]
             })
             .collect()
+    }
+
+    fn well_formed_commands(gate_type: GateType) -> Vec<(&'static str, GateCommand)> {
+        if gate_type == GateType::Idle {
+            return vec![(
+                "duration",
+                GateCommand::idle(pecos_core::QubitId(0), pecos_core::TimeUnits::new(23)),
+            )];
+        }
+        let qubits = (0..gate_type.quantum_arity())
+            .map(QubitId)
+            .collect::<Vec<_>>();
+        let angle_arity = gate_type.angle_arity();
+        if angle_arity == 0 {
+            return vec![("no angles", GateCommand::new(gate_type, qubits))];
+        }
+        vec![
+            (
+                "Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits.clone(),
+                    vec![pecos_core::Angle64::QUARTER_TURN; angle_arity],
+                ),
+            ),
+            (
+                "non-Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits,
+                    vec![pecos_core::Angle64::from_radians(0.3); angle_arity],
+                ),
+            ),
+        ]
+    }
+
+    #[test]
+    fn supports_agrees_with_executor_for_every_gate_type() {
+        for &gate_type in GateType::ALL {
+            for (angle_case, command) in well_formed_commands(gate_type) {
+                let declared = ImportanceSamplingRunner::<SparseStab>::supports(&command);
+                let executed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let num_qubits = gate_type.quantum_arity();
+                    let mut runner =
+                        ImportanceSamplingRunner::new(SparseStab::with_seed(num_qubits, 42));
+                    runner.execute_command(&command).is_ok()
+                }))
+                .is_ok_and(|executed| executed);
+                assert_eq!(
+                    declared, executed,
+                    "ImportanceSamplingRunner support mismatch for {gate_type:?} with {angle_case}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/exp/pecos-neo/src/sampling/path.rs
+++ b/exp/pecos-neo/src/sampling/path.rs
@@ -371,6 +371,42 @@ pub struct PathExplorer<S: CliffordGateable + ForcedMeasurement> {
 }
 
 impl<S: CliffordGateable + ForcedMeasurement> PathExplorer<S> {
+    /// Whether this explorer can execute a well-formed static circuit command.
+    pub(crate) fn supports(command: &GateCommand) -> bool {
+        command.has_valid_shape()
+            && matches!(
+                command.gate_type,
+                GateType::I
+                    | GateType::X
+                    | GateType::Y
+                    | GateType::Z
+                    | GateType::H
+                    | GateType::F
+                    | GateType::Fdg
+                    | GateType::SX
+                    | GateType::SXdg
+                    | GateType::SY
+                    | GateType::SYdg
+                    | GateType::SZ
+                    | GateType::SZdg
+                    | GateType::CX
+                    | GateType::CY
+                    | GateType::CZ
+                    | GateType::SZZ
+                    | GateType::SZZdg
+                    | GateType::SXX
+                    | GateType::SXXdg
+                    | GateType::SYY
+                    | GateType::SYYdg
+                    | GateType::SWAP
+                    | GateType::MZ
+                    | GateType::MeasureLeaked
+                    | GateType::MeasureFree
+                    | GateType::PZ
+                    | GateType::QAlloc
+            )
+    }
+
     /// Create a new path explorer with the given simulator.
     pub fn new(simulator: S) -> Self {
         Self {
@@ -735,6 +771,61 @@ mod tests {
     use super::*;
     use crate::command::CommandBuilder;
     use pecos_simulators::SparseStab;
+
+    fn well_formed_commands(gate_type: GateType) -> Vec<(&'static str, GateCommand)> {
+        if gate_type == GateType::Idle {
+            return vec![(
+                "duration",
+                GateCommand::idle(pecos_core::QubitId(0), pecos_core::TimeUnits::new(23)),
+            )];
+        }
+        let qubits = (0..gate_type.quantum_arity())
+            .map(QubitId)
+            .collect::<Vec<_>>();
+        let angle_arity = gate_type.angle_arity();
+        if angle_arity == 0 {
+            return vec![("no angles", GateCommand::new(gate_type, qubits))];
+        }
+        vec![
+            (
+                "Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits.clone(),
+                    vec![pecos_core::Angle64::QUARTER_TURN; angle_arity],
+                ),
+            ),
+            (
+                "non-Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits,
+                    vec![pecos_core::Angle64::from_radians(0.3); angle_arity],
+                ),
+            ),
+        ]
+    }
+
+    #[test]
+    fn supports_agrees_with_executor_for_every_gate_type() {
+        for &gate_type in GateType::ALL {
+            for (angle_case, command) in well_formed_commands(gate_type) {
+                let declared = PathExplorer::<SparseStab>::supports(&command);
+                let executed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut explorer =
+                        PathExplorer::new(SparseStab::with_seed(gate_type.quantum_arity(), 42));
+                    let mut outcomes = MeasurementOutcomes::new();
+                    let mut path = MeasurementPath::new();
+                    explorer.execute_command_recording(&command, &mut outcomes, &mut path);
+                }))
+                .is_ok();
+                assert_eq!(
+                    declared, executed,
+                    "PathExplorer support mismatch for {gate_type:?} with {angle_case}"
+                );
+            }
+        }
+    }
 
     #[test]
     #[should_panic(expected = "PathExplorer cannot execute circuit gate T")]

--- a/exp/pecos-neo/src/sampling/subset.rs
+++ b/exp/pecos-neo/src/sampling/subset.rs
@@ -73,7 +73,8 @@
 //! println!("P(failure) = {:.2e}", result.probability());
 //! ```
 
-use crate::command::CommandQueue;
+use crate::command::{CommandQueue, GateCommand, GateType};
+use crate::extensible::is_clifford_angle;
 use crate::noise::ComposableNoiseModel;
 use crate::outcome::MeasurementOutcomes;
 use crate::runner::CircuitRunner;
@@ -81,6 +82,59 @@ use crate::sampling::weight::SampleWeight;
 use pecos_random::{PecosRng, resolve_seed};
 use pecos_simulators::{CliffordGateable, SparseStab};
 use rand::RngExt;
+
+/// Whether subset simulation's `CircuitRunner<SparseStab>` can execute a
+/// well-formed static circuit command.
+pub(crate) fn supports(command: &GateCommand) -> bool {
+    if !command.has_valid_shape() {
+        return false;
+    }
+    if matches!(
+        command.gate_type,
+        GateType::I
+            | GateType::X
+            | GateType::Y
+            | GateType::Z
+            | GateType::H
+            | GateType::F
+            | GateType::Fdg
+            | GateType::SX
+            | GateType::SXdg
+            | GateType::SY
+            | GateType::SYdg
+            | GateType::SZ
+            | GateType::SZdg
+            | GateType::CX
+            | GateType::CY
+            | GateType::CZ
+            | GateType::SZZ
+            | GateType::SZZdg
+            | GateType::SXX
+            | GateType::SXXdg
+            | GateType::SYY
+            | GateType::SYYdg
+            | GateType::SWAP
+            | GateType::MZ
+            | GateType::MeasureLeaked
+            | GateType::MeasureFree
+            | GateType::PZ
+            | GateType::QAlloc
+            | GateType::Idle
+    ) {
+        return true;
+    }
+    matches!(
+        command.gate_type,
+        GateType::RX
+            | GateType::RY
+            | GateType::RZ
+            | GateType::RXX
+            | GateType::RYY
+            | GateType::RZZ
+            | GateType::RXY1Q
+            | GateType::U
+    ) && command.angles().iter().copied().all(is_clifford_angle)
+}
 
 /// Configuration for subset simulation.
 #[derive(Debug, Clone)]
@@ -2326,6 +2380,58 @@ pub fn phase_flip_syndrome_circuit() -> CommandQueue {
 #[allow(clippy::float_cmp, clippy::cast_precision_loss)]
 mod tests {
     use super::*;
+
+    fn well_formed_commands(gate_type: GateType) -> Vec<(&'static str, GateCommand)> {
+        if gate_type == GateType::Idle {
+            return vec![(
+                "duration",
+                GateCommand::idle(pecos_core::QubitId(0), pecos_core::TimeUnits::new(23)),
+            )];
+        }
+        let qubits = (0..gate_type.quantum_arity())
+            .map(pecos_core::QubitId)
+            .collect::<Vec<_>>();
+        let angle_arity = gate_type.angle_arity();
+        if angle_arity == 0 {
+            return vec![("no angles", GateCommand::new(gate_type, qubits))];
+        }
+        vec![
+            (
+                "Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits.clone(),
+                    vec![pecos_core::Angle64::QUARTER_TURN; angle_arity],
+                ),
+            ),
+            (
+                "non-Clifford angles",
+                GateCommand::with_angles(
+                    gate_type,
+                    qubits,
+                    vec![pecos_core::Angle64::from_radians(0.3); angle_arity],
+                ),
+            ),
+        ]
+    }
+
+    #[test]
+    fn supports_agrees_with_executor_for_every_gate_type() {
+        for &gate_type in GateType::ALL {
+            for (angle_case, command) in well_formed_commands(gate_type) {
+                let declared = supports(&command);
+                let circuit = std::iter::once(command).collect();
+                let mut simulator = SparseStab::with_seed(gate_type.quantum_arity(), 42);
+                let executed = CircuitRunner::new()
+                    .apply_circuit(&mut simulator, &circuit)
+                    .is_ok();
+                assert_eq!(
+                    declared, executed,
+                    "SubsetSimulation support mismatch for {gate_type:?} with {angle_case}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_subset_config_builder() {

--- a/exp/pecos-neo/src/tool.rs
+++ b/exp/pecos-neo/src/tool.rs
@@ -34,12 +34,13 @@
 //!     .insert_resource(0u32)
 //!     .add_system(Stage::Execute, |res: &mut Resources| {
 //!         *res.get_mut::<u32>() += 1;
+//!         Ok(())
 //!     });
 //!
-//! tool.run();
+//! tool.run().unwrap();
 //! assert_eq!(*tool.resource::<u32>(), 1);
 //!
-//! tool.run();
+//! tool.run().unwrap();
 //! assert_eq!(*tool.resource::<u32>(), 2);
 //! ```
 //!
@@ -69,6 +70,7 @@
 //!         tool.insert_resource_mut(self.initial);
 //!         tool.add_system_mut(Stage::Execute, |res: &mut Resources| {
 //!             *res.get_mut::<u32>() += 1;
+//!             Ok(())
 //!         });
 //!     }
 //! }
@@ -76,7 +78,7 @@
 //! let mut tool = Tool::new()
 //!     .add_plugin(&CounterPlugin { initial: 10 });
 //!
-//! tool.run();
+//! tool.run().expect("tool should run successfully");
 //! assert_eq!(*tool.resource::<u32>(), 11);
 //! ```
 

--- a/exp/pecos-neo/src/tool/core.rs
+++ b/exp/pecos-neo/src/tool/core.rs
@@ -16,6 +16,7 @@ use super::Stage;
 use super::plugin::{Plugin, PluginGroup};
 use super::resource::{Resource, Resources};
 use super::system::{IntoSystem, Schedule};
+use pecos_core::errors::PecosError;
 
 /// The core Tool type - a Bevy-inspired application container.
 ///
@@ -35,9 +36,10 @@ use super::system::{IntoSystem, Schedule};
 ///     .add_system(Stage::Startup, |res: &mut Resources| {
 ///         let value = res.get::<u32>();
 ///         println!("Starting with value: {}", value);
+///         Ok(())
 ///     });
 ///
-/// tool.run();
+/// tool.run().unwrap();
 /// ```
 pub struct Tool {
     resources: Resources,
@@ -195,19 +197,26 @@ impl Tool {
     ///
     /// For multi-shot simulation, this runs a single "iteration".
     /// Use `run_shots()` for multiple iterations.
-    pub fn run(&mut self) {
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by a system.
+    pub fn run(&mut self) -> Result<(), PecosError> {
         // Startup runs only once
         if !self.has_run_startup {
-            self.schedule.run_stage(Stage::Startup, &mut self.resources);
+            self.schedule
+                .run_stage(Stage::Startup, &mut self.resources)?;
             self.has_run_startup = true;
         }
 
         // Main execution stages
-        self.schedule.run_stage(Stage::PreShot, &mut self.resources);
-        self.schedule.run_stage(Stage::Execute, &mut self.resources);
         self.schedule
-            .run_stage(Stage::PostShot, &mut self.resources);
-        self.schedule.run_stage(Stage::Finish, &mut self.resources);
+            .run_stage(Stage::PreShot, &mut self.resources)?;
+        self.schedule
+            .run_stage(Stage::Execute, &mut self.resources)?;
+        self.schedule
+            .run_stage(Stage::PostShot, &mut self.resources)?;
+        self.schedule.run_stage(Stage::Finish, &mut self.resources)
     }
 
     /// Run multiple shots.
@@ -219,23 +228,30 @@ impl Tool {
     ///    - `Execute`
     ///    - `PostShot`
     /// 3. `Finish` (once)
-    pub fn run_shots(&mut self, shots: usize) {
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by a system and stops the schedule.
+    pub fn run_shots(&mut self, shots: usize) -> Result<(), PecosError> {
         // Startup runs only once
         if !self.has_run_startup {
-            self.schedule.run_stage(Stage::Startup, &mut self.resources);
+            self.schedule
+                .run_stage(Stage::Startup, &mut self.resources)?;
             self.has_run_startup = true;
         }
 
         // Shot loop
         for _ in 0..shots {
-            self.schedule.run_stage(Stage::PreShot, &mut self.resources);
-            self.schedule.run_stage(Stage::Execute, &mut self.resources);
             self.schedule
-                .run_stage(Stage::PostShot, &mut self.resources);
+                .run_stage(Stage::PreShot, &mut self.resources)?;
+            self.schedule
+                .run_stage(Stage::Execute, &mut self.resources)?;
+            self.schedule
+                .run_stage(Stage::PostShot, &mut self.resources)?;
         }
 
         // Finish runs once at end
-        self.schedule.run_stage(Stage::Finish, &mut self.resources);
+        self.schedule.run_stage(Stage::Finish, &mut self.resources)
     }
 
     /// Run the complete shot loop using the schedule directly on provided resources.
@@ -243,8 +259,12 @@ impl Tool {
     /// Unlike `run_shots()`, this always runs Startup (no `has_run_startup` guard)
     /// and operates on the provided resources rather than the Tool's own resources.
     /// Used by parallel workers that each have their own Resources.
-    pub fn run_shots_on(&self, resources: &mut Resources, shots: usize) {
-        self.schedule.run_shots(resources, shots);
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by a system and stops the schedule.
+    pub fn run_shots_on(&self, resources: &mut Resources, shots: usize) -> Result<(), PecosError> {
+        self.schedule.run_shots(resources, shots)
     }
 
     /// Reset the tool for another run.
@@ -284,12 +304,13 @@ mod tests {
                 .insert_resource(0u32)
                 .add_system(Stage::Execute, |res: &mut Resources| {
                     *res.get_mut::<u32>() += 1;
+                    Ok(())
                 });
 
-        tool.run();
+        tool.run().unwrap();
         assert_eq!(*tool.resource::<u32>(), 1);
 
-        tool.run();
+        tool.run().unwrap();
         assert_eq!(*tool.resource::<u32>(), 2);
     }
 
@@ -299,13 +320,15 @@ mod tests {
             .insert_resource(Vec::<&str>::new())
             .add_system(Stage::Startup, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("startup");
+                Ok(())
             })
             .add_system(Stage::Execute, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("execute");
+                Ok(())
             });
 
-        tool.run();
-        tool.run();
+        tool.run().unwrap();
+        tool.run().unwrap();
 
         // Startup should only appear once
         assert_eq!(
@@ -321,9 +344,10 @@ mod tests {
                 .insert_resource(0u32)
                 .add_system(Stage::PreShot, |res: &mut Resources| {
                     *res.get_mut::<u32>() += 1;
+                    Ok(())
                 });
 
-        tool.run_shots(5);
+        tool.run_shots(5).unwrap();
         assert_eq!(*tool.resource::<u32>(), 5);
     }
 
@@ -333,21 +357,26 @@ mod tests {
             .insert_resource(Vec::<&str>::new())
             .add_system(Stage::Startup, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("startup");
+                Ok(())
             })
             .add_system(Stage::PreShot, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("pre_shot");
+                Ok(())
             })
             .add_system(Stage::Execute, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("execute");
+                Ok(())
             })
             .add_system(Stage::PostShot, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("post_shot");
+                Ok(())
             })
             .add_system(Stage::Finish, |res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("finish");
+                Ok(())
             });
 
-        tool.run();
+        tool.run().unwrap();
 
         assert_eq!(
             *tool.resource::<Vec<&str>>(),

--- a/exp/pecos-neo/src/tool/importance.rs
+++ b/exp/pecos-neo/src/tool/importance.rs
@@ -32,7 +32,7 @@
 //! // Add importance sampling with 10x boost
 //! sim.tool_mut().add_plugin_mut(&ImportanceSamplingPlugin::new(0.001, 10.0));
 //!
-//! let results = sim.run();
+//! let results = sim.run().expect("simulation should succeed");
 //! // Use weighted statistics to analyze results...
 //! ```
 
@@ -207,9 +207,18 @@ impl Plugin for ImportanceSamplingPlugin {
         }
 
         // Add systems for weight tracking
-        tool.add_system_mut(Stage::PreShot, importance_pre_shot);
-        tool.add_system_mut(Stage::PostShot, importance_post_shot);
-        tool.add_system_mut(Stage::Finish, importance_finish);
+        tool.add_system_mut(Stage::PreShot, |resources: &mut Resources| {
+            importance_pre_shot(resources);
+            Ok(())
+        });
+        tool.add_system_mut(Stage::PostShot, |resources: &mut Resources| {
+            importance_post_shot(resources);
+            Ok(())
+        });
+        tool.add_system_mut(Stage::Finish, |resources: &mut Resources| {
+            importance_finish(resources);
+            Ok(())
+        });
     }
 }
 

--- a/exp/pecos-neo/src/tool/plugin.rs
+++ b/exp/pecos-neo/src/tool/plugin.rs
@@ -35,6 +35,7 @@ use super::Tool;
 ///         tool.insert_resource_mut(42u32);
 ///         tool.add_system_mut(Stage::Execute, |res: &mut Resources| {
 ///             *res.get_mut::<u32>() += 1;
+///             Ok(())
 ///         });
 ///     }
 /// }

--- a/exp/pecos-neo/src/tool/simulation.rs
+++ b/exp/pecos-neo/src/tool/simulation.rs
@@ -40,7 +40,7 @@
 //!     .sampling(monte_carlo(1000))
 //!     .seed(42)
 //!     .build()
-//!     .run();
+//!     .run().expect("simulation should succeed");
 //! ```
 //!
 //! ## QASM Programs
@@ -69,7 +69,7 @@
 //!     .sampling(monte_carlo(1000))
 //!     .seed(42)
 //!     .build()
-//!     .run();
+//!     .run().expect("simulation should succeed");
 //! ```
 //!
 //! ## Other Program Types
@@ -84,7 +84,7 @@
 //! let results = sim_neo(qis_engine().qis(&qis_program)).auto()
 //!     .sampling(monte_carlo(1000))
 //!     .build()
-//!     .run();
+//!     .run().expect("simulation should succeed");
 //! ```
 //!
 //! ## Reusable Simulations
@@ -100,12 +100,12 @@
 //!     .sampling(monte_carlo(1000))
 //!     .build();
 //!
-//! let results1 = sim.run();
-//! let results2 = sim.seed(123).run();  // Different seed
-//! let results3 = sim.shots(5000).run(); // More shots
+//! let results1 = sim.run().expect("simulation should succeed");
+//! let results2 = sim.seed(123).run().expect("simulation should succeed");  // Different seed
+//! let results3 = sim.shots(5000).run().expect("simulation should succeed"); // More shots
 //! ```
 
-use crate::command::CommandQueue;
+use crate::command::{CommandQueue, GateCommand};
 use crate::extensible::GateDefinitions;
 use crate::noise::ComposableNoiseModel;
 use crate::outcome::{MeasurementOutcomes, RegisterMap};
@@ -113,7 +113,10 @@ use crate::program::{CommandSource, DynProgramRunner, ProgramRunner, StaticProgr
 use crate::runner::{EventHandlers, GateOverrides};
 use crate::sampling::importance_runner::ImportanceSamplingRunner;
 use crate::sampling::path::{PathEnumerator, PathExplorer};
-use crate::sampling::subset::{SubsetConfig, SubsetResult, SubsetSimulation};
+use crate::sampling::subset::{
+    SubsetConfig, SubsetResult, SubsetSimulation, supports as subset_sampler_supports,
+};
+use pecos_core::errors::PecosError;
 use pecos_core::rng::RngManageable;
 use pecos_core::rng::rng_manageable::derive_seed;
 use pecos_random::PecosRng;
@@ -265,7 +268,8 @@ impl From<StateVecBuilder> for QuantumBackend {
 ///     .quantum(sparse_stab())
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run()
+///     .expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn sparse_stab() -> SparseStabBuilder {
@@ -289,7 +293,7 @@ pub fn sparse_stab() -> SparseStabBuilder {
 ///     .quantum(stabilizer())
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn stabilizer() -> StabilizerBuilder {
@@ -312,7 +316,7 @@ pub fn stabilizer() -> StabilizerBuilder {
 ///     .quantum(state_vector())
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn state_vector() -> StateVecBuilder {
@@ -363,12 +367,13 @@ pub trait SimulatorFactory: Send + Sync {
 }
 #[doc(hidden)]
 pub trait AdaptedQuantumEngineFactory: Send + Sync {
-    fn create_runner(&self, num_qubits: usize, seed: Option<u64>) -> Box<dyn DynProgramRunner>;
-
-    fn create_parallel_runner_factory(
+    fn create_runner(
         &self,
         num_qubits: usize,
-    ) -> Box<dyn ParallelQuantumRunnerFactory>;
+        seed: Option<u64>,
+    ) -> Result<Box<dyn DynProgramRunner>, PecosError>;
+
+    fn create_parallel_runner_factory(&self) -> Box<dyn ParallelQuantumRunnerFactory>;
 }
 struct QuantumEngineSimulatorFactory<B>
 where
@@ -380,25 +385,25 @@ impl<B> AdaptedQuantumEngineFactory for QuantumEngineSimulatorFactory<B>
 where
     B: pecos_engines::QuantumEngineBuilder + Clone + 'static,
 {
-    fn create_runner(&self, num_qubits: usize, seed: Option<u64>) -> Box<dyn DynProgramRunner> {
+    fn create_runner(
+        &self,
+        num_qubits: usize,
+        seed: Option<u64>,
+    ) -> Result<Box<dyn DynProgramRunner>, PecosError> {
         let mut builder = self.builder.clone();
         builder.set_qubits_if_needed(num_qubits);
-        let mut engine = builder
-            .build()
-            .expect("Failed to build quantum engine backend");
+        let mut engine = builder.build()?;
         if let Some(seed) = seed {
             engine.set_seed(seed);
         }
-        Box::new(crate::adapter::QuantumEngineProgramRunner::new(engine))
+        Ok(Box::new(crate::adapter::QuantumEngineProgramRunner::new(
+            engine,
+        )))
     }
 
-    fn create_parallel_runner_factory(
-        &self,
-        num_qubits: usize,
-    ) -> Box<dyn ParallelQuantumRunnerFactory> {
+    fn create_parallel_runner_factory(&self) -> Box<dyn ParallelQuantumRunnerFactory> {
         Box::new(AdaptedQuantumEngineRunnerFactory {
             builder: self.builder.clone(),
-            num_qubits,
         })
     }
 }
@@ -479,7 +484,7 @@ impl From<CustomBackendBuilder> for QuantumBackend {
 ///     .sampling(monte_carlo(100))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn custom_backend<S, F>(factory: F) -> CustomBackendBuilder
@@ -526,7 +531,7 @@ pub fn custom_backend_from_factory(
 ///     .sampling(monte_carlo(100))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn custom_backend_with_rotations<S, F>(factory: F) -> CustomBackendBuilder
@@ -635,7 +640,7 @@ impl SimNeoInput for Box<dyn CommandSource + Send + Sync> {
 ///     .classical(qasm_engine())
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 impl SimNeoInput for &str {
     fn into_sim_neo_builder(self) -> SimNeoBuilder {
@@ -667,14 +672,14 @@ impl SimNeoInput for String {
 ///     .auto()
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 ///
 /// // Explicit mode
 /// sim_neo(Qasm::from_string(qasm_code)).auto()
 ///     .classical(qasm_engine())
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 impl SimNeoInput for pecos_programs::Qasm {
     fn into_sim_neo_builder(self) -> SimNeoBuilder {
@@ -706,7 +711,7 @@ impl SimNeoInput for pecos_programs::Hugr {
 ///     .auto()
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 impl SimNeoInput for pecos_programs::Program {
     fn into_sim_neo_builder(self) -> SimNeoBuilder {
@@ -762,7 +767,7 @@ impl Default for SimConfig {
 ///         .with_p_meas(0.001)
 ///         .with_boost(10.0))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[derive(Debug, Clone)]
 pub struct ImportanceSamplingBuilder {
@@ -914,7 +919,8 @@ impl From<ImportanceSamplingBuilder> for Sampling {
 ///         .with_p2(0.01)
 ///         .with_boost(10.0))
 ///     .build()
-///     .run();
+///     .run()
+///     .expect("simulation should succeed");
 ///
 /// // Compute weighted statistics
 /// if let Some(rate) = results.weighted_mean(|outcome| {
@@ -996,7 +1002,8 @@ impl From<PathEnumerationBuilder> for Sampling {
 /// let results = sim_neo(circuit)
 ///     .quantum(sparse_stab())
 ///     .sampling(path_enumeration(1))
-///     .run();
+///     .run()
+///     .expect("simulation should succeed");
 ///
 /// // Two paths (00 and 11), each with probability 0.5.
 /// for (outcome, weight) in results
@@ -1169,7 +1176,8 @@ impl From<SubsetSimulationBuilder> for Sampling {
 ///             .failure(|o| o.iter().all(|m| m.outcome)),
 ///     )
 ///     .seed(42)
-///     .run();
+///     .run()
+///     .expect("simulation should succeed");
 ///
 /// let subset = results.subset.expect("subset strategy produces an estimate");
 /// println!("P(failure) = {:.2e}", subset.probability());
@@ -1463,7 +1471,8 @@ impl SimulationResults {
     /// let mut reg = RegisterMap::new();
     /// reg.add_register("c", &[QubitId(0), QubitId(1)]);
     ///
-    /// let results = sim_neo(circuit).auto().sampling(monte_carlo(100)).seed(42).run();
+    /// let results = sim_neo(circuit).auto().sampling(monte_carlo(100)).seed(42)
+    ///     .run().expect("simulation should succeed");
     /// let columns = results.as_register_columns(&reg);
     /// assert_eq!(columns["c"].len(), 100);
     /// ```
@@ -1511,7 +1520,8 @@ impl SimulationResults {
     /// let mut reg = RegisterMap::new();
     /// reg.add_register("c", &[QubitId(0)]);
     ///
-    /// let results = sim_neo(circuit).auto().sampling(monte_carlo(1000)).seed(42).run();
+    /// let results = sim_neo(circuit).auto().sampling(monte_carlo(1000)).seed(42)
+    ///     .run().expect("simulation should succeed");
     /// let counts = results.register_counts(&reg, "c");
     /// // Should have entries for [false] and [true]
     /// ```
@@ -1732,6 +1742,20 @@ fn infer_num_qubits_from_circuit(circuit: &CommandQueue) -> usize {
         .map_or(1, |max| max + 1)
 }
 
+fn validate_sampler_circuit(
+    circuit: &CommandQueue,
+    sampler_name: &str,
+    supports: impl Fn(&GateCommand) -> bool,
+) {
+    if let Some(command) = circuit.iter().find(|command| !supports(command)) {
+        panic!(
+            "{sampler_name} cannot execute static circuit gate {:?}; use Monte Carlo sampling \
+             with a backend that supports this gate.",
+            command.gate_type
+        );
+    }
+}
+
 // --- SimNeoBuilder ---
 
 /// Builder for configuring simulation tools (builder-of-builders pattern).
@@ -1756,7 +1780,7 @@ fn infer_num_qubits_from_circuit(circuit: &CommandQueue) -> usize {
 ///     .sampling(monte_carlo(1000))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 ///
 /// ## QASM Program (builder-of-builders pattern)
@@ -1772,7 +1796,7 @@ fn infer_num_qubits_from_circuit(circuit: &CommandQueue) -> usize {
 ///     .sampling(monte_carlo(1000))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 ///
 /// ## Pre-configured Engine Builder
@@ -1787,7 +1811,7 @@ fn infer_num_qubits_from_circuit(circuit: &CommandQueue) -> usize {
 ///     .with_engine(qasm_engine().qasm(qasm_code))
 ///     .sampling(monte_carlo(1000))
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 pub struct SimNeoBuilder {
     /// The program source (circuit, raw source, or engine builder).
@@ -1906,7 +1930,7 @@ impl SimNeoBuilder {
     ///     .classical(qasm_engine())  // stores builder as data
     ///     .sampling(monte_carlo(1000))
     ///     .build()  // configures builder, builds engine, creates Tool
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     ///
     /// For pre-configured engine builders, use `.with_engine()` instead:
@@ -1920,7 +1944,7 @@ impl SimNeoBuilder {
     ///     .with_engine(qasm_engine().qasm(qasm_code))
     ///     .sampling(monte_carlo(1000))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     ///
     /// # Panics
@@ -1999,7 +2023,7 @@ impl SimNeoBuilder {
     ///     .with_engine(qasm_engine().qasm(qasm_code))
     ///     .sampling(monte_carlo(1000))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn with_engine<B>(mut self, engine_builder: B) -> Self
@@ -2040,7 +2064,7 @@ impl SimNeoBuilder {
     ///     .auto()
     ///     .sampling(monte_carlo(1000))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     ///
     /// # Panics
@@ -2137,13 +2161,13 @@ impl SimNeoBuilder {
     /// let results = sim_neo(circuit.clone()).auto()
     ///     .sampling(monte_carlo(1000).workers(4))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     ///
     /// // Auto-detect worker count
     /// let results = sim_neo(circuit).auto()
     ///     .sampling(monte_carlo(1000).auto_workers())
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn sampling(mut self, sampling: impl Into<Sampling>) -> Self {
@@ -2198,14 +2222,14 @@ impl SimNeoBuilder {
     ///     .quantum(sparse_stab())
     ///     .sampling(monte_carlo(1000))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     ///
     /// // Use state vector (supports T gates, rotations)
     /// let results = sim_neo(circuit)
     ///     .quantum(state_vector())
     ///     .sampling(monte_carlo(1000))
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn quantum<B: Into<QuantumBackend>>(mut self, backend: B) -> Self {
@@ -2270,7 +2294,7 @@ impl SimNeoBuilder {
     ///     .sampling(monte_carlo(100))
     ///     .seed(42)
     ///     .build()
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn gate_definitions(mut self, definitions: GateDefinitions) -> Self {
@@ -2295,7 +2319,7 @@ impl SimNeoBuilder {
     ///     .max_decomp_depth(20)
     ///     .sampling(monte_carlo(100))
     ///     .seed(42)
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn max_decomp_depth(mut self, depth: usize) -> Self {
@@ -2336,7 +2360,7 @@ impl SimNeoBuilder {
     ///     .gate_overrides(overrides)
     ///     .sampling(monte_carlo(100))
     ///     .seed(42)
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn gate_overrides(mut self, overrides: impl Into<StoredOverrides>) -> Self {
@@ -2371,7 +2395,7 @@ impl SimNeoBuilder {
     ///     .event_handlers(handlers)
     ///     .sampling(monte_carlo(100))
     ///     .seed(42)
-    ///     .run();
+    ///     .run().expect("simulation should succeed");
     /// ```
     #[must_use]
     pub fn event_handlers(mut self, handlers: EventHandlers) -> Self {
@@ -2617,6 +2641,11 @@ impl SimNeoBuilder {
                          Classical engines are not supported."
                     )
                 };
+                validate_sampler_circuit(
+                    circuit,
+                    "Importance sampling",
+                    ImportanceSamplingRunner::<SparseStab>::supports,
+                );
                 if is_config.workers > 1 {
                     let circuit = circuit.clone();
                     let num_qubits = self
@@ -2652,6 +2681,11 @@ impl SimNeoBuilder {
                          and dynamic command sources are not supported."
                     ),
                 };
+                validate_sampler_circuit(
+                    &circuit,
+                    "Path enumeration",
+                    PathExplorer::<SparseStab>::supports,
+                );
                 assert!(
                     matches!(quantum_backend, QuantumBackend::SparseStab),
                     "Path enumeration currently supports only the sparse_stab() backend \
@@ -2680,6 +2714,11 @@ impl SimNeoBuilder {
         let subset_spec = match &sampling {
             Sampling::SubsetSimulation { config: ss_config } => {
                 assert!(
+                    ss_config.samples_per_level > 0,
+                    "Subset simulation requires samples_per_level > 0; \
+                     call subset_simulation with at least one sample."
+                );
+                assert!(
                     ss_config.score.is_some() && ss_config.failure.is_some(),
                     "Subset simulation requires both .score(..) and .failure(..) on the \
                      subset_simulation(..) builder; neither has a sensible default."
@@ -2698,6 +2737,7 @@ impl SimNeoBuilder {
                          and dynamic command sources are not supported."
                     ),
                 };
+                validate_sampler_circuit(&circuit, "Subset simulation", subset_sampler_supports);
                 assert!(
                     matches!(quantum_backend, QuantumBackend::SparseStab),
                     "Subset simulation currently supports only the sparse_stab() backend \
@@ -2787,10 +2827,13 @@ impl SimNeoBuilder {
     /// let results = sim_neo(qasm_code).auto()
     ///     .classical(qasm_engine())
     ///     .sampling(monte_carlo(1000))
-    ///     .run();  // builds and runs
+    ///     .run().expect("simulation should succeed");  // builds and runs
     /// ```
-    #[must_use]
-    pub fn run(self) -> SimulationResults {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if simulation startup or execution fails.
+    pub fn run(self) -> Result<SimulationResults, PecosError> {
         self.build().run()
     }
 }
@@ -2825,7 +2868,10 @@ impl Plugin for UnifiedSimulationPlugin {
 
         // Add simulation systems
         tool.add_system_mut(Stage::Startup, unified_simulation_startup);
-        tool.add_system_mut(Stage::PreShot, unified_simulation_pre_shot);
+        tool.add_system_mut(Stage::PreShot, |resources: &mut Resources| {
+            unified_simulation_pre_shot(resources);
+            Ok(())
+        });
         tool.add_system_mut(Stage::Execute, unified_simulation_execute);
         tool.add_system_mut(Stage::PostShot, unified_simulation_post_shot);
     }
@@ -2849,7 +2895,10 @@ pub enum QuantumRunner {
 
 impl QuantumRunner {
     /// Run a shot and return the result.
-    pub fn run_shot(&mut self, source: &mut dyn CommandSource) -> crate::program::ProgramResult {
+    pub fn run_shot(
+        &mut self,
+        source: &mut dyn CommandSource,
+    ) -> Result<crate::program::ProgramResult, PecosError> {
         match self {
             Self::SparseStab(runner) => runner.run_shot(source),
             Self::Stabilizer(runner) => runner.run_shot(source),
@@ -2878,6 +2927,9 @@ pub struct UnifiedShotState {
     /// Current shot index.
     pub shot_index: usize,
 }
+
+/// Global shot index assigned to the first shot of a parallel worker.
+struct ParallelShotStart(usize);
 
 /// Validate that stored gate overrides match the resolved backend.
 ///
@@ -3036,79 +3088,91 @@ where
 }
 
 /// Startup system for unified simulation.
-fn unified_simulation_startup(resources: &mut Resources) {
+fn unified_simulation_startup(resources: &mut Resources) -> Result<(), PecosError> {
     let config = resources.get::<SimConfig>().clone();
     let explicit_qubits = resources.get::<ExplicitNumQubits>().0;
 
     // Check if we already have a UnifiedShotState (from a previous run)
     // If so, just reset it instead of rebuilding
     if resources.contains::<UnifiedShotState>() {
+        let shot_index = resources
+            .try_get::<ParallelShotStart>()
+            .map_or(0, |start| start.0);
         let state = resources.get_mut::<UnifiedShotState>();
-        state.shot_index = 0;
-        state.command_source.reset();
+        state.shot_index = shot_index;
+        state.command_source.reset()?;
 
         // Clear previous results
         resources.get_mut::<SimulationResults>().clear();
-        return;
+        return Ok(());
     }
 
-    // First run - take the program source and build
-    let source_resource = resources.remove::<ProgramSourceResource>();
+    // Prepare the command source without consuming the stored input. A failing
+    // startup must leave the simulation reusable for another run attempt.
+    let (prepared_command_source, num_qubits): (
+        Option<Box<dyn CommandSource + Send + Sync>>,
+        usize,
+    ) = match &resources.get::<ProgramSourceResource>().0 {
+        ProgramSource::Static(circuit) => {
+            // Determine num_qubits from circuit
+            let inferred_qubits = circuit
+                .iter()
+                .flat_map(|cmd| cmd.qubits.iter())
+                .map(|q| q.0)
+                .max()
+                .map_or(1, |max| max + 1);
 
-    // Build the command source and determine num_qubits
-    let (command_source, num_qubits): (Box<dyn CommandSource + Send + Sync>, usize) =
-        match source_resource.0 {
-            ProgramSource::Static(circuit) => {
-                // Determine num_qubits from circuit
-                let inferred_qubits = circuit
-                    .iter()
-                    .flat_map(|cmd| cmd.qubits.iter())
-                    .map(|q| q.0)
-                    .max()
-                    .map_or(1, |max| max + 1);
-
-                let num_qubits = explicit_qubits.unwrap_or(inferred_qubits);
-                let program = StaticProgram::new(circuit, num_qubits);
-                (Box::new(program), num_qubits)
-            }
-            ProgramSource::Dynamic(source) => {
-                let num_qubits = explicit_qubits.unwrap_or_else(|| source.num_qubits());
-                (source, num_qubits)
-            }
-            ProgramSource::RawSource(_) => {
-                // This should never happen - build() resolves RawSource with engine factory
-                unreachable!(
-                    "RawSource should be resolved to Classical by SimNeoBuilder::build(). \
+            let num_qubits = explicit_qubits.unwrap_or(inferred_qubits);
+            let program = StaticProgram::new(circuit.clone(), num_qubits);
+            (Some(Box::new(program)), num_qubits)
+        }
+        ProgramSource::Dynamic(source) => {
+            let num_qubits = explicit_qubits.unwrap_or_else(|| source.num_qubits());
+            (None, num_qubits)
+        }
+        ProgramSource::RawSource(_) => {
+            // This should never happen - build() resolves RawSource with engine factory
+            unreachable!(
+                "RawSource should be resolved to Classical by SimNeoBuilder::build(). \
                      This is a bug in the simulation builder."
-                );
-            }
-            ProgramSource::Typed(_) => {
-                // This should never happen - build() catches Typed without .auto()
-                unreachable!(
-                    "Typed program should be resolved by .auto() or caught by build(). \
+            );
+        }
+        ProgramSource::Typed(_) => {
+            // This should never happen - build() catches Typed without .auto()
+            unreachable!(
+                "Typed program should be resolved by .auto() or caught by build(). \
                      This is a bug in the simulation builder."
-                );
-            }
-            ProgramSource::Classical(engine_builder) => {
-                // Build the engine adapter
-                let adapter = engine_builder
-                    .build_adapter()
-                    .expect("Failed to build classical engine");
+            );
+        }
+        ProgramSource::Classical(engine_builder) => {
+            // Build the engine adapter
+            let adapter = engine_builder.clone().build_adapter().map_err(|error| {
+                PecosError::with_context(error, "Failed to build classical engine")
+            })?;
 
-                let num_qubits = explicit_qubits.unwrap_or_else(|| adapter.num_qubits());
-                (adapter, num_qubits)
-            }
-        };
+            let num_qubits = explicit_qubits.unwrap_or_else(|| adapter.num_qubits());
+            (Some(adapter), num_qubits)
+        }
+    };
 
-    // Take quantum backend choice (take ownership for Custom variant)
-    let backend = resources.remove::<QuantumBackendResource>().0;
-
-    // Create quantum runner based on backend choice
-    let noise = resources.try_remove::<NoiseResource>();
-    let definitions = resources.try_remove::<GateDefinitionsResource>();
-    let max_depth = resources.try_remove::<MaxDecompDepthResource>();
-    let overrides = resources.try_remove::<GateOverridesResource>();
-    let event_handlers = resources.try_remove::<EventHandlersResource>();
+    // Clone runner configuration so a fallible backend build cannot consume
+    // the inputs needed by a retry.
+    let noise = resources
+        .try_get::<NoiseResource>()
+        .map(|noise| NoiseResource(noise.0.clone()));
+    let definitions = resources
+        .try_get::<GateDefinitionsResource>()
+        .map(|definitions| GateDefinitionsResource(definitions.0.clone()));
+    let max_depth = resources
+        .try_get::<MaxDecompDepthResource>()
+        .map(|depth| MaxDecompDepthResource(depth.0));
+    let overrides = resources
+        .try_get::<GateOverridesResource>()
+        .map(|overrides| GateOverridesResource(overrides.0.clone()));
+    let event_handlers = resources
+        .try_get::<EventHandlersResource>()
+        .map(|handlers| EventHandlersResource(handlers.0.clone()));
+    let backend = &resources.get::<QuantumBackendResource>().0;
     let quantum_runner = match backend {
         QuantumBackend::SparseStab => {
             let mut runner = clifford_runner(
@@ -3213,7 +3277,11 @@ fn unified_simulation_startup(resources: &mut Resources) {
                 "QuantumEngineBuilder backends do not support sim_neo noise modeling. \
                  Use a noise-modeling runner/backend instead."
             );
-            let runner = factory.create_runner(num_qubits, config.seed);
+            let runner = factory
+                .create_runner(num_qubits, config.seed)
+                .map_err(|error| {
+                    PecosError::with_context(error, "Failed to build quantum engine backend")
+                })?;
             QuantumRunner::Custom(runner)
         }
         QuantumBackend::Custom(factory) => {
@@ -3231,6 +3299,19 @@ fn unified_simulation_startup(resources: &mut Resources) {
         }
     };
 
+    // Initialization has succeeded. Only now consume the startup inputs.
+    let source_resource = resources.remove::<ProgramSourceResource>();
+    let command_source = prepared_command_source.unwrap_or_else(|| match source_resource.0 {
+        ProgramSource::Dynamic(source) => source,
+        _ => unreachable!("only dynamic sources are deferred until startup succeeds"),
+    });
+    resources.remove::<QuantumBackendResource>();
+    resources.try_remove::<NoiseResource>();
+    resources.try_remove::<GateDefinitionsResource>();
+    resources.try_remove::<MaxDecompDepthResource>();
+    resources.try_remove::<GateOverridesResource>();
+    resources.try_remove::<EventHandlersResource>();
+
     // Store unified shot state
     resources.insert(UnifiedShotState {
         quantum_runner,
@@ -3240,6 +3321,7 @@ fn unified_simulation_startup(resources: &mut Resources) {
 
     // Clear previous results
     resources.get_mut::<SimulationResults>().clear();
+    Ok(())
 }
 
 /// Pre-shot system for unified simulation.
@@ -3255,18 +3337,19 @@ fn unified_simulation_pre_shot(resources: &mut Resources) {
 }
 
 /// Execute system for unified simulation.
-fn unified_simulation_execute(resources: &mut Resources) {
+fn unified_simulation_execute(resources: &mut Resources) -> Result<(), PecosError> {
     let state = resources.get_mut::<UnifiedShotState>();
 
     // Run the program (handles both static and dynamic programs)
-    let result = state.quantum_runner.run_shot(&mut *state.command_source);
+    let result = state.quantum_runner.run_shot(&mut *state.command_source)?;
 
     // Store outcomes temporarily for post-shot processing
     resources.insert(CurrentOutcomes(result.outcomes));
+    Ok(())
 }
 
 /// Post-shot system for unified simulation.
-fn unified_simulation_post_shot(resources: &mut Resources) {
+fn unified_simulation_post_shot(resources: &mut Resources) -> Result<(), PecosError> {
     // Move outcomes to results
     let outcomes = resources.remove::<CurrentOutcomes>();
     resources
@@ -3279,7 +3362,7 @@ fn unified_simulation_post_shot(resources: &mut Resources) {
     let shot = resources
         .get::<UnifiedShotState>()
         .command_source
-        .shot_results();
+        .shot_results()?;
     if let Some(shot) = shot {
         resources
             .get_mut::<SimulationResults>()
@@ -3307,6 +3390,7 @@ fn unified_simulation_post_shot(resources: &mut Resources) {
 
     // Increment shot counter
     resources.get_mut::<UnifiedShotState>().shot_index += 1;
+    Ok(())
 }
 
 // --- Importance Sampling Simulation Plugin ---
@@ -3332,10 +3416,22 @@ impl Plugin for ImportanceSamplingSimPlugin {
         tool.insert_resource_mut(ExplicitNumQubits(self.explicit_num_qubits));
         tool.insert_resource_mut(ISConfigResource(self.is_config.clone()));
 
-        tool.add_system_mut(Stage::Startup, is_sim_startup);
-        tool.add_system_mut(Stage::PreShot, is_sim_pre_shot);
-        tool.add_system_mut(Stage::Execute, is_sim_execute);
-        tool.add_system_mut(Stage::PostShot, is_sim_post_shot);
+        tool.add_system_mut(Stage::Startup, |resources: &mut Resources| {
+            is_sim_startup(resources);
+            Ok(())
+        });
+        tool.add_system_mut(Stage::PreShot, |resources: &mut Resources| {
+            is_sim_pre_shot(resources);
+            Ok(())
+        });
+        tool.add_system_mut(Stage::Execute, |resources: &mut Resources| {
+            is_sim_execute(resources);
+            Ok(())
+        });
+        tool.add_system_mut(Stage::PostShot, |resources: &mut Resources| {
+            is_sim_post_shot(resources);
+            Ok(())
+        });
     }
 }
 
@@ -3398,6 +3494,7 @@ fn is_sim_startup(resources: &mut Resources) {
         return;
     }
 
+    // These inputs may only stay consumed while this startup function is infallible.
     // First run - consume resources and build the runner
     let source_resource = resources.remove::<ProgramSourceResource>();
     let is_config = resources.remove::<ISConfigResource>().0;
@@ -3504,11 +3601,11 @@ fn is_sim_post_shot(resources: &mut Resources) {
 /// let circuit = CommandBuilder::new().pz(&[0]).h(&[0]).mz(&[0]).build();
 /// let mut sim = sim_neo(circuit).auto().sampling(monte_carlo(1000)).build();
 ///
-/// let results1 = sim.run();
+/// let results1 = sim.run().expect("simulation should succeed");
 ///
 /// // Reconfigure and run again
 /// sim.shots(2000).seed(123);
-/// let results2 = sim.run();
+/// let results2 = sim.run().expect("simulation should succeed");
 /// ```
 pub struct Simulation {
     tool: Tool,
@@ -3547,17 +3644,22 @@ enum NativeParallelBackend {
 }
 
 trait ParallelCommandSourceFactory: Send + Sync {
-    fn create_source(&self) -> Box<dyn CommandSource + Send + Sync>;
+    fn create_source(&self) -> Result<Box<dyn CommandSource + Send + Sync>, PecosError>;
 }
 
 #[doc(hidden)]
 pub trait ParallelQuantumRunnerFactory: Send + Sync {
-    fn create_runner(&self, seed: Option<u64>) -> QuantumRunner;
+    fn create_runner(
+        &self,
+        num_qubits: usize,
+        seed: Option<u64>,
+    ) -> Result<QuantumRunner, PecosError>;
 }
 
 struct ParallelExecutionPlan {
     command_source_factory: Box<dyn ParallelCommandSourceFactory>,
     quantum_runner_factory: Box<dyn ParallelQuantumRunnerFactory>,
+    explicit_num_qubits: Option<usize>,
 }
 
 struct StaticCommandSourceFactory {
@@ -3566,25 +3668,26 @@ struct StaticCommandSourceFactory {
 }
 
 impl ParallelCommandSourceFactory for StaticCommandSourceFactory {
-    fn create_source(&self) -> Box<dyn CommandSource + Send + Sync> {
-        Box::new(StaticProgram::new(self.circuit.clone(), self.num_qubits))
+    fn create_source(&self) -> Result<Box<dyn CommandSource + Send + Sync>, PecosError> {
+        Ok(Box::new(StaticProgram::new(
+            self.circuit.clone(),
+            self.num_qubits,
+        )))
     }
 }
 struct ClassicalCommandSourceFactory {
     builder: Box<dyn BoxedEngineBuilder>,
 }
 impl ParallelCommandSourceFactory for ClassicalCommandSourceFactory {
-    fn create_source(&self) -> Box<dyn CommandSource + Send + Sync> {
-        self.builder
-            .clone()
-            .build_adapter()
-            .expect("Failed to build classical engine for worker")
+    fn create_source(&self) -> Result<Box<dyn CommandSource + Send + Sync>, PecosError> {
+        self.builder.clone().build_adapter().map_err(|error| {
+            PecosError::with_context(error, "Failed to build classical engine for worker")
+        })
     }
 }
 
 struct NativeQuantumRunnerFactory {
     backend: NativeParallelBackend,
-    num_qubits: usize,
     noise: Option<ComposableNoiseModel>,
     definitions: Option<GateDefinitions>,
     max_decomp_depth: Option<usize>,
@@ -3593,16 +3696,20 @@ struct NativeQuantumRunnerFactory {
 }
 
 impl ParallelQuantumRunnerFactory for NativeQuantumRunnerFactory {
-    fn create_runner(&self, seed: Option<u64>) -> QuantumRunner {
+    fn create_runner(
+        &self,
+        num_qubits: usize,
+        seed: Option<u64>,
+    ) -> Result<QuantumRunner, PecosError> {
         let noise = self.noise.clone().map(NoiseResource);
         let definitions = self.definitions.clone().map(GateDefinitionsResource);
         let max_depth = self.max_decomp_depth.map(MaxDecompDepthResource);
         let event_handlers = self.event_handlers.clone().map(EventHandlersResource);
 
-        match self.backend {
+        Ok(match self.backend {
             NativeParallelBackend::SparseStab => {
                 let mut runner = clifford_runner(
-                    SparseStab::new(self.num_qubits),
+                    SparseStab::new(num_qubits),
                     definitions,
                     noise,
                     seed,
@@ -3630,7 +3737,7 @@ impl ParallelQuantumRunnerFactory for NativeQuantumRunnerFactory {
             }
             NativeParallelBackend::Stabilizer => {
                 let mut runner = clifford_runner(
-                    Stabilizer::new(self.num_qubits),
+                    Stabilizer::new(num_qubits),
                     definitions,
                     noise,
                     seed,
@@ -3658,7 +3765,7 @@ impl ParallelQuantumRunnerFactory for NativeQuantumRunnerFactory {
             }
             NativeParallelBackend::StateVec => {
                 let mut runner = rotation_runner(
-                    StateVec::new(self.num_qubits),
+                    StateVec::new(num_qubits),
                     definitions,
                     noise,
                     seed,
@@ -3684,7 +3791,7 @@ impl ParallelQuantumRunnerFactory for NativeQuantumRunnerFactory {
                 runner = apply_event_handlers(runner, event_handlers);
                 QuantumRunner::StateVec(runner)
             }
-        }
+        })
     }
 }
 /// Per-worker runner factory for custom `SimulatorFactory` backends.
@@ -3694,16 +3801,20 @@ impl ParallelQuantumRunnerFactory for NativeQuantumRunnerFactory {
 /// schedule, exactly as for built-in backends.
 struct CustomRunnerFactory {
     factory: Arc<dyn SimulatorFactory>,
-    num_qubits: usize,
     noise: Option<ComposableNoiseModel>,
 }
 
 impl ParallelQuantumRunnerFactory for CustomRunnerFactory {
-    fn create_runner(&self, seed: Option<u64>) -> QuantumRunner {
-        QuantumRunner::Custom(
-            self.factory
-                .create_runner(self.num_qubits, self.noise.clone(), seed),
-        )
+    fn create_runner(
+        &self,
+        num_qubits: usize,
+        seed: Option<u64>,
+    ) -> Result<QuantumRunner, PecosError> {
+        Ok(QuantumRunner::Custom(self.factory.create_runner(
+            num_qubits,
+            self.noise.clone(),
+            seed,
+        )))
     }
 }
 
@@ -3712,23 +3823,26 @@ where
     B: pecos_engines::QuantumEngineBuilder + Clone + 'static,
 {
     builder: B,
-    num_qubits: usize,
 }
 impl<B> ParallelQuantumRunnerFactory for AdaptedQuantumEngineRunnerFactory<B>
 where
     B: pecos_engines::QuantumEngineBuilder + Clone + 'static,
 {
-    fn create_runner(&self, seed: Option<u64>) -> QuantumRunner {
+    fn create_runner(
+        &self,
+        num_qubits: usize,
+        seed: Option<u64>,
+    ) -> Result<QuantumRunner, PecosError> {
         let mut builder = self.builder.clone();
-        builder.set_qubits_if_needed(self.num_qubits);
-        let mut engine = builder
-            .build()
-            .expect("Failed to build quantum engine backend for worker");
+        builder.set_qubits_if_needed(num_qubits);
+        let mut engine = builder.build().map_err(|error| {
+            PecosError::with_context(error, "Failed to build quantum engine backend for worker")
+        })?;
         if let Some(seed) = seed {
             engine.set_seed(seed);
         }
-        QuantumRunner::Custom(Box::new(crate::adapter::QuantumEngineProgramRunner::new(
-            engine,
+        Ok(QuantumRunner::Custom(Box::new(
+            crate::adapter::QuantumEngineProgramRunner::new(engine),
         )))
     }
 }
@@ -3744,33 +3858,19 @@ fn build_parallel_execution_plan(
     overrides: Option<StoredOverrides>,
     event_handlers: Option<EventHandlers>,
 ) -> Option<ParallelExecutionPlan> {
-    let (source_factory, num_qubits): (Box<dyn ParallelCommandSourceFactory>, usize) = match source
-    {
+    let source_factory: Box<dyn ParallelCommandSourceFactory> = match source {
         ProgramSource::Static(circuit) => {
             let num_qubits =
                 explicit_num_qubits.unwrap_or_else(|| infer_num_qubits_from_circuit(circuit));
-            (
-                Box::new(StaticCommandSourceFactory {
-                    circuit: circuit.clone(),
-                    num_qubits,
-                }),
+            Box::new(StaticCommandSourceFactory {
+                circuit: circuit.clone(),
                 num_qubits,
-            )
+            })
         }
         ProgramSource::Dynamic(_) => return None,
-        ProgramSource::Classical(engine_builder) => {
-            let probe = engine_builder
-                .clone()
-                .build_adapter()
-                .expect("Failed to build classical engine while preparing parallel plan");
-            let num_qubits = explicit_num_qubits.unwrap_or_else(|| probe.num_qubits());
-            (
-                Box::new(ClassicalCommandSourceFactory {
-                    builder: engine_builder.clone(),
-                }),
-                num_qubits,
-            )
-        }
+        ProgramSource::Classical(engine_builder) => Box::new(ClassicalCommandSourceFactory {
+            builder: engine_builder.clone(),
+        }),
         ProgramSource::RawSource(_) | ProgramSource::Typed(_) => {
             unreachable!("raw and typed sources should be resolved before plan construction")
         }
@@ -3779,7 +3879,6 @@ fn build_parallel_execution_plan(
     let runner_factory: Box<dyn ParallelQuantumRunnerFactory> = match backend {
         QuantumBackend::SparseStab => Box::new(NativeQuantumRunnerFactory {
             backend: NativeParallelBackend::SparseStab,
-            num_qubits,
             noise,
             definitions,
             max_decomp_depth,
@@ -3788,7 +3887,6 @@ fn build_parallel_execution_plan(
         }),
         QuantumBackend::Stabilizer => Box::new(NativeQuantumRunnerFactory {
             backend: NativeParallelBackend::Stabilizer,
-            num_qubits,
             noise,
             definitions,
             max_decomp_depth,
@@ -3797,7 +3895,6 @@ fn build_parallel_execution_plan(
         }),
         QuantumBackend::StateVec => Box::new(NativeQuantumRunnerFactory {
             backend: NativeParallelBackend::StateVec,
-            num_qubits,
             noise,
             definitions,
             max_decomp_depth,
@@ -3812,11 +3909,10 @@ fn build_parallel_execution_plan(
                 overrides.as_ref(),
                 event_handlers.as_ref(),
             );
-            factory.create_parallel_runner_factory(num_qubits)
+            factory.create_parallel_runner_factory()
         }
         QuantumBackend::Custom(factory) => Box::new(CustomRunnerFactory {
             factory: Arc::clone(factory),
-            num_qubits,
             noise,
         }),
     };
@@ -3824,6 +3920,7 @@ fn build_parallel_execution_plan(
     Some(ParallelExecutionPlan {
         command_source_factory: source_factory,
         quantum_runner_factory: runner_factory,
+        explicit_num_qubits,
     })
 }
 
@@ -3861,7 +3958,13 @@ impl Simulation {
     /// Panics if the parallel execution plan or subset spec is missing for
     /// the corresponding strategy; `SimNeoBuilder::build()` validates both,
     /// so it cannot happen for simulations constructed through the builder.
-    pub fn run(&mut self) -> SimulationResults {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a source, simulator, startup system, or scheduled
+    /// system fails. Parallel Monte Carlo returns the lowest-indexed worker's
+    /// error when multiple workers fail.
+    pub fn run(&mut self) -> Result<SimulationResults, PecosError> {
         let config = self.tool.resource::<SimConfig>().clone();
 
         // Dispatch based on sampling strategy
@@ -3878,7 +3981,7 @@ impl Simulation {
                     .is_parallel_spec
                     .as_ref()
                     .expect("parallel IS spec captured at build time");
-                Self::run_parallel_importance(&config, is_config, spec)
+                Ok(Self::run_parallel_importance(&config, is_config, spec))
             }
             Sampling::PathEnumeration { config: pe_config } => {
                 let spec = self
@@ -3902,12 +4005,12 @@ impl Simulation {
                     }
                 }
 
-                SimulationResults {
+                Ok(SimulationResults {
                     outcomes,
                     weights: Some(weights),
                     subset: None,
                     shots: None,
-                }
+                })
             }
             Sampling::SubsetSimulation { config: ss_config } => {
                 let spec = self
@@ -3941,23 +4044,23 @@ impl Simulation {
                 .with_noise_builder(move || noise.clone())
                 .with_config(subset_config)
                 .run();
-                SimulationResults {
+                Ok(SimulationResults {
                     outcomes: Vec::new(),
                     weights: None,
                     subset: Some(result),
                     shots: None,
-                }
+                })
             }
             _ => {
                 // Both MonteCarlo{workers:1} and ImportanceSampling run via the Tool.
                 // IS uses ImportanceSamplingSimPlugin instead of UnifiedSimulationPlugin.
                 self.tool.reset();
-                self.tool.run_shots(config.shots);
+                self.tool.run_shots(config.shots)?;
 
                 // Take results and re-insert empty for next run
                 let results = self.tool.take_resource::<SimulationResults>();
                 self.tool.insert_resource_mut(SimulationResults::new());
-                results
+                Ok(results)
             }
         }
     }
@@ -4042,7 +4145,7 @@ impl Simulation {
         config: &SimConfig,
         plan: &ParallelExecutionPlan,
         num_workers: usize,
-    ) -> SimulationResults {
+    ) -> Result<SimulationResults, PecosError> {
         let shots = config.shots;
 
         // Distribute shots among workers and compute starting indices
@@ -4052,16 +4155,28 @@ impl Simulation {
             start_indices[i] = start_indices[i - 1] + shots_per_worker[i - 1];
         }
 
-        let schedule = self.tool.schedule();
+        // Resolve an inferred qubit count once for the entire run. Builders
+        // can be stateful across clones, so sizing from each worker's source
+        // independently would make behavior depend on the worker count.
+        // This probe also makes zero-shot runs surface source-build failures.
+        let num_qubits = match plan.explicit_num_qubits {
+            Some(num_qubits) => num_qubits,
+            None => plan.command_source_factory.create_source()?.num_qubits(),
+        };
 
         // Run in parallel, each worker with its own Resources
-        let all_results: Vec<SimulationResults> = (0..num_workers)
+        let all_results: Vec<Result<SimulationResults, PecosError>> = (0..num_workers)
             .into_par_iter()
             .map(|worker_id| {
                 let worker_shots = shots_per_worker[worker_id];
                 if worker_shots == 0 {
-                    return SimulationResults::new();
+                    return Ok(SimulationResults::new());
                 }
+
+                let command_source = plan.command_source_factory.create_source()?;
+                let quantum_runner = plan
+                    .quantum_runner_factory
+                    .create_runner(num_qubits, config.seed)?;
 
                 // Build per-worker Resources with the same configuration
                 let mut resources = Resources::new();
@@ -4070,32 +4185,20 @@ impl Simulation {
                     seed: config.seed,
                 });
                 resources.insert(ExplicitNumQubits(None));
+                resources.insert(ParallelShotStart(start_indices[worker_id]));
                 resources.insert(SimulationResults::new());
                 resources.insert(UnifiedShotState {
-                    quantum_runner: plan.quantum_runner_factory.create_runner(config.seed),
-                    command_source: plan.command_source_factory.create_source(),
+                    quantum_runner,
+                    command_source,
                     shot_index: 0,
                 });
 
-                // Run Startup. Since the worker state is already assembled, the
-                // unified startup system only resets the command source and clears results.
-                schedule.run_stage(Stage::Startup, &mut resources);
-
-                // Set global starting shot index so per-shot seeding matches sequential
-                resources.get_mut::<UnifiedShotState>().shot_index = start_indices[worker_id];
-
-                // Run shot loop (PreShot/Execute/PostShot per shot)
-                for _ in 0..worker_shots {
-                    schedule.run_stage(Stage::PreShot, &mut resources);
-                    schedule.run_stage(Stage::Execute, &mut resources);
-                    schedule.run_stage(Stage::PostShot, &mut resources);
-                }
-
-                // Run Finish
-                schedule.run_stage(Stage::Finish, &mut resources);
+                // Run the shared fallible schedule. The worker start resource
+                // preserves global shot indices for deterministic seeding.
+                self.tool.run_shots_on(&mut resources, worker_shots)?;
 
                 // Extract results
-                resources.remove::<SimulationResults>()
+                Ok(resources.remove::<SimulationResults>())
             })
             .collect();
 
@@ -4104,6 +4207,7 @@ impl Simulation {
         let mut outcomes = Vec::new();
         let mut shots: Option<pecos_results::ShotVec> = None;
         for worker_results in all_results {
+            let worker_results = worker_results?;
             outcomes.extend(worker_results.outcomes);
             if let Some(worker_shots) = worker_results.shots {
                 shots
@@ -4127,12 +4231,12 @@ impl Simulation {
             outcomes.len(),
         );
 
-        SimulationResults {
+        Ok(SimulationResults {
             outcomes,
             weights: None,
             subset: None,
             shots,
-        }
+        })
     }
 
     /// Get a reference to the current configuration.
@@ -4181,7 +4285,7 @@ impl Simulation {
 ///     .sampling(monte_carlo(1000))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 ///
 /// ## QASM Program
@@ -4207,7 +4311,7 @@ impl Simulation {
 ///     .sampling(monte_carlo(1000))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 ///
 /// ## Reusable Simulation
@@ -4221,8 +4325,8 @@ impl Simulation {
 ///     .sampling(monte_carlo(1000))
 ///     .build();
 ///
-/// let results1 = sim.run();
-/// let results2 = sim.seed(123).shots(2000).run();
+/// let results1 = sim.run().expect("simulation should succeed");
+/// let results2 = sim.seed(123).shots(2000).run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn sim_neo<I: SimNeoInput>(input: I) -> SimNeoBuilder {
@@ -4257,7 +4361,7 @@ pub fn sim_neo<I: SimNeoInput>(input: I) -> SimNeoBuilder {
 ///     .sampling(monte_carlo(1000))
 ///     .seed(42)
 ///     .build()
-///     .run();
+///     .run().expect("simulation should succeed");
 /// ```
 #[must_use]
 pub fn sim_neo_builder() -> SimNeoBuilder {
@@ -4338,7 +4442,7 @@ mod tests {
             .seed(42)
             .build();
 
-        let results = sim.run();
+        let results = sim.run().expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -4357,12 +4461,12 @@ mod tests {
 
         let mut sim = sim_neo(circuit).auto().sampling(monte_carlo(5)).build();
 
-        let results1 = sim.run();
+        let results1 = sim.run().expect("simulation should succeed");
         assert_eq!(results1.len(), 5);
 
         // Reconfigure and run again
         sim.shots(10);
-        let results2 = sim.run();
+        let results2 = sim.run().expect("simulation should succeed");
         assert_eq!(results2.len(), 10);
     }
 
@@ -4380,14 +4484,16 @@ mod tests {
             .sampling(monte_carlo(20))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let results2 = sim_neo(circuit)
             .auto()
             .sampling(monte_carlo(20))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results1.outcomes.len(), results2.outcomes.len());
         for (o1, o2) in results1.outcomes.iter().zip(results2.outcomes.iter()) {
@@ -4419,7 +4525,8 @@ mod tests {
             .sampling(monte_carlo(100))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -4457,7 +4564,8 @@ mod tests {
             .sampling(monte_carlo(20))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let results2 = sim_neo(circuit)
             .auto()
@@ -4465,7 +4573,8 @@ mod tests {
             .sampling(monte_carlo(20))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for (o1, o2) in results1.outcomes.iter().zip(results2.outcomes.iter()) {
             assert_eq!(
@@ -4488,7 +4597,8 @@ mod tests {
             .sampling(monte_carlo(50))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 50);
 
@@ -4516,7 +4626,8 @@ mod tests {
             .sampling(monte_carlo(100))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -4551,7 +4662,8 @@ mod tests {
             .sampling(monte_carlo(100))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -4583,7 +4695,8 @@ mod tests {
             .sampling(monte_carlo(200))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 200);
 
@@ -4614,7 +4727,8 @@ mod tests {
             .sampling(monte_carlo(200))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 200);
 
@@ -4653,7 +4767,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -4685,7 +4800,8 @@ mod tests {
             .classical(pecos_qasm::qasm_engine())
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -4720,7 +4836,8 @@ mod tests {
             .sampling(monte_carlo(50))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 50);
 
@@ -4746,7 +4863,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(100).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -4772,13 +4890,15 @@ mod tests {
             .auto()
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let results2 = sim_neo(circuit)
             .auto()
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results1.outcomes.len(), results2.outcomes.len());
         for (o1, o2) in results1.outcomes.iter().zip(results2.outcomes.iter()) {
@@ -4799,7 +4919,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(20).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 20);
 
@@ -4822,12 +4943,14 @@ mod tests {
             .auto()
             .sampling(monte_carlo(30))
             .seed(7)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let r2 = sim_neo(circuit)
             .auto()
             .seed(7)
             .sampling(monte_carlo(30))
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(r1.outcomes.len(), r2.outcomes.len());
         for (o1, o2) in r1.outcomes.iter().zip(r2.outcomes.iter()) {
@@ -4883,7 +5006,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(10))
             .seed(1)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         assert_eq!(results.len(), 10);
         for outcome in &results.outcomes {
             assert!(outcome.get_bit(QubitId(0)).unwrap());
@@ -4907,7 +5031,8 @@ mod tests {
             .quantum(state_vector())
             .sampling(monte_carlo(5))
             .seed(1)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         assert_eq!(results.len(), 5);
     }
 
@@ -4956,12 +5081,18 @@ mod tests {
         // the blessed shorthand for that common case.
         let circuit = CommandBuilder::new().pz(&[0]).h(&[0]).mz(&[0]).build();
 
-        let shortcut = sim_neo(circuit.clone()).auto().shots(40).seed(11).run();
+        let shortcut = sim_neo(circuit.clone())
+            .auto()
+            .shots(40)
+            .seed(11)
+            .run()
+            .expect("simulation should succeed");
         let explicit = sim_neo(circuit)
             .auto()
             .sampling(monte_carlo(40))
             .seed(11)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(shortcut.outcomes.len(), 40);
         assert_eq!(shortcut.outcomes.len(), explicit.outcomes.len());
@@ -4977,7 +5108,13 @@ mod tests {
         let circuit = CommandBuilder::new().pz(&[0]).x(&[0]).mz(&[0]).build();
 
         #[allow(deprecated)]
-        let results = sim_neo(circuit).auto().workers(2).shots(30).seed(5).run();
+        let results = sim_neo(circuit)
+            .auto()
+            .workers(2)
+            .shots(30)
+            .seed(5)
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 30);
         for outcome in &results.outcomes {
@@ -4994,7 +5131,8 @@ mod tests {
             .auto()
             .sampling(importance_sampling(35).with_uniform_error(0.01))
             .seed(3)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 35);
         assert!(results.has_weights());
@@ -5021,6 +5159,7 @@ mod tests {
                 )
                 .seed(42)
                 .run()
+                .expect("simulation should succeed")
         };
 
         let sequential = run(1);
@@ -5066,6 +5205,7 @@ mod tests {
                 .sampling(importance_sampling(30).with_uniform_error(0.01).workers(3))
                 .seed(5)
                 .run()
+                .expect("simulation should succeed")
         };
         let r1 = run();
         let r2 = run();
@@ -5095,7 +5235,8 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(10))
             .seed(1)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for outcome in &results.outcomes {
             assert_eq!(
@@ -5119,7 +5260,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(3))
             .seed(1)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert!(
             results.shots.is_none(),
@@ -5155,7 +5297,8 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(5))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let shots = results
             .shots
@@ -5178,7 +5321,8 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let shots = results
             .shots
@@ -5207,7 +5351,8 @@ mod tests {
         let results = sim_neo(circuit)
             .quantum(sparse_stab())
             .sampling(path_enumeration(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.outcomes.len(), 2, "Two measurement branches");
         let weights = results.weights.as_ref().unwrap();
@@ -5235,7 +5380,11 @@ mod tests {
         // even though 2^2 forced paths are enumerated.
         let circuit = CommandBuilder::new().pz(&[0]).x(&[0]).mz(&[0]).build();
 
-        let results = sim_neo(circuit).auto().sampling(path_enumeration(2)).run();
+        let results = sim_neo(circuit)
+            .auto()
+            .sampling(path_enumeration(2))
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.outcomes.len(), 1, "One distinct path");
         let weights = results.weights.as_ref().unwrap();
@@ -5249,7 +5398,8 @@ mod tests {
         let results = sim_neo(three_qubit_h_circuit())
             .auto()
             .sampling(path_enumeration(3))
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.outcomes.len(), 8);
         let weights = results.weights.as_ref().unwrap();
@@ -5319,7 +5469,8 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(subset_simulation(2000).score(count_ones).failure(all_ones))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert!(results.outcomes.is_empty());
         let subset = results.subset.expect("subset strategy returns an estimate");
@@ -5339,7 +5490,8 @@ mod tests {
             .auto()
             .sampling(subset_simulation(200).score(count_ones).failure(all_ones))
             .seed(7)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let subset = results.subset.expect("subset estimate");
         assert!(
@@ -5360,7 +5512,8 @@ mod tests {
             .noise(noise)
             .sampling(subset_simulation(2000).score(count_ones).failure(all_ones))
             .seed(11)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let p = results.subset.expect("subset estimate").probability();
         assert!(
@@ -5377,6 +5530,7 @@ mod tests {
                 .sampling(subset_simulation(500).score(count_ones).failure(all_ones))
                 .seed(99)
                 .run()
+                .expect("simulation should succeed")
                 .subset
                 .expect("subset estimate")
                 .probability()
@@ -5440,7 +5594,8 @@ mod tests {
                     .allow_biased_multilevel(),
             )
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         assert!(
             results.subset.is_some(),
             "multi-level opt-in must produce an estimate"
@@ -5455,7 +5610,8 @@ mod tests {
             .auto()
             .sampling(subset_simulation(500).score(count_ones).failure(all_ones))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let subset = results.subset.expect("subset estimate");
         assert_eq!(
             subset.levels.len(),
@@ -5479,14 +5635,16 @@ mod tests {
             .auto()
             .sampling(monte_carlo(50))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Run with parallel Monte Carlo sampling (4 workers)
         let parallel_results = sim_neo(circuit)
             .auto()
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Results should be identical
         assert_eq!(
@@ -5529,7 +5687,8 @@ mod tests {
             .noise(noise_single)
             .sampling(monte_carlo(50))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Run with parallel Monte Carlo sampling
         let parallel_results = sim_neo(circuit)
@@ -5537,7 +5696,8 @@ mod tests {
             .noise(noise_par)
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Results should be identical shot-for-shot
         assert_eq!(
@@ -5577,14 +5737,16 @@ mod tests {
             .noise(noise1)
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let results2 = sim_neo(circuit)
             .auto()
             .noise(noise2)
             .sampling(monte_carlo(50).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for (i, (r1, r2)) in results1
             .outcomes
@@ -5611,7 +5773,8 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -5634,7 +5797,8 @@ mod tests {
             .quantum(stabilizer())
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -5660,7 +5824,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(12))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 12);
         for outcome in &results.outcomes {
@@ -5687,7 +5852,8 @@ mod tests {
             .quantum(pecos_engines::state_vector())
             .sampling(monte_carlo(8))
             .seed(123)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 8);
         for outcome in &results.outcomes {
@@ -5709,7 +5875,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .noise(noise)
             .sampling(monte_carlo(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     #[should_panic(
@@ -5723,7 +5890,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .noise(noise)
             .sampling(monte_carlo(2).workers(2))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     #[should_panic(
@@ -5738,7 +5906,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .gate_definitions(GateDefinitions::new())
             .sampling(monte_carlo(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     #[should_panic(
@@ -5751,7 +5920,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .max_decomp_depth(20)
             .sampling(monte_carlo(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     #[should_panic(
@@ -5769,7 +5939,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .gate_overrides(overrides)
             .sampling(monte_carlo(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     #[should_panic(
@@ -5784,7 +5955,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .event_handlers(handlers)
             .sampling(monte_carlo(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
     #[test]
     fn test_sim_neo_quantum_engine_builder_parallel_static_circuit() {
@@ -5794,7 +5966,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5815,7 +5988,8 @@ mod tests {
             .quantum(pecos_engines::state_vector())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5856,7 +6030,8 @@ mod tests {
             .quantum(stabilizer())
             .sampling(monte_carlo(6))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5874,7 +6049,7 @@ mod tests {
             .seed(42)
             .build();
 
-        let first = sim.run();
+        let first = sim.run().expect("simulation should succeed");
         assert_eq!(first.len(), 2);
         for outcome in &first.outcomes {
             assert_eq!(outcome.get_bit(QubitId(0)), Some(true));
@@ -5882,7 +6057,7 @@ mod tests {
         }
 
         sim.shots(4);
-        let second = sim.run();
+        let second = sim.run().expect("simulation should succeed");
         assert_eq!(second.len(), 4);
         for outcome in &second.outcomes {
             assert_eq!(outcome.get_bit(QubitId(0)), Some(true));
@@ -5898,7 +6073,8 @@ mod tests {
             .quantum(stabilizer())
             .sampling(monte_carlo(6))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5913,7 +6089,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(6))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5931,7 +6108,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(6))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5949,7 +6127,8 @@ mod tests {
             .quantum(stabilizer())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5967,7 +6146,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -5986,7 +6166,8 @@ mod tests {
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(6).workers(2))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 6);
         for outcome in &results.outcomes {
@@ -6003,7 +6184,8 @@ mod tests {
         let _ = sim_neo(deterministic_conditional_program())
             .quantum(pecos_engines::stabilizer())
             .sampling(monte_carlo(2).workers(2))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
 
     #[test]
@@ -6017,7 +6199,8 @@ mod tests {
             .quantum(state_vector())
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6041,13 +6224,15 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let sparse2 = sim_neo(circuit.clone())
             .quantum(sparse_stab())
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for (o1, o2) in sparse1.outcomes.iter().zip(sparse2.outcomes.iter()) {
             assert_eq!(
@@ -6062,13 +6247,15 @@ mod tests {
             .quantum(state_vector())
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let sv2 = sim_neo(circuit)
             .quantum(state_vector())
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for (o1, o2) in sv1.outcomes.iter().zip(sv2.outcomes.iter()) {
             assert_eq!(
@@ -6090,7 +6277,8 @@ mod tests {
             .quantum(state_vector())
             .sampling(monte_carlo(100).workers(4))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -6112,7 +6300,8 @@ mod tests {
         let _ = sim_neo(deterministic_conditional_program())
             .auto()
             .sampling(importance_sampling(1))
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
 
     #[test]
@@ -6136,7 +6325,8 @@ mod tests {
                     .with_boost(5.0),
             )
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
         assert!(
@@ -6163,7 +6353,8 @@ mod tests {
                         .workers(workers),
                 )
                 .seed(42)
-                .run();
+                .run()
+                .expect("simulation should succeed");
 
             for outcomes in &results.outcomes {
                 let outcome = outcomes.get(QubitId(0)).unwrap();
@@ -6222,7 +6413,8 @@ mod tests {
                     .with_boost(10.0),
             )
             .seed(123)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 50);
         assert!(results.has_weights());
@@ -6249,7 +6441,8 @@ mod tests {
                     .with_boost(100.0), // Very aggressive boost
             )
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Compute weighted mean of outcome
         let weighted_one_rate = results
@@ -6284,9 +6477,15 @@ mod tests {
             .auto()
             .sampling(is_builder.clone())
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
-        let results2 = sim_neo(circuit).auto().sampling(is_builder).seed(42).run();
+        let results2 = sim_neo(circuit)
+            .auto()
+            .sampling(is_builder)
+            .seed(42)
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results1.outcomes.len(), results2.outcomes.len());
         for (i, (o1, o2)) in results1
@@ -6337,7 +6536,8 @@ mod tests {
                     .with_boost(10.0),
             )
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
         assert!(results.has_weights());
@@ -6358,7 +6558,8 @@ mod tests {
                     .with_boost(10.0),
             )
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Use weighted_stats to compute mean and variance
         let stats = results.weighted_stats(|outcome| {
@@ -6395,7 +6596,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6421,13 +6623,15 @@ mod tests {
             .quantum(sparse_stab())
             .sampling(monte_carlo(50))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let custom_results = sim_neo(circuit)
             .quantum(custom_backend(|n| SparseStab::with_seed(n, 42)))
             .sampling(monte_carlo(50))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(
             builtin_results.outcomes.len(),
@@ -6463,7 +6667,8 @@ mod tests {
             .sampling(monte_carlo(100))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 100);
 
@@ -6488,13 +6693,15 @@ mod tests {
             .quantum(custom_backend(|n| SparseStab::with_seed(n, 42)))
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         let results2 = sim_neo(circuit)
             .quantum(custom_backend(|n| SparseStab::with_seed(n, 42)))
             .sampling(monte_carlo(20))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         for (o1, o2) in results1.outcomes.iter().zip(results2.outcomes.iter()) {
             assert_eq!(
@@ -6516,6 +6723,7 @@ mod tests {
                 .sampling(monte_carlo(50).workers(workers))
                 .seed(42)
                 .run()
+                .expect("simulation should succeed")
         };
 
         let sequential = run(1);
@@ -6548,6 +6756,7 @@ mod tests {
                 .sampling(monte_carlo(40).workers(workers))
                 .seed(7)
                 .run()
+                .expect("simulation should succeed")
         };
 
         let sequential = run(1);
@@ -6576,7 +6785,8 @@ mod tests {
             .quantum(custom_backend(|n| StateVec::with_seed(n, 42)))
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6602,7 +6812,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(200))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let counts = results.register_counts(&reg, "c");
 
         // Should have entries for both [false] and [true]
@@ -6634,7 +6845,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(100))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let counts = results.register_counts(&reg, "c");
 
         // Bell state: only |00> and |11> should appear
@@ -6664,7 +6876,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(5))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let columns = results.as_register_columns(&reg);
 
         assert_eq!(columns.len(), 2);
@@ -6691,7 +6904,8 @@ mod tests {
             .auto()
             .sampling(monte_carlo(10))
             .seed(42)
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let counts = results.register_counts(&reg, "missing");
 
         assert!(
@@ -6718,7 +6932,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6745,7 +6960,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6773,7 +6989,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6804,7 +7021,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6831,7 +7049,8 @@ mod tests {
             .sampling(monte_carlo(10).workers(2))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6854,7 +7073,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6877,7 +7097,8 @@ mod tests {
             .sampling(monte_carlo(10).workers(2))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6904,7 +7125,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6937,7 +7159,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6967,7 +7190,8 @@ mod tests {
             .sampling(monte_carlo(10).workers(2))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -6996,7 +7220,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 
@@ -7024,7 +7249,8 @@ mod tests {
             .sampling(monte_carlo(1))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
 
     #[test]
@@ -7042,7 +7268,8 @@ mod tests {
             .sampling(monte_carlo(1))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
     }
 
     #[test]
@@ -7067,7 +7294,8 @@ mod tests {
             .sampling(monte_carlo(10))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         // Z|0> = |0>, so all outcomes should be 0
         for outcome in &results.outcomes {
@@ -7092,7 +7320,8 @@ mod tests {
             .sampling(monte_carlo(10).workers(2))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
 
         assert_eq!(results.len(), 10);
 

--- a/exp/pecos-neo/src/tool/system.rs
+++ b/exp/pecos-neo/src/tool/system.rs
@@ -16,6 +16,7 @@
 
 use super::Stage;
 use super::resource::Resources;
+use pecos_core::errors::PecosError;
 
 /// A system that can be executed during a stage.
 ///
@@ -25,17 +26,23 @@ use super::resource::Resources;
 /// # Example
 ///
 /// ```no_run
+/// use pecos_core::errors::PecosError;
 /// use pecos_neo::tool::Resources;
 ///
-/// fn my_system(resources: &mut Resources) {
+/// fn my_system(resources: &mut Resources) -> Result<(), PecosError> {
 ///     // Access resources and do work
 ///     // let config = resources.get::<MyConfig>();
 ///     // let mut results = resources.get_mut::<MyResults>();
+///     Ok(())
 /// }
 /// ```
 pub trait System: Send + Sync {
     /// Execute this system with access to resources.
-    fn run(&self, resources: &mut Resources);
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the system cannot complete its work.
+    fn run(&self, resources: &mut Resources) -> Result<(), PecosError>;
 
     /// Optional: name for debugging/logging.
     fn name(&self) -> &str {
@@ -46,7 +53,7 @@ pub trait System: Send + Sync {
 /// Wrapper to convert a function into a System.
 pub struct FnSystem<F>
 where
-    F: Fn(&mut Resources) + Send + Sync,
+    F: Fn(&mut Resources) -> Result<(), PecosError> + Send + Sync,
 {
     func: F,
     name: &'static str,
@@ -54,7 +61,7 @@ where
 
 impl<F> FnSystem<F>
 where
-    F: Fn(&mut Resources) + Send + Sync,
+    F: Fn(&mut Resources) -> Result<(), PecosError> + Send + Sync,
 {
     /// Create a new function-based system.
     pub fn new(func: F, name: &'static str) -> Self {
@@ -64,10 +71,10 @@ where
 
 impl<F> System for FnSystem<F>
 where
-    F: Fn(&mut Resources) + Send + Sync,
+    F: Fn(&mut Resources) -> Result<(), PecosError> + Send + Sync,
 {
-    fn run(&self, resources: &mut Resources) {
-        (self.func)(resources);
+    fn run(&self, resources: &mut Resources) -> Result<(), PecosError> {
+        (self.func)(resources)
     }
 
     fn name(&self) -> &str {
@@ -80,7 +87,7 @@ where
 /// This is the primary way to create systems from closures or functions.
 pub fn into_system<F>(func: F) -> Box<dyn System>
 where
-    F: Fn(&mut Resources) + Send + Sync + 'static,
+    F: Fn(&mut Resources) -> Result<(), PecosError> + Send + Sync + 'static,
 {
     Box::new(FnSystem::new(func, std::any::type_name::<F>()))
 }
@@ -126,23 +133,32 @@ impl Schedule {
     }
 
     /// Run all systems in a stage.
-    pub fn run_stage(&self, stage: Stage, resources: &mut Resources) {
+    ///
+    /// # Errors
+    ///
+    /// Returns the first system error and stops the stage.
+    pub fn run_stage(&self, stage: Stage, resources: &mut Resources) -> Result<(), PecosError> {
         for system in self.systems(stage) {
-            system.run(resources);
+            system.run(resources)?;
         }
+        Ok(())
     }
 
     /// Run a complete shot loop: Startup, then per-shot PreShot/Execute/PostShot, then Finish.
-    pub fn run_shots(&self, resources: &mut Resources, shots: usize) {
-        self.run_stage(Stage::Startup, resources);
+    ///
+    /// # Errors
+    ///
+    /// Returns the first system error and stops the schedule.
+    pub fn run_shots(&self, resources: &mut Resources, shots: usize) -> Result<(), PecosError> {
+        self.run_stage(Stage::Startup, resources)?;
 
         for _ in 0..shots {
-            self.run_stage(Stage::PreShot, resources);
-            self.run_stage(Stage::Execute, resources);
-            self.run_stage(Stage::PostShot, resources);
+            self.run_stage(Stage::PreShot, resources)?;
+            self.run_stage(Stage::Execute, resources)?;
+            self.run_stage(Stage::PostShot, resources)?;
         }
 
-        self.run_stage(Stage::Finish, resources);
+        self.run_stage(Stage::Finish, resources)
     }
 }
 
@@ -163,7 +179,7 @@ impl IntoSystem for Box<dyn System> {
 
 impl<F> IntoSystem for F
 where
-    F: Fn(&mut Resources) + Send + Sync + 'static,
+    F: Fn(&mut Resources) -> Result<(), PecosError> + Send + Sync + 'static,
 {
     fn into_system(self) -> Box<dyn System> {
         into_system(self)
@@ -181,12 +197,13 @@ mod tests {
 
         let system = into_system(|res: &mut Resources| {
             *res.get_mut::<u32>() += 1;
+            Ok(())
         });
 
-        system.run(&mut resources);
+        system.run(&mut resources).unwrap();
         assert_eq!(*resources.get::<u32>(), 1);
 
-        system.run(&mut resources);
+        system.run(&mut resources).unwrap();
         assert_eq!(*resources.get::<u32>(), 2);
     }
 
@@ -200,6 +217,7 @@ mod tests {
             Stage::Startup,
             into_system(|res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("startup");
+                Ok(())
             }),
         );
 
@@ -207,6 +225,7 @@ mod tests {
             Stage::Execute,
             into_system(|res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("execute");
+                Ok(())
             }),
         );
 
@@ -214,12 +233,13 @@ mod tests {
             Stage::Finish,
             into_system(|res: &mut Resources| {
                 res.get_mut::<Vec<&str>>().push("finish");
+                Ok(())
             }),
         );
 
-        schedule.run_stage(Stage::Startup, &mut resources);
-        schedule.run_stage(Stage::Execute, &mut resources);
-        schedule.run_stage(Stage::Finish, &mut resources);
+        schedule.run_stage(Stage::Startup, &mut resources).unwrap();
+        schedule.run_stage(Stage::Execute, &mut resources).unwrap();
+        schedule.run_stage(Stage::Finish, &mut resources).unwrap();
 
         assert_eq!(
             *resources.get::<Vec<&str>>(),

--- a/exp/pecos-neo/tests/command_validation_regressions.rs
+++ b/exp/pecos-neo/tests/command_validation_regressions.rs
@@ -12,7 +12,7 @@ use pecos_simulators::SparseStab;
 #[test]
 fn fallible_shot_boundaries_report_raw_queue_errors() {
     use pecos_neo::adapter::QuantumEngineProgramRunner;
-    use pecos_neo::program::{ProgramRunner, StaticProgram};
+    use pecos_neo::program::{DynProgramRunner, ProgramRunner, StaticProgram};
     use pecos_neo::sampling::ImportanceSamplingRunner;
 
     for command in [
@@ -27,13 +27,13 @@ fn fallible_shot_boundaries_report_raw_queue_errors() {
         let mut program = StaticProgram::new(queue.clone(), 1);
         assert!(
             ProgramRunner::new(SparseStab::with_seed(1, 42))
-                .try_run_shot(&mut program)
+                .run_shot(&mut program)
                 .is_err()
         );
         let mut engine = QuantumEngineProgramRunner::new(Box::new(
             pecos_engines::quantum::SparseStabEngine::with_seed(1, 42),
         ));
-        assert!(engine.try_run_shot(&mut program).is_err());
+        assert!(engine.run_shot(&mut program).is_err());
     }
 
     let duration = (1_u64 << 53) + 1;
@@ -46,7 +46,7 @@ fn fallible_shot_boundaries_report_raw_queue_errors() {
     ));
     assert!(
         engine
-            .try_run_shot(&mut program)
+            .run_shot(&mut program)
             .expect_err("lossless core conversion required")
             .to_string()
             .contains("cannot be represented exactly")

--- a/exp/pecos-neo/tests/error_propagation_test.rs
+++ b/exp/pecos-neo/tests/error_propagation_test.rs
@@ -1,0 +1,223 @@
+use std::any::Any;
+
+use pecos_core::errors::PecosError;
+use pecos_engines::{
+    ByteMessage, ClassicalControlEngineBuilder, ClassicalEngine, ControlEngine, Engine, EngineStage,
+};
+use pecos_neo::prelude::*;
+use pecos_neo::tool::{
+    importance_sampling, monte_carlo, path_enumeration, sim_neo, sim_neo_builder, sparse_stab,
+    subset_simulation,
+};
+use pecos_results::Shot;
+
+#[derive(Clone)]
+struct ContinueFailureEngine;
+
+impl Engine for ContinueFailureEngine {
+    type Input = ();
+    type Output = Shot;
+
+    fn process(&mut self, _input: ()) -> Result<Shot, PecosError> {
+        Ok(Shot::default())
+    }
+
+    fn reset(&mut self) -> Result<(), PecosError> {
+        Ok(())
+    }
+}
+
+impl ClassicalEngine for ContinueFailureEngine {
+    fn num_qubits(&self) -> usize {
+        1
+    }
+
+    fn generate_commands(&mut self) -> Result<ByteMessage, PecosError> {
+        Ok(ByteMessage::create_empty())
+    }
+
+    fn handle_measurements(&mut self, _message: ByteMessage) -> Result<(), PecosError> {
+        Ok(())
+    }
+
+    fn get_results(&self) -> Result<Shot, PecosError> {
+        Ok(Shot::default())
+    }
+
+    fn compile(&self) -> Result<(), PecosError> {
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Result<(), PecosError> {
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl ControlEngine for ContinueFailureEngine {
+    type Input = ();
+    type Output = Shot;
+    type EngineInput = ByteMessage;
+    type EngineOutput = ByteMessage;
+
+    fn start(&mut self, _input: ()) -> Result<EngineStage<ByteMessage, Shot>, PecosError> {
+        let commands = ByteMessage::quantum_operations_builder()
+            .h(&[0])
+            .mz(&[0])
+            .build();
+        Ok(EngineStage::NeedsProcessing(commands))
+    }
+
+    fn continue_processing(
+        &mut self,
+        _result: ByteMessage,
+    ) -> Result<EngineStage<ByteMessage, Shot>, PecosError> {
+        Err(PecosError::Processing("stub continue failure".into()))
+    }
+
+    fn reset(&mut self) -> Result<(), PecosError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ContinueFailureBuilder;
+
+impl ClassicalControlEngineBuilder for ContinueFailureBuilder {
+    type Engine = ContinueFailureEngine;
+
+    fn build(self) -> Result<ContinueFailureEngine, PecosError> {
+        Ok(ContinueFailureEngine)
+    }
+}
+
+#[derive(Clone)]
+struct BuildFailureBuilder;
+
+impl ClassicalControlEngineBuilder for BuildFailureBuilder {
+    type Engine = ContinueFailureEngine;
+
+    fn build(self) -> Result<ContinueFailureEngine, PecosError> {
+        Err(PecosError::Processing("stub builder failure".into()))
+    }
+}
+
+#[test]
+fn sequential_classical_error_is_returned() {
+    let error = sim_neo_builder()
+        .with_engine(ContinueFailureBuilder)
+        .quantum(sparse_stab())
+        .qubits(1)
+        .sampling(monte_carlo(3))
+        .run()
+        .expect_err("classical engine failure should be returned");
+
+    assert!(error.to_string().contains("stub continue failure"));
+}
+
+#[test]
+fn sequential_quantum_error_is_returned() {
+    let circuit = CommandBuilder::new().rz(&[0], 0.3).build();
+    let error = sim_neo(circuit)
+        .quantum(sparse_stab())
+        .sampling(monte_carlo(1))
+        .run()
+        .expect_err("non-Clifford execution failure should be returned");
+
+    assert!(error.to_string().contains("has a non-Clifford angle"));
+}
+
+#[test]
+fn parallel_classical_error_is_returned() {
+    let error = sim_neo_builder()
+        .with_engine(ContinueFailureBuilder)
+        .quantum(sparse_stab())
+        .qubits(1)
+        .sampling(monte_carlo(8).workers(4))
+        .run()
+        .expect_err("parallel classical engine failure should be returned");
+
+    assert!(error.to_string().contains("stub continue failure"));
+}
+
+#[test]
+fn startup_error_is_returned_on_every_run() {
+    let mut simulation = sim_neo_builder()
+        .with_engine(BuildFailureBuilder)
+        .quantum(sparse_stab())
+        .qubits(1)
+        .sampling(monte_carlo(1))
+        .build();
+
+    for _ in 0..2 {
+        let error = simulation
+            .run()
+            .expect_err("classical engine build failure should be returned on every run");
+        assert!(error.to_string().contains("stub builder failure"));
+    }
+}
+
+#[test]
+fn event_handler_gate_error_is_returned() {
+    let injected_gate = CommandBuilder::new()
+        .rz(&[0], 0.3)
+        .build()
+        .iter()
+        .next()
+        .expect("injected circuit should contain one gate")
+        .clone();
+    let handlers = EventHandlers::new()
+        .on_before_gate(move |_| NoiseResponse::inject_gate(injected_gate.clone()));
+
+    let error = sim_neo(CommandBuilder::new().h(&[0]).build())
+        .quantum(sparse_stab())
+        .event_handlers(handlers)
+        .sampling(monte_carlo(1))
+        .run()
+        .expect_err("event-handler gate failure should be returned");
+
+    assert!(error.to_string().contains("has a non-Clifford angle"));
+}
+
+#[test]
+#[should_panic(expected = "Importance sampling cannot execute static circuit gate RZ")]
+fn importance_sampling_rejects_non_clifford_circuit_at_build() {
+    let _ = sim_neo(CommandBuilder::new().rz(&[0], 0.3).build())
+        .quantum(sparse_stab())
+        .sampling(importance_sampling(1))
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "Path enumeration cannot execute static circuit gate RZ")]
+fn path_enumeration_rejects_non_clifford_circuit_at_build() {
+    let _ = sim_neo(CommandBuilder::new().rz(&[0], 0.3).build())
+        .quantum(sparse_stab())
+        .sampling(path_enumeration(1))
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "Subset simulation cannot execute static circuit gate RZ")]
+fn subset_simulation_rejects_non_clifford_circuit_at_build() {
+    let _ = sim_neo(CommandBuilder::new().rz(&[0], 0.3).build())
+        .quantum(sparse_stab())
+        .sampling(subset_simulation(1).score(|_| 0.0).failure(|_| false))
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "Subset simulation requires samples_per_level > 0")]
+fn subset_simulation_rejects_zero_samples_at_build() {
+    let _ = sim_neo(CommandBuilder::new().mz(&[0]).build())
+        .quantum(sparse_stab())
+        .sampling(subset_simulation(0).score(|_| 0.0).failure(|_| false))
+        .build();
+}

--- a/exp/pecos-neo/tests/event_handlers_test.rs
+++ b/exp/pecos-neo/tests/event_handlers_test.rs
@@ -40,7 +40,8 @@ fn event_handlers_on_before_gate_fires_through_sim_neo() {
         .event_handlers(handlers)
         .sampling(monte_carlo(10))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results.len(), 10);
     // H gate fires on_before_gate once per shot
@@ -64,7 +65,8 @@ fn event_handlers_parallel_workers_fire_per_worker() {
         .event_handlers(handlers)
         .sampling(monte_carlo(20).workers(2))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results.len(), 20);
     // Each shot has 1 H gate -> 20 on_before_gate calls total across workers
@@ -84,13 +86,15 @@ fn event_handlers_empty_is_noop() {
         .event_handlers(handlers)
         .sampling(monte_carlo(10))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     let results_without = sim_neo(circuit)
         .auto()
         .sampling(monte_carlo(10))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results_with.len(), results_without.len());
     for (a, b) in results_with
@@ -138,7 +142,8 @@ fn event_handlers_multiple_handler_types() {
         .event_handlers(handlers)
         .sampling(monte_carlo(5))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results.len(), 5);
     assert_eq!(gate_count.load(Ordering::Relaxed), 5); // 1 H per shot
@@ -189,7 +194,8 @@ fn signal_handler_fires_through_sim_neo() {
         .event_handlers(handlers)
         .sampling(monte_carlo(5))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results.len(), 5);
     assert_eq!(counter.load(Ordering::Relaxed), 5);
@@ -217,7 +223,8 @@ fn signal_handler_fires_through_sim_neo_parallel() {
         .event_handlers(handlers)
         .sampling(monte_carlo(10).workers(2))
         .seed(42)
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     assert_eq!(results.len(), 10);
     // 2 signals per shot, 10 shots = 20 handler calls

--- a/exp/pecos-neo/tests/extensible_integration_test.rs
+++ b/exp/pecos-neo/tests/extensible_integration_test.rs
@@ -427,7 +427,7 @@ fn test_noisy_execution_statistics() {
             .with_noise(noise)
             .with_seed(seed as u64);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
         if result.outcomes.get_bit(QubitId(0)) == Some(true) {
             ones_count += 1;
         }
@@ -476,9 +476,9 @@ impl CommandSource for UserGateProgram {
     fn next_commands(
         &mut self,
         _outcomes: Option<&MeasurementOutcomes>,
-    ) -> Option<pecos_neo::command::CommandQueue> {
+    ) -> Result<Option<pecos_neo::command::CommandQueue>, pecos_core::errors::PecosError> {
         if self.executed {
-            return None;
+            return Ok(None);
         }
         self.executed = true;
 
@@ -486,7 +486,7 @@ impl CommandSource for UserGateProgram {
         // Note: The CommandBuilder doesn't directly support custom GateIds,
         // so for now we use standard gates to verify the CommandSource pattern works.
         // The actual user gate integration would require CommandBuilder extension.
-        Some(
+        Ok(Some(
             CommandBuilder::new()
                 .pz(&[0])
                 .pz(&[1])
@@ -495,15 +495,16 @@ impl CommandSource for UserGateProgram {
                 .mz(&[0])
                 .mz(&[1])
                 .build(),
-        )
+        ))
     }
 
     fn is_complete(&self) -> bool {
         self.executed
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<(), pecos_core::errors::PecosError> {
         self.executed = false;
+        Ok(())
     }
 
     fn num_qubits(&self) -> usize {
@@ -530,7 +531,7 @@ fn test_command_source_with_user_gates() {
     let mut program = UserGateProgram::new(user_gate_id);
     let mut runner = ProgramRunner::new(SparseStab::with_seed(2, 42)).with_seed(42);
 
-    let result = runner.run_shot(&mut program);
+    let result = runner.run_shot(&mut program).expect("shot should succeed");
 
     // Verify execution completed
     assert_eq!(result.num_batches, 1);
@@ -567,7 +568,7 @@ fn test_conditional_program_with_feedback() {
         let mut runner =
             ProgramRunner::new(SparseStab::with_seed(1, seed as u64)).with_seed(seed as u64);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
 
         // If there were 2 batches, we did the correction
         if result.num_batches == 2 {

--- a/exp/pecos-neo/tests/sampling_demonstration_test.rs
+++ b/exp/pecos-neo/tests/sampling_demonstration_test.rs
@@ -402,7 +402,7 @@ fn demo_conditional_program() {
     // Run multiple shots to see both branches
     let mut corrected_count = 0;
     for shot in 0..10 {
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
         let num_batches = result.num_batches;
         let corrected = num_batches == 2;
         if corrected {
@@ -436,38 +436,40 @@ fn demo_repeat_until_success() {
         fn next_commands(
             &mut self,
             outcomes: Option<&MeasurementOutcomes>,
-        ) -> Option<pecos_neo::command::CommandQueue> {
+        ) -> Result<Option<pecos_neo::command::CommandQueue>, pecos_core::errors::PecosError>
+        {
             // Check if previous attempt succeeded (measured 0)
             if let Some(o) = outcomes
                 && o.get_bit(QubitId(0)) == Some(false)
             {
                 self.success = true;
-                return None; // Success!
+                return Ok(None); // Success!
             }
 
             if self.current_attempt >= self.max_attempts {
-                return None; // Give up
+                return Ok(None); // Give up
             }
 
             self.current_attempt += 1;
 
             // Try again: prepare, rotate slightly, measure
-            Some(
+            Ok(Some(
                 CommandBuilder::new()
                     .pz(&[0])
                     .h(&[0]) // 50% chance of 0
                     .mz(&[0])
                     .build(),
-            )
+            ))
         }
 
         fn is_complete(&self) -> bool {
             self.success || self.current_attempt >= self.max_attempts
         }
 
-        fn reset(&mut self) {
+        fn reset(&mut self) -> Result<(), pecos_core::errors::PecosError> {
             self.current_attempt = 0;
             self.success = false;
+            Ok(())
         }
 
         fn num_qubits(&self) -> usize {
@@ -486,7 +488,7 @@ fn demo_repeat_until_success() {
     println!("\nRepeat-Until-Success Demo:");
 
     for trial in 0..5 {
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
         println!(
             "  Trial {}: {} attempts, success={}",
             trial, result.num_batches, program.success

--- a/exp/pecos-neo/tests/sim_neo_comparison_test.rs
+++ b/exp/pecos-neo/tests/sim_neo_comparison_test.rs
@@ -142,7 +142,8 @@ fn test_sim_neo_vs_sim_deterministic_x() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Both should produce all 1s
@@ -188,7 +189,8 @@ fn test_sim_neo_vs_sim_hadamard() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Both should be roughly 50/50
@@ -250,7 +252,8 @@ fn test_sim_neo_vs_sim_bell_state() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1)]);
 
     // Both should only have 00 and 11
@@ -313,7 +316,8 @@ fn test_sim_neo_vs_sim_depolarizing_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Both should have mostly 1s with some errors
@@ -380,7 +384,8 @@ fn test_sim_neo_vs_sim_measurement_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Error rate should be ~p_meas (measuring |0> but getting 1)
@@ -463,7 +468,7 @@ fn test_sim_neo_vs_sim_conditional_x_correction() {
         let seed = 42u64.wrapping_add(shot_idx as u64);
         let mut runner = ProgramRunner::new(SparseStab::with_seed(1, seed)).with_seed(seed);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
 
         // The final measurement should always be 0 (after correction)
         // Get the last measurement outcome
@@ -556,7 +561,7 @@ fn test_sim_neo_vs_sim_conditional_with_noise() {
             .with_noise(neo_noise)
             .with_seed(seed);
 
-        let result = runner.run_shot(&mut program);
+        let result = runner.run_shot(&mut program).expect("shot should succeed");
 
         if !result.outcomes.get_bit(QubitId(0)).unwrap_or(true) {
             neo_zeros += 1;
@@ -687,7 +692,8 @@ fn test_sim_neo_ergonomic_builder_direct() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Both should have similar error rates
@@ -714,7 +720,8 @@ fn test_sim_neo_convenience_methods() {
         .sampling(monte_carlo(500))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     // Using explicit GeneralNoiseModelBuilder - must match what .depolarizing() does
     let results_explicit = sim_neo(circuit)
@@ -729,7 +736,8 @@ fn test_sim_neo_convenience_methods() {
         .sampling(monte_carlo(500))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     // Both should produce similar results
     let conv_errors: usize = results_convenience
@@ -764,12 +772,12 @@ fn test_sim_neo_reusable() {
         .build();
 
     // First run
-    let results1 = sim.run();
+    let results1 = sim.run().expect("simulation should succeed");
     assert_eq!(results1.len(), 100);
 
     // Reconfigure and run again
     sim.shots(200).seed(123);
-    let results2 = sim.run();
+    let results2 = sim.run().expect("simulation should succeed");
     assert_eq!(results2.len(), 200);
 
     // Results should be different (different seeds)
@@ -808,14 +816,16 @@ fn test_sim_neo_determinism() {
         .sampling(monte_carlo(100))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     let results2 = sim_neo(circuit)
         .auto()
         .sampling(monte_carlo(100))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
 
     // Results should be identical
     for (o1, o2) in results1.outcomes.iter().zip(results2.outcomes.iter()) {
@@ -865,7 +875,8 @@ fn test_sim_neo_vs_sim_noiseless_exact() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1)]);
 
     // Both should produce 100% |11>
@@ -919,7 +930,8 @@ fn test_sim_neo_noise_level_scaling() {
             .sampling(monte_carlo(NUM_SHOTS))
             .seed(42)
             .build()
-            .run();
+            .run()
+            .expect("simulation should succeed");
         let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
         let neo_err = *neo_counts.get("0").unwrap_or(&0) as f64 / NUM_SHOTS as f64;
 
@@ -1006,7 +1018,8 @@ fn test_sim_neo_vs_sim_zero_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1)]);
 
     // Bell state should be 100% correlated (only |00> and |11>)
@@ -1056,7 +1069,8 @@ fn test_sim_neo_high_noise_chaos() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // At high noise, we expect significant errors but not 50/50
@@ -1131,7 +1145,8 @@ fn test_sim_neo_vs_sim_two_qubit_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1)]);
 
     // Expected: |11> with some errors from CX noise
@@ -1195,7 +1210,8 @@ fn test_sim_neo_vs_sim_preparation_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0)]);
 
     // Error rate should be ~p_prep (preparing |0> but getting |1>)
@@ -1278,7 +1294,8 @@ fn test_sim_neo_vs_sim_combined_noise() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1)]);
 
     // For Bell state, ideal is 50% |00> and 50% |11> (correlated)
@@ -1354,7 +1371,8 @@ fn test_sim_neo_vs_sim_ghz_state() {
         .sampling(monte_carlo(NUM_SHOTS))
         .seed(42)
         .build()
-        .run();
+        .run()
+        .expect("simulation should succeed");
     let neo_counts = extract_neo_outcomes(&neo_results, &[QubitId(0), QubitId(1), QubitId(2)]);
 
     // Both should only have 000 and 111

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -970,7 +970,9 @@ impl PySimNeoBuilder {
         }
 
         let mut sim = builder.build();
-        let results = sim.run();
+        let results = sim
+            .run()
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
 
         let mut all_shots = Vec::with_capacity(shots);
         for shot_outcomes in &results.outcomes {
@@ -1015,7 +1017,8 @@ impl PySimNeoBuilder {
             .quantum(pecos_neo::tool::sparse_stab())
             .sampling(pecos_neo::tool::path_enumeration(max_measurements))
             .build()
-            .run();
+            .run()
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
 
         let rows: Vec<Vec<u8>> = results
             .outcomes


### PR DESCRIPTION
## Summary

Makes every run-time failure inside a pecos-neo simulation surface as `Err(PecosError)` from `sim_neo()`, `SimNeoBuilder::run()`, `Simulation::run()` and the `pecos::sim()` facade's neo route. Before this change a failing classical engine was printed to stderr and reported as a completed shot, a simulator that could not execute a gate panicked, and the tool scheduler had no way to carry an error at all.

Rebased onto `dev` after #711 merged. `dev` meanwhile gained construction-time `GateCommand` validation and `ExecutionError::InvalidCommand` (#701); this change keeps those and replaces the `try_run_shot` + panicking `run_shot` pairs #701 added with the single fallible `run_shot`.

### What changed

- `CommandSource::{next_commands, reset, shot_results}`, `ProgramRunner::run_shot` and `DynProgramRunner::run_shot` return `Result`. `ClassicalEngineAdapter` returns the wrapped engine's error instead of printing it; `QuantumEngineProgramRunner` no longer panics on reset, processing or outcome decoding. A continuation requested without the previous batch's outcomes is now an error rather than a silent completion.
- `ExecutionError` converts into `PecosError::Processing` (message preserved) and gains a `QubitArity` variant for injected gates whose target count does not match their arity.
- Noise- and event-handler-injected gates that the backend cannot execute return `ExecutionError` through `apply_noise_response` and `CircuitRunner::apply_noise` instead of asserting. Event handlers are user closures with no build-time validation, so this was a reachable run-time panic.
- `System::run`, `Schedule::{run_stage, run_shots}`, `Tool::{run, run_shots, run_shots_on}` and `Simulation::run` are fallible; the schedule stops at the first error. Startup-stage engine and backend construction failures propagate the same way, and startup no longer consumes the program source before its fallible build, so a `Simulation` re-run after a failed start returns the error again instead of panicking.
- Parallel Monte Carlo returns the error of the lowest-indexed failing worker (collected in index order, independent of completion order). The qubit count is established once per run from a single probe source so all workers agree; workers still build their own sources.
- Importance sampling, path enumeration and subset simulation only accept static circuits, so a gate they cannot execute is now rejected at `build()` beside the existing configuration validators (same loud pattern, pinned with `should_panic` tests). `subset_simulation(0)` is rejected there too instead of underflowing. Each sampler's gate-support predicate lives in its own module and is pinned by an exhaustive agreement test that runs the real executor for every `GateType` variant; `GateType::ALL` is enforced complete at compile time.
- The `pecos::sim()` facade propagates with `?`; the `pecos-rslib-exp` bindings map the error to `PyRuntimeError`. Doc examples that discarded the result now use `?` or `expect`.

Build-time configuration validation that panics inside `SimNeoBuilder::build()` is unchanged and out of scope. `run_parallel_importance` uses the separate importance runner, which has no fallible operation on that path.

### Tests

`exp/pecos-neo/tests/error_propagation_test.rs` (nine tests). Each was run against the pre-change tree first and observed to fail for the stated reason:

- sequential classical continuation error: previously `Ok` with a printed error, now `Err` carrying the engine's message
- sequential non-Clifford rotation on `sparse_stab()`: previously a panic in `ProgramRunner::run_shot`, now `Err`
- parallel classical continuation error over four workers: previously `Ok`, now `Err`
- startup error on every run: previously a panic on the second `run()`, now `Err` twice
- event-handler-injected non-Clifford gate: previously an assertion in `execute_noise_gate`, now `Err`
- importance sampling, path enumeration and subset simulation with a non-Clifford gate, and `subset_simulation(0)`: previously panics inside the executors, now rejected at `build()`

Plus three agreement tests (`supports_agrees_with_executor_for_every_gate_type`) in the sampler modules, each shown to fail when one arm is removed from its predicate.

### Verification

```
cargo fmt --all -- --check
cargo clippy --locked -p pecos-neo --all-targets --all-features -- -D warnings
cargo clippy --locked -p pecos-neo --all-targets -- -D warnings
cargo clippy --locked -p pecos -p pecos-rslib-exp -p benchmarks --all-targets --all-features -- -D warnings
cargo test --locked -p pecos-neo --all-features
cargo test --locked -p pecos --features neo --test neo_routing_test --test neo_emission_test --test neo_v6_example_sweep_test --test neo_equivalence_matrix_test --test neo_hugr_routing_test
cargo check --locked --workspace --all-targets --all-features
```

All green on a cold build (changed crates cleaned first). The Python wheel cannot be rebuilt in the development environment; `cargo clippy -p pecos-rslib-exp` is the compile gate for the bindings and the behaviour is exercised by CI.

