### PR TITLE
Correct the deferred Clifford frame's CX and CZ phase rules for its Pauli convention

### DIFF
--- a/crates/pecos-core/src/clifford.rs
+++ b/crates/pecos-core/src/clifford.rs
@@ -269,6 +269,76 @@ impl Clifford {
         self.num_qubits() == 2
     }
 
+    /// Returns the canonical phase-fixed matrix for a named two-qubit Clifford.
+    ///
+    /// Rows and columns use `|q0 q1>` order, with q0 the most significant bit.
+    /// Controlled gates embed the canonical Pauli table; roots reuse the
+    /// `GateType` table. SWAP exchanges `|01>` and `|10>`, iSWAP multiplies
+    /// those exchanges by i, and G is CZ (H tensor H) CZ. Daggers are adjoints.
+    #[must_use]
+    pub const fn canonical_2q_matrix(self) -> Option<crate::gate_type::TwoQubitGateMatrix> {
+        let mut matrix = [0.0; 32];
+        match self {
+            Self::CX | Self::CY | Self::CZ => {
+                let pauli = match self {
+                    Self::CX => gate_type_matrix(GateType::X),
+                    Self::CY => gate_type_matrix(GateType::Y),
+                    _ => gate_type_matrix(GateType::Z),
+                };
+                matrix[0] = 1.0;
+                matrix[10] = 1.0;
+                let mut row = 0;
+                while row < 2 {
+                    let mut col = 0;
+                    while col < 2 {
+                        let dst = 2 * (4 * (row + 2) + col + 2);
+                        let src = 2 * (2 * row + col);
+                        matrix[dst] = pauli[src];
+                        matrix[dst + 1] = pauli[src + 1];
+                        col += 1;
+                    }
+                    row += 1;
+                }
+            }
+            Self::SWAP | Self::ISWAP | Self::ISWAPdg => {
+                matrix[0] = 1.0;
+                matrix[30] = 1.0;
+                if matches!(self, Self::SWAP) {
+                    matrix[12] = 1.0;
+                    matrix[18] = 1.0;
+                } else {
+                    let sign = if matches!(self, Self::ISWAP) {
+                        1.0
+                    } else {
+                        -1.0
+                    };
+                    matrix[13] = sign;
+                    matrix[19] = sign;
+                }
+            }
+            Self::G | Self::Gdg => {
+                // G is real, symmetric and self-inverse.
+                let entries = [
+                    0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5,
+                    0.5,
+                ];
+                let mut i = 0;
+                while i < 16 {
+                    matrix[2 * i] = entries[i];
+                    i += 1;
+                }
+            }
+            Self::SXX => return GateType::SXX.canonical_2q_matrix(),
+            Self::SXXdg => return GateType::SXXdg.canonical_2q_matrix(),
+            Self::SYY => return GateType::SYY.canonical_2q_matrix(),
+            Self::SYYdg => return GateType::SYYdg.canonical_2q_matrix(),
+            Self::SZZ => return GateType::SZZ.canonical_2q_matrix(),
+            Self::SZZdg => return GateType::SZZdg.canonical_2q_matrix(),
+            _ => return None,
+        }
+        Some(matrix)
+    }
+
     /// Returns the canonical phase-fixed matrix for a single-qubit Clifford.
     ///
     /// Each representative has its exact Clifford-group order: H is H1 and

