### PR TITLE
Bridge the Y frame phase conversion so StabVec measurement and Pauli gates stay phase-exact

### DIFF
--- a/crates/pecos-simulators/src/clifford_frame.rs
+++ b/crates/pecos-simulators/src/clifford_frame.rs
@@ -1058,14 +1058,31 @@ mod tests {
     }
 
     #[test]
-    fn only_computational_basis_diagonal_frames_are_diagonal() {
-        assert!(CliffordFrame::IDENTITY.is_diagonal());
-        assert!(CliffordFrame::Z.is_diagonal());
-        assert!(CliffordFrame::SZ.is_diagonal());
-        assert!(CliffordFrame::SZDG.is_diagonal());
-        assert!(!CliffordFrame::X.is_diagonal());
-        assert!(!CliffordFrame::Y.is_diagonal());
-        assert!(!CliffordFrame::H.is_diagonal());
+    fn computational_basis_phases_match_all_element_matrices() {
+        for index in 0..24 {
+            let frame = CliffordFrame::from_index(index);
+            for outcome in [false, true] {
+                let phase = frame.computational_basis_phase(outcome);
+                assert_eq!(
+                    frame.is_diagonal(),
+                    phase.is_some(),
+                    "element {index}, outcome {outcome}: diagonal/phase disagreement"
+                );
+
+                if let Some(phase) = phase {
+                    let matrix = ELEMENT_MATRIX[index as usize];
+                    let diagonal_offset = if outcome { 6 } else { 0 };
+                    let expected =
+                        Complex64::new(matrix[diagonal_offset], matrix[diagonal_offset + 1]);
+                    let actual = phase.cis();
+                    assert!(
+                        (actual - expected).norm() < 1e-12,
+                        "element {index}, outcome {outcome}: basis phase {actual:?} does not match \
+                         ELEMENT_MATRIX eigenvalue {expected:?}"
+                    );
+                }
+            }
+        }
     }
 
     fn mat_mul(a: &Mat2, b: &Mat2) -> Mat2 {

--- a/crates/pecos-simulators/src/clifford_frame.rs
+++ b/crates/pecos-simulators/src/clifford_frame.rs
@@ -29,6 +29,8 @@
 //! Anders & Briegel, "Fast simulation of stabilizer circuits using a graph-state
 //! representation", [arXiv:quant-ph/0504117](https://arxiv.org/abs/quant-ph/0504117).
 
+use pecos_core::Angle64;
+
 /// Which Pauli axis.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -772,6 +774,23 @@ impl CliffordFrame {
     pub fn is_diagonal(self) -> bool {
         let (_, _, z_axis, z_neg) = HEIS[self.0 as usize];
         z_axis == 2 && !z_neg
+    }
+
+    /// Phase contributed when this diagonal Clifford acts on a computational-basis state.
+    ///
+    /// Returns `None` for a non-diagonal Clifford. For a diagonal Clifford and
+    /// basis state `|b⟩`, the returned angle `phase` satisfies
+    /// `ELEMENT_MATRIX[self] |b⟩ = exp(i * phase) |b⟩`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn computational_basis_phase(self, outcome: bool) -> Option<Angle64> {
+        match (self.0, outcome) {
+            (0 | 3 | 4 | 5, false) | (0, true) => Some(Angle64::ZERO),
+            (3, true) => Some(Angle64::HALF_TURN),
+            (4, true) => Some(Angle64::QUARTER_TURN),
+            (5, true) => Some(-Angle64::QUARTER_TURN),
+            _ => None,
+        }
     }
 
     /// Decompose into Pauli × Coset: `self_matrix` = pauli · coset.

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -68,7 +68,7 @@ use pecos_random::{PecosRng, Rng, RngExt, SeedableRng};
 ///     .build();
 /// ```
 ///
-use crate::clifford_frame::{CliffordFrame, GEN_LENS, GENERATORS, PHASE_COCYCLE};
+use crate::clifford_frame::{CliffordFrame, GATE_PHASE_DELTA, GEN_LENS, GENERATORS, PHASE_COCYCLE};
 
 #[derive(Clone, Debug)]
 pub struct StabVecGeneric<S: IndexSet = BitSet, R: SeedableRng + Rng + Debug = PecosRng> {
@@ -77,7 +77,7 @@ pub struct StabVecGeneric<S: IndexSet = BitSet, R: SeedableRng + Rng + Debug = P
     /// Pending RZ angles per qubit.
     pending_rz: Vec<Angle64>,
     /// Single-qubit Clifford frame per qubit. All 24 Clifford elements tracked.
-    /// State = frame * `pending_rz` * |`stored_state`⟩.
+    /// State = `pending_rz` * frame * |`stored_state`⟩.
     /// Single-qubit Cliffords compose into the frame in O(1).
     /// Flushed via H+S generator sequence when a two-qubit gate or measurement arrives.
     cliff_frame: Vec<CliffordFrame>,
@@ -456,6 +456,17 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         }
     }
 
+    /// Compose a named gate into the deferred Clifford frame, including the
+    /// phase conversion between the gate and element-matrix conventions.
+    fn compose_cliff_frame(&mut self, q: usize, gate: CliffordFrame) {
+        let old = self.cliff_frame[q];
+        self.frame_phase = (self.frame_phase
+            + (8 - GATE_PHASE_DELTA[gate.index() as usize])
+            + PHASE_COCYCLE[gate.index() as usize][old.index() as usize])
+            & 7;
+        self.cliff_frame[q] = gate.compose(old);
+    }
+
     /// Flush the Clifford frame on qubit q by applying its H+S generator sequence.
     fn flush_cliff_frame(&mut self, q: usize) {
         let cf = self.cliff_frame[q];
@@ -484,6 +495,11 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
                     self.apply_clifford(|ch| {
                         ch.y(&[qid]);
                     });
+                    // The frame phase is relative to ELEMENT_MATRIX[2], while
+                    // CH-form's named Y emits the standard Y matrix.
+                    self.frame_phase = (self.frame_phase
+                        + GATE_PHASE_DELTA[CliffordFrame::Y.index() as usize])
+                        & 7;
                 }
                 3 => {
                     // Z: diagonal, commutes with RZ
@@ -494,6 +510,22 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
                 _ => {}
             }
             return;
