### PR TITLE
Materialize a pending RZ through its deferred frame in every consumer

### DIFF
--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -441,14 +441,35 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         }
     }
 
-    /// Flush pending RZ on a specific qubit.
+    /// Flush pending RZ on a specific qubit through its deferred Clifford frame.
     fn flush_pending_rz(&mut self, q: usize) {
-        let angle = self.pending_rz[q];
-        if angle == Angle64::default() {
+        let pending_angle = self.pending_rz[q];
+        if pending_angle == Angle64::default() {
             return;
         }
+
+        // The represented state is RZ(p) F |stored>. To retain F while
+        // materializing the rotation, apply
+        //
+        //     F^-1 RZ(p) F = RZ(s p)
+        //
+        // to |stored>, where F^-1 Z F = s Z. A pending RZ can coexist only
+        // with a frame that preserves the Z axis. X/Y composition already
+        // negated p when it moved the Pauli to the right of the rotation, so
+        // the negative Z image here restores the angle needed on |stored>.
+        let z_image = self.cliff_frame[q].z_image();
+        debug_assert_eq!(
+            z_image.axis,
+            crate::clifford_frame::PauliAxis::Z,
+            "a pending RZ requires a frame that preserves the Z axis"
+        );
+        let materialized_angle = if z_image.positive {
+            pending_angle
+        } else {
+            -pending_angle
+        };
         self.pending_rz[q] = Angle64::default();
-        self.apply_rz_immediate(angle, q);
+        self.apply_rz_immediate(materialized_angle, q);
     }
 
     /// Materialize a pending RZ together with its current Clifford frame before
@@ -477,25 +498,25 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
         if cf.is_identity() {
             return;
         }
-        self.cliff_frame[q] = CliffordFrame::IDENTITY;
 
         // Fast paths for common frames (avoid GENERATORS lookup overhead).
         let qid = QubitId(q);
         if cf.is_pauli() {
+            // X and Y carry an angle negation paired with the frame. Consume
+            // that pair while the frame is still visible to flush_pending_rz.
+            if matches!(cf.index(), 1 | 2) {
+                self.flush_pending_rz(q);
+            }
+            self.cliff_frame[q] = CliffordFrame::IDENTITY;
+
             // Paulis: diagonal part is cheap, non-diagonal part uses X/Y gate.
             match cf.index() {
                 1 => {
-                    // X: must flush pending_rz (X anticommutes with RZ)
-                    self.pending_rz[q] = -self.pending_rz[q];
-                    self.flush_pending_rz(q);
                     self.apply_clifford(|ch| {
                         ch.x(&[qid]);
                     });
                 }
                 2 => {
-                    // Y: anticommutes with RZ
-                    self.pending_rz[q] = -self.pending_rz[q];
-                    self.flush_pending_rz(q);
                     self.apply_clifford(|ch| {
                         ch.y(&[qid]);
                     });
@@ -516,24 +537,10 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             return;
         }
 
-        // A pending RZ can coexist only with a frame that preserves the Z axis.
-        // Anti-diagonal frames carry the sign negation performed by X/Y
-        // composition; restore it before materializing the frame to the right
-        // of the RZ. The Pauli X/Y fast paths above do the same thing.
-        if self.pending_rz[q] != Angle64::ZERO {
-            let z_image = cf.z_image();
-            debug_assert_eq!(
-                z_image.axis,
-                crate::clifford_frame::PauliAxis::Z,
-                "a pending RZ requires a frame that preserves the Z axis"
-            );
-            if !z_image.positive {
-                self.pending_rz[q] = -self.pending_rz[q];
-            }
-        }
-
         // Flush pending RZ first (non-diagonal Cliffords don't commute with RZ).
+        // Keep the frame visible until the paired angle has been materialized.
         self.flush_pending_rz(q);
+        self.cliff_frame[q] = CliffordFrame::IDENTITY;
 
         // General path: apply via H+S generator decomposition.
         let idx = cf.index() as usize;
@@ -647,6 +654,28 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             ch.apply_gamma_delta(&delta);
             ch.set_shared_m(shared_m.clone());
         }
+    }
+
+    /// Apply an XX root to stored terms after its caller has handled frames.
+    /// YY roots reuse this decomposition without propagating their frames again.
+    fn apply_xx_root(&mut self, pairs: &[(QubitId, QubitId)], dagger: bool) {
+        let q0s: Vec<QubitId> = pairs.iter().map(|p| p.0).collect();
+        let q1s: Vec<QubitId> = pairs.iter().map(|p| p.1).collect();
+        self.apply_clifford(|ch| {
+            ch.h(&q0s);
+            ch.h(&q1s);
+        });
+        self.apply_c_type_clifford(|ch| {
+            if dagger {
+                ch.szzdg(pairs);
+            } else {
+                ch.szz(pairs);
+            }
+        });
+        self.apply_clifford(|ch| {
+            ch.h(&q0s);
+            ch.h(&q1s);
+        });
     }
 
     /// Buffer an RZ gate. Fuses with any pending RZ on the same qubit.
@@ -771,23 +800,6 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             self.terms.push((z_coeff, ch_z));
             self.terms[i].0 *= cos_half_val;
         }