--- a/crates/pecos-core/src/clifford.rs
+++ b/crates/pecos-core/src/clifford.rs
@@ -275,6 +275,10 @@ impl Clifford {
     /// Controlled gates embed the canonical Pauli table; roots reuse the
     /// `GateType` table. SWAP exchanges `|01>` and `|10>`, iSWAP multiplies
     /// those exchanges by i, and G is CZ (H tensor H) CZ. Daggers are adjoints.
+    ///
+    /// Covers all 14 two-qubit variants and returns `None` for single-qubit
+    /// variants. Unlike this method, [`GateType::canonical_2q_matrix`] covers
+    /// only the six Pauli roots; its entries for the other eight gates are `None`.
     #[must_use]
     pub const fn canonical_2q_matrix(self) -> Option<crate::gate_type::TwoQubitGateMatrix> {
         let mut matrix = [0.0; 32];

--- a/crates/pecos-core/src/gate_type.rs
+++ b/crates/pecos-core/src/gate_type.rs
@@ -533,6 +533,11 @@ impl GateType {
     /// multiplicative order four. The parameterized rotation family remains
     /// `RP(theta) = exp(-i theta P / 2)` and is deliberately not represented
     /// by this table.
+    ///
+    /// Only `SXX`, `SXXdg`, `SYY`, `SYYdg`, `SZZ`, and `SZZdg` have entries.
+    /// All other variants, including `CX`, `CY`, `CZ`, `SWAP`, `ISWAP`,
+    /// `ISWAPdg`, `G`, and `Gdg`, return `None`. For all 14 named two-qubit
+    /// Cliffords, use [`Clifford::canonical_2q_matrix`](crate::Clifford::canonical_2q_matrix).
     #[must_use]
     pub const fn canonical_2q_matrix(self) -> Option<TwoQubitGateMatrix> {
         match self {

--- a/crates/pecos-simulators/src/clifford_frame.rs
+++ b/crates/pecos-simulators/src/clifford_frame.rs
@@ -54,6 +54,80 @@ pub struct SignedPauli {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CliffordFrame(u8);
 
+/// Gates with a direct Pauli-frame propagation path in amplitude simulators.
+/// The transition owns the two output frames AND their scalar, so callers cannot
+/// install the projective result without also accumulating its phase.
+#[derive(Clone, Copy)]
+pub(crate) enum PauliFrameGate {
+    Cx,
+    Cz,
+    Sxx,
+    SxxDg,
+    Syy,
+    SyyDg,
+    Szz,
+    SzzDg,
+    ISwap,
+}
+
+impl PauliFrameGate {
+    /// Propagate frames represented by `ELEMENT_MATRIX` through the named gate.
+    /// Returns false without changing anything if either frame is non-Pauli.
+    pub(crate) fn propagate(
+        self,
+        frames: &mut [CliffordFrame],
+        phase: &mut u8,
+        pair: (usize, usize),
+    ) -> bool {
+        self.propagate_with_convention(frames, phase, pair, false)
+    }
+
+    /// Propagate the transposed representatives used by `StabVec`'s sequential
+    /// execution of `GENERATORS`. Both frames and the phase are updated together.
+    pub(crate) fn propagate_transposed(
+        self,
+        frames: &mut [CliffordFrame],
+        phase: &mut u8,
+        pair: (usize, usize),
+    ) -> bool {
+        self.propagate_with_convention(frames, phase, pair, true)
+    }
+
+    fn propagate_with_convention(
+        self,
+        frames: &mut [CliffordFrame],
+        phase: &mut u8,
+        (q, r): (usize, usize),
+        transposed: bool,
+    ) -> bool {
+        let (left, right) = (frames[q], frames[r]);
+        if !left.is_pauli() || !right.is_pauli() {
+            return false;
+        }
+        // These kernels compute U† E U = omega^k E'. All gates here have
+        // symmetric canonical matrices. Transposing the identity gives
+        // U E^T U† = omega^k E'^T, exactly StabVec's physical frame update.
+        // For untransposed E, forward propagation instead conjugates the
+        // phase. Dagger gates reverse that choice again.
+        let (new_left, new_right, mut delta) = match self {
+            Self::Cx => CliffordFrame::push_through_cx(left, right),
+            Self::Cz => CliffordFrame::push_through_cz(left, right),
+            Self::Sxx | Self::SxxDg => CliffordFrame::push_through_sxx(left, right),
+            Self::Syy | Self::SyyDg => CliffordFrame::push_through_syy(left, right),
+            Self::Szz | Self::SzzDg => CliffordFrame::push_through_szz(left, right),
+            Self::ISwap => CliffordFrame::push_through_iswap(left, right),
+        };
+        let dagger = matches!(self, Self::SxxDg | Self::SyyDg | Self::SzzDg);
+        if dagger == transposed {
+            delta = (8 - delta) & 7;
+        }
+        frames[q] = new_left;
+        frames[r] = new_right;
+        *phase = (*phase + delta) & 7;
+        true
+    }
+}
+
 // ============================================================================
 // Heisenberg action data
 // ============================================================================
@@ -567,7 +641,7 @@ pub const ELEMENT_MATRIX: [[f64; 8]; 24] = {
     [
         [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],  //  0: I
         [0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0],  //  1: X
-        [0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0], //  2: Y (= iXZ, differs from std Y by phase -i)
+        [0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0], //  2: Y representative = ZX = i * standard Y
         [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0], //  3: Z
         [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  //  4: S
         [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0], //  5: Sdg
@@ -849,15 +923,15 @@ impl CliffordFrame {
     #[inline]
     #[must_use]
     pub fn push_through_cx(ctrl_pauli: Self, targ_pauli: Self) -> (Self, Self, u8) {
-        // Phase: CX†(P1⊗P2)CX = phase * P1'⊗P2'. Nonzero only for XZ→YY and YY→XZ.
-        // Lookup: index = ctrl_pauli * 4 + targ_pauli (both 0-3).
-        const CX_PHASE: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 4, 0, 0, 0, 0, 0];
+        // ELEMENT_MATRIX Paulis are Z^z X^x (Y_elem = ZX = iY).
+        // Conjugation preserves this Z-before-X ordering under CX:
+        // Zc^zc Zt^zt Xc^xc Xt^xt ->
+        // Zc^(zc xor zt) Zt^zt Xc^xc Xt^(xc xor xt), with no scalar.
         let (xc, zc) = ctrl_pauli.pauli_xz_bits();
         let (xt, zt) = targ_pauli.pauli_xz_bits();
         let new_ctrl = Self::pauli_from_xz(xc, zc ^ zt);
         let new_targ = Self::pauli_from_xz(xc ^ xt, zt);
-        let phase = CX_PHASE[ctrl_pauli.0 as usize * 4 + targ_pauli.0 as usize];
-        (new_ctrl, new_targ, phase)
+        (new_ctrl, new_targ, 0)
     }
 
     /// Push Pauli frames through a CZ gate.
@@ -867,13 +941,15 @@ impl CliffordFrame {
     #[inline]
     #[must_use]
     pub fn push_through_cz(ctrl_pauli: Self, targ_pauli: Self) -> (Self, Self, u8) {
-        // Phase: nonzero only for XY→YX and YX→XY.
-        const CZ_PHASE: [u8; 16] = [0, 0, 0, 0, 0, 0, 4, 0, 0, 4, 0, 0, 0, 0, 0, 0];
+        // CZ maps Xc -> Xc Zt and Xt -> Zc Xt. Putting the product
+        // back into ELEMENT_MATRIX's Z-before-X order crosses Xc and Zc
+        // exactly when xc && xt, giving (-1)^(xc*xt). Standard-Y sign
+        // tables are incompatible with this generator-based convention.
         let (xc, zc) = ctrl_pauli.pauli_xz_bits();
         let (xt, zt) = targ_pauli.pauli_xz_bits();
         let new_ctrl = Self::pauli_from_xz(xc, zc ^ xt);
         let new_targ = Self::pauli_from_xz(xt, zt ^ xc);
-        let phase = CZ_PHASE[ctrl_pauli.0 as usize * 4 + targ_pauli.0 as usize];
+        let phase = if xc && xt { 4 } else { 0 };
         (new_ctrl, new_targ, phase)
     }
 
@@ -1641,201 +1717,22 @@ mod tests {
 
     #[test]
     fn test_cx_cz_pauli_passthrough() {
-        // Verify CX and CZ Pauli pass-through in the ELEMENT_MATRIX convention.
-        //
-        // CX is phase-free: conjugating any Pauli tensor product by CX yields
-        // exactly the expected Pauli tensor product with no extra phase.
-        //
-        // CZ picks up a sign of (-1)^{xc * xt} in the element convention,
-        // where xc, xt are the X-bits of the input Paulis. This comes from
-        // two sources: (1) the Pauli anticommutation sign when CZ introduces
-        // Z factors that must be moved past X factors on the same qubit, and
-        // (2) the element convention phase for Y (Y_elem = i * Y_std). These
-        // combine to give phase = -1 exactly when both inputs have X-bit set
-        // (i.e., both are X or Y).
-
-        const ELEM: &[[f64; 8]; 24] = &ELEMENT_MATRIX;
-
-        // --- 4x4 complex matrix helpers using [re, im] pairs ---
-        // A 4x4 complex matrix is [[f64; 2]; 16], stored row-major:
-        //   entry (r, c) at index r*4 + c.
-        type Mat4 = [[f64; 2]; 16];
-
-        const CZERO: [f64; 2] = [0.0, 0.0];
-
-        fn cmul(a: [f64; 2], b: [f64; 2]) -> [f64; 2] {
-            [a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0]]
-        }
-
-        fn cadd(a: [f64; 2], b: [f64; 2]) -> [f64; 2] {
-            [a[0] + b[0], a[1] + b[1]]
-        }
-
-        fn mat4_zero() -> Mat4 {
-            [CZERO; 16]
-        }
-
-        fn mat4_mul(a: &Mat4, b: &Mat4) -> Mat4 {
-            let mut r = mat4_zero();
-            for i in 0..4 {
-                for j in 0..4 {
-                    let mut s = CZERO;
-                    for k in 0..4 {
-                        s = cadd(s, cmul(a[i * 4 + k], b[k * 4 + j]));
-                    }
-                    r[i * 4 + j] = s;
-                }
-            }
-            r
-        }
-
-        fn mat4_dag(a: &Mat4) -> Mat4 {
-            let mut r = mat4_zero();
-            for i in 0..4 {
-                for j in 0..4 {
-                    let v = a[j * 4 + i];
-                    r[i * 4 + j] = [v[0], -v[1]]; // conjugate transpose
-                }
-            }
-            r
-        }
-
-        /// Build a 4x4 matrix from the tensor product of two `ELEMENT_MATRIX` entries.
-        fn tensor(a_idx: usize, b_idx: usize) -> Mat4 {
-            let a = &ELEM[a_idx];
-            let b = &ELEM[b_idx];
-            // a is [[a00, a01], [a10, a11]] with a_rc = (a[r*4+c*2], a[r*4+c*2+1])
-            // tensor product: (A tensor B)_{(ia,ib),(ja,jb)} = A_{ia,ja} * B_{ib,jb}
-            let mut r = mat4_zero();
-            for ia in 0..2 {
-                for ja in 0..2 {
-                    let a_val = [a[ia * 4 + ja * 2], a[ia * 4 + ja * 2 + 1]];
-                    for ib in 0..2 {
-                        for jb in 0..2 {
-                            let b_val = [b[ib * 4 + jb * 2], b[ib * 4 + jb * 2 + 1]];
-                            let row = ia * 2 + ib;
-                            let col = ja * 2 + jb;
-                            r[row * 4 + col] = cmul(a_val, b_val);
-                        }
-                    }
-                }
-            }
-            r
-        }
-
-        /// CX matrix in computational basis (control qubit 0, target qubit 1):
-        /// |00> -> |00>, |01> -> |01>, |10> -> |11>, |11> -> |10>
-        fn mat_cx() -> Mat4 {
-            let mut m = mat4_zero();
-            let one = [1.0, 0.0];
-            m[0] = one; // |00> -> |00>
-            m[4 + 1] = one; // |01> -> |01>
-            m[2 * 4 + 3] = one; // |10> -> |11>
-            m[3 * 4 + 2] = one; // |11> -> |10>
-            m
-        }
-
-        /// CZ matrix: diag(1, 1, 1, -1)
-        fn mat_cz() -> Mat4 {
-            let mut m = mat4_zero();
-            let one = [1.0, 0.0];
-            m[0] = one;
-            m[4 + 1] = one;
-            m[2 * 4 + 2] = one;
-            m[3 * 4 + 3] = [-1.0, 0.0];
-            m
-        }
-
-        fn mat4_eq(a: &Mat4, b: &Mat4, tol: f64) -> bool {
-            for i in 0..16 {
-                let dr = a[i][0] - b[i][0];
-                let di = a[i][1] - b[i][1];
-                if (dr * dr + di * di).sqrt() > tol {
-                    return false;
-                }
-            }
-            true
-        }
-
-        /// Extract (`x_bit`, `z_bit`) from Pauli index 0..3.
-        fn pauli_xz(idx: usize) -> (bool, bool) {
-            match idx {
-                0 => (false, false), // I
-                1 => (true, false),  // X
-                2 => (true, true),   // Y
-                3 => (false, true),  // Z
-                _ => unreachable!(),
-            }
-        }
-
-        /// Construct Pauli index from (`x_bit`, `z_bit`).
-        fn pauli_from_xz(x: bool, z: bool) -> usize {
-            match (x, z) {
-                (false, false) => 0,
-                (true, false) => 1,
-                (true, true) => 2,
-                (false, true) => 3,
-            }
-        }
-
-        // --- Test CX ---
-        let cx = mat_cx();
-        let cx_dag = mat4_dag(&cx); // CX is self-adjoint, but compute anyway
-
-        for pc in 0..4 {
-            for pt in 0..4 {
-                let input = tensor(pc, pt);
-                // CX * input * CX^dag
-                let conjugated = mat4_mul(&cx, &mat4_mul(&input, &cx_dag));
-
-                // Compute expected output Paulis via symplectic rules
-                let (xc, zc) = pauli_xz(pc);
-                let (xt, zt) = pauli_xz(pt);
-                let pc_out = pauli_from_xz(xc, zc ^ zt);
-                let pt_out = pauli_from_xz(xc ^ xt, zt);
-
-                let expected = tensor(pc_out, pt_out);
-
-                assert!(
-                    mat4_eq(&conjugated, &expected, 1e-10),
-                    "CX phase-free check failed for pc={pc}, pt={pt}: \
-                     expected Pauli ({pc_out}, {pt_out})"
-                );
-            }
-        }
-
-        // --- Test CZ ---
-        // CZ picks up (-1)^{xc*xt} in the element convention.
-        let cz = mat_cz();
-        let cz_dag = mat4_dag(&cz); // CZ is self-adjoint
-
-        for pc in 0..4 {
-            for pt in 0..4 {
-                let input = tensor(pc, pt);
-                // CZ * input * CZ^dag
-                let conjugated = mat4_mul(&cz, &mat4_mul(&input, &cz_dag));
-
-                // Compute expected output Paulis via symplectic rules
-                let (xc, zc) = pauli_xz(pc);
-                let (xt, zt) = pauli_xz(pt);
-                let pc_out = pauli_from_xz(xc, zc ^ xt);
-                let pt_out = pauli_from_xz(xt, zt ^ xc);
-
-                // Element-convention phase: (-1) when both X-bits are set
-                let phase: f64 = if xc && xt { -1.0 } else { 1.0 };
-
-                let raw_expected = tensor(pc_out, pt_out);
-                let mut expected = mat4_zero();
-                for i in 0..16 {
-                    expected[i] = [raw_expected[i][0] * phase, raw_expected[i][1] * phase];
-                }
-
-                assert!(
-                    mat4_eq(&conjugated, &expected, 1e-10),
-                    "CZ check failed for pc={pc}, pt={pt}: \
-                     expected Pauli ({pc_out}, {pt_out}) with phase={phase}"
-                );
-            }
+        // Exercise the production phase-returning API, not a separate copy of
+        // its symplectic formulas: the old check verified the right algebra
+        // while the production methods returned standard-Y phases.
+        for (gate, propagate) in [
+            (
+                pecos_core::Clifford::CX,
+                CliffordFrame::push_through_cx as fn(_, _) -> _,
+            ),
+            (
+                pecos_core::Clifford::CZ,
+                CliffordFrame::push_through_cz as fn(_, _) -> _,
+            ),
+        ] {
+            let matrix = gate.canonical_2q_matrix().unwrap();
+            let matrix = std::array::from_fn(|i| [matrix[2 * i], matrix[2 * i + 1]]);
+            verify_push_through_all_16(&matrix, propagate, &gate.to_string());
         }
     }
 

--- a/crates/pecos-simulators/src/clifford_frame.rs
+++ b/crates/pecos-simulators/src/clifford_frame.rs
@@ -84,6 +84,8 @@ impl PauliFrameGate {
 
     /// Propagate the transposed representatives used by `StabVec`'s sequential
     /// execution of `GENERATORS`. Both frames and the phase are updated together.
+    /// Requires a symmetric canonical gate matrix, enforced by
+    /// `test_pauli_frame_gate_canonical_matrices_are_symmetric`.
     pub(crate) fn propagate_transposed(
         self,
         frames: &mut [CliffordFrame],
@@ -1713,6 +1715,49 @@ mod tests {
         assert_eq!(s2, CliffordFrame::Z, "S² should be Z");
         assert_eq!(s3, CliffordFrame::SZDG, "S³ should be Sdg");
         assert_eq!(s4, CliffordFrame::IDENTITY, "S⁴ should be I");
+    }
+
+    #[test]
+    fn test_pauli_frame_gate_canonical_matrices_are_symmetric() {
+        use pecos_core::Clifford;
+
+        for gate in [
+            PauliFrameGate::Cx,
+            PauliFrameGate::Cz,
+            PauliFrameGate::Sxx,
+            PauliFrameGate::SxxDg,
+            PauliFrameGate::Syy,
+            PauliFrameGate::SyyDg,
+            PauliFrameGate::Szz,
+            PauliFrameGate::SzzDg,
+            PauliFrameGate::ISwap,
+        ] {
+            // Keep this exhaustive: every new propagation variant must have
+            // its canonical matrix checked before using the transpose identity.
+            let clifford = match gate {
+                PauliFrameGate::Cx => Clifford::CX,
+                PauliFrameGate::Cz => Clifford::CZ,
+                PauliFrameGate::Sxx => Clifford::SXX,
+                PauliFrameGate::SxxDg => Clifford::SXXdg,
+                PauliFrameGate::Syy => Clifford::SYY,
+                PauliFrameGate::SyyDg => Clifford::SYYdg,
+                PauliFrameGate::Szz => Clifford::SZZ,
+                PauliFrameGate::SzzDg => Clifford::SZZdg,
+                PauliFrameGate::ISwap => Clifford::ISWAP,
+            };
+            let matrix = clifford.canonical_2q_matrix().unwrap();
+            for row in 0..4 {
+                for col in 0..4 {
+                    let entry = 2 * (4 * row + col);
+                    let transposed = 2 * (4 * col + row);
+                    assert_eq!(
+                        &matrix[entry..entry + 2],
+                        &matrix[transposed..transposed + 2],
+                        "{clifford} must be symmetric for transposed frame propagation"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/pecos-simulators/src/clifford_gateable.rs
+++ b/crates/pecos-simulators/src/clifford_gateable.rs
@@ -893,9 +893,9 @@ pub trait CliffordGateable: QuantumSimulator {
     /// # Matrix Representation
     /// ```text
     /// CY = [[1,  0,  0,  0],
+    ///       [0,  1,  0,  0],
     ///       [0,  0,  0, -i],
-    ///       [0,  0,  1,  0],
-    ///       [0, +i,  0,  0]]
+    ///       [0,  0, +i,  0]]
     /// ```
     ///
     /// # Returns

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -83,7 +83,9 @@ const DENSE_CROSSOVER_DENOMINATOR: usize = 2;
 ///     .build();
 /// ```
 ///
-use crate::clifford_frame::{CliffordFrame, GATE_PHASE_DELTA, GEN_LENS, GENERATORS, PHASE_COCYCLE};
+use crate::clifford_frame::{
+    CliffordFrame, GATE_PHASE_DELTA, GEN_LENS, GENERATORS, PHASE_COCYCLE, PauliFrameGate,
+};
 
 #[derive(Clone, Debug)]
 pub struct StabVecGeneric<S: IndexSet = BitSet, R: SeedableRng + Rng + Debug = PecosRng> {
@@ -94,6 +96,8 @@ pub struct StabVecGeneric<S: IndexSet = BitSet, R: SeedableRng + Rng + Debug = P
     /// Pending RZ angles per qubit.
     pending_rz: Vec<Angle64>,
     /// Single-qubit Clifford frame per qubit. All 24 Clifford elements tracked.
+    /// The physical representative is `ELEMENT_MATRIX[frame]^T`: `GENERATORS`
+    /// are executed in listed order, reversing their documented matrix product.
     /// State = `pending_rz` * frame * |`stored_state`⟩.
     /// Single-qubit Cliffords compose into the frame in O(1).
     /// Flushed via H+S generator sequence when a two-qubit gate or measurement arrives.
@@ -574,6 +578,14 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             + PHASE_COCYCLE[gate.index() as usize][old.index() as usize])
             & 7;
         self.cliff_frame[q] = gate.compose(old);
+    }
+
+    /// Move a deferred pair through a gate as one phase-exact transition.
+    fn propagate_cliff_frames(&mut self, q: usize, r: usize, gate: PauliFrameGate) {
+        if !gate.propagate_transposed(&mut self.cliff_frame, &mut self.frame_phase, (q, r)) {
+            self.flush_cliff_frame(q);
+            self.flush_cliff_frame(r);
+        }
     }
 
     /// Flush the Clifford frame on qubit q by applying its H+S generator sequence.
@@ -1471,17 +1483,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             // A target RZ does not commute with CX. Materialize it against the
             // frame it is paired with, before CX propagation changes that frame.
             self.flush_pending_rz(t);
-            let fc = self.cliff_frame[c];
-            let ft = self.cliff_frame[t];
-            if fc.is_pauli() && ft.is_pauli() {
-                let (new_c, new_t, phase) = CliffordFrame::push_through_cx(fc, ft);
-                self.cliff_frame[c] = new_c;
-                self.cliff_frame[t] = new_t;
-                self.frame_phase = (self.frame_phase + phase) & 7;
-            } else {
-                self.flush_cliff_frame(c);
-                self.flush_cliff_frame(t);
-            }
+            self.propagate_cliff_frames(c, t, PauliFrameGate::Cx);
         }
         self.apply_clifford(|ch| {
             ch.cx(pairs);
@@ -1497,17 +1499,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let q = q0.index();
             let r = q1.index();
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_cz(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + phase) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::Cz);
         }
         self.apply_c_type_clifford(|ch| {
             ch.cz(pairs);
@@ -1523,17 +1515,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let q = q0.index();
             let r = q1.index();
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_szz(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + phase) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::Szz);
         }
         self.apply_c_type_clifford(|ch| {
             ch.szz(pairs);
@@ -1550,18 +1532,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
         for &(q0, q1) in pairs {
             let q = q0.index();
             let r = q1.index();
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_szz(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                // SZZdg has opposite phase from SZZ propagation
-                self.frame_phase = (self.frame_phase + (8 - phase) % 8) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::SzzDg);
         }
         self.apply_c_type_clifford(|ch| {
             ch.szzdg(pairs);
@@ -1580,17 +1551,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             for target in [q, r] {
                 self.flush_noncommuting_pending_rz(target);
             }
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_sxx(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + phase) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::Sxx);
         }
         // SXX = H*H * SZZ * H*H
         self.apply_xx_root(pairs, false);
@@ -1608,17 +1569,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             for target in [q, r] {
                 self.flush_noncommuting_pending_rz(target);
             }
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_sxx(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + (8 - phase) % 8) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::SxxDg);
         }
         self.apply_xx_root(pairs, true);
         self
@@ -1635,17 +1586,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             for target in [q, r] {
                 self.flush_noncommuting_pending_rz(target);
             }
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_syy(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + phase) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::Syy);
         }
         // SYY = S*S * SXX * Sdg*Sdg
         let all_qubits: Vec<QubitId> = pairs.iter().flat_map(|&(q0, q1)| [q0, q1]).collect();
@@ -1670,17 +1611,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> CliffordGateable for Sta
             for target in [q, r] {
                 self.flush_noncommuting_pending_rz(target);
             }
-            let fq = self.cliff_frame[q];
-            let fr = self.cliff_frame[r];
-            if fq.is_pauli() && fr.is_pauli() {
-                let (new_q, new_r, phase) = CliffordFrame::push_through_syy(fq, fr);
-                self.cliff_frame[q] = new_q;
-                self.cliff_frame[r] = new_r;
-                self.frame_phase = (self.frame_phase + (8 - phase) % 8) & 7;
-            } else {
-                self.flush_cliff_frame(q);
-                self.flush_cliff_frame(r);
-            }
+            self.propagate_cliff_frames(q, r, PauliFrameGate::SyyDg);
         }
         let all_qubits: Vec<QubitId> = pairs.iter().flat_map(|&(q0, q1)| [q0, q1]).collect();
         self.apply_c_type_clifford(|ch| {

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -38,6 +38,9 @@ pub mod exact_scalar;
 pub mod quadratic_form;
 pub mod sparse_binary_matrix;
 
+use crate::clifford_frame::{
+    CliffordFrame, GATE_PHASE_DELTA, GEN_LENS, GENERATORS, PHASE_COCYCLE, PauliFrameGate,
+};
 use crate::{
     ArbitraryRotationGateable, CliffordGateable, MeasurementResult, QuantumSimulator, StateVecSoA,
 };
@@ -83,10 +86,6 @@ const DENSE_CROSSOVER_DENOMINATOR: usize = 2;
 ///     .build();
 /// ```
 ///
-use crate::clifford_frame::{
-    CliffordFrame, GATE_PHASE_DELTA, GEN_LENS, GENERATORS, PHASE_COCYCLE, PauliFrameGate,
-};
-
 #[derive(Clone, Debug)]
 pub struct StabVecGeneric<S: IndexSet = BitSet, R: SeedableRng + Rng + Debug = PecosRng> {
     num_qubits: usize,

--- a/crates/pecos-simulators/src/state_vec_sparse_soa.rs
+++ b/crates/pecos-simulators/src/state_vec_sparse_soa.rs
@@ -34,7 +34,9 @@
 //!
 //! 3. **Binary Search**: Uses same algorithm as `AoS` for pair lookup
 
-use crate::clifford_frame::{CliffordFrame, ELEMENT_MATRIX, PHASE_COCYCLE, PHASE_ROOTS, PauliAxis};
+use crate::clifford_frame::{
+    CliffordFrame, ELEMENT_MATRIX, PHASE_COCYCLE, PHASE_ROOTS, PauliAxis, PauliFrameGate,
+};
 use crate::clifford_gateable::MeasurementResult;
 use crate::{ArbitraryRotationGateable, CliffordGateable, QuantumSimulator};
 use num_complex::Complex64;
@@ -2115,13 +2117,7 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
         if pairs.len() == 1 {
             // Single pair: fast path
             let (c, t) = (pairs[0].0.0, pairs[0].1.0);
-            let fc = self.frames[c];
-            let ft = self.frames[t];
-            if fc.is_pauli() && ft.is_pauli() {
-                let (new_c, new_t, _phase) = CliffordFrame::push_through_cx(fc, ft);
-                self.frames[c] = new_c;
-                self.frames[t] = new_t;
-            } else {
+            if !PauliFrameGate::Cx.propagate(&mut self.frames, &mut self.frame_phases[c], (c, t)) {
                 self.flush_frame(c);
                 self.flush_frame(t);
             }
@@ -2130,13 +2126,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
             // Multiple pairs: process all frames, then batch physical ops.
             for &(q0, q1) in pairs {
                 let (c, t) = (q0.0, q1.0);
-                let fc = self.frames[c];
-                let ft = self.frames[t];
-                if fc.is_pauli() && ft.is_pauli() {
-                    let (new_c, new_t, _phase) = CliffordFrame::push_through_cx(fc, ft);
-                    self.frames[c] = new_c;
-                    self.frames[t] = new_t;
-                } else {
+                if !PauliFrameGate::Cx.propagate(
+                    &mut self.frames,
+                    &mut self.frame_phases[c],
+                    (c, t),
+                ) {
                     self.flush_frame(c);
                     self.flush_frame(t);
                 }
@@ -2168,18 +2162,7 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
         if pairs.len() == 1 {
             // Single pair: fast path
             let (c, t) = (pairs[0].0.0, pairs[0].1.0);
-            let fc = self.frames[c];
-            let ft = self.frames[t];
-            if fc.is_pauli() && ft.is_pauli() {
-                let (xc, _) = fc.pauli_xz_bits();
-                let (xt, _) = ft.pauli_xz_bits();
-                let (new_c, new_t, _phase) = CliffordFrame::push_through_cz(fc, ft);
-                self.frames[c] = new_c;
-                self.frames[t] = new_t;
-                if xc && xt {
-                    self.frame_phases[c] = (self.frame_phases[c] + 4) % 8;
-                }
-            } else {
+            if !PauliFrameGate::Cz.propagate(&mut self.frames, &mut self.frame_phases[c], (c, t)) {
                 self.flush_frame(c);
                 self.flush_frame(t);
             }
@@ -2188,18 +2171,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
             // Multiple pairs: process all frames, then batch physical sign flips
             for &(q0, q1) in pairs {
                 let (c, t) = (q0.0, q1.0);
-                let fc = self.frames[c];
-                let ft = self.frames[t];
-                if fc.is_pauli() && ft.is_pauli() {
-                    let (xc, _) = fc.pauli_xz_bits();
-                    let (xt, _) = ft.pauli_xz_bits();
-                    let (new_c, new_t, _phase) = CliffordFrame::push_through_cz(fc, ft);
-                    self.frames[c] = new_c;
-                    self.frames[t] = new_t;
-                    if xc && xt {
-                        self.frame_phases[c] = (self.frame_phases[c] + 4) % 8;
-                    }
-                } else {
+                if !PauliFrameGate::Cz.propagate(
+                    &mut self.frames,
+                    &mut self.frame_phases[c],
+                    (c, t),
+                ) {
                     self.flush_frame(c);
                     self.flush_frame(t);
                 }
@@ -2295,22 +2271,17 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
     // (O(1) frame update + phase correction) instead of flushing (O(k)).
     // Then apply the physical gate directly.
     //
-    // Note: push_through_* functions return the Heisenberg-picture phase
-    // (G† P G = phase · P'), but we need the Schrödinger-picture phase
-    // (G P G† = phase* · P'). For 8th-root phases, conjugation is (8-k)%8.
+    // PauliFrameGate owns the conversion from the kernels' Heisenberg phase
+    // to this simulator's forward ELEMENT_MATRIX convention, including daggers.
 
     fn szz(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         if pairs.len() == 1 {
             let (q1, q2) = (pairs[0].0.0, pairs[0].1.0);
-            let f1 = self.frames[q1];
-            let f2 = self.frames[q2];
-            if f1.is_pauli() && f2.is_pauli() {
-                let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_szz(f1, f2);
-                self.frames[q1] = new_f1;
-                self.frames[q2] = new_f2;
-                let schrod_phase = (8 - heis_phase) % 8;
-                self.frame_phases[q1] = (self.frame_phases[q1] + schrod_phase) % 8;
-            } else {
+            if !PauliFrameGate::Szz.propagate(
+                &mut self.frames,
+                &mut self.frame_phases[q1],
+                (q1, q2),
+            ) {
                 self.flush_frame(q1);
                 self.flush_frame(q2);
             }
@@ -2319,15 +2290,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
             // Multiple pairs: process frames, then batch physical diagonal phase
             for &(qa, qb) in pairs {
                 let (q1, q2) = (qa.0, qb.0);
-                let f1 = self.frames[q1];
-                let f2 = self.frames[q2];
-                if f1.is_pauli() && f2.is_pauli() {
-                    let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_szz(f1, f2);
-                    self.frames[q1] = new_f1;
-                    self.frames[q2] = new_f2;
-                    let schrod_phase = (8 - heis_phase) % 8;
-                    self.frame_phases[q1] = (self.frame_phases[q1] + schrod_phase) % 8;
-                } else {
+                if !PauliFrameGate::Szz.propagate(
+                    &mut self.frames,
+                    &mut self.frame_phases[q1],
+                    (q1, q2),
+                ) {
                     self.flush_frame(q1);
                     self.flush_frame(q2);
                 }
@@ -2384,16 +2351,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
     fn szzdg(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         if pairs.len() == 1 {
             let (q1, q2) = (pairs[0].0.0, pairs[0].1.0);
-            let f1 = self.frames[q1];
-            let f2 = self.frames[q2];
-            if f1.is_pauli() && f2.is_pauli() {
-                let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_szz(f1, f2);
-                self.frames[q1] = new_f1;
-                self.frames[q2] = new_f2;
-                // For SZZdg, Schrödinger phase = Heisenberg phase of SZZ (no conjugation),
-                // because SZZdg Schrödinger = SZZ† · P · SZZ = SZZ Heisenberg.
-                self.frame_phases[q1] = (self.frame_phases[q1] + heis_phase) % 8;
-            } else {
+            if !PauliFrameGate::SzzDg.propagate(
+                &mut self.frames,
+                &mut self.frame_phases[q1],
+                (q1, q2),
+            ) {
                 self.flush_frame(q1);
                 self.flush_frame(q2);
             }
@@ -2402,14 +2364,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
             // Multiple pairs: process frames, then batch physical diagonal phase
             for &(qa, qb) in pairs {
                 let (q1, q2) = (qa.0, qb.0);
-                let f1 = self.frames[q1];
-                let f2 = self.frames[q2];
-                if f1.is_pauli() && f2.is_pauli() {
-                    let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_szz(f1, f2);
-                    self.frames[q1] = new_f1;
-                    self.frames[q2] = new_f2;
-                    self.frame_phases[q1] = (self.frame_phases[q1] + heis_phase) % 8;
-                } else {
+                if !PauliFrameGate::SzzDg.propagate(
+                    &mut self.frames,
+                    &mut self.frame_phases[q1],
+                    (q1, q2),
+                ) {
                     self.flush_frame(q1);
                     self.flush_frame(q2);
                 }
@@ -2466,15 +2425,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
     fn iswap(&mut self, pairs: &[(QubitId, QubitId)]) -> &mut Self {
         if pairs.len() == 1 {
             let (q1, q2) = (pairs[0].0.0, pairs[0].1.0);
-            let f1 = self.frames[q1];
-            let f2 = self.frames[q2];
-            if f1.is_pauli() && f2.is_pauli() {
-                let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_iswap(f1, f2);
-                self.frames[q1] = new_f1;
-                self.frames[q2] = new_f2;
-                let schrod_phase = (8 - heis_phase) % 8;
-                self.frame_phases[q1] = (self.frame_phases[q1] + schrod_phase) % 8;
-            } else {
+            if !PauliFrameGate::ISwap.propagate(
+                &mut self.frames,
+                &mut self.frame_phases[q1],
+                (q1, q2),
+            ) {
                 self.flush_frame(q1);
                 self.flush_frame(q2);
             }
@@ -2483,15 +2438,11 @@ impl<R: Rng + Debug> CliffordGateable for SparseStateVecSoA<R> {
             // Multiple pairs: process frames, then batch physical iSWAP
             for &(qa, qb) in pairs {
                 let (q1, q2) = (qa.0, qb.0);
-                let f1 = self.frames[q1];
-                let f2 = self.frames[q2];
-                if f1.is_pauli() && f2.is_pauli() {
-                    let (new_f1, new_f2, heis_phase) = CliffordFrame::push_through_iswap(f1, f2);
-                    self.frames[q1] = new_f1;
-                    self.frames[q2] = new_f2;
-                    let schrod_phase = (8 - heis_phase) % 8;
-                    self.frame_phases[q1] = (self.frame_phases[q1] + schrod_phase) % 8;
-                } else {
+                if !PauliFrameGate::ISwap.propagate(
+                    &mut self.frames,
+                    &mut self.frame_phases[q1],
+                    (q1, q2),
+                ) {
                     self.flush_frame(q1);
                     self.flush_frame(q2);
                 }

--- a/crates/pecos-simulators/tests/cross_simulator_tests.rs
+++ b/crates/pecos-simulators/tests/cross_simulator_tests.rs
@@ -1186,7 +1186,12 @@ fn batch_cx_matches_sequential() {
 
 #[test]
 fn batch_2q_gates_match_sequential() {
-    let batch_qubits = [(QubitId(0), QubitId(1)), (QubitId(2), QubitId(3))];
+    // An odd pair count prevents a per-pair global sign error from cancelling.
+    let batch_qubits = [
+        (QubitId(0), QubitId(1)),
+        (QubitId(2), QubitId(3)),
+        (QubitId(4), QubitId(5)),
+    ];
 
     // Test several 2q gates in batch mode
     let gates: Vec<BatchGateTestEntry> = vec![
@@ -1197,7 +1202,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.cz(&[(QubitId(0), QubitId(1))])
-                    .cz(&[(QubitId(2), QubitId(3))]);
+                    .cz(&[(QubitId(2), QubitId(3))])
+                    .cz(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1207,7 +1213,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.swap(&[(QubitId(0), QubitId(1))])
-                    .swap(&[(QubitId(2), QubitId(3))]);
+                    .swap(&[(QubitId(2), QubitId(3))])
+                    .swap(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1217,7 +1224,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.sxx(&[(QubitId(0), QubitId(1))])
-                    .sxx(&[(QubitId(2), QubitId(3))]);
+                    .sxx(&[(QubitId(2), QubitId(3))])
+                    .sxx(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1227,7 +1235,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.syy(&[(QubitId(0), QubitId(1))])
-                    .syy(&[(QubitId(2), QubitId(3))]);
+                    .syy(&[(QubitId(2), QubitId(3))])
+                    .syy(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1237,7 +1246,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.szz(&[(QubitId(0), QubitId(1))])
-                    .szz(&[(QubitId(2), QubitId(3))]);
+                    .szz(&[(QubitId(2), QubitId(3))])
+                    .szz(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1247,7 +1257,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.iswap(&[(QubitId(0), QubitId(1))])
-                    .iswap(&[(QubitId(2), QubitId(3))]);
+                    .iswap(&[(QubitId(2), QubitId(3))])
+                    .iswap(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1257,7 +1268,8 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.iswapdg(&[(QubitId(0), QubitId(1))])
-                    .iswapdg(&[(QubitId(2), QubitId(3))]);
+                    .iswapdg(&[(QubitId(2), QubitId(3))])
+                    .iswapdg(&[(QubitId(4), QubitId(5))]);
             }),
         ),
         (
@@ -1267,20 +1279,21 @@ fn batch_2q_gates_match_sequential() {
             }),
             Box::new(|s: &mut StateVec| {
                 s.g(&[(QubitId(0), QubitId(1))])
-                    .g(&[(QubitId(2), QubitId(3))]);
+                    .g(&[(QubitId(2), QubitId(3))])
+                    .g(&[(QubitId(4), QubitId(5))]);
             }),
         ),
     ];
 
     for (name, batch_fn, seq_fn) in &gates {
-        let mut sv_batch = StateVec::new(4);
-        for q in 0..4 {
+        let mut sv_batch = StateVec::new(6);
+        for q in 0..6 {
             sv_batch.h(&qid(q));
         }
         batch_fn(&mut sv_batch, &batch_qubits);
 
-        let mut sv_seq = StateVec::new(4);
-        for q in 0..4 {
+        let mut sv_seq = StateVec::new(6);
+        for q in 0..6 {
             sv_seq.h(&qid(q));
         }
         seq_fn(&mut sv_seq);

--- a/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
+++ b/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
@@ -810,20 +810,22 @@ fn deferred_frames_preserve_phase_across_disjoint_batched_pairs() {
 }
 
 fn check_disjoint_batched_pairs<S: StateVectorSimulator + Clone>() {
-    let mut input_sim = S::with_seed(4, 721);
-    let mut input = vec![Complex64::new(0.0, 0.0); 16];
+    let mut input_sim = S::with_seed(6, 721);
+    let mut input = vec![Complex64::new(0.0, 0.0); 64];
     input[0] = Complex64::new(1.0, 0.0);
     for (gate, q) in [
         (Clifford::H, 0),
         (Clifford::H, 1),
         (Clifford::H, 2),
         (Clifford::H, 3),
+        (Clifford::H, 4),
+        (Clifford::H, 5),
         (Clifford::SZ, 3),
     ] {
         apply_clifford_gate(&mut input_sim, gate, &[QubitId(q)]);
         apply_canonical_matrix(&mut input, gate.canonical_1q_matrix().unwrap(), QubitId(q));
     }
-    let actual: Vec<_> = (0..16).map(|i| input_sim.get_amplitude(i)).collect();
+    let actual: Vec<_> = (0..64).map(|i| input_sim.get_amplitude(i)).collect();
     assert_phase_exact_state(
         std::any::type_name::<S>(),
         "batched input",
@@ -831,7 +833,12 @@ fn check_disjoint_batched_pairs<S: StateVectorSimulator + Clone>() {
         &input,
         F64_TOLERANCE,
     );
-    let pairs = [(QubitId(3), QubitId(1)), (QubitId(0), QubitId(2))];
+    // An odd pair count prevents a per-pair global sign error from cancelling.
+    let pairs = [
+        (QubitId(3), QubitId(1)),
+        (QubitId(0), QubitId(2)),
+        (QubitId(5), QubitId(4)),
+    ];
     for &left in Clifford::all_1q() {
         for &right in Clifford::all_1q() {
             let mut framed = input_sim.clone();
@@ -841,6 +848,8 @@ fn check_disjoint_batched_pairs<S: StateVectorSimulator + Clone>() {
                 (right, pairs[0].1),
                 (right, pairs[1].0),
                 (left, pairs[1].1),
+                (left, pairs[2].0),
+                (right, pairs[2].1),
             ] {
                 apply_clifford_gate(&mut framed, local, &[q]);
                 apply_canonical_matrix(
@@ -861,7 +870,7 @@ fn check_disjoint_batched_pairs<S: StateVectorSimulator + Clone>() {
                         r,
                     );
                 }
-                let actual: Vec<_> = (0..16).map(|i| sim.get_amplitude(i)).collect();
+                let actual: Vec<_> = (0..64).map(|i| sim.get_amplitude(i)).collect();
                 assert_phase_exact_state(
                     std::any::type_name::<S>(),
                     &format!("{gate} batched, local=({left},{right})"),

--- a/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
+++ b/crates/pecos-simulators/tests/phase_exact_single_qubit_tests.rs
@@ -615,3 +615,261 @@ fn ch_form_matches_two_qubit_root_conventions() {
         }
     }
 }
+
+fn apply_two_qubit_clifford<S: CliffordGateable>(
+    sim: &mut S,
+    gate: Clifford,
+    pairs: &[(QubitId, QubitId)],
+) {
+    match gate {
+        Clifford::CX => sim.cx(pairs),
+        Clifford::CY => sim.cy(pairs),
+        Clifford::CZ => sim.cz(pairs),
+        Clifford::SWAP => sim.swap(pairs),
+        Clifford::ISWAP => sim.iswap(pairs),
+        Clifford::ISWAPdg => sim.iswapdg(pairs),
+        Clifford::G => sim.g(pairs),
+        Clifford::Gdg => sim.gdg(pairs),
+        Clifford::SXX => sim.sxx(pairs),
+        Clifford::SXXdg => sim.sxxdg(pairs),
+        Clifford::SYY => sim.syy(pairs),
+        Clifford::SYYdg => sim.syydg(pairs),
+        Clifford::SZZ => sim.szz(pairs),
+        Clifford::SZZdg => sim.szzdg(pairs),
+        _ => panic!("expected a two-qubit Clifford: {gate}"),
+    };
+}
+
+fn read_three_qubit_state<S: StateVectorSimulator>(sim: &mut S) -> Vec<Complex64> {
+    (0..8).map(|index| sim.get_amplitude(index)).collect()
+}
+
+fn superposed_clifford_input<S: StateVectorSimulator>(basis: usize) -> (S, Vec<Complex64>) {
+    let mut sim = S::with_seed(3, 721);
+    let mut expected = vec![Complex64::new(0.0, 0.0); 8];
+    expected[0] = Complex64::new(1.0, 0.0);
+    // Four orthogonal superpositions on q0/q2 give a spanning input set.
+    // The spectator q1 stays superposed too. Prepare exclusively with canonical
+    // matrices on the reference side, never from a simulator's output.
+    for (gate, q) in [
+        (Clifford::H, 0),
+        (Clifford::SZ, 0),
+        (Clifford::H, 1),
+        (Clifford::H, 2),
+    ] {
+        apply_clifford_gate(&mut sim, gate, &[QubitId(q)]);
+        apply_canonical_matrix(
+            &mut expected,
+            gate.canonical_1q_matrix().unwrap(),
+            QubitId(q),
+        );
+    }
+    for (bit, q) in [(1, 0), (2, 2)] {
+        if basis & bit != 0 {
+            sim.z(&[QubitId(q)]);
+            apply_canonical_matrix(
+                &mut expected,
+                Clifford::Z.canonical_1q_matrix().unwrap(),
+                QubitId(q),
+            );
+        }
+    }
+    // Materialize preparation only. Subsequent local gates must remain deferred
+    // across the tested two-qubit compositions.
+    assert_phase_exact_state(
+        std::any::type_name::<S>(),
+        "conformance input",
+        &read_three_qubit_state(&mut sim),
+        &expected,
+        F64_TOLERANCE,
+    );
+    (sim, expected)
+}
+
+#[test]
+fn stab_vec_two_qubit_compositions_match_canonical_matrices() {
+    check_two_qubit_compositions::<StabVec>();
+}
+
+#[test]
+fn sparse_soa_two_qubit_compositions_match_canonical_matrices() {
+    check_two_qubit_compositions::<SparseStateVecSoA>();
+}
+
+fn check_two_qubit_compositions<S: StateVectorSimulator + Clone>() {
+    for basis in 0..4 {
+        let (input_sim, input) = superposed_clifford_input::<S>(basis);
+        for pair in [(QubitId(0), QubitId(2)), (QubitId(2), QubitId(0))] {
+            for &left in Clifford::all_1q() {
+                for &right in Clifford::all_1q() {
+                    let mut framed = input_sim.clone();
+                    let mut framed_expected = input.clone();
+                    for (local, q) in [(left, pair.0), (right, pair.1)] {
+                        apply_clifford_gate(&mut framed, local, &[q]);
+                        apply_canonical_matrix(
+                            &mut framed_expected,
+                            local.canonical_1q_matrix().unwrap(),
+                            q,
+                        );
+                    }
+                    for &gate in Clifford::all_2q() {
+                        let mut sim = framed.clone();
+                        let mut expected = framed_expected.clone();
+                        apply_two_qubit_clifford(&mut sim, gate, &[pair]);
+                        apply_canonical_two_qubit_matrix(
+                            &mut expected,
+                            gate.canonical_2q_matrix().unwrap(),
+                            pair.0,
+                            pair.1,
+                        );
+                        assert_phase_exact_state(
+                            std::any::type_name::<S>(),
+                            &format!(
+                                "{gate}, local=({left},{right}), pair={pair:?}, basis={basis}"
+                            ),
+                            &read_three_qubit_state(&mut sim),
+                            &expected,
+                            F64_TOLERANCE,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn stab_vec_two_qubit_products_match_canonical_matrices() {
+    for basis in 0..4 {
+        let (input_sim, input) = superposed_clifford_input::<StabVec>(basis);
+        for &first in Clifford::all_2q() {
+            for &second in Clifford::all_2q() {
+                for left in [Clifford::I, Clifford::X, Clifford::Y, Clifford::Z] {
+                    for right in [Clifford::I, Clifford::X, Clifford::Y, Clifford::Z] {
+                        let mut sim = input_sim.clone();
+                        let mut expected = input.clone();
+                        for (local, q) in [(left, QubitId(0)), (right, QubitId(2))] {
+                            apply_clifford_gate(&mut sim, local, &[q]);
+                            apply_canonical_matrix(
+                                &mut expected,
+                                local.canonical_1q_matrix().unwrap(),
+                                q,
+                            );
+                        }
+                        for (gate, pair) in [
+                            (first, (QubitId(0), QubitId(2))),
+                            (second, (QubitId(2), QubitId(0))),
+                        ] {
+                            apply_two_qubit_clifford(&mut sim, gate, &[pair]);
+                            apply_canonical_two_qubit_matrix(
+                                &mut expected,
+                                gate.canonical_2q_matrix().unwrap(),
+                                pair.0,
+                                pair.1,
+                            );
+                        }
+                        assert_phase_exact_state(
+                            "StabVec",
+                            &format!("{second} * {first}, local=({left},{right}), basis={basis}"),
+                            &read_three_qubit_state(&mut sim),
+                            &expected,
+                            F64_TOLERANCE,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn canonical_two_qubit_tables_match_unitary_definitions() {
+    use pecos_quantum::ToMatrix;
+    for &gate in Clifford::all_2q() {
+        let canonical = gate.canonical_2q_matrix().unwrap();
+        // Matrix tables put the first operand in the MSB, while ToMatrix
+        // indexes physical qubits little-endian.
+        let independent = gate.to_unitary_rep_on_qubits(1, 0).to_matrix();
+        for row in 0..4 {
+            for col in 0..4 {
+                let i = 2 * (4 * row + col);
+                let entry = Complex64::new(canonical[i], canonical[i + 1]);
+                assert!(
+                    (entry - independent[(row, col)]).norm() <= F64_TOLERANCE,
+                    "{gate} canonical table disagrees with its unitary definition at ({row},{col})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn deferred_frames_preserve_phase_across_disjoint_batched_pairs() {
+    check_disjoint_batched_pairs::<StabVec>();
+    check_disjoint_batched_pairs::<SparseStateVecSoA>();
+}
+
+fn check_disjoint_batched_pairs<S: StateVectorSimulator + Clone>() {
+    let mut input_sim = S::with_seed(4, 721);
+    let mut input = vec![Complex64::new(0.0, 0.0); 16];
+    input[0] = Complex64::new(1.0, 0.0);
+    for (gate, q) in [
+        (Clifford::H, 0),
+        (Clifford::H, 1),
+        (Clifford::H, 2),
+        (Clifford::H, 3),
+        (Clifford::SZ, 3),
+    ] {
+        apply_clifford_gate(&mut input_sim, gate, &[QubitId(q)]);
+        apply_canonical_matrix(&mut input, gate.canonical_1q_matrix().unwrap(), QubitId(q));
+    }
+    let actual: Vec<_> = (0..16).map(|i| input_sim.get_amplitude(i)).collect();
+    assert_phase_exact_state(
+        std::any::type_name::<S>(),
+        "batched input",
+        &actual,
+        &input,
+        F64_TOLERANCE,
+    );
+    let pairs = [(QubitId(3), QubitId(1)), (QubitId(0), QubitId(2))];
+    for &left in Clifford::all_1q() {
+        for &right in Clifford::all_1q() {
+            let mut framed = input_sim.clone();
+            let mut framed_expected = input.clone();
+            for (local, q) in [
+                (left, pairs[0].0),
+                (right, pairs[0].1),
+                (right, pairs[1].0),
+                (left, pairs[1].1),
+            ] {
+                apply_clifford_gate(&mut framed, local, &[q]);
+                apply_canonical_matrix(
+                    &mut framed_expected,
+                    local.canonical_1q_matrix().unwrap(),
+                    q,
+                );
+            }
+            for &gate in Clifford::all_2q() {
+                let mut sim = framed.clone();
+                let mut expected = framed_expected.clone();
+                apply_two_qubit_clifford(&mut sim, gate, &pairs);
+                for &(q, r) in &pairs {
+                    apply_canonical_two_qubit_matrix(
+                        &mut expected,
+                        gate.canonical_2q_matrix().unwrap(),
+                        q,
+                        r,
+                    );
+                }
+                let actual: Vec<_> = (0..16).map(|i| sim.get_amplitude(i)).collect();
+                assert_phase_exact_state(
+                    std::any::type_name::<S>(),
+                    &format!("{gate} batched, local=({left},{right})"),
+                    &actual,
+                    &expected,
+                    F64_TOLERANCE,
+                );
+            }
+        }
+    }
+}

--- a/crates/pecos-simulators/tests/stab_vec_pending_rz_frame.rs
+++ b/crates/pecos-simulators/tests/stab_vec_pending_rz_frame.rs
@@ -374,9 +374,9 @@ enum CliffordTGate {
     Tdg(usize),
 }
 
-fn random_gate(rng: &mut StdRng, num_qubits: usize) -> CliffordTGate {
+fn random_gate(rng: &mut StdRng, num_qubits: usize, include_t: bool) -> CliffordTGate {
     let q = rng.random_range(0..num_qubits);
-    match rng.random_range(0..11) {
+    match rng.random_range(0..if include_t { 11 } else { 9 }) {
         0 => CliffordTGate::H(q),
         1 => CliffordTGate::S(q),
         2 => CliffordTGate::Sdg(q),
@@ -492,7 +492,16 @@ fn phase_alignment_removes_only_global_phase() {
 }
 
 #[test]
-fn seeded_random_clifford_t_circuits_match_after_global_phase_alignment() {
+fn seeded_random_clifford_t_circuits_match_raw_amplitudes() {
+    check_seeded_random_circuits(true);
+}
+
+#[test]
+fn seeded_random_clifford_circuits_match_raw_amplitudes() {
+    check_seeded_random_circuits(false);
+}
+
+fn check_seeded_random_circuits(include_t: bool) {
     const NUM_QUBITS: usize = 5;
     const DEPTH: usize = 30;
     const CIRCUITS: usize = 200;
@@ -507,7 +516,7 @@ fn seeded_random_clifford_t_circuits_match_after_global_phase_alignment() {
 
     for circuit_index in 0..CIRCUITS {
         let gates: Vec<_> = (0..DEPTH)
-            .map(|_| random_gate(&mut rng, NUM_QUBITS))
+            .map(|_| random_gate(&mut rng, NUM_QUBITS, include_t))
             .collect();
         let mut stab = StabVec::builder(NUM_QUBITS)
             .pruning_threshold(0.0)
@@ -540,10 +549,14 @@ fn seeded_random_clifford_t_circuits_match_after_global_phase_alignment() {
     }
 
     eprintln!(
-        "random Clifford+T differential: raw={raw_mismatches}/{CIRCUITS}, \
+        "random differential (include_t={include_t}): raw={raw_mismatches}/{CIRCUITS}, \
          global-phase-only={global_phase_only_mismatches}/{CIRCUITS}, \
          aligned={aligned_mismatches}/{CIRCUITS}, \
          worst-aligned={worst_aligned_error:e} at circuit {worst_circuit}"
+    );
+    assert_eq!(
+        raw_mismatches, 0,
+        "random differential (include_t={include_t}) must preserve raw complex amplitudes; seed=0x720_C11F_F04D"
     );
     assert_eq!(
         aligned_mismatches, 0,
@@ -552,4 +565,33 @@ fn seeded_random_clifford_t_circuits_match_after_global_phase_alignment() {
          ({raw_mismatches} raw mismatches, {global_phase_only_mismatches} global-phase-only); \
          seed=0x720_C11F_F04D, gates={worst_gates:?}"
     );
+}
+
+#[test]
+fn pure_clifford_cz_global_sign_reproducers() {
+    for gates in [
+        vec![
+            CliffordTGate::X(0),
+            CliffordTGate::X(1),
+            CliffordTGate::Cz(0, 1),
+        ],
+        vec![
+            CliffordTGate::X(0),
+            CliffordTGate::Cx(0, 1),
+            CliffordTGate::Cz(1, 0),
+        ],
+    ] {
+        let mut stab = StabVec::builder(2).seed(1).build();
+        let mut dense = StateVecSoA::with_seed(2, 1);
+        for &gate in &gates {
+            apply_gate(&mut stab, gate);
+            apply_gate(&mut dense, gate);
+        }
+        assert_phase_exact_state_matches(
+            &stab.state_vector(),
+            &dense.state(),
+            TOLERANCE,
+            &format!("{gates:?}"),
+        );
+    }
 }


### PR DESCRIPTION
Closes #721.

## The defect

`CliffordFrame` represents Paulis as `E(x,z) = Z^z X^x`, so its `Y` representative is `iY`, not the standard `Y`. The CX and CZ phase rules were written against **standard-Y signs**, so a deferred frame carrying `X` or `Y` picked up the wrong scalar when it propagated through a two-qubit gate.

Three Clifford gates reproduce it -- no rotations:

```rust
sv.x(&[0.into()]); sv.x(&[1.into()]); sv.cz(&[(0.into(), 1.into())]);
```

`|11>` came out `+1` where the answer is `-1`. Checkable by hand: `X (x) X |00> = |11>` and `CZ|11> = -|11>`.

## The correction

From the canonical conjugations under this convention:

- **CX** preserves Z-before-X ordering, so its phase correction is **zero**.
- **CZ** introduces one anticommutation when both input X bits are set, giving **`(-1)^(x1*x2)`**.

`StabVec` materialises `E^T` because it executes the generator sequence in listed order; transposing `U† E U = w^k E'` gives `U E^T U† = w^k E'^T`, which also explains the existing root-phase conventions and dagger signs.

The shared `PauliFrameGate` transition now updates both frames and their scalar together, including convention and dagger handling, and **both** amplitude-carrying frame consumers use it -- `state_vec_sparse_soa.rs` previously carried duplicated phase arithmetic and is migrated onto the same path rather than fixed twice.

## Per-path audit

| path | verdict |
|---|---|
| `cx` | fixed -- standard-Y signs removed; correction is zero |
| `cz` | fixed -- missing signs for XX and YY frames |
| `cy` | already correct: materialises frames before applying |
| `swap` | already correct: the three CX sign errors cancel; SWAP preserves total Y count |
| `iswap`, `iswapdg` | affected through their CX decompositions; fixed |
| `g`, `gdg` | affected through CZ; fixed |
| `sxx`, `sxxdg` | already correct: element-convention phase `6(z1 xor z2)`, negated for the dagger |
| `syy`, `syydg` | already correct: composed S/SXX/Sdg phases and dagger reversal are exact |
| `szz`, `szzdg` | already correct: phase `2(x1 xor x2)`, negated for the dagger |

## The structural half

`phase_exact_single_qubit_tests.rs` pinned **single-qubit** gates only, which is exactly why this survived: every gate's phase was individually right and the *composition* was wrong.

It now also covers all 14 named two-qubit Cliffords against the **canonical matrix tables** -- not against another PECOS backend -- across all 24x24 deferred local Cliffords, four orthogonal superposed inputs (a definite input cannot see a global phase), `(0,2)` and `(2,0)` orderings, all two-gate products with Pauli frames, and disjoint batched pairs. The canonical tables for all 14 two-qubit Cliffords were added to `pecos-core` and are themselves cross-checked against the existing symbolic unitary definitions.

## Results

Seeded sweeps against `StateVecSoA`, five qubits, depth 30, tolerance `1e-12`:

| sweep | before (raw / phase-aligned) | after |
|---|---:|---:|
| 200 Clifford circuits | 10 / 0 | **0 / 0** |
| 200 Clifford+T circuits | 6 / 0 | **0 / 0** |

Independently re-verified: a 400-circuit sweep over 16 gates including CY, SWAP, iSWAP and the two-qubit roots gives **0/400 raw mismatches, worst error exactly 0**. Both reproducers now return `-1`.

**The existing randomized differential test now asserts raw agreement.** It previously had to concede global-phase differences and assert only on failures surviving phase removal -- that concession is no longer needed, which is the clearest signal this closes the class.

Mutation-verified: restoring the old CX/CZ rules fails the new conformance tests, including CZ after `(X,X)` and a CX product after `(Y,Y)`, with maximum amplitude error about 0.7071.

## Verification

1,261 release tests and 1,265 debug tests pass across `pecos-simulators` and `pecos-core`, the slow pinned corpus passes in both profiles, cold clippy `--all-targets --all-features -- -D warnings` exit 0, and `pre-commit run --all-files` exit 0 with nothing modified.

The #716 harness and its reference data are **untouched** -- no pinned amplitude changed, and `regenerate_reference_data` was never invoked.