### PR TITLE
Seed the two unseeded RNG uniformity tests so they cannot fail by chance

### DIFF
--- a/python/pecos-rslib/tests/test_numpy_random_comparison.py
+++ b/python/pecos-rslib/tests/test_numpy_random_comparison.py
@@ -239,6 +239,8 @@ class TestRandintComparison:
 
     def test_randint_uniformity(self) -> None:
         """Test that randint produces uniform distribution."""
+        # Use a fixed seed for deterministic test behavior
+        pc.random.seed(17)
         low, high = 0, 10
         vals = pc.random.randint(low, high, 10000)
 
@@ -318,6 +320,8 @@ class TestChoiceComparison:
 
     def test_choice_uniformity(self) -> None:
         """Test that choice samples uniformly from array."""
+        # Use a fixed seed for deterministic test behavior
+        pc.random.seed(29)
         items = [0, 1, 2, 3, 4]
         samples = pc.random.choice(items, 10000)
 


### PR DESCRIPTION
## Summary

`test_randint_uniformity` and `test_choice_uniformity` in `python/pecos-rslib/tests/test_numpy_random_comparison.py` run a chi-square test at `p > 0.01` on unseeded draws. By construction that fails about one CI run in a hundred; it took down the `pr-core-python (rest)` shard on #711 (p=0.0093) for a change that does not touch the RNG.

Every other statistical test in the file already calls `pc.random.seed(...)` "for deterministic test behavior". This applies the same convention to the two that were missed, with seeds not used elsewhere in the file.

## Verification

```
uv run --frozen pytest python/pecos-rslib/tests/test_numpy_random_comparison.py -k uniformity
```

4 passed. `pre-commit run --files` on the changed file: all hooks pass.