-    }
-
-    /// Apply RX(theta) on a qubit.
-    ///
-    /// RX(theta) = H * RZ(theta) * H
-    #[allow(dead_code)]
-    fn apply_rx(&mut self, theta: Angle64, q: usize) {
-        self.h(&[QubitId(q)]);
-        self.apply_rz(theta, q);
-        self.h(&[QubitId(q)]);
-    }
-
-    #[allow(dead_code)]
-    fn apply_rzz(&mut self, theta: Angle64, q0: usize, q1: usize) {
-        self.cx(&[(QubitId(q0), QubitId(q1))]);
-        self.apply_rz(theta, q1);
-        self.cx(&[(QubitId(q0), QubitId(q1))]);
     }
 
     /// Measure a qubit. Returns the measurement result and projects the state.
@@ -1302,6 +1314,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let c = q0.index();
             let t = q1.index();
+            // A target RZ does not commute with CX. Materialize it against the
+            // frame it is paired with, before CX propagation changes that frame.
+            self.flush_pending_rz(t);
             let fc = self.cliff_frame[c];
             let ft = self.cliff_frame[t];
             if fc.is_pauli() && ft.is_pauli() {
@@ -1313,7 +1328,6 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
                 self.flush_cliff_frame(c);
                 self.flush_cliff_frame(t);
             }
-            self.flush_pending_rz(t);
         }
         self.apply_clifford(|ch| {
             ch.cx(pairs);
@@ -1409,19 +1423,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             }
         }
         // SXX = H*H * SZZ * H*H
-        let q0s: Vec<QubitId> = pairs.iter().map(|p| p.0).collect();
-        let q1s: Vec<QubitId> = pairs.iter().map(|p| p.1).collect();
-        self.apply_clifford(|ch| {
-            ch.h(&q0s);
-            ch.h(&q1s);
-        });
-        self.apply_c_type_clifford(|ch| {
-            ch.szz(pairs);
-        });
-        self.apply_clifford(|ch| {
-            ch.h(&q0s);
-            ch.h(&q1s);
-        });
+        self.apply_xx_root(pairs, false);
         self
     }
 
@@ -1444,19 +1446,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
                 self.flush_cliff_frame(r);
             }
         }
-        let q0s: Vec<QubitId> = pairs.iter().map(|p| p.0).collect();
-        let q1s: Vec<QubitId> = pairs.iter().map(|p| p.1).collect();
-        self.apply_clifford(|ch| {
-            ch.h(&q0s);
-            ch.h(&q1s);
-        });
-        self.apply_c_type_clifford(|ch| {
-            ch.szzdg(pairs);
-        });
-        self.apply_clifford(|ch| {
-            ch.h(&q0s);
-            ch.h(&q1s);
-        });
+        self.apply_xx_root(pairs, true);
         self
     }
 
@@ -1464,6 +1454,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let q = q0.index();
             let r = q1.index();