+        }
+
+        // A pending RZ can coexist only with a frame that preserves the Z axis.
+        // Anti-diagonal frames carry the sign negation performed by X/Y
+        // composition; restore it before materializing the frame to the right
+        // of the RZ. The Pauli X/Y fast paths above do the same thing.
+        if self.pending_rz[q] != Angle64::ZERO {
+            let z_image = cf.z_image();
+            debug_assert_eq!(
+                z_image.axis,
+                crate::clifford_frame::PauliAxis::Z,
+                "a pending RZ requires a frame that preserves the Z axis"
+            );
+            if !z_image.positive {
+                self.pending_rz[q] = -self.pending_rz[q];
+            }
         }
 
         // Flush pending RZ first (non-diagonal Cliffords don't commute with RZ).
@@ -1083,9 +1115,11 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         } else {
             -discarded_pending_rz.signed_half()
         };
-        let frame_branch_phase = discarded_diagonal_frame
-            .and_then(|frame| frame.computational_basis_phase(outcome))
-            .unwrap_or(Angle64::ZERO);
+        let frame_branch_phase = discarded_diagonal_frame.map_or(Angle64::ZERO, |frame| {
+            frame
+                .computational_basis_phase(outcome)
+                .expect("a diagonal frame must have a basis phase")
+        });
         self.apply_global_phase(rz_branch_phase + frame_branch_phase, &[QubitId(q)]);
 
         MeasurementResult {
@@ -1165,11 +1199,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &q in qubits {
             let qi = q.index();
             self.pending_rz[qi] = -self.pending_rz[qi]; // X anticommutes with RZ
-            let old = self.cliff_frame[qi];
-            self.frame_phase = (self.frame_phase
-                + PHASE_COCYCLE[CliffordFrame::X.index() as usize][old.index() as usize])
-                & 7;
-            self.cliff_frame[qi] = CliffordFrame::X.compose(old);
+            self.compose_cliff_frame(qi, CliffordFrame::X);
         }
         self
     }
@@ -1178,11 +1208,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &q in qubits {
             let qi = q.index();
             self.pending_rz[qi] = -self.pending_rz[qi]; // Y anticommutes with RZ
-            let old = self.cliff_frame[qi];
-            self.frame_phase = (self.frame_phase
-                + PHASE_COCYCLE[CliffordFrame::Y.index() as usize][old.index() as usize])
-                & 7;
-            self.cliff_frame[qi] = CliffordFrame::Y.compose(old);
+            self.compose_cliff_frame(qi, CliffordFrame::Y);
         }
         self
     }
@@ -1191,11 +1217,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &q in qubits {
             let qi = q.index();
             // Z commutes with RZ, no negation needed.
-            let old = self.cliff_frame[qi];
-            self.frame_phase = (self.frame_phase
-                + PHASE_COCYCLE[CliffordFrame::Z.index() as usize][old.index() as usize])
-                & 7;
-            self.cliff_frame[qi] = CliffordFrame::Z.compose(old);
+            self.compose_cliff_frame(qi, CliffordFrame::Z);
         }
         self
     }
@@ -1204,11 +1226,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &q in qubits {
             let qi = q.index();
             // S is diagonal, commutes with RZ.
-            let old = self.cliff_frame[qi];
-            self.frame_phase = (self.frame_phase
-                + PHASE_COCYCLE[CliffordFrame::SZ.index() as usize][old.index() as usize])
-                & 7;
-            self.cliff_frame[qi] = CliffordFrame::SZ.compose(old);
+            self.compose_cliff_frame(qi, CliffordFrame::SZ);
         }
         self
     }
@@ -1216,11 +1234,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
     fn szdg(&mut self, qubits: &[QubitId]) -> &mut Self {
         for &q in qubits {
             let qi = q.index();
-            let old = self.cliff_frame[qi];
-            self.frame_phase = (self.frame_phase
-                + PHASE_COCYCLE[CliffordFrame::SZDG.index() as usize][old.index() as usize])
-                & 7;
-            self.cliff_frame[qi] = CliffordFrame::SZDG.compose(old);
+            self.compose_cliff_frame(qi, CliffordFrame::SZDG);
         }
         self
     }
@@ -1232,11 +1246,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             let qi = q.index();
             if self.pending_rz[qi] == Angle64::default() {
                 // No pending RZ: safe to compose H into frame.
-                let old = self.cliff_frame[qi];
-                self.frame_phase = (self.frame_phase
-                    + PHASE_COCYCLE[CliffordFrame::H.index() as usize][old.index() as usize])
-                    & 7;
-                self.cliff_frame[qi] = CliffordFrame::H.compose(old);
+                self.compose_cliff_frame(qi, CliffordFrame::H);
             } else {
                 // Pending RZ exists: must flush frame and RZ, then apply H.
                 self.flush_cliff_frame(qi);
@@ -1254,9 +1264,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             self.flush_noncommuting_pending_rz(q.index());
         }
         self.sz(qubits).y(qubits);
-        // Correct the projective frame composition to canonical H3 phase.
+        // H3 = exp(-i*pi/4) * Y * SZ.
         for _ in qubits {
-            self.frame_phase = (self.frame_phase + 1) & 7;
+            self.frame_phase = (self.frame_phase + 7) & 7;
         }
         self
     }
@@ -1277,11 +1287,6 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         self.sx(qubits)
             .y(qubits)
             .apply_global_phase(-(Angle64::QUARTER_TURN / 2u64), qubits);
-        // Compensate for the current Y-frame cocycle so the composition has
-        // the canonical H6 phase. Remove this with the issue #699 fix.
-        for _ in qubits {
-            self.frame_phase = (self.frame_phase + 2) & 7;
-        }
         self
     }
 
@@ -1532,15 +1537,6 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         let results = self.mz(qubits);
         self.x(qubits);
         results
-    }
-
-    fn pnz(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // Prepare |1⟩ by phase-exactly projecting and preparing |0⟩, then
-        // flipping it. Because no measurement result is returned, this is
-        // equivalent to MPNZ while retaining the selected physical branch's phase.
-        self.mpz(qubits);
-        self.x(qubits);
-        self
     }
 }
 