+            for target in [q, r] {
+                self.flush_noncommuting_pending_rz(target);
+            }
             let fq = self.cliff_frame[q];
             let fr = self.cliff_frame[r];
             if fq.is_pauli() && fr.is_pauli() {
@@ -1481,7 +1474,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         self.apply_c_type_clifford(|ch| {
             ch.sz(&all_qubits);
         });
-        self.sxx(pairs);
+        self.apply_xx_root(pairs, false);
         self.apply_c_type_clifford(|ch| {
             ch.szdg(&all_qubits);
         });
@@ -1492,6 +1485,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let q = q0.index();
             let r = q1.index();
+            for target in [q, r] {
+                self.flush_noncommuting_pending_rz(target);
+            }
             let fq = self.cliff_frame[q];
             let fr = self.cliff_frame[r];
             if fq.is_pauli() && fr.is_pauli() {
@@ -1508,7 +1504,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         self.apply_c_type_clifford(|ch| {
             ch.sz(&all_qubits);
         });
-        self.sxxdg(pairs);
+        self.apply_xx_root(pairs, true);
         self.apply_c_type_clifford(|ch| {
             ch.szdg(&all_qubits);
         });
@@ -1517,6 +1513,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
 
     fn cy(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         for &(q0, q1) in pairs {
+            // Target RZ does not commute with CY. An identity or Z frame
+            // flush would leave it pending, so consume it explicitly.
+            self.flush_pending_rz(q1.index());
             self.flush_cliff_frame(q0.index());
             self.flush_cliff_frame(q1.index());
         }

--- a/crates/pecos-simulators/tests/stab_vec_pending_rz_frame.rs
+++ b/crates/pecos-simulators/tests/stab_vec_pending_rz_frame.rs
@@ -1,0 +1,555 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at https://www.apache.org/licenses/LICENSE-2.0
+
+//! Differential coverage for pending RZ rotations paired with deferred Clifford frames.
+
+use num_complex::Complex64;
+use pecos_core::{Angle64, QubitId};
+use pecos_simulators::state_vector_test_utils::assert_phase_exact_state_matches;
+use pecos_simulators::{ArbitraryRotationGateable, CliffordGateable, StabVec, StateVecSoA};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+const TOLERANCE: f64 = 1e-12;
+
+fn qid(index: usize) -> [QubitId; 1] {
+    [QubitId(index)]
+}
+
+#[test]
+fn cx_materializes_x_negated_pending_rz_with_its_frame() {
+    let mut stab = StabVec::builder(5).pruning_threshold(0.0).seed(7).build();
+    let mut dense = StateVecSoA::with_seed(5, 7);
+
+    stab.h(&qid(3));
+    dense.h(&qid(3));
+    stab.cx(&[(QubitId(3), QubitId(1))]);
+    dense.cx(&[(QubitId(3), QubitId(1))]);
+    stab.cx(&[(QubitId(1), QubitId(2))]);
+    dense.cx(&[(QubitId(1), QubitId(2))]);
+    let angle = Angle64::from_radians(std::f64::consts::FRAC_PI_4);
+    stab.rz(angle, &qid(2)).x(&qid(2));
+    dense.rz(angle, &qid(2)).x(&qid(2));
+
+    // Observe the state without disturbing the deferred frame/rotation in the
+    // simulator used below. Control qubit 4 is |0>, so the final CX is identity.
+    let before_final_cx = stab.clone().state_vector();
+    stab.cx(&[(QubitId(4), QubitId(2))]);
+    dense.cx(&[(QubitId(4), QubitId(2))]);
+
+    let actual = stab.state_vector();
+    let expected = dense.state();
+    assert_phase_exact_state_matches(
+        &actual,
+        &before_final_cx,
+        TOLERANCE,
+        "CX with a zero control changed the StabVec state",
+    );
+    assert_phase_exact_state_matches(
+        &actual,
+        &expected,
+        TOLERANCE,
+        "StabVec pending-RZ/frame CX regression",
+    );
+}
+
+fn prepare_negated_pending_rotations(stab: &mut StabVec, dense: &mut StateVecSoA) {
+    stab.h(&qid(0)).sz(&qid(0)).h(&qid(1)).szdg(&qid(1));
+    dense.h(&qid(0)).sz(&qid(0)).h(&qid(1)).szdg(&qid(1));
+    stab.cx(&[(QubitId(0), QubitId(1))]);
+    dense.cx(&[(QubitId(0), QubitId(1))]);
+
+    // Start the scenario from a materialized, phase-exact entangled state.
+    let actual_input = stab.state_vector();
+    let expected_input = dense.state();
+    assert_phase_exact_state_matches(
+        &actual_input,
+        &expected_input,
+        TOLERANCE,
+        "two-qubit pending-RZ test input",
+    );
+
+    let x_angle = Angle64::from_radians(0.37);
+    let y_angle = Angle64::from_radians(-0.53);
+    stab.rz(x_angle, &qid(0))
+        .x(&qid(0))
+        .rz(y_angle, &qid(1))
+        .y(&qid(1));
+    dense
+        .rz(x_angle, &qid(0))
+        .x(&qid(0))
+        .rz(y_angle, &qid(1))
+        .y(&qid(1));
+}
+
+#[test]
+fn public_pending_rz_flush_keeps_each_negated_angle_with_its_frame() {
+    let mut stab = StabVec::builder(2)
+        .pruning_threshold(0.0)
+        .seed(0x720)
+        .build();
+    let mut dense = StateVecSoA::with_seed(2, 0x720);
+    prepare_negated_pending_rotations(&mut stab, &mut dense);
+
+    stab.flush_all_pending_rz();
+    assert_phase_exact_state_matches(
+        &stab.state_vector(),
+        &dense.state(),
+        TOLERANCE,
+        "public pending-RZ flush",
+    );
+}
+
+#[test]
+fn cy_materializes_target_rz_even_with_an_identity_or_z_frame() {
+    for z_frame in [false, true] {
+        let mut stab = StabVec::builder(2).pruning_threshold(0.0).seed(7).build();
+        let mut dense = StateVecSoA::with_seed(2, 7);
+        stab.h(&qid(0)).h(&qid(1));
+        dense.h(&qid(0)).h(&qid(1));
+        let angle = Angle64::from_radians(0.37);
+        stab.rz(angle, &qid(1));
+        dense.rz(angle, &qid(1));
+        if z_frame {
+            stab.z(&qid(1));
+            dense.z(&qid(1));
+        }
+        stab.cy(&[(QubitId(0), QubitId(1))]);
+        dense.cy(&[(QubitId(0), QubitId(1))]);
+        assert_phase_exact_state_matches(
+            &stab.state_vector(),
+            &dense.state(),
+            TOLERANCE,
+            &format!("CY with pending target RZ, Z frame={z_frame}"),
+        );
+    }
+}
+
+fn apply_z_axis_frame<S: CliffordGateable>(sim: &mut S, frame: usize, q: usize) {
+    for _ in 0..frame % 4 {
+        sim.sz(&qid(q));
+    }
+    if frame >= 4 {
+        sim.x(&qid(q));
+    }
+}
+
+#[test]
+fn public_flush_and_measurement_preserve_all_z_axis_frames() {
+    // S^k and X S^k exhaust the eight frames compatible with a pending RZ.
+    for frame in 0..8 {
+        for seed in 0..16 {
+            let mut stab = StabVec::builder(2)
+                .pruning_threshold(0.0)
+                .seed(seed)
+                .build();
+            let mut dense = StateVecSoA::with_seed(2, seed);
+            prepare_negated_pending_rotations(&mut stab, &mut dense);
+            apply_z_axis_frame(&mut stab, frame, 0);
+            apply_z_axis_frame(&mut dense, frame, 0);
+
+            let label = format!("Z-axis frame {frame}, seed {seed}");
+            let mut flushed = stab.clone();
+            flushed.flush_all_pending_rz();
+            assert_phase_exact_state_matches(
+                &flushed.state_vector(),
+                &dense.state(),
+                TOLERANCE,
+                &label,
+            );
+
+            // Compare with the dense state's normalized projection onto the
+            // sampled branch. The other qubit's RZ/frame remains deferred.
+            let outcome = stab.mz(&qid(0))[0].outcome;
+            let mut projected = dense.state();
+            for (index, amplitude) in projected.iter_mut().enumerate() {
+                if (index & 1 != 0) != outcome {
+                    *amplitude = Complex64::new(0.0, 0.0);
+                }
+            }
+            let norm = projected
+                .iter()
+                .map(Complex64::norm_sqr)
+                .sum::<f64>()
+                .sqrt();
+            assert!(norm > TOLERANCE, "{label}: sampled an impossible outcome");
+            for amplitude in &mut projected {
+                *amplitude /= norm;
+            }
+            assert_phase_exact_state_matches(&stab.state_vector(), &projected, TOLERANCE, &label);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TwoQubitGate {
+    Cx,
+    Cy,
+    Cz,
+    Swap,
+    Sxx,
+    Sxxdg,
+    Syy,
+    Syydg,
+    Szz,
+    Szzdg,
+    Iswap,
+    Iswapdg,
+    G,
+    Gdg,
+    Rxx,
+    Ryy,
+    Rzz,
+    Rxxryyrzz,
+    U2q,
+}
+
+fn apply_two_qubit_gate<S>(simulator: &mut S, gate: TwoQubitGate)
+where
+    S: ArbitraryRotationGateable + CliffordGateable,
+{
+    let pair = [(QubitId(0), QubitId(1))];
+    match gate {
+        TwoQubitGate::Cx => {
+            simulator.cx(&pair);
+        }
+        TwoQubitGate::Cy => {
+            simulator.cy(&pair);
+        }
+        TwoQubitGate::Cz => {
+            simulator.cz(&pair);
+        }
+        TwoQubitGate::Swap => {
+            simulator.swap(&pair);
+        }
+        TwoQubitGate::Sxx => {
+            simulator.sxx(&pair);
+        }
+        TwoQubitGate::Sxxdg => {
+            simulator.sxxdg(&pair);
+        }
+        TwoQubitGate::Syy => {
+            simulator.syy(&pair);
+        }
+        TwoQubitGate::Syydg => {
+            simulator.syydg(&pair);
+        }
+        TwoQubitGate::Szz => {
+            simulator.szz(&pair);
+        }
+        TwoQubitGate::Szzdg => {
+            simulator.szzdg(&pair);
+        }
+        TwoQubitGate::Iswap => {
+            simulator.iswap(&pair);
+        }
+        TwoQubitGate::Iswapdg => {
+            simulator.iswapdg(&pair);
+        }
+        TwoQubitGate::G => {
+            simulator.g(&pair);
+        }
+        TwoQubitGate::Gdg => {
+            simulator.gdg(&pair);
+        }
+        TwoQubitGate::Rxx => {
+            simulator.rxx(Angle64::from_radians(0.31), &pair);
+        }
+        TwoQubitGate::Ryy => {
+            simulator.ryy(Angle64::from_radians(0.31), &pair);
+        }
+        TwoQubitGate::Rzz => {
+            simulator.rzz(Angle64::from_radians(0.31), &pair);
+        }
+        TwoQubitGate::Rxxryyrzz => {
+            simulator.rxxryyrzz(
+                Angle64::from_radians(0.31),
+                Angle64::from_radians(-0.47),
+                Angle64::from_radians(0.23),
+                &pair,
+            );
+        }
+        TwoQubitGate::U2q => {
+            let angles = [0.31, -0.47, 0.23].map(Angle64::from_radians);
+            simulator.u2q([angles; 2], angles, [angles; 2], &pair);
+        }
+    }
+}
+
+#[test]
+fn two_qubit_paths_preserve_x_and_y_negated_pending_rz_pairings() {
+    for gate in [
+        TwoQubitGate::Cx,
+        TwoQubitGate::Cy,
+        TwoQubitGate::Cz,
+        TwoQubitGate::Swap,
+        TwoQubitGate::Sxx,
+        TwoQubitGate::Sxxdg,
+        TwoQubitGate::Syy,
+        TwoQubitGate::Syydg,
+        TwoQubitGate::Szz,
+        TwoQubitGate::Szzdg,
+        TwoQubitGate::Iswap,
+        TwoQubitGate::Iswapdg,
+        TwoQubitGate::G,
+        TwoQubitGate::Gdg,
+        TwoQubitGate::Rxx,
+        TwoQubitGate::Ryy,
+        TwoQubitGate::Rzz,
+        TwoQubitGate::Rxxryyrzz,
+        TwoQubitGate::U2q,
+    ] {
+        let mut stab = StabVec::builder(2)
+            .pruning_threshold(0.0)
+            .seed(0x720)
+            .build();
+        let mut dense = StateVecSoA::with_seed(2, 0x720);
+        prepare_negated_pending_rotations(&mut stab, &mut dense);
+
+        apply_two_qubit_gate(&mut stab, gate);
+        apply_two_qubit_gate(&mut dense, gate);
+        assert_phase_exact_state_matches(
+            &stab.state_vector(),
+            &dense.state(),
+            TOLERANCE,
+            &format!("{gate:?} with X/Y-negated pending rotations"),
+        );
+    }
+}
+
+#[test]
+fn yy_roots_propagate_unflushed_partner_frames_once() {
+    for gate in [TwoQubitGate::Syy, TwoQubitGate::Syydg] {
+        for rotated in 0..2 {
+            for pauli in [
+                CliffordTGate::X(1 - rotated),
+                CliffordTGate::Y(1 - rotated),
+                CliffordTGate::Z(1 - rotated),
+            ] {
+                let mut stab = StabVec::builder(2).pruning_threshold(0.0).seed(7).build();
+                let mut dense = StateVecSoA::with_seed(2, 7);
+                stab.h(&qid(0)).h(&qid(1));
+                dense.h(&qid(0)).h(&qid(1));
+                // Materialize preparation, then leave a pending RZ on just one
+                // qubit and an independent Pauli frame on the other.
+                assert_phase_exact_state_matches(
+                    &stab.state_vector(),
+                    &dense.state(),
+                    TOLERANCE,
+                    "YY root input",
+                );
+                let angle = Angle64::from_radians(0.37);
+                stab.rz(angle, &qid(rotated)).x(&qid(rotated));
+                dense.rz(angle, &qid(rotated)).x(&qid(rotated));
+                apply_gate(&mut stab, pauli);
+                apply_gate(&mut dense, pauli);
+                apply_two_qubit_gate(&mut stab, gate);
+                apply_two_qubit_gate(&mut dense, gate);
+                assert_phase_exact_state_matches(
+                    &stab.state_vector(),
+                    &dense.state(),
+                    TOLERANCE,
+                    &format!("{gate:?}, RZ on {rotated}, partner {pauli:?}"),
+                );
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CliffordTGate {
+    H(usize),
+    S(usize),
+    Sdg(usize),
+    Z(usize),
+    X(usize),
+    Y(usize),
+    Sx(usize),
+    Cx(usize, usize),
+    Cz(usize, usize),
+    T(usize),
+    Tdg(usize),
+}
+
+fn random_gate(rng: &mut StdRng, num_qubits: usize) -> CliffordTGate {
+    let q = rng.random_range(0..num_qubits);
+    match rng.random_range(0..11) {
+        0 => CliffordTGate::H(q),
+        1 => CliffordTGate::S(q),
+        2 => CliffordTGate::Sdg(q),
+        3 => CliffordTGate::Z(q),
+        4 => CliffordTGate::X(q),
+        5 => CliffordTGate::Y(q),
+        6 => CliffordTGate::Sx(q),
+        7 => {
+            let mut target = rng.random_range(0..num_qubits - 1);
+            if target >= q {
+                target += 1;
+            }
+            CliffordTGate::Cx(q, target)
+        }
+        8 => {
+            let mut other = rng.random_range(0..num_qubits - 1);
+            if other >= q {
+                other += 1;
+            }
+            CliffordTGate::Cz(q, other)
+        }
+        9 => CliffordTGate::T(q),
+        _ => CliffordTGate::Tdg(q),
+    }
+}
+
+fn apply_gate<S>(simulator: &mut S, gate: CliffordTGate)
+where
+    S: ArbitraryRotationGateable + CliffordGateable,
+{
+    match gate {
+        CliffordTGate::H(q) => {
+            simulator.h(&qid(q));
+        }
+        CliffordTGate::S(q) => {
+            simulator.sz(&qid(q));
+        }
+        CliffordTGate::Sdg(q) => {
+            simulator.szdg(&qid(q));
+        }
+        CliffordTGate::Z(q) => {
+            simulator.z(&qid(q));
+        }
+        CliffordTGate::X(q) => {
+            simulator.x(&qid(q));
+        }
+        CliffordTGate::Y(q) => {
+            simulator.y(&qid(q));
+        }
+        CliffordTGate::Sx(q) => {
+            simulator.sx(&qid(q));
+        }
+        CliffordTGate::Cx(control, target) => {
+            simulator.cx(&[(QubitId(control), QubitId(target))]);
+        }
+        CliffordTGate::Cz(q0, q1) => {
+            simulator.cz(&[(QubitId(q0), QubitId(q1))]);
+        }
+        CliffordTGate::T(q) => {
+            simulator.t(&qid(q));
+        }
+        CliffordTGate::Tdg(q) => {
+            simulator.tdg(&qid(q));
+        }
+    }
+}
+
+fn max_amplitude_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+    assert_eq!(actual.len(), expected.len());
+    assert!(!expected.is_empty());
+    assert!(
+        actual
+            .iter()
+            .chain(expected)
+            .all(|z| z.re.is_finite() && z.im.is_finite())
+    );
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
+fn max_phase_aligned_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+    let (reference_index, _) = expected
+        .iter()
+        .enumerate()
+        .max_by(|(_, lhs), (_, rhs)| lhs.norm_sqr().total_cmp(&rhs.norm_sqr()))
+        .expect("a nonempty reference state");
+    if actual[reference_index].norm() <= TOLERANCE {
+        return f64::INFINITY;
+    }
+    let ratio = expected[reference_index] / actual[reference_index];
+    // Remove only a unit scalar: a norm error must remain a failing error.
+    let phase = ratio / ratio.norm();
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (phase * actual - expected).norm())
+        .fold(0.0, f64::max)
+}
+
+#[test]
+fn phase_alignment_removes_only_global_phase() {
+    let a = Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+    let expected = [a, a];
+    let global = [a * Complex64::i(), a * Complex64::i()];
+    assert!(max_amplitude_error(&global, &expected) > TOLERANCE);
+    assert!(max_phase_aligned_error(&global, &expected) <= TOLERANCE);
+    for wrong in [[a, -a], [2.0 * a, 2.0 * a], [a, Complex64::new(0.0, 0.0)]] {
+        assert!(max_phase_aligned_error(&wrong, &expected) > TOLERANCE);
+    }
+}
+
+#[test]
+fn seeded_random_clifford_t_circuits_match_after_global_phase_alignment() {
+    const NUM_QUBITS: usize = 5;
+    const DEPTH: usize = 30;
+    const CIRCUITS: usize = 200;
+
+    let mut rng = StdRng::seed_from_u64(0x720_C11F_F04D);
+    let mut raw_mismatches = 0;
+    let mut global_phase_only_mismatches = 0;
+    let mut aligned_mismatches = 0;
+    let mut worst_aligned_error = 0.0_f64;
+    let mut worst_circuit = 0;
+    let mut worst_gates = Vec::new();
+
+    for circuit_index in 0..CIRCUITS {
+        let gates: Vec<_> = (0..DEPTH)
+            .map(|_| random_gate(&mut rng, NUM_QUBITS))
+            .collect();
+        let mut stab = StabVec::builder(NUM_QUBITS)
+            .pruning_threshold(0.0)
+            .seed(circuit_index as u64)
+            .build();
+        let mut dense = StateVecSoA::with_seed(NUM_QUBITS, circuit_index as u64);
+        for &gate in &gates {
+            apply_gate(&mut stab, gate);
+            apply_gate(&mut dense, gate);
+        }
+
+        let actual = stab.state_vector();
+        let expected = dense.state();
+        let raw_error = max_amplitude_error(&actual, &expected);
+        let aligned_error = max_phase_aligned_error(&actual, &expected);
+        if raw_error > TOLERANCE {
+            raw_mismatches += 1;
+            if aligned_error <= TOLERANCE {
+                global_phase_only_mismatches += 1;
+            }
+        }
+        if aligned_error > TOLERANCE {
+            aligned_mismatches += 1;
+        }
+        if aligned_error > worst_aligned_error {
+            worst_aligned_error = aligned_error;
+            worst_circuit = circuit_index;
+            worst_gates = gates;
+        }
+    }
+
+    eprintln!(
+        "random Clifford+T differential: raw={raw_mismatches}/{CIRCUITS}, \
+         global-phase-only={global_phase_only_mismatches}/{CIRCUITS}, \
+         aligned={aligned_mismatches}/{CIRCUITS}, \
+         worst-aligned={worst_aligned_error:e} at circuit {worst_circuit}"
+    );
+    assert_eq!(
+        aligned_mismatches, 0,
+        "{aligned_mismatches}/{CIRCUITS} random circuits still differ after removing global phase; \
+         worst error {worst_aligned_error:e} at circuit {worst_circuit} \
+         ({raw_mismatches} raw mismatches, {global_phase_only_mismatches} global-phase-only); \
+         seed=0x720_C11F_F04D, gates={worst_gates:?}"
+    );
+}


### PR DESCRIPTION
Closes #720.

## The defect

`StabVecGeneric` conjugated a pending RZ when a two-qubit gate targeted a qubit whose rotation had been negated by a preceding `x()` or `y()`. Six gates reproduce it:

```rust
sv.h(&[3.into()]);
sv.cx(&[(3.into(), 1.into())]);
sv.cx(&[(1.into(), 2.into())]);
sv.rz(Angle64::from_radians(std::f64::consts::FRAC_PI_4), &[2.into()]);
sv.x(&[2.into()]);
sv.cx(&[(4.into(), 2.into())]);
```

Qubit 4 is never operated on, so it is `|0>` and that CX is the **identity**. Without it StabVec matched `StateVecSoA` exactly; with it every imaginary part sign-flipped. A no-op gate changed the state, so this was not a phase convention.

## The fix

`x()` and `y()` negate the target's `pending_rz`, and that negation is only correct paired with the frame that accompanies it (`X · RZ(theta) == RZ(-theta) · X`). Consumers that materialised the rotation while the frame was still deferred applied it with the wrong sign.

Rather than patch `cx`, the fix is central: `flush_pending_rz` now materialises through the frame's Z image, applying `F^-1 RZ(p) F = RZ(s p)` where `F^-1 Z F = s Z`, with a debug assertion that a pending RZ only coexists with a Z-axis-preserving frame. Every consumer is fixed at once. #714 fixed this same pairing for one consumer (#715); this closes the class.

## The audit found two more defects

Every consumer that materialises a pending rotation and every two-qubit path was enumerated:

- **CY** left an RZ buffered across `I`/`Z` target frames. Fixed with explicit central target flushing; control handling was already correct.
- **SYY/SYYdg** propagated an unflushed partner frame twice through nested frame-aware SXX. Fixed with a shared stored-term helper.

Also removed two unused private methods, `apply_rx` and `apply_rzz`, which bypassed the public RZ frame checks and had no callers -- latent instances of the same hazard.

Sites confirmed already correct and left alone: CX control (its RZ commutes), CZ and SZZ/SZZdg (both rotations commute, propagation preserves Z signs), SXX/SXXdg, diagonal-frame measurement (direct buffer consumption was correct), G/Gdg, SWAP and iSWAP (inherit the corrected CX), and the RZZ/RXX/RYY and `u2q` compositions.

## Results

Randomized sweep, 200 five-qubit depth-30 Clifford+T circuits, compared against `StateVecSoA` on full complex amplitudes:

| | raw mismatches | genuine (after removing global phase) |
|---|---:|---:|
| before | 20/200 | **4/200** |
| after | 12/200 | **0/200**, worst error exactly `0` |

The six-gate reproducer now matches exactly. Mutation-verified: reverting the central fix fails the new tests, and a partial revert (central sign only) produces 44 aligned failures.

A seeded randomized differential sweep is now committed in `tests/stab_vec_pending_rz_frame.rs` -- this defect class has escaped hand-written tests three times (#713, #715, #720), so the suite now has coverage that does not depend on someone guessing the gate combination. It runs in about 0.02 s in release and asserts only on failures that survive removing a global phase.

## Remaining residual is a separate issue

The 12 remaining raw mismatches are **all pure global `-1` factors**, reproducible in three Clifford gates with no rotations at all (`X(0); X(1); CZ(0,1)`). Filed separately as **#721**; untouched here.

## Verification

`cargo test -p pecos-simulators` green in both debug and release, the slow pinned harness case passes in both, cold `cargo clippy --all-targets --all-features -- -D warnings` exit 0, `pre-commit run --all-files` exit 0 with nothing modified.

The #716 correctness harness and its reference data are **byte-unchanged** -- verified against a hash recorded before the work began. `regenerate_reference_data` was never invoked.