@@ -2025,11 +2021,10 @@ mod tests {
         let q1 = qid(1);
 
         // Leave both non-zero rotations pending while accumulating X/Y frames.
-        // The extra Z composition also leaves a non-trivial global frame phase.
+        // Y's standard-gate phase leaves a non-trivial global frame phase.
         reset_sim
             .rz(Angle64::from_radians(0.37), &q0)
-            .y(&q0)
-            .z(&q0)
+            .x(&q0)
             .rz(Angle64::from_radians(-0.91), &q1)
             .y(&q1);
         assert_eq!(reset_sim.cliff_frame[0], CliffordFrame::X);
@@ -2901,65 +2896,305 @@ mod tests {
         projected
     }
 
-    #[test]
-    fn measurement_preserves_pending_rz_branch_phase() {
-        let q0 = qid(0);
-        let angle = Angle64::from_radians(0.37);
-        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
-        let mut state_vec = StateVecSoA::new(1);
-
-        stab_vec.h(&q0).rz(angle, &q0);
-        state_vec.h(&q0).rz(angle, &q0);
-        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::IDENTITY);
-        assert_eq!(stab_vec.pending_rz[0], angle);
-
-        let input = state_vec.state();
-        for outcome in [false, true] {
-            let expected = normalized_z_projection(&input, 0, outcome, "pending RZ");
-            let mut measured = stab_vec.clone();
-            let result = measured.measure_qubit(0, Some(outcome));
-            assert_eq!(result.outcome, outcome);
-            assert_phase_exact_state_matches(
-                &measured.state_vector(),
-                &expected,
-                &format!("pending RZ, outcome {outcome}"),
-            );
+    fn apply_deferred_test_gate<S: CliffordGateable>(
+        simulator: &mut S,
+        gate: &str,
+        qubits: &[QubitId],
+    ) {
+        match gate {
+            "X" => {
+                simulator.x(qubits);
+            }
+            "Y" => {
+                simulator.y(qubits);
+            }
+            _ => unreachable!("test gate must be X or Y"),
         }
     }
 
     #[test]
-    fn measurement_preserves_diagonal_clifford_branch_phase() {
+    fn x_and_y_preserve_phase_on_every_clifford_input_frame() {
         let q0 = qid(0);
-        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
-        let mut state_vec = StateVecSoA::new(1);
+        for input_frame in 0..24 {
+            for pauli in ["X", "Y"] {
+                let mut stab_vec = StabVec::builder(1).seed(0x715).build();
+                let mut state_vec = StateVecSoA::with_seed(1, 0x715);
+                stab_vec
+                    .ry(Angle64::from_radians(0.731), &q0)
+                    .rz(Angle64::from_radians(-0.417), &q0);
+                state_vec
+                    .ry(Angle64::from_radians(0.731), &q0)
+                    .rz(Angle64::from_radians(-0.417), &q0);
+                let _ = stab_vec.state_vector();
+                let _ = state_vec.state();
 
-        stab_vec.h(&q0);
-        stab_vec.flush_all_cliff_frames();
-        stab_vec.sz(&q0);
-        state_vec.h(&q0).sz(&q0);
-        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::SZ);
-        assert_eq!(stab_vec.pending_rz[0], Angle64::ZERO);
-
-        let input = state_vec.state();
-        for outcome in [false, true] {
-            let expected = normalized_z_projection(&input, 0, outcome, "diagonal S frame");
-            let mut measured = stab_vec.clone();
-            let result = measured.measure_qubit(0, Some(outcome));
-            assert_eq!(result.outcome, outcome);
-            assert_phase_exact_state_matches(
-                &measured.state_vector(),
-                &expected,
-                &format!("diagonal S frame, outcome {outcome}"),
-            );
+                for &generator in &GENERATORS[input_frame][..GEN_LENS[input_frame] as usize] {
+                    match generator {
+                        0 => {
+                            stab_vec.h(&q0);
+                            state_vec.h(&q0);
+                        }
+                        1 => {
+                            stab_vec.sz(&q0);
+                            state_vec.sz(&q0);
+                        }
+                        _ => unreachable!("generator sequence contains only H and S"),
+                    }
+                }
+                assert_eq!(usize::from(stab_vec.cliff_frame[0].index()), input_frame);
+                apply_deferred_test_gate(&mut stab_vec, pauli, &q0);
+                apply_deferred_test_gate(&mut state_vec, pauli, &q0);
+                assert_phase_exact_state_matches(
+                    &stab_vec.state_vector(),
+                    &state_vec.state(),
+                    &format!("frame {input_frame}; {pauli} on a generic state"),
+                );
+            }
         }
+
+        for input_frame in [0, 3, 4, 5] {
+            for pauli in ["X", "Y"] {
+                let mut stab_vec = StabVec::builder(1).seed(0x715).build();
+                let mut state_vec = StateVecSoA::with_seed(1, 0x715);
+                for &generator in &GENERATORS[input_frame][..GEN_LENS[input_frame] as usize] {
+                    match generator {
+                        0 => {
+                            stab_vec.h(&q0);
+                            state_vec.h(&q0);
+                        }
+                        1 => {
+                            stab_vec.sz(&q0);
+                            state_vec.sz(&q0);
+                        }
+                        _ => unreachable!("generator sequence contains only H and S"),
+                    }
+                }
+                let angle = Angle64::from_radians(0.37);
+                stab_vec.rz(angle, &q0);
+                state_vec.rz(angle, &q0);
+                assert_eq!(stab_vec.pending_rz[0], angle);
+
+                apply_deferred_test_gate(&mut stab_vec, pauli, &q0);
+                apply_deferred_test_gate(&mut state_vec, pauli, &q0);
+                assert_phase_exact_state_matches(
+                    &stab_vec.state_vector(),
+                    &state_vec.state(),
+                    &format!("diagonal frame {input_frame}; RZ; {pauli}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pauli_gates_preserve_phase_when_flushing_an_existing_frame() {
+        let q0 = qid(0);
+
+        let mut stab_x = StabVec::builder(1).seed(0x715).build();
+        let mut state_x = StateVecSoA::with_seed(1, 0x715);
+        stab_x.z(&q0).x(&q0);
+        state_x.z(&q0).x(&q0);
+        assert_phase_exact_state_matches(&stab_x.state_vector(), &state_x.state(), "Z; X");
+
+        let angle = Angle64::from_radians(0.37);
+        let mut stab_rz_x = StabVec::builder(1).seed(0x715).build();
+        let mut state_rz_x = StateVecSoA::with_seed(1, 0x715);
+        stab_rz_x.sz(&q0).rz(angle, &q0).x(&q0);
+        state_rz_x.sz(&q0).rz(angle, &q0).x(&q0);
+        assert_phase_exact_state_matches(
+            &stab_rz_x.state_vector(),
+            &state_rz_x.state(),
+            "S; RZ(0.37); X",
+        );
+
+        let mut stab_y = StabVec::builder(1).seed(0x715).build();
+        let mut state_y = StateVecSoA::with_seed(1, 0x715);
+        stab_y.z(&q0).y(&q0);
+        state_y.z(&q0).y(&q0);
+        assert_phase_exact_state_matches(&stab_y.state_vector(), &state_y.state(), "Z; Y");
+
+        let mut stab_rz_y = StabVec::builder(1).seed(0x715).build();
+        let mut state_rz_y = StateVecSoA::with_seed(1, 0x715);
+        stab_rz_y.sz(&q0).rz(angle, &q0).y(&q0);
+        state_rz_y.sz(&q0).rz(angle, &q0).y(&q0);
+        assert_phase_exact_state_matches(
+            &stab_rz_y.state_vector(),
+            &state_rz_y.state(),
+            "S; RZ(0.37); Y",
+        );
+    }
+
+    #[test]
+    fn negative_z_measurements_preserve_phase_when_flushing_an_existing_frame() {
+        let q0 = qid(0);
+        let mut stab_mnz = StabVec::builder(1).seed(0x715).build();
+        let mut state_mnz = StateVecSoA::with_seed(1, 0x715);
+        stab_mnz.z(&q0);
+        state_mnz.z(&q0);
+        let stab_result = stab_mnz.mnz(&q0);
+        let state_result = state_mnz.mnz(&q0);
+        assert_eq!(stab_result[0].outcome, state_result[0].outcome);
+        assert_eq!(
+            stab_result[0].is_deterministic,
+            state_result[0].is_deterministic
+        );
+        assert_phase_exact_state_matches(&stab_mnz.state_vector(), &state_mnz.state(), "Z; MNZ");
+
+        let mut stab_mpnz = StabVec::builder(1).seed(0x715).build();
+        let mut state_mpnz = StateVecSoA::with_seed(1, 0x715);
+        stab_mpnz.z(&q0);
+        state_mpnz.z(&q0);
+        let stab_result = stab_mpnz.mpnz(&q0);
+        let state_result = state_mpnz.mpnz(&q0);
+        assert_eq!(stab_result[0].outcome, state_result[0].outcome);
+        assert_eq!(
+            stab_result[0].is_deterministic,
+            state_result[0].is_deterministic
+        );
+        assert_phase_exact_state_matches(&stab_mpnz.state_vector(), &state_mpnz.state(), "Z; MPNZ");
+    }
+
+    #[test]
+    fn measurement_preserves_pending_rz_branch_phase() {
+        let q0 = qid(0);
+        let ordinary = Angle64::from_radians(0.37);
+        for (label, angles, expected_pending, expected_global_phase) in [
+            (
+                "ordinary pending RZ",
+                vec![ordinary],
+                ordinary,
+                Angle64::ZERO,
+            ),
+            (
+                "pending RZ above a half turn",
+                vec![Angle64::THREE_QUARTERS_TURN],
+                Angle64::THREE_QUARTERS_TURN,
+                Angle64::ZERO,
+            ),
+            (
+                "pending RZ at pi",
+                vec![Angle64::HALF_TURN],
+                Angle64::HALF_TURN,
+                Angle64::ZERO,
+            ),
+            (
+                "pending RZ accumulated across the 2pi wrap",
+                vec![Angle64::THREE_QUARTERS_TURN, Angle64::THREE_QUARTERS_TURN],
+                Angle64::HALF_TURN,
+                Angle64::HALF_TURN,
+            ),
+        ] {
+            let mut stab_vec = StabVec::builder(1).seed(0x714).build();
+            let mut state_vec = StateVecSoA::with_seed(1, 0x714);
+
+            stab_vec.h(&q0);
+            state_vec.h(&q0);
+            for angle in angles {
+                stab_vec.rz(angle, &q0);
+                state_vec.rz(angle, &q0);
+            }
+            assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::IDENTITY);
+            assert_eq!(stab_vec.pending_rz[0], expected_pending);
+            assert_eq!(stab_vec.global_phase, expected_global_phase);
+
+            let input = state_vec.state();
+            for outcome in [false, true] {
+                let expected = normalized_z_projection(&input, 0, outcome, label);
+                let mut measured = stab_vec.clone();
+                let result = measured.measure_qubit(0, Some(outcome));
+                assert_eq!(result.outcome, outcome);
+                assert_phase_exact_state_matches(
+                    &measured.state_vector(),
+                    &expected,
+                    &format!("{label}, outcome {outcome}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn measurement_preserves_every_diagonal_clifford_branch_phase() {
+        let q0 = qid(0);
+        for (name, frame) in [
+            ("I", CliffordFrame::IDENTITY),
+            ("Z", CliffordFrame::Z),
+            ("S", CliffordFrame::SZ),
+            ("Sdg", CliffordFrame::SZDG),
+        ] {
+            let mut stab_vec = StabVec::builder(1).seed(0x714).build();
+            let mut state_vec = StateVecSoA::with_seed(1, 0x714);
+
+            stab_vec.h(&q0);
+            stab_vec.flush_all_cliff_frames();
+            state_vec.h(&q0);
+            match frame.index() {
+                0 => {}
+                3 => {
+                    stab_vec.z(&q0);
+                    state_vec.z(&q0);
+                }
+                4 => {
+                    stab_vec.sz(&q0);
+                    state_vec.sz(&q0);
+                }
+                5 => {
+                    stab_vec.szdg(&q0);
+                    state_vec.szdg(&q0);
+                }
+                _ => unreachable!("test table contains only diagonal frames"),
+            }
+            assert_eq!(stab_vec.cliff_frame[0], frame);
+            assert_eq!(stab_vec.pending_rz[0], Angle64::ZERO);
+
+            let label = format!("diagonal {name} frame");
+            let input = state_vec.state();
+            for outcome in [false, true] {
+                let expected = normalized_z_projection(&input, 0, outcome, &label);
+                let mut measured = stab_vec.clone();
+                let result = measured.measure_qubit(0, Some(outcome));
+                assert_eq!(result.outcome, outcome);
+                assert_phase_exact_state_matches(
+                    &measured.state_vector(),
+                    &expected,
+                    &format!("{label}, outcome {outcome}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn diagonal_phase_emission_does_not_change_seeded_outcome_streams() {
+        let q0 = qid(0);
+        let angle = Angle64::from_radians(0.37);
+        let mut with_phase = Vec::with_capacity(16_750);
+        let mut without_phase = Vec::with_capacity(16_750);
+
+        for seed in 0..67 {
+            let mut phase_sim = StabVec::builder(1).seed(seed).build();
+            let mut reference_sim = StabVec::builder(1).seed(seed).build();
+            for _ in 0..250 {
+                phase_sim.h(&q0);
+                phase_sim.flush_all_cliff_frames();
+                phase_sim.sz(&q0).rz(angle, &q0);
+                with_phase.push(u8::from(phase_sim.mz(&q0)[0].outcome));
+
+                reference_sim.h(&q0);
+                without_phase.push(u8::from(reference_sim.mz(&q0)[0].outcome));
+
+                phase_sim.reset();
+                reference_sim.reset();
+            }
+        }
+
+        assert_eq!(with_phase.len(), 16_750);
+        assert_eq!(with_phase, without_phase);
     }
 
     #[test]
     fn measurement_preserves_combined_diagonal_frame_and_rz_branch_phase() {
         let q0 = qid(0);
         let angle = Angle64::from_radians(-0.43);
-        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
-        let mut state_vec = StateVecSoA::new(1);
+        let mut stab_vec = StabVec::builder(1).seed(0x714).build();
+        let mut state_vec = StateVecSoA::with_seed(1, 0x714);
 
         stab_vec.h(&q0);
         stab_vec.flush_all_cliff_frames();
@@ -2989,8 +3224,8 @@ mod tests {
         let q1 = qid(1);
         let measured_angle = Angle64::from_radians(0.37);
         let other_angle = Angle64::from_radians(0.61);
-        let mut stab_vec = StabVec::builder(3).pruning_threshold(0.0).build();
-        let mut state_vec = StateVecSoA::new(3);
+        let mut stab_vec = StabVec::builder(3).seed(0x714).build();
+        let mut state_vec = StateVecSoA::with_seed(3, 0x714);
 
         stab_vec
             .h(&q0)
@@ -3025,30 +3260,91 @@ mod tests {
     }
 
     #[test]
-    fn z_preparations_preserve_the_selected_measurement_branch_phase() {
+    fn z_preparations_preserve_both_sampled_branches_and_reference_trajectories() {
         let q0 = qid(0);
+        let q1 = qid(1);
         let angle = Angle64::from_radians(0.37);
+        let preparation_angle = Angle64::from_radians(0.8);
+        let mut workaround_complement_count = 0;
 
-        let mut stab_pz = StabVec::builder(1).pruning_threshold(0.0).build();
-        let mut state_pz = StateVecSoA::new(1);
-        stab_pz.x(&q0);
-        stab_pz.flush_all_cliff_frames();
-        stab_pz.sz(&q0).rz(angle, &q0).pz(&q0);
-        state_pz.x(&q0).sz(&q0).rz(angle, &q0).pz(&q0);
-        assert_phase_exact_state_matches(
-            &stab_pz.state_vector(),
-            &state_pz.state(),
-            "PZ after diagonal S frame and pending RZ",
-        );
+        for prepare_negative_z in [false, true] {
+            let name = if prepare_negative_z { "PNZ" } else { "PZ" };
+            let mut saw_partner_branch = [false; 2];
 
-        let mut stab_pnz = StabVec::builder(1).pruning_threshold(0.0).build();
-        let mut state_pnz = StateVecSoA::new(1);
-        stab_pnz.sz(&q0).rz(angle, &q0).pnz(&q0);
-        state_pnz.sz(&q0).rz(angle, &q0).pnz(&q0);
-        assert_phase_exact_state_matches(
-            &stab_pnz.state_vector(),
-            &state_pnz.state(),
-            "PNZ after diagonal S frame and pending RZ",
+            for seed in 0..40 {
+                let mut stab_vec = StabVec::builder(2).seed(seed).build();
+                let mut state_vec = StateVecSoA::with_seed(2, seed);
+                stab_vec
+                    .ry(preparation_angle, &q0)
+                    .cx(&[(QubitId(0), QubitId(1))])
+                    .sz(&q0)
+                    .rz(angle, &q0);
+                state_vec
+                    .ry(preparation_angle, &q0)
+                    .cx(&[(QubitId(0), QubitId(1))])
+                    .sz(&q0)
+                    .rz(angle, &q0);
+
+                let mut old_pnz_workaround = prepare_negative_z.then(|| stab_vec.clone());
+                let mut explicit_reference = stab_vec.clone();
+                if prepare_negative_z {
+                    stab_vec.pnz(&q0);
+                    explicit_reference.mpnz(&q0);
+                } else {
+                    stab_vec.pz(&q0);
+                    explicit_reference.mpz(&q0);
+                }
+
+                let actual = stab_vec.state_vector();
+                let partner_is_one = actual
+                    .iter()
+                    .enumerate()
+                    .filter(|(basis, _)| basis & (1 << q1[0].index()) != 0)
+                    .map(|(_, amplitude)| amplitude.norm_sqr())
+                    .sum::<f64>()
+                    > 0.5;
+                saw_partner_branch[usize::from(partner_is_one)] = true;
+
+                let label = format!("{name} sampled trajectory for seed {seed}");
+                let mut expected =
+                    normalized_z_projection(&state_vec.state(), 0, partner_is_one, &label);
+                if partner_is_one != prepare_negative_z {
+                    for amplitudes in expected.as_chunks_mut::<2>().0 {
+                        amplitudes.swap(0, 1);
+                    }
+                }
+                assert_phase_exact_state_matches(&actual, &expected, &label);
+                assert_phase_exact_state_matches(
+                    &actual,
+                    &explicit_reference.state_vector(),
+                    &format!("{name} reference decomposition for seed {seed}"),
+                );
+
+                if let Some(workaround) = &mut old_pnz_workaround {
+                    workaround.mpz(&q0);
+                    workaround.x(&q0);
+                    let workaround_state = workaround.state_vector();
+                    let workaround_partner_is_one = workaround_state
+                        .iter()
+                        .enumerate()
+                        .filter(|(basis, _)| basis & (1 << q1[0].index()) != 0)
+                        .map(|(_, amplitude)| amplitude.norm_sqr())
+                        .sum::<f64>()
+                        > 0.5;
+                    workaround_complement_count +=
+                        usize::from(workaround_partner_is_one != partner_is_one);
+                }
+            }
+
+            assert!(
+                saw_partner_branch.into_iter().all(std::convert::identity),
+                "{name} did not cover both nondeterministic input branches"
+            );
+        }
+
+        assert_eq!(
+            workaround_complement_count, 9,
+            "the removed MPZ; X workaround no longer witnesses the reviewed trajectory divergence"
         );
     }
 

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -764,22 +764,27 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         // Z-basis measurement on qubit q.
         // Frames and pending_rz on OTHER qubits commute with Z_q -- no flush needed.
         // Only qubit q's frame matters:
-        // - Diagonal frame (Z→+Z): discard frame.
+        // - Diagonal frame (Z→+Z): retain its selected branch's phase.
         // - Non-diagonal frame: must flush (changes measurement basis).
-        // Pending_rz on q is diagonal: doesn't affect Z measurement. Discard after.
+        // Pending_rz on q is diagonal: retain its selected branch's phase too.
         let cf_q = self.cliff_frame[q];
-        if !cf_q.is_identity() {
-            if cf_q.is_diagonal() {
-                // is_diagonal() guarantees Z→+Z, so this cannot flip the outcome.
-                self.cliff_frame[q] = CliffordFrame::IDENTITY;
-            } else {
-                // Non-diagonal: flush this qubit's frame (needs pending_rz flushed first).
-                self.flush_cliff_frame(q);
-            }
+        let discarded_diagonal_frame = if cf_q.is_diagonal() {
+            // A diagonal frame cannot flip the outcome, but its eigenvalue on
+            // the selected basis state remains as a branch-global phase.
+            self.cliff_frame[q] = CliffordFrame::IDENTITY;
+            Some(cf_q)
+        } else {
+            // Non-diagonal: flush this qubit's frame (needs pending_rz flushed first).
+            self.flush_cliff_frame(q);
+            None
+        };
+        // A non-diagonal frame flush materialized its pending RZ. Otherwise,
+        // defer the diagonal RZ eigenvalue until the outcome has been selected.
+        let discarded_pending_rz = self.pending_rz[q];
+        self.pending_rz[q] = Angle64::ZERO;
+        if discarded_diagonal_frame.is_none() {
+            debug_assert_eq!(discarded_pending_rz, Angle64::ZERO);
         }
-        // Pending RZ on q doesn't affect Z measurement. Discard it.
-        // After measurement, qubit is in Z eigenstate; pending phase is irrelevant.
-        self.pending_rz[q] = Angle64::default();
 
         // Compute probability of measuring 0. Optimized multi-term paths are
         // valid only while all terms share the CH structure they precompute.
@@ -1069,6 +1074,19 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
                 *coeff *= inv_norm;
             }
         }
+
+        // RZ(theta) = diag(exp(-i*theta/2), exp(i*theta/2)). The discarded
+        // diagonal Clifford likewise acts on the surviving basis state by a
+        // scalar eigenvalue. Preserve both through the simulator's global-phase hook.
+        let rz_branch_phase = if outcome {
+            discarded_pending_rz.signed_half()
+        } else {
+            -discarded_pending_rz.signed_half()
+        };
+        let frame_branch_phase = discarded_diagonal_frame
+            .and_then(|frame| frame.computational_basis_phase(outcome))
+            .unwrap_or(Angle64::ZERO);
+        self.apply_global_phase(rz_branch_phase + frame_branch_phase, &[QubitId(q)]);
 
         MeasurementResult {
             outcome,
@@ -1516,31 +1534,12 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         results
     }
 
-    fn pz(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // Prep |0⟩: discard diagonal frame and pending_rz (they don't survive reset).
-        for &q in qubits {
-            let qi = q.index();
-            if self.cliff_frame[qi].is_diagonal() {
-                // Diagonal frame: outcome might flip but we force |0⟩ anyway. Discard.
-                self.cliff_frame[qi] = CliffordFrame::IDENTITY;
-                self.pending_rz[qi] = Angle64::default();
-            }
-            // Non-diagonal: default mpz handles it (flushes everything).
-        }
-        self.mpz(qubits);
-        self
-    }
-
     fn pnz(&mut self, qubits: &[QubitId]) -> &mut Self {
-        // Prep |1⟩: same as pz but flip.
-        for &q in qubits {
-            let qi = q.index();
-            if self.cliff_frame[qi].is_diagonal() {
-                self.cliff_frame[qi] = CliffordFrame::IDENTITY;
-                self.pending_rz[qi] = Angle64::default();
-            }
-        }
-        self.mpnz(qubits);
+        // Prepare |1⟩ by phase-exactly projecting and preparing |0⟩, then
+        // flipping it. Because no measurement result is returned, this is
+        // equivalent to MPNZ while retaining the selected physical branch's phase.
+        self.mpz(qubits);
+        self.x(qubits);
         self
     }
 }
@@ -2873,6 +2872,184 @@ mod tests {
                  StateVecSoA={expected:.12}"
             );
         }
+    }
+
+    fn normalized_z_projection(
+        input: &[Complex64],
+        measured_qubit: usize,
+        outcome: bool,
+        label: &str,
+    ) -> Vec<Complex64> {
+        let mut projected = input.to_vec();
+        for (basis, amplitude) in projected.iter_mut().enumerate() {
+            if (((basis >> measured_qubit) & 1) != 0) != outcome {
+                *amplitude = Complex64::new(0.0, 0.0);
+            }
+        }
+        let norm = projected
+            .iter()
+            .map(Complex64::norm_sqr)
+            .sum::<f64>()
+            .sqrt();
+        assert!(
+            norm > EPS,
+            "{label}: outcome {outcome} has zero probability"
+        );
+        for amplitude in &mut projected {
+            *amplitude /= norm;
+        }
+        projected
+    }
+
+    #[test]
+    fn measurement_preserves_pending_rz_branch_phase() {
+        let q0 = qid(0);
+        let angle = Angle64::from_radians(0.37);
+        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
+        let mut state_vec = StateVecSoA::new(1);
+
+        stab_vec.h(&q0).rz(angle, &q0);
+        state_vec.h(&q0).rz(angle, &q0);
+        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::IDENTITY);
+        assert_eq!(stab_vec.pending_rz[0], angle);
+
+        let input = state_vec.state();
+        for outcome in [false, true] {
+            let expected = normalized_z_projection(&input, 0, outcome, "pending RZ");
+            let mut measured = stab_vec.clone();
+            let result = measured.measure_qubit(0, Some(outcome));
+            assert_eq!(result.outcome, outcome);
+            assert_phase_exact_state_matches(
+                &measured.state_vector(),
+                &expected,
+                &format!("pending RZ, outcome {outcome}"),
+            );
+        }
+    }
+
+    #[test]
+    fn measurement_preserves_diagonal_clifford_branch_phase() {
+        let q0 = qid(0);
+        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
+        let mut state_vec = StateVecSoA::new(1);
+
+        stab_vec.h(&q0);
+        stab_vec.flush_all_cliff_frames();
+        stab_vec.sz(&q0);
+        state_vec.h(&q0).sz(&q0);
+        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::SZ);
+        assert_eq!(stab_vec.pending_rz[0], Angle64::ZERO);
+
+        let input = state_vec.state();
+        for outcome in [false, true] {
+            let expected = normalized_z_projection(&input, 0, outcome, "diagonal S frame");
+            let mut measured = stab_vec.clone();
+            let result = measured.measure_qubit(0, Some(outcome));
+            assert_eq!(result.outcome, outcome);
+            assert_phase_exact_state_matches(
+                &measured.state_vector(),
+                &expected,
+                &format!("diagonal S frame, outcome {outcome}"),
+            );
+        }
+    }
+
+    #[test]
+    fn measurement_preserves_combined_diagonal_frame_and_rz_branch_phase() {
+        let q0 = qid(0);
+        let angle = Angle64::from_radians(-0.43);
+        let mut stab_vec = StabVec::builder(1).pruning_threshold(0.0).build();
+        let mut state_vec = StateVecSoA::new(1);
+
+        stab_vec.h(&q0);
+        stab_vec.flush_all_cliff_frames();
+        stab_vec.sz(&q0).rz(angle, &q0);
+        state_vec.h(&q0).sz(&q0).rz(angle, &q0);
+        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::SZ);
+        assert_eq!(stab_vec.pending_rz[0], angle);
+
+        let label = "diagonal S frame with pending negative RZ";
+        let input = state_vec.state();
+        for outcome in [false, true] {
+            let expected = normalized_z_projection(&input, 0, outcome, label);
+            let mut measured = stab_vec.clone();
+            let result = measured.measure_qubit(0, Some(outcome));
+            assert_eq!(result.outcome, outcome);
+            assert_phase_exact_state_matches(
+                &measured.state_vector(),
+                &expected,
+                &format!("{label}, outcome {outcome}"),
+            );
+        }
+    }
+
+    #[test]
+    fn entangled_measurement_preserves_branch_phase_with_other_amplitudes() {
+        let q0 = qid(0);
+        let q1 = qid(1);
+        let measured_angle = Angle64::from_radians(0.37);
+        let other_angle = Angle64::from_radians(0.61);
+        let mut stab_vec = StabVec::builder(3).pruning_threshold(0.0).build();
+        let mut state_vec = StateVecSoA::new(3);
+
+        stab_vec
+            .h(&q0)
+            .h(&q1)
+            .cx(&[(QubitId(0), QubitId(2))])
+            .rz(other_angle, &q1)
+            .sz(&q0)
+            .rz(measured_angle, &q0);
+        state_vec
+            .h(&q0)
+            .h(&q1)
+            .cx(&[(QubitId(0), QubitId(2))])
+            .rz(other_angle, &q1)
+            .sz(&q0)
+            .rz(measured_angle, &q0);
+        assert_eq!(stab_vec.cliff_frame[0], CliffordFrame::SZ);
+        assert_eq!(stab_vec.pending_rz[0], measured_angle);
+        assert_eq!(stab_vec.pending_rz[1], other_angle);
+
+        let input = state_vec.state();
+        for outcome in [false, true] {
+            let expected = normalized_z_projection(&input, 0, outcome, "entangled measured qubit");
+            let mut measured = stab_vec.clone();
+            let result = measured.measure_qubit(0, Some(outcome));
+            assert_eq!(result.outcome, outcome);
+            assert_phase_exact_state_matches(
+                &measured.state_vector(),
+                &expected,
+                &format!("entangled measured qubit, outcome {outcome}"),
+            );
+        }
+    }
+
+    #[test]
+    fn z_preparations_preserve_the_selected_measurement_branch_phase() {
+        let q0 = qid(0);
+        let angle = Angle64::from_radians(0.37);
+
+        let mut stab_pz = StabVec::builder(1).pruning_threshold(0.0).build();
+        let mut state_pz = StateVecSoA::new(1);
+        stab_pz.x(&q0);
+        stab_pz.flush_all_cliff_frames();
+        stab_pz.sz(&q0).rz(angle, &q0).pz(&q0);
+        state_pz.x(&q0).sz(&q0).rz(angle, &q0).pz(&q0);
+        assert_phase_exact_state_matches(
+            &stab_pz.state_vector(),
+            &state_pz.state(),
+            "PZ after diagonal S frame and pending RZ",
+        );
+
+        let mut stab_pnz = StabVec::builder(1).pruning_threshold(0.0).build();
+        let mut state_pnz = StateVecSoA::new(1);
+        stab_pnz.sz(&q0).rz(angle, &q0).pnz(&q0);
+        state_pnz.sz(&q0).rz(angle, &q0).pnz(&q0);
+        assert_phase_exact_state_matches(
+            &stab_pnz.state_vector(),
+            &state_pnz.state(),
+            "PNZ after diagonal S frame and pending RZ",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #713. Closes #715. Closes #699.

`StabVecGeneric::measure_qubit` discarded the measured qubit's pending RZ and its diagonal Clifford frame, on the reasoning that neither can affect a Z-basis outcome or its probability. Both claims are true; neither justifies dropping the phase they carry, and the post-measurement amplitudes were wrong by that factor.

Reproducer, verified before and after:

```rust
let mut a = StabVec::builder(1).seed(0x5eed).build();
a.h(&[0.into()]);
a.rz(Angle64::from_radians(0.37), &[0.into()]);
let _ = a.mz(&[0.into()]);
```

| | basis 1 amplitude |
|---|---|
| before | `1.0 + 0.0i` |
| after | `0.9829362506302315 + 0.18394653352804122i` |
| `StateVecSoA` | `0.9829362506302314 + 0.1839465335280412i` |

## The phase

With this repo's convention `RZ(theta) = diag(e^{-i*theta/2}, e^{+i*theta/2})`, the surviving branch keeps `e^{-i*theta/2}` on outcome 0 and `e^{+i*theta/2}` on outcome 1. The implementation uses `Angle64::signed_half()` so negative and principal-value angles keep the repository's exact sign convention rather than re-deriving it.

Diagonal Clifford frames are not phase-free either: `SZ = diag(1, i)`, so outcome 1 must retain `i`. The eigenphase for outcome 1 is `I -> 0`, `Z -> pi`, `S -> pi/2`, `Sdg -> -pi/2`; outcome 0 is always phase-free. The separately accumulated Clifford cocycle `frame_phase` was already retained and is untouched.

The phase is delivered through `apply_global_phase` -- available on `CliffordGateable` since #668 -- rather than described in a comment.

## Both discard sites were defective, and two more were found

An adversarial review established that the first sweep was **incomplete**, and that the remaining gap shared a root cause with the two other open phase issues. All three are fixed here.

The single underlying defect: a composed Clifford frame landing on element 2 (`Y`) was flushed via `ch.y()`, the standard Y, while the cocycle bookkeeping used `ELEMENT_MATRIX[2] = -i * Y_std`. `GATE_PHASE_DELTA[2] = 6` exists to bridge exactly that and was never applied. Separately, `x()` and `y()` negate `pending_rz` and the non-Pauli path in `flush_cliff_frame` did not undo it, while the Pauli fast paths did. Named-gate frame composition is now centralised, including `GATE_PHASE_DELTA`, and the general flush restores the pending-RZ sign from the frame's Z image.

What that fixes, each verified against `StateVecSoA` on a **superposed** input since a definite input cannot see a global phase:

- **#713**: `MZ`, `PZ` and `PNZ` keep the sampled branch's phase.
- **#715**: `x()`/`y()` no longer lose phase on a non-identity frame, so `MNZ`/`MPNZ` are exact. `Z; X` on |0> gives `[0, 1+0i]` (was `[0, 0+1i]`); `Z; MNZ` gives `[1+0i, 0]` (was `[0+1i, 0]`); `S; RZ(0.37); X` gives `0.98294-0.18395i` (the sign was flipped).
- **#699**: `y; y` is now exactly identity (maxdiff 0.0, previously `-I`), and **all 36 ordered gate pairs are correct** where that issue measured 13 of 36 wrong.

Consequently **both compensating constants are gone**. `h3` moves from `+1` to `+7`, which is what the trait documentation prescribes for `H3 = exp(-i*pi/4) * Y * SZ`, so it is now independently correct rather than absorbing the cocycle defect; `h6`'s `+2` octant compensation is replaced by an explicit `apply_global_phase(-pi/4)`.

The `pnz` override is **removed**, not re-documented. It previously routed through `MPZ; X`, which was load-bearing only because of #715 and was distribution-equivalent to `MPNZ` rather than equivalent -- 9 of 40 fixed seeds collapsed an entangled partner onto the complementary branch. `StabVec` now inherits the reference `MPNZ` decomposition, which also resolves the inconsistency where `mnz` used the reference and `pnz` did not. Those 9 seeded trajectories change deliberately, back to the reference route.

The phase-dropping `pz` shortcut is removed. No equivalent discard exists in `ch_form.rs`. `QuantumSimulator::reset()` clears phase deliberately, since it replaces the whole state.

## Why it survived

The phase is branch-dependent, so it is a global phase per shot rather than a relative one within a measurement. Probability checks cannot see it, and neither can any comparison performed "up to global phase". #601 and #668 made the named gates phase-exact and #705 added StabVec to `phase_exact_single_qubit_tests.rs` for all 24 single-qubit Cliffords -- that covers the gate path; nothing covered the measurement path.

## Tests

Full complex amplitudes against `StateVecSoA` for both outcomes, with a superposed input, since a definite input hides this entirely: pending RZ, `SZ` frame, both together with a negative angle, and a three-qubit entangled case where the surviving branch's phase is checked against other surviving amplitudes.

Mutation-verified: removing the emitted phase fails all three isolated regressions (pending-RZ outcome 0 gives `1+0i` against `0.982936-0.183947i`; `SZ` outcome 1 gives `1+0i` against `0+1i`).

Measurement statistics are unchanged -- the phase is emitted only after outcome selection, and the existing 10,000-shot and two-qubit sampling tests pass.

## Verification

`cargo test -p pecos-simulators` green in **both** debug and release (some contract assertions in this crate are `#[cfg(debug_assertions)]`), cold `cargo clippy -p pecos-simulators --all-targets --all-features -- -D warnings` exit 0, `cargo fmt --all -- --check` clean. Re-verified after merging current `dev`.

## Context

Found while building a correctness harness for #704. The harness compares full complex amplitudes against `StateVecSoA` and pins them exactly; this failed on its first run. Work on #704 was blocked on this, because pinning current behaviour would have recorded the defect as expected data.


## Review findings closed

Two mutations previously survived the entire 779-test crate suite: zeroing the `Z` eigenphase and zeroing the `Sdg` eigenphase in `computational_basis_phase`, which had **no direct unit test anywhere** and whose only coverage built `SZ` frames. There is now a direct test across all 24 frame elements checking `is_diagonal()` if and only if `Some`, with eigenvalues cross-checked against `ELEMENT_MATRIX` rather than against the function's own match arms. Both mutants now fail.

The silent `.unwrap_or(Angle64::ZERO)` on the diagonal-frame lookup is now a loud `.expect(...)`: it could not distinguish "no diagonal frame" from "a frame `is_diagonal()` accepts but which has no phase arm", and a future drift there would silently drop phase -- precisely the bug this PR fixes.

Test gaps closed: angles above a half turn, exactly pi (the `signed_half()` branch boundary), RZ accumulated across the 2pi wrap, all four diagonal frame variants on both outcomes, and `pz`/`pnz` on non-deterministic entangled qubits.

Measurement statistics remain unchanged, proven rather than argued: 16,750 outcome bits across fixed seeds are byte-identical with and without the phase emission.