### PR TITLE
Wait for the ETXTBSY window to clear before using the fake llvm-config, and log why LLVM detection failed

### DIFF
--- a/crates/pecos-build/src/cmake/installer.rs
+++ b/crates/pecos-build/src/cmake/installer.rs
@@ -370,6 +370,15 @@ fn verify_runtime(cmake_dir: &Path) -> Result<()> {
         ));
     };
 
+    // First execution of the just-extracted binary, which races the unpack.
+    if !crate::executable::wait_until_executable(&cmake_bin, &["--version"]) {
+        println!("FAILED");
+        return Err(Error::Config(format!(
+            "extracted cmake at {} could not be executed",
+            cmake_bin.display()
+        )));
+    }
+
     let output = std::process::Command::new(&cmake_bin)
         .arg("--version")
         .output()

--- a/crates/pecos-build/src/cmake/installer.rs
+++ b/crates/pecos-build/src/cmake/installer.rs
@@ -371,7 +371,7 @@ fn verify_runtime(cmake_dir: &Path) -> Result<()> {
     };
 
     // First execution of the just-extracted binary, which races the unpack.
-    if let Err(error) = crate::executable::wait_until_executable(&cmake_bin, &["--version"]) {
+    if let Err(error) = crate::executable::run_when_executable(&cmake_bin, &["--version"]) {
         println!("FAILED");
         return Err(Error::Config(format!(
             "extracted cmake at {} could not be executed: {error}",

--- a/crates/pecos-build/src/cmake/installer.rs
+++ b/crates/pecos-build/src/cmake/installer.rs
@@ -371,10 +371,10 @@ fn verify_runtime(cmake_dir: &Path) -> Result<()> {
     };
 
     // First execution of the just-extracted binary, which races the unpack.
-    if !crate::executable::wait_until_executable(&cmake_bin, &["--version"]) {
+    if let Err(error) = crate::executable::wait_until_executable(&cmake_bin, &["--version"]) {
         println!("FAILED");
         return Err(Error::Config(format!(
-            "extracted cmake at {} could not be executed",
+            "extracted cmake at {} could not be executed: {error}",
             cmake_bin.display()
         )));
     }

--- a/crates/pecos-build/src/cuda.rs
+++ b/crates/pecos-build/src/cuda.rs
@@ -126,6 +126,11 @@ pub fn get_cuda_version(cuda_path: &Path) -> Result<String> {
     let exe_ext = if cfg!(windows) { ".exe" } else { "" };
     let nvcc = cuda_path.join("bin").join(format!("nvcc{exe_ext}"));
 
+    // nvcc may have been copied into place moments ago by the installer, so
+    // this can be its first execution and races the copy.
+    crate::executable::wait_until_executable(&nvcc, &["--version"])
+        .map_err(|e| Error::Cuda(format!("Failed to execute {}: {e}", nvcc.display())))?;
+
     let output = Command::new(&nvcc)
         .arg("--version")
         .output()

--- a/crates/pecos-build/src/cuda.rs
+++ b/crates/pecos-build/src/cuda.rs
@@ -127,14 +127,10 @@ pub fn get_cuda_version(cuda_path: &Path) -> Result<String> {
     let nvcc = cuda_path.join("bin").join(format!("nvcc{exe_ext}"));
 
     // nvcc may have been copied into place moments ago by the installer, so
-    // this can be its first execution and races the copy.
-    crate::executable::wait_until_executable(&nvcc, &["--version"])
+    // this can be its first execution and races the copy. The helper returns
+    // the successful run's output, so nvcc is launched once, not twice.
+    let output = crate::executable::run_when_executable(&nvcc, &["--version"])
         .map_err(|e| Error::Cuda(format!("Failed to execute {}: {e}", nvcc.display())))?;
-
-    let output = Command::new(&nvcc)
-        .arg("--version")
-        .output()
-        .map_err(|e| Error::Cuda(format!("Failed to execute nvcc: {e}")))?;
 
     if !output.status.success() {
         return Err(Error::Cuda("nvcc --version failed".into()));

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -243,8 +243,8 @@ mod tests {
         assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
         assert_eq!(attempts.runs, MAX_EXEC_WAIT_ATTEMPTS);
         assert_eq!(
-            attempts.sleeps.len() as u32,
-            MAX_EXEC_WAIT_ATTEMPTS - 1,
+            attempts.sleeps.len(),
+            usize::try_from(MAX_EXEC_WAIT_ATTEMPTS - 1).expect("attempt count fits a usize"),
             "no sleep after the last attempt"
         );
         assert_eq!(

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -15,13 +15,15 @@
 //! Executable lookup shared by external-tool detectors.
 
 use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 
-/// Attempts before [`wait_until_executable`] gives up, so a genuinely unusable
+/// Attempts before [`run_when_executable`] gives up, so a genuinely unusable
 /// file reports failure instead of looping. Backoff is capped, giving a budget
 /// of roughly half a second.
 const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 
-/// Run `path` with `args` until it is no longer reported as busy.
+/// Run `path` with `args` until it is no longer reported as busy, and return
+/// the output of the run that succeeded.
 ///
 /// Writing a file and immediately executing it races with process creation
 /// elsewhere in the same process. A concurrent `fork` inherits the still-open
@@ -49,13 +51,12 @@ const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 /// naming the attempt count when it stayed busy for the whole budget. Callers
 /// report the cause; a bare boolean would leave it only in the log, which a
 /// library consumer need not have initialized.
-pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> std::io::Result<()> {
+pub(crate) fn run_when_executable(path: &Path, args: &[&str]) -> std::io::Result<Output> {
     use std::io::{Error, ErrorKind};
-    use std::process::Command;
 
     for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
         match Command::new(path).args(args).output() {
-            Ok(_) => return Ok(()),
+            Ok(output) => return Ok(output),
             Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
                 // No point sleeping when no attempt remains.
                 if attempt + 1 == MAX_EXEC_WAIT_ATTEMPTS {
@@ -99,48 +100,125 @@ pub(crate) fn which_in_path(name: &str, extensions: &[&str]) -> Option<PathBuf> 
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::wait_until_executable;
+    use super::run_when_executable;
     use std::fs;
     use std::io::ErrorKind;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Write an executable stub and return its path.
+    /// Write an executable shell stub and return its path.
     fn write_stub(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
         let path = dir.join(name);
-        fs::write(&path, "#!/bin/sh\necho 21.1.8\n").expect("Should write stub");
+        fs::write(&path, "#!/bin/sh\necho 21.1.8 \"$@\"\n").expect("Should write stub");
         let mut permissions = fs::metadata(&path).expect("Should stat stub").permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&path, permissions).expect("Should chmod stub");
         path
     }
 
+    #[test]
+    fn a_missing_target_reports_the_operating_system_error() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let error = run_when_executable(&temp.path().join("absent"), &["--version"])
+            .expect_err("a missing file is not executable");
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn a_non_executable_target_reports_the_operating_system_error() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let path = temp.path().join("not-executable");
+        fs::write(&path, "#!/bin/sh\n").expect("Should write file");
+        let error = run_when_executable(&path, &["--version"])
+            .expect_err("a file without the execute bit is not executable");
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn the_successful_run_output_is_returned() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let path = write_stub(temp.path(), "reports-version");
+        let output = run_when_executable(&path, &["--version"]).expect("stub should run");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "21.1.8 --version"
+        );
+    }
+
+    /// The caller's arguments are forwarded, not a fixed set. Every current
+    /// caller happens to pass `--version`, so without this the contract would
+    /// be untested.
+    #[test]
+    fn the_supplied_arguments_are_forwarded() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let path = write_stub(temp.path(), "echoes-args");
+        let output =
+            run_when_executable(&path, &["--prefix", "--libdir"]).expect("stub should run");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "21.1.8 --prefix --libdir"
+        );
+    }
+
     /// An open writable descriptor is exactly the condition that produces
-    /// `ETXTBSY`, so holding one ourselves reproduces it without any race.
-    /// Nothing about this test is timing-dependent.
+    /// `ETXTBSY`, so holding one reproduces it with no race at all.
+    ///
+    /// Linux only. Apple's XNU has the equivalent open-writer check compiled
+    /// out, so a held descriptor does not block execution there and this would
+    /// assert on a condition the platform never produces.
+    #[cfg(target_os = "linux")]
     #[test]
     fn a_held_writable_descriptor_is_reported_rather_than_waited_out() {
         let temp = tempfile::tempdir().expect("Should create probe dir");
-        let path = write_stub(temp.path(), "held-open");
+        for (name, source) in [("held-script", None), ("held-binary", Some("/bin/true"))] {
+            let path = match source {
+                None => write_stub(temp.path(), name),
+                // A native binary, not just a shell script: the barrier must
+                // not special-case one kind of executable.
+                Some(binary) => {
+                    let path = temp.path().join(name);
+                    fs::copy(binary, &path).expect("Should copy a native binary");
+                    let mut permissions =
+                        fs::metadata(&path).expect("Should stat copy").permissions();
+                    permissions.set_mode(0o755);
+                    fs::set_permissions(&path, permissions).expect("Should chmod copy");
+                    path
+                }
+            };
 
-        let writer = fs::OpenOptions::new()
-            .write(true)
-            .open(&path)
-            .expect("Should hold the stub open for writing");
+            let writer = fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("Should hold the target open for writing");
 
-        let error = wait_until_executable(&path, &["--version"])
-            .expect_err("a stub held open for writing must not be reported as executable");
-        assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
+            let started = std::time::Instant::now();
+            let error = run_when_executable(&path, &["--version"])
+                .expect_err("a target held open for writing is not executable");
+            assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy, "{name}");
+            // The retry budget is bounded; a regression that widened it would
+            // otherwise only show up as a slow or hanging CI run.
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(5),
+                "{name} gave up only after {:?}",
+                started.elapsed()
+            );
 
-        drop(writer);
-        wait_until_executable(&path, &["--version"])
-            .expect("the stub becomes executable once the writer is gone");
+            drop(writer);
+            run_when_executable(&path, &["--version"]).unwrap_or_else(|error| {
+                panic!("{name} should run once the writer is gone: {error}")
+            });
+        }
     }
 
-    /// The barrier must actually wait for the writer to go away, not simply
-    /// let enough wall-clock time pass. Releasing the descriptor part-way
-    /// through means only a helper that keeps re-checking can succeed.
+    /// The barrier must keep re-checking until the writer goes away, rather
+    /// than letting wall-clock time pass and hoping.
+    ///
+    /// The writer is released well after any plausible fixed delay, and the
+    /// verification happens INSIDE the scope: leaving the scope would join the
+    /// releasing thread and establish readiness by itself, which would let a
+    /// helper that does nothing pass.
+    #[cfg(target_os = "linux")]
     #[test]
     fn the_barrier_waits_for_the_writer_to_be_released() {
         let temp = tempfile::tempdir().expect("Should create probe dir");
@@ -153,31 +231,27 @@ mod tests {
 
         std::thread::scope(|scope| {
             scope.spawn(move || {
-                std::thread::sleep(std::time::Duration::from_millis(60));
+                std::thread::sleep(std::time::Duration::from_millis(250));
                 drop(writer);
             });
-            wait_until_executable(&path, &["--version"])
+            run_when_executable(&path, &["--version"])
                 .expect("the barrier should wait until the writer is released");
+            Command::new(&path)
+                .arg("--version")
+                .output()
+                .expect("the stub runs once the barrier reports it ready");
         });
-
-        Command::new(&path)
-            .arg("--version")
-            .output()
-            .expect("the stub runs once the barrier reports it ready");
     }
 
     /// Writing a script and executing it immediately fails with `ETXTBSY` at a
     /// double-digit rate when other threads are spawning processes. Reproduce
     /// that load and assert the barrier absorbs it.
     ///
-    /// The second execution is the part that matters. Asserting only on the
-    /// helper's return value would pass even if the helper returned `Ok`
-    /// without doing anything, so each stub is run again afterwards to confirm
-    /// the barrier really did make it executable.
+    /// Each stub is run again after the barrier reports success, because
+    /// asserting only on the helper's return value would pass even if the
+    /// helper did nothing at all.
     #[test]
     fn newly_written_scripts_are_executable_while_other_threads_spawn() {
-        // TempDir removes itself even if a worker panics, and its name cannot
-        // collide with another run's directory.
         let temp = tempfile::tempdir().expect("Should create probe dir");
         let dir = temp.path().to_path_buf();
 
@@ -197,21 +271,12 @@ mod tests {
                 let post_barrier_busy = &post_barrier_busy;
                 scope.spawn(move || {
                     for i in 0..150 {
-                        let path = dir.join(format!("stub-{worker}-{i}"));
-                        fs::write(&path, "#!/bin/sh\necho 21.1.8\n").expect("Should write stub");
-                        let mut permissions =
-                            fs::metadata(&path).expect("Should stat stub").permissions();
-                        permissions.set_mode(0o755);
-                        fs::set_permissions(&path, permissions).expect("Should chmod stub");
-
-                        if wait_until_executable(&path, &["--version"]).is_err() {
+                        let path = write_stub(dir, &format!("stub-{worker}-{i}"));
+                        if run_when_executable(&path, &["--version"]).is_err() {
                             failures.fetch_add(1, Ordering::Relaxed);
                             let _ = fs::remove_file(&path);
                             continue;
                         }
-                        // Execute independently of the helper's own return
-                        // value. Trusting that value would pass even if the
-                        // barrier did nothing at all.
                         if let Err(error) = Command::new(&path).arg("--version").output() {
                             assert_eq!(
                                 error.kind(),

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -14,7 +14,54 @@
 
 //! Executable lookup shared by external-tool detectors.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Attempts before [`wait_until_executable`] gives up, so a genuinely unusable
+/// file reports failure instead of looping. Backoff is capped, giving a budget
+/// of roughly half a second.
+const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
+
+/// Run `path` with `args` until it is not reported as busy, and return whether
+/// it became executable.
+///
+/// Writing a file and immediately executing it races with process creation
+/// elsewhere in the same process. A concurrent `fork` inherits the still-open
+/// write descriptor, and `execve` on that file reports `ETXTBSY` until the
+/// child completes its own `exec` and the inherited descriptor closes.
+/// `O_CLOEXEC` does not avoid this, because the descriptor is still open when
+/// the kernel performs the check (rust-lang/rust#39186). The condition cannot
+/// be prevented from inside a multi-threaded process, and writing to a
+/// temporary name and renaming does not help either, because the check tracks
+/// the inode rather than the path.
+///
+/// One successful execution closes the window permanently for this path. It
+/// proves every child that inherited the write descriptor has finished
+/// exec'ing, and nothing opens the file for writing again afterwards, so this
+/// is a one-time barrier rather than a standing retry.
+///
+/// A program that runs and exits non-zero still counts as executable.
+pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
+    use std::io::ErrorKind;
+    use std::process::Command;
+
+    for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
+        match Command::new(path).args(args).output() {
+            Ok(_) => return true,
+            Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
+                std::thread::sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
+            }
+            Err(error) => {
+                log::warn!("Could not run {}: {error}", path.display());
+                return false;
+            }
+        }
+    }
+    log::warn!(
+        "{} was still busy after {MAX_EXEC_WAIT_ATTEMPTS} attempts",
+        path.display()
+    );
+    false
+}
 
 /// Resolve an executable via `PATH` using the caller's platform suffix policy.
 #[must_use]
@@ -29,4 +76,61 @@ pub(crate) fn which_in_path(name: &str, extensions: &[&str]) -> Option<PathBuf> 
         }
     }
     None
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::wait_until_executable;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Writing a script and executing it immediately fails with `ETXTBSY` at a
+    /// double-digit rate when other threads are spawning processes. Reproduce
+    /// that load and assert the barrier absorbs it: without the wait inside
+    /// [`wait_until_executable`] this fails within a few iterations.
+    #[test]
+    fn newly_written_scripts_are_executable_while_other_threads_spawn() {
+        let dir = std::env::temp_dir().join(format!("pecos_exec_wait_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("Should create probe dir");
+
+        let failures = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    for _ in 0..600 {
+                        let _ = Command::new("/bin/true").output();
+                    }
+                });
+            }
+            for worker in 0..4 {
+                let dir = &dir;
+                let failures = &failures;
+                scope.spawn(move || {
+                    for i in 0..150 {
+                        let path = dir.join(format!("stub-{worker}-{i}"));
+                        fs::write(&path, "#!/bin/sh\necho 21.1.8\n").expect("Should write stub");
+                        let mut permissions =
+                            fs::metadata(&path).expect("Should stat stub").permissions();
+                        permissions.set_mode(0o755);
+                        fs::set_permissions(&path, permissions).expect("Should chmod stub");
+
+                        if !wait_until_executable(&path, &["--version"]) {
+                            failures.fetch_add(1, Ordering::Relaxed);
+                        }
+                        let _ = fs::remove_file(&path);
+                    }
+                });
+            }
+        });
+
+        let _ = fs::remove_dir_all(&dir);
+        assert_eq!(
+            failures.load(Ordering::Relaxed),
+            0,
+            "a freshly written script could not be executed"
+        );
+    }
 }

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -106,6 +106,66 @@ mod tests {
     use std::process::Command;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Write an executable stub and return its path.
+    fn write_stub(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, "#!/bin/sh\necho 21.1.8\n").expect("Should write stub");
+        let mut permissions = fs::metadata(&path).expect("Should stat stub").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("Should chmod stub");
+        path
+    }
+
+    /// An open writable descriptor is exactly the condition that produces
+    /// `ETXTBSY`, so holding one ourselves reproduces it without any race.
+    /// Nothing about this test is timing-dependent.
+    #[test]
+    fn a_held_writable_descriptor_is_reported_rather_than_waited_out() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let path = write_stub(temp.path(), "held-open");
+
+        let writer = fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("Should hold the stub open for writing");
+
+        let error = wait_until_executable(&path, &["--version"])
+            .expect_err("a stub held open for writing must not be reported as executable");
+        assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
+
+        drop(writer);
+        wait_until_executable(&path, &["--version"])
+            .expect("the stub becomes executable once the writer is gone");
+    }
+
+    /// The barrier must actually wait for the writer to go away, not simply
+    /// let enough wall-clock time pass. Releasing the descriptor part-way
+    /// through means only a helper that keeps re-checking can succeed.
+    #[test]
+    fn the_barrier_waits_for_the_writer_to_be_released() {
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let path = write_stub(temp.path(), "released-midway");
+
+        let writer = fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("Should hold the stub open for writing");
+
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                drop(writer);
+            });
+            wait_until_executable(&path, &["--version"])
+                .expect("the barrier should wait until the writer is released");
+        });
+
+        Command::new(&path)
+            .arg("--version")
+            .output()
+            .expect("the stub runs once the barrier reports it ready");
+    }
+
     /// Writing a script and executing it immediately fails with `ETXTBSY` at a
     /// double-digit rate when other threads are spawning processes. Reproduce
     /// that load and assert the barrier absorbs it.

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -52,17 +52,47 @@ const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 /// report the cause; a bare boolean would leave it only in the log, which a
 /// library consumer need not have initialized.
 pub(crate) fn run_when_executable(path: &Path, args: &[&str]) -> std::io::Result<Output> {
+    retry_while_busy(path, &mut RealAttempts, |runner| runner.run(path, args))
+}
+
+/// The two effects the retry loop performs, so tests can supply them directly.
+///
+/// Timing-based tests of this loop were repeatedly vacuous: a fixed delay long
+/// enough to outlast the test's own writer passes without ever retrying. Making
+/// the attempt and the sleep injectable lets the retry behaviour be asserted
+/// exactly, on every platform, without racing the scheduler.
+trait Attempts {
+    fn run(&mut self, path: &Path, args: &[&str]) -> std::io::Result<Output>;
+    fn sleep(&mut self, duration: std::time::Duration);
+}
+
+struct RealAttempts;
+
+impl Attempts for RealAttempts {
+    fn run(&mut self, path: &Path, args: &[&str]) -> std::io::Result<Output> {
+        Command::new(path).args(args).output()
+    }
+    fn sleep(&mut self, duration: std::time::Duration) {
+        std::thread::sleep(duration);
+    }
+}
+
+fn retry_while_busy<A: Attempts>(
+    path: &Path,
+    attempts: &mut A,
+    mut run: impl FnMut(&mut A) -> std::io::Result<Output>,
+) -> std::io::Result<Output> {
     use std::io::{Error, ErrorKind};
 
     for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
-        match Command::new(path).args(args).output() {
+        match run(attempts) {
             Ok(output) => return Ok(output),
             Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
                 // No point sleeping when no attempt remains.
                 if attempt + 1 == MAX_EXEC_WAIT_ATTEMPTS {
                     break;
                 }
-                std::thread::sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
+                attempts.sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
             }
             Err(error) => {
                 log::warn!("Could not run {}: {error}", path.display());
@@ -106,6 +136,153 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::{Attempts, MAX_EXEC_WAIT_ATTEMPTS, retry_while_busy};
+    use std::io::Error;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+    use std::time::Duration;
+
+    /// Reports busy for the first `busy_before_success` attempts, then hands
+    /// back `result`. Records every attempt and every requested sleep.
+    struct ScriptedAttempts {
+        busy_before_success: u32,
+        result: Option<std::io::Result<Output>>,
+        runs: u32,
+        sleeps: Vec<Duration>,
+    }
+
+    impl ScriptedAttempts {
+        fn busy_then(busy_before_success: u32, result: std::io::Result<Output>) -> Self {
+            Self {
+                busy_before_success,
+                result: Some(result),
+                runs: 0,
+                sleeps: Vec::new(),
+            }
+        }
+        fn always_busy() -> Self {
+            Self {
+                busy_before_success: u32::MAX,
+                result: None,
+                runs: 0,
+                sleeps: Vec::new(),
+            }
+        }
+    }
+
+    impl Attempts for ScriptedAttempts {
+        fn run(&mut self, _path: &std::path::Path, _args: &[&str]) -> std::io::Result<Output> {
+            self.runs += 1;
+            if self.runs <= self.busy_before_success {
+                return Err(Error::from_raw_os_error(26));
+            }
+            self.result
+                .take()
+                .expect("the scripted result is consumed once")
+        }
+        fn sleep(&mut self, duration: Duration) {
+            self.sleeps.push(duration);
+        }
+    }
+
+    fn output(stdout: &str, stderr: &str, code: i32) -> Output {
+        Output {
+            status: ExitStatus::from_raw(code << 8),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    /// The loop must keep re-attempting while busy, and hand back the
+    /// successful attempt's result untouched: same stdout, stderr and exit
+    /// status, from exactly one successful execution.
+    #[test]
+    fn a_busy_target_is_retried_and_its_eventual_output_returned_verbatim() {
+        let mut attempts = ScriptedAttempts::busy_then(3, Ok(output("21.1.8", "a warning", 3)));
+        let result = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
+            a.run(std::path::Path::new("/probe"), &["--version"])
+        })
+        .expect("the fourth attempt succeeds");
+
+        assert_eq!(attempts.runs, 4, "three busy attempts then one success");
+        assert_eq!(String::from_utf8_lossy(&result.stdout), "21.1.8");
+        assert_eq!(String::from_utf8_lossy(&result.stderr), "a warning");
+        assert_eq!(
+            result.status.code(),
+            Some(3),
+            "a non-zero exit is preserved"
+        );
+    }
+
+    /// Backoff doubles and then caps, so a widened budget cannot slip in.
+    #[test]
+    fn the_backoff_doubles_up_to_the_cap() {
+        let mut attempts = ScriptedAttempts::busy_then(5, Ok(output("ok", "", 0)));
+        retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
+            a.run(std::path::Path::new("/probe"), &[])
+        })
+        .expect("succeeds after five busy attempts");
+        assert_eq!(
+            attempts.sleeps,
+            [1, 2, 4, 8, 16].map(Duration::from_millis),
+            "backoff should double from 1ms"
+        );
+    }
+
+    /// A target that never stops being busy is given up on after the bounded
+    /// number of attempts, with no sleep after the final one.
+    #[test]
+    fn a_permanently_busy_target_is_abandoned_after_the_bounded_attempts() {
+        let mut attempts = ScriptedAttempts::always_busy();
+        let error = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
+            a.run(std::path::Path::new("/probe"), &[])
+        })
+        .expect_err("a permanently busy target is not executable");
+
+        assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
+        assert_eq!(attempts.runs, MAX_EXEC_WAIT_ATTEMPTS);
+        assert_eq!(
+            attempts.sleeps.len() as u32,
+            MAX_EXEC_WAIT_ATTEMPTS - 1,
+            "no sleep after the last attempt"
+        );
+        assert_eq!(
+            attempts.sleeps.iter().max(),
+            Some(&Duration::from_millis(32)),
+            "backoff is capped"
+        );
+    }
+
+    /// An error that is not "busy" is returned as it came from the operating
+    /// system, not reclassified or replaced.
+    #[test]
+    fn a_non_busy_error_is_returned_unchanged() {
+        let mut attempts = ScriptedAttempts::busy_then(0, Err(Error::from_raw_os_error(13)));
+        let error = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
+            a.run(std::path::Path::new("/probe"), &[])
+        })
+        .expect_err("a permission error is not retried");
+
+        assert_eq!(error.raw_os_error(), Some(13), "the OS error is preserved");
+        assert_eq!(attempts.runs, 1, "a non-busy error is not retried");
+        assert!(attempts.sleeps.is_empty());
+    }
+
+    /// Produce an executable at `name`: a shell stub, or a copy of `source`
+    /// when a native binary is wanted.
+    #[cfg(target_os = "linux")]
+    fn materialise(dir: &std::path::Path, name: &str, source: Option<&str>) -> std::path::PathBuf {
+        let Some(binary) = source else {
+            return write_stub(dir, name);
+        };
+        let path = dir.join(name);
+        fs::copy(binary, &path).expect("Should copy a native binary");
+        let mut permissions = fs::metadata(&path).expect("Should stat copy").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("Should chmod copy");
+        path
+    }
 
     /// Write an executable shell stub and return its path.
     fn write_stub(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
@@ -172,37 +349,16 @@ mod tests {
     fn a_held_writable_descriptor_is_reported_rather_than_waited_out() {
         let temp = tempfile::tempdir().expect("Should create probe dir");
         for (name, source) in [("held-script", None), ("held-binary", Some("/bin/true"))] {
-            let path = match source {
-                None => write_stub(temp.path(), name),
-                // A native binary, not just a shell script: the barrier must
-                // not special-case one kind of executable.
-                Some(binary) => {
-                    let path = temp.path().join(name);
-                    fs::copy(binary, &path).expect("Should copy a native binary");
-                    let mut permissions =
-                        fs::metadata(&path).expect("Should stat copy").permissions();
-                    permissions.set_mode(0o755);
-                    fs::set_permissions(&path, permissions).expect("Should chmod copy");
-                    path
-                }
-            };
+            let path = materialise(temp.path(), name, source);
 
             let writer = fs::OpenOptions::new()
                 .write(true)
                 .open(&path)
                 .expect("Should hold the target open for writing");
 
-            let started = std::time::Instant::now();
             let error = run_when_executable(&path, &["--version"])
                 .expect_err("a target held open for writing is not executable");
             assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy, "{name}");
-            // The retry budget is bounded; a regression that widened it would
-            // otherwise only show up as a slow or hanging CI run.
-            assert!(
-                started.elapsed() < std::time::Duration::from_secs(5),
-                "{name} gave up only after {:?}",
-                started.elapsed()
-            );
 
             drop(writer);
             run_when_executable(&path, &["--version"]).unwrap_or_else(|error| {
@@ -222,25 +378,32 @@ mod tests {
     #[test]
     fn the_barrier_waits_for_the_writer_to_be_released() {
         let temp = tempfile::tempdir().expect("Should create probe dir");
-        let path = write_stub(temp.path(), "released-midway");
+        // A shell script and a native binary: recovery from a real busy launch
+        // must work for both, so an ELF special case cannot hide here.
+        for (name, source) in [
+            ("released-script", None),
+            ("released-binary", Some("/bin/true")),
+        ] {
+            let path = materialise(temp.path(), name, source);
 
-        let writer = fs::OpenOptions::new()
-            .write(true)
-            .open(&path)
-            .expect("Should hold the stub open for writing");
+            let writer = fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("Should hold the target open for writing");
 
-        std::thread::scope(|scope| {
-            scope.spawn(move || {
-                std::thread::sleep(std::time::Duration::from_millis(250));
-                drop(writer);
+            std::thread::scope(|scope| {
+                scope.spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(250));
+                    drop(writer);
+                });
+                run_when_executable(&path, &["--version"])
+                    .unwrap_or_else(|error| panic!("{name} should wait for release: {error}"));
+                Command::new(&path)
+                    .arg("--version")
+                    .output()
+                    .unwrap_or_else(|error| panic!("{name} should run once ready: {error}"));
             });
-            run_when_executable(&path, &["--version"])
-                .expect("the barrier should wait until the writer is released");
-            Command::new(&path)
-                .arg("--version")
-                .output()
-                .expect("the stub runs once the barrier reports it ready");
-        });
+        }
     }
 
     /// Writing a script and executing it immediately fails with `ETXTBSY` at a

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -138,18 +138,26 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{Attempts, MAX_EXEC_WAIT_ATTEMPTS, retry_while_busy};
-    use std::io::Error;
     use std::os::unix::process::ExitStatusExt;
     use std::process::{ExitStatus, Output};
     use std::time::Duration;
 
+    /// What the loop did, in order. Recording runs and sleeps in one sequence
+    /// pins their interleaving; separate counters would accept an
+    /// implementation that performed all its sleeps at the end.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Event {
+        Ran,
+        Slept(Duration),
+    }
+
     /// Reports busy for the first `busy_before_success` attempts, then hands
-    /// back `result`. Records every attempt and every requested sleep.
+    /// back `result`, recording every event in order.
     struct ScriptedAttempts {
         busy_before_success: u32,
         result: Option<std::io::Result<Output>>,
         runs: u32,
-        sleeps: Vec<Duration>,
+        events: Vec<Event>,
     }
 
     impl ScriptedAttempts {
@@ -158,7 +166,7 @@ mod tests {
                 busy_before_success,
                 result: Some(result),
                 runs: 0,
-                sleeps: Vec::new(),
+                events: Vec::new(),
             }
         }
         fn always_busy() -> Self {
@@ -166,107 +174,165 @@ mod tests {
                 busy_before_success: u32::MAX,
                 result: None,
                 runs: 0,
-                sleeps: Vec::new(),
+                events: Vec::new(),
             }
+        }
+        fn sleeps(&self) -> Vec<Duration> {
+            self.events
+                .iter()
+                .filter_map(|event| match event {
+                    Event::Slept(duration) => Some(*duration),
+                    Event::Ran => None,
+                })
+                .collect()
         }
     }
 
     impl Attempts for ScriptedAttempts {
         fn run(&mut self, _path: &std::path::Path, _args: &[&str]) -> std::io::Result<Output> {
             self.runs += 1;
+            self.events.push(Event::Ran);
             if self.runs <= self.busy_before_success {
-                return Err(Error::from_raw_os_error(26));
+                // The kind, not a raw errno: the numeric value of ETXTBSY is
+                // not the same on every unix.
+                return Err(ErrorKind::ExecutableFileBusy.into());
             }
             self.result
                 .take()
                 .expect("the scripted result is consumed once")
         }
         fn sleep(&mut self, duration: Duration) {
-            self.sleeps.push(duration);
+            self.events.push(Event::Slept(duration));
         }
     }
 
-    fn output(stdout: &str, stderr: &str, code: i32) -> Output {
+    fn output(stdout: &[u8], stderr: &[u8], code: i32) -> Output {
         Output {
             status: ExitStatus::from_raw(code << 8),
-            stdout: stdout.as_bytes().to_vec(),
-            stderr: stderr.as_bytes().to_vec(),
+            stdout: stdout.to_vec(),
+            stderr: stderr.to_vec(),
         }
+    }
+
+    fn drive(attempts: &mut ScriptedAttempts) -> std::io::Result<Output> {
+        retry_while_busy(std::path::Path::new("/probe"), attempts, |a| {
+            a.run(std::path::Path::new("/probe"), &["--version"])
+        })
+    }
+
+    /// The budget and backoff are asserted against literals, not against the
+    /// production constant. Deriving them from `MAX_EXEC_WAIT_ATTEMPTS` would
+    /// accept any value that constant was changed to.
+    #[test]
+    fn the_retry_budget_and_backoff_are_exactly_as_documented() {
+        assert_eq!(MAX_EXEC_WAIT_ATTEMPTS, 20);
+        let mut attempts = ScriptedAttempts::always_busy();
+        drive(&mut attempts).expect_err("a permanently busy target is not executable");
+
+        assert_eq!(attempts.runs, 20);
+        let expected: Vec<Duration> = [1u64, 2, 4, 8, 16]
+            .into_iter()
+            .chain(std::iter::repeat_n(32, 14))
+            .map(Duration::from_millis)
+            .collect();
+        assert_eq!(
+            attempts.sleeps(),
+            expected,
+            "19 sleeps, doubling then capped"
+        );
+        assert_eq!(
+            attempts.events.first(),
+            Some(&Event::Ran),
+            "the first thing it does is try"
+        );
+        assert_eq!(
+            attempts.events.last(),
+            Some(&Event::Ran),
+            "no sleep after the final attempt"
+        );
+    }
+
+    /// A success on the very last permitted attempt is a success, not
+    /// exhaustion.
+    #[test]
+    fn a_success_on_the_final_permitted_attempt_is_returned() {
+        let mut attempts = ScriptedAttempts::busy_then(19, Ok(output(b"late", b"", 0)));
+        let result = drive(&mut attempts).expect("the twentieth attempt succeeds");
+        assert_eq!(result.stdout, b"late");
+        assert_eq!(attempts.runs, 20);
+    }
+
+    /// A non-busy error arriving after some busy attempts is still that error,
+    /// not reported as exhaustion.
+    #[test]
+    fn a_non_busy_error_after_busy_attempts_is_returned_as_itself() {
+        let mut attempts =
+            ScriptedAttempts::busy_then(3, Err(std::io::Error::from_raw_os_error(13)));
+        let error = drive(&mut attempts).expect_err("the permission error surfaces");
+        assert_eq!(error.raw_os_error(), Some(13));
+        assert_eq!(attempts.runs, 4);
     }
 
     /// The loop must keep re-attempting while busy, and hand back the
-    /// successful attempt's result untouched: same stdout, stderr and exit
-    /// status, from exactly one successful execution.
+    /// successful attempt's result untouched.
+    ///
+    /// The fixtures are deliberately hostile: stdout that is not valid UTF-8,
+    /// non-empty stderr, and a non-zero exit. Comparing bytes and the whole
+    /// `ExitStatus` stops a reconstructed-but-lossy result from passing.
     #[test]
     fn a_busy_target_is_retried_and_its_eventual_output_returned_verbatim() {
-        let mut attempts = ScriptedAttempts::busy_then(3, Ok(output("21.1.8", "a warning", 3)));
-        let result = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
-            a.run(std::path::Path::new("/probe"), &["--version"])
-        })
-        .expect("the fourth attempt succeeds");
+        let expected = output(&[0x21, 0xff, 0xfe, 0x2e], b"a warning", 3);
+        let mut attempts = ScriptedAttempts::busy_then(3, Ok(expected.clone()));
+        let result = drive(&mut attempts).expect("the fourth attempt succeeds");
 
         assert_eq!(attempts.runs, 4, "three busy attempts then one success");
-        assert_eq!(String::from_utf8_lossy(&result.stdout), "21.1.8");
-        assert_eq!(String::from_utf8_lossy(&result.stderr), "a warning");
+        assert_eq!(result.stdout, expected.stdout, "raw bytes, not lossy text");
+        assert_eq!(result.stderr, expected.stderr);
+        assert_eq!(result.status, expected.status, "the whole exit status");
         assert_eq!(
-            result.status.code(),
-            Some(3),
-            "a non-zero exit is preserved"
+            attempts.sleeps(),
+            [1, 2, 4].map(Duration::from_millis),
+            "one sleep between each pair of attempts"
         );
     }
 
-    /// Backoff doubles and then caps, so a widened budget cannot slip in.
+    /// A process killed by a signal has no exit code; the status must survive
+    /// rather than being flattened to success.
     #[test]
-    fn the_backoff_doubles_up_to_the_cap() {
-        let mut attempts = ScriptedAttempts::busy_then(5, Ok(output("ok", "", 0)));
-        retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
-            a.run(std::path::Path::new("/probe"), &[])
-        })
-        .expect("succeeds after five busy attempts");
-        assert_eq!(
-            attempts.sleeps,
-            [1, 2, 4, 8, 16].map(Duration::from_millis),
-            "backoff should double from 1ms"
-        );
-    }
-
-    /// A target that never stops being busy is given up on after the bounded
-    /// number of attempts, with no sleep after the final one.
-    #[test]
-    fn a_permanently_busy_target_is_abandoned_after_the_bounded_attempts() {
-        let mut attempts = ScriptedAttempts::always_busy();
-        let error = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
-            a.run(std::path::Path::new("/probe"), &[])
-        })
-        .expect_err("a permanently busy target is not executable");
-
-        assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
-        assert_eq!(attempts.runs, MAX_EXEC_WAIT_ATTEMPTS);
-        assert_eq!(
-            attempts.sleeps.len(),
-            usize::try_from(MAX_EXEC_WAIT_ATTEMPTS - 1).expect("attempt count fits a usize"),
-            "no sleep after the last attempt"
-        );
-        assert_eq!(
-            attempts.sleeps.iter().max(),
-            Some(&Duration::from_millis(32)),
-            "backoff is capped"
-        );
+    fn a_signal_terminated_result_is_returned_unchanged() {
+        let killed = Output {
+            status: ExitStatus::from_raw(9),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        };
+        let mut attempts = ScriptedAttempts::busy_then(1, Ok(killed.clone()));
+        let result = drive(&mut attempts).expect("the second attempt runs");
+        assert_eq!(result.status, killed.status);
+        assert_eq!(result.status.code(), None, "signal death has no exit code");
     }
 
     /// An error that is not "busy" is returned as it came from the operating
     /// system, not reclassified or replaced.
     #[test]
     fn a_non_busy_error_is_returned_unchanged() {
-        let mut attempts = ScriptedAttempts::busy_then(0, Err(Error::from_raw_os_error(13)));
-        let error = retry_while_busy(std::path::Path::new("/probe"), &mut attempts, |a| {
-            a.run(std::path::Path::new("/probe"), &[])
-        })
-        .expect_err("a permission error is not retried");
+        let mut attempts =
+            ScriptedAttempts::busy_then(0, Err(std::io::Error::from_raw_os_error(13)));
+        let error = drive(&mut attempts).expect_err("a permission error is not retried");
 
         assert_eq!(error.raw_os_error(), Some(13), "the OS error is preserved");
         assert_eq!(attempts.runs, 1, "a non-busy error is not retried");
-        assert!(attempts.sleeps.is_empty());
+        assert!(attempts.sleeps().is_empty());
+    }
+
+    /// Exhaustion says which file and how many attempts, so a build log
+    /// identifies the target without needing logging configured.
+    #[test]
+    fn exhaustion_reports_the_path_and_attempt_count() {
+        let mut attempts = ScriptedAttempts::always_busy();
+        let error = drive(&mut attempts).expect_err("permanently busy");
+        let message = error.to_string();
+        assert!(message.contains("/probe"), "{message}");
+        assert!(message.contains("20"), "{message}");
     }
 
     /// Produce an executable at `name`: a shell stub, or a copy of `source`

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -21,8 +21,7 @@ use std::path::{Path, PathBuf};
 /// of roughly half a second.
 const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 
-/// Run `path` with `args` until it is not reported as busy, and return whether
-/// it became executable.
+/// Run `path` with `args` until it is no longer reported as busy.
 ///
 /// Writing a file and immediately executing it races with process creation
 /// elsewhere in the same process. A concurrent `fork` inherits the still-open
@@ -43,13 +42,20 @@ const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 /// it, which is the situation this is for.
 ///
 /// A program that runs and exits non-zero still counts as executable.
-pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
-    use std::io::ErrorKind;
+///
+/// # Errors
+/// Returns the operating system's error when the file cannot be run for a
+/// reason other than being busy, or an [`ErrorKind::ExecutableFileBusy`] error
+/// naming the attempt count when it stayed busy for the whole budget. Callers
+/// report the cause; a bare boolean would leave it only in the log, which a
+/// library consumer need not have initialized.
+pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> std::io::Result<()> {
+    use std::io::{Error, ErrorKind};
     use std::process::Command;
 
     for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
         match Command::new(path).args(args).output() {
-            Ok(_) => return true,
+            Ok(_) => return Ok(()),
             Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
                 // No point sleeping when no attempt remains.
                 if attempt + 1 == MAX_EXEC_WAIT_ATTEMPTS {
@@ -59,7 +65,7 @@ pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
             }
             Err(error) => {
                 log::warn!("Could not run {}: {error}", path.display());
-                return false;
+                return Err(error);
             }
         }
     }
@@ -67,7 +73,13 @@ pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
         "{} was still busy after {MAX_EXEC_WAIT_ATTEMPTS} attempts",
         path.display()
     );
-    false
+    Err(Error::new(
+        ErrorKind::ExecutableFileBusy,
+        format!(
+            "{} was still busy after {MAX_EXEC_WAIT_ATTEMPTS} attempts",
+            path.display()
+        ),
+    ))
 }
 
 /// Resolve an executable via `PATH` using the caller's platform suffix policy.
@@ -99,14 +111,15 @@ mod tests {
     /// that load and assert the barrier absorbs it.
     ///
     /// The second execution is the part that matters. Asserting only on the
-    /// helper's return value would pass even if the helper returned `true`
+    /// helper's return value would pass even if the helper returned `Ok`
     /// without doing anything, so each stub is run again afterwards to confirm
     /// the barrier really did make it executable.
     #[test]
     fn newly_written_scripts_are_executable_while_other_threads_spawn() {
-        let dir = std::env::temp_dir().join(format!("pecos_exec_wait_{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("Should create probe dir");
+        // TempDir removes itself even if a worker panics, and its name cannot
+        // collide with another run's directory.
+        let temp = tempfile::tempdir().expect("Should create probe dir");
+        let dir = temp.path().to_path_buf();
 
         let failures = AtomicUsize::new(0);
         let post_barrier_busy = AtomicUsize::new(0);
@@ -131,7 +144,7 @@ mod tests {
                         permissions.set_mode(0o755);
                         fs::set_permissions(&path, permissions).expect("Should chmod stub");
 
-                        if !wait_until_executable(&path, &["--version"]) {
+                        if wait_until_executable(&path, &["--version"]).is_err() {
                             failures.fetch_add(1, Ordering::Relaxed);
                             let _ = fs::remove_file(&path);
                             continue;
@@ -153,7 +166,6 @@ mod tests {
             }
         });
 
-        let _ = fs::remove_dir_all(&dir);
         assert_eq!(
             failures.load(Ordering::Relaxed),
             0,

--- a/crates/pecos-build/src/executable.rs
+++ b/crates/pecos-build/src/executable.rs
@@ -26,18 +26,21 @@ const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 ///
 /// Writing a file and immediately executing it races with process creation
 /// elsewhere in the same process. A concurrent `fork` inherits the still-open
-/// write descriptor, and `execve` on that file reports `ETXTBSY` until the
-/// child completes its own `exec` and the inherited descriptor closes.
-/// `O_CLOEXEC` does not avoid this, because the descriptor is still open when
-/// the kernel performs the check (rust-lang/rust#39186). The condition cannot
-/// be prevented from inside a multi-threaded process, and writing to a
-/// temporary name and renaming does not help either, because the check tracks
-/// the inode rather than the path.
+/// write descriptor, and `execve` on that file reports `ETXTBSY` until the last
+/// reference to that writable file description is released. `O_CLOEXEC` does
+/// not avoid this, because the descriptor is still open when the kernel
+/// performs the check (rust-lang/rust#114554). Writing to a temporary name and
+/// renaming does not help either, because the check tracks the inode rather
+/// than the path.
 ///
-/// One successful execution closes the window permanently for this path. It
-/// proves every child that inherited the write descriptor has finished
-/// exec'ing, and nothing opens the file for writing again afterwards, so this
-/// is a one-time barrier rather than a standing retry.
+/// This is a barrier against writers that already exist, not a permanent
+/// guarantee about the path. A successful execution establishes that no
+/// writable description of that inode remains open, so writers inherited from
+/// earlier forks cannot recreate one. It does not promise the file stays
+/// executable: a later writer, including one reaching the same inode through a
+/// hard link, reopens the window, and replacing the inode at that path is a
+/// different file entirely. Both callers write a stub once and never rewrite
+/// it, which is the situation this is for.
 ///
 /// A program that runs and exits non-zero still counts as executable.
 pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
@@ -48,6 +51,10 @@ pub(crate) fn wait_until_executable(path: &Path, args: &[&str]) -> bool {
         match Command::new(path).args(args).output() {
             Ok(_) => return true,
             Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
+                // No point sleeping when no attempt remains.
+                if attempt + 1 == MAX_EXEC_WAIT_ATTEMPTS {
+                    break;
+                }
                 std::thread::sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
             }
             Err(error) => {
@@ -82,14 +89,19 @@ pub(crate) fn which_in_path(name: &str, extensions: &[&str]) -> Option<PathBuf> 
 mod tests {
     use super::wait_until_executable;
     use std::fs;
+    use std::io::ErrorKind;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Writing a script and executing it immediately fails with `ETXTBSY` at a
     /// double-digit rate when other threads are spawning processes. Reproduce
-    /// that load and assert the barrier absorbs it: without the wait inside
-    /// [`wait_until_executable`] this fails within a few iterations.
+    /// that load and assert the barrier absorbs it.
+    ///
+    /// The second execution is the part that matters. Asserting only on the
+    /// helper's return value would pass even if the helper returned `true`
+    /// without doing anything, so each stub is run again afterwards to confirm
+    /// the barrier really did make it executable.
     #[test]
     fn newly_written_scripts_are_executable_while_other_threads_spawn() {
         let dir = std::env::temp_dir().join(format!("pecos_exec_wait_{}", std::process::id()));
@@ -97,6 +109,7 @@ mod tests {
         fs::create_dir_all(&dir).expect("Should create probe dir");
 
         let failures = AtomicUsize::new(0);
+        let post_barrier_busy = AtomicUsize::new(0);
         std::thread::scope(|scope| {
             for _ in 0..4 {
                 scope.spawn(|| {
@@ -108,6 +121,7 @@ mod tests {
             for worker in 0..4 {
                 let dir = &dir;
                 let failures = &failures;
+                let post_barrier_busy = &post_barrier_busy;
                 scope.spawn(move || {
                     for i in 0..150 {
                         let path = dir.join(format!("stub-{worker}-{i}"));
@@ -119,6 +133,19 @@ mod tests {
 
                         if !wait_until_executable(&path, &["--version"]) {
                             failures.fetch_add(1, Ordering::Relaxed);
+                            let _ = fs::remove_file(&path);
+                            continue;
+                        }
+                        // Execute independently of the helper's own return
+                        // value. Trusting that value would pass even if the
+                        // barrier did nothing at all.
+                        if let Err(error) = Command::new(&path).arg("--version").output() {
+                            assert_eq!(
+                                error.kind(),
+                                ErrorKind::ExecutableFileBusy,
+                                "unexpected failure running a stub: {error}"
+                            );
+                            post_barrier_busy.fetch_add(1, Ordering::Relaxed);
                         }
                         let _ = fs::remove_file(&path);
                     }
@@ -131,6 +158,11 @@ mod tests {
             failures.load(Ordering::Relaxed),
             0,
             "a freshly written script could not be executed"
+        );
+        assert_eq!(
+            post_barrier_busy.load(Ordering::Relaxed),
+            0,
+            "a script was still ETXTBSY after the barrier reported it ready"
         );
     }
 }

--- a/crates/pecos-build/src/home.rs
+++ b/crates/pecos-build/src/home.rs
@@ -545,23 +545,12 @@ mod tests {
     /// Write an executable stub reporting `version`, and return only once it can
     /// actually be executed.
     ///
-    /// Writing a file and immediately executing it races with process creation
-    /// anywhere else in this test binary. A concurrent `fork` inherits the
-    /// still-open write descriptor, and `execve` on that file reports
-    /// `ETXTBSY` until the child completes its own `exec` and the inherited
-    /// descriptor closes. `O_CLOEXEC` does not avoid this, because the
-    /// descriptor is still open when the kernel performs the check
-    /// (rust-lang/rust#39186). The condition cannot be prevented from inside a
-    /// multi-threaded process, so the stub waits for it to clear instead.
-    ///
-    /// One successful execution is enough. It proves every child that inherited
-    /// the write descriptor has finished exec'ing, and nothing opens this file
-    /// for writing again, so the window cannot reopen for this path.
+    /// Every test using this stub executes it immediately, which races the
+    /// write. See [`crate::executable::wait_until_executable`] for why, and why
+    /// waiting is the available remedy.
     #[cfg(unix)]
     fn create_fake_llvm_config(llvm_dir: &Path, version: &str) {
-        use std::io::ErrorKind;
         use std::os::unix::fs::PermissionsExt;
-        use std::process::Command;
 
         let bin_dir = llvm_dir.join("bin");
         fs::create_dir_all(&bin_dir).expect("Should create fake llvm bin dir");
@@ -578,24 +567,12 @@ mod tests {
         fs::set_permissions(&llvm_config, permissions)
             .expect("Should make fake llvm-config executable");
 
-        for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
-            match Command::new(&llvm_config).arg("--version").output() {
-                Ok(_) => return,
-                Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
-                    std::thread::sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
-                }
-                Err(error) => panic!("fake llvm-config is not executable: {error}"),
-            }
-        }
-        panic!(
-            "fake llvm-config at {} stayed busy for {MAX_EXEC_WAIT_ATTEMPTS} attempts",
+        assert!(
+            crate::executable::wait_until_executable(&llvm_config, &["--version"]),
+            "fake llvm-config at {} never became executable",
             llvm_config.display()
         );
     }
-
-    /// Bounded so a genuinely stuck stub fails the test instead of hanging.
-    #[cfg(unix)]
-    const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 
     #[test]
     fn test_get_pecos_home_default() {

--- a/crates/pecos-build/src/home.rs
+++ b/crates/pecos-build/src/home.rs
@@ -567,10 +567,13 @@ mod tests {
         fs::set_permissions(&llvm_config, permissions)
             .expect("Should make fake llvm-config executable");
 
-        assert!(
-            crate::executable::wait_until_executable(&llvm_config, &["--version"]),
-            "fake llvm-config at {} never became executable",
-            llvm_config.display()
+        crate::executable::wait_until_executable(&llvm_config, &["--version"]).unwrap_or_else(
+            |error| {
+                panic!(
+                    "fake llvm-config at {} never became executable: {error}",
+                    llvm_config.display()
+                )
+            },
         );
     }
 

--- a/crates/pecos-build/src/home.rs
+++ b/crates/pecos-build/src/home.rs
@@ -542,9 +542,26 @@ mod tests {
         std::env::temp_dir().join(format!("pecos_test_{prefix}_{pid}_{id}"))
     }
 
+    /// Write an executable stub reporting `version`, and return only once it can
+    /// actually be executed.
+    ///
+    /// Writing a file and immediately executing it races with process creation
+    /// anywhere else in this test binary. A concurrent `fork` inherits the
+    /// still-open write descriptor, and `execve` on that file reports
+    /// `ETXTBSY` until the child completes its own `exec` and the inherited
+    /// descriptor closes. `O_CLOEXEC` does not avoid this, because the
+    /// descriptor is still open when the kernel performs the check
+    /// (rust-lang/rust#39186). The condition cannot be prevented from inside a
+    /// multi-threaded process, so the stub waits for it to clear instead.
+    ///
+    /// One successful execution is enough. It proves every child that inherited
+    /// the write descriptor has finished exec'ing, and nothing opens this file
+    /// for writing again, so the window cannot reopen for this path.
     #[cfg(unix)]
     fn create_fake_llvm_config(llvm_dir: &Path, version: &str) {
+        use std::io::ErrorKind;
         use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
 
         let bin_dir = llvm_dir.join("bin");
         fs::create_dir_all(&bin_dir).expect("Should create fake llvm bin dir");
@@ -560,7 +577,25 @@ mod tests {
         permissions.set_mode(0o755);
         fs::set_permissions(&llvm_config, permissions)
             .expect("Should make fake llvm-config executable");
+
+        for attempt in 0..MAX_EXEC_WAIT_ATTEMPTS {
+            match Command::new(&llvm_config).arg("--version").output() {
+                Ok(_) => return,
+                Err(error) if error.kind() == ErrorKind::ExecutableFileBusy => {
+                    std::thread::sleep(std::time::Duration::from_millis(1 << attempt.min(5)));
+                }
+                Err(error) => panic!("fake llvm-config is not executable: {error}"),
+            }
+        }
+        panic!(
+            "fake llvm-config at {} stayed busy for {MAX_EXEC_WAIT_ATTEMPTS} attempts",
+            llvm_config.display()
+        );
     }
+
+    /// Bounded so a genuinely stuck stub fails the test instead of hanging.
+    #[cfg(unix)]
+    const MAX_EXEC_WAIT_ATTEMPTS: u32 = 20;
 
     #[test]
     fn test_get_pecos_home_default() {

--- a/crates/pecos-build/src/home.rs
+++ b/crates/pecos-build/src/home.rs
@@ -546,7 +546,7 @@ mod tests {
     /// actually be executed.
     ///
     /// Every test using this stub executes it immediately, which races the
-    /// write. See [`crate::executable::wait_until_executable`] for why, and why
+    /// write. See [`crate::executable::run_when_executable`] for why, and why
     /// waiting is the available remedy.
     #[cfg(unix)]
     fn create_fake_llvm_config(llvm_dir: &Path, version: &str) {
@@ -567,7 +567,7 @@ mod tests {
         fs::set_permissions(&llvm_config, permissions)
             .expect("Should make fake llvm-config executable");
 
-        crate::executable::wait_until_executable(&llvm_config, &["--version"]).unwrap_or_else(
+        crate::executable::run_when_executable(&llvm_config, &["--version"]).unwrap_or_else(
             |error| {
                 panic!(
                     "fake llvm-config at {} never became executable: {error}",

--- a/crates/pecos-build/src/llvm.rs
+++ b/crates/pecos-build/src/llvm.rs
@@ -128,7 +128,13 @@ pub fn parse_llvm_version_output(output: &str) -> Option<String> {
 /// Run `<tool_path> --version` and parse the LLVM version it reports.
 #[must_use]
 pub fn get_tool_llvm_version(tool_path: &Path) -> Option<String> {
-    let output = Command::new(tool_path).arg("--version").output().ok()?;
+    let output = match Command::new(tool_path).arg("--version").output() {
+        Ok(output) => output,
+        Err(error) => {
+            log::warn!("Could not run {} --version: {error}", tool_path.display());
+            return None;
+        }
+    };
     if !output.status.success() {
         return None;
     }
@@ -322,14 +328,28 @@ pub fn is_valid_llvm(path: &Path) -> bool {
         return false;
     }
 
-    if let Ok(output) = Command::new(&llvm_config).arg("--version").output()
-        && output.status.success()
-    {
-        let version = String::from_utf8_lossy(&output.stdout);
-        return is_required_llvm_version(&version);
+    // A failure to *run* llvm-config is not the same as an incompatible LLVM,
+    // and reporting it as one leaves no trace of the real cause. Callers scan
+    // candidate paths, so the answer stays a bool, but the reason is logged.
+    match Command::new(&llvm_config).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let version = String::from_utf8_lossy(&output.stdout);
+            is_required_llvm_version(&version)
+        }
+        Ok(output) => {
+            log::warn!(
+                "{} --version exited with {}: {}",
+                llvm_config.display(),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            false
+        }
+        Err(error) => {
+            log::warn!("Could not run {}: {error}", llvm_config.display());
+            false
+        }
     }
-
-    false
 }
 
 /// Get the version of LLVM at the given path

--- a/crates/pecos-build/src/llvm/installer.rs
+++ b/crates/pecos-build/src/llvm/installer.rs
@@ -809,9 +809,15 @@ fn apply_platform_fixes(llvm_dir: &Path) -> Result<()> {
 
     // This is the first execution of the just-extracted llvm-config, so it
     // races the archive write the same way the wrapper below does.
+    // A readiness failure is not evidence that the platform fix is
+    // unnecessary. Skipping here would let a broken install proceed to a
+    // generic "verification failed" later, with the real cause only on stdout.
     if let Err(error) = crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
-        println!("Skipped ({error})");
-        return Ok(());
+        println!("FAILED");
+        return Err(Error::Llvm(format!(
+            "Could not execute {} after extraction: {error}",
+            llvm_config.display()
+        )));
     }
 
     let Ok(output) = Command::new(&llvm_config)

--- a/crates/pecos-build/src/llvm/installer.rs
+++ b/crates/pecos-build/src/llvm/installer.rs
@@ -856,6 +856,16 @@ printf '%s\n' "$output"
     permissions.set_mode(0o755);
     fs::set_permissions(&llvm_config, permissions)?;
 
+    // The caller verifies the installation by executing this wrapper straight
+    // away, which would otherwise race the write and report a good install as
+    // a failed one.
+    if !crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+        return Err(Error::Llvm(format!(
+            "Wrote {} but it could not be executed",
+            llvm_config.display()
+        )));
+    }
+
     println!("OK");
     Ok(())
 }

--- a/crates/pecos-build/src/llvm/installer.rs
+++ b/crates/pecos-build/src/llvm/installer.rs
@@ -807,6 +807,13 @@ fn apply_platform_fixes(llvm_dir: &Path) -> Result<()> {
     .into_iter()
     .find(|path| path.exists());
 
+    // This is the first execution of the just-extracted llvm-config, so it
+    // races the archive write the same way the wrapper below does.
+    if !crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+        println!("Skipped (llvm-config could not be executed)");
+        return Ok(());
+    }
+
     let Ok(output) = Command::new(&llvm_config)
         .args(["--system-libs", "--link-static"])
         .output()

--- a/crates/pecos-build/src/llvm/installer.rs
+++ b/crates/pecos-build/src/llvm/installer.rs
@@ -809,8 +809,8 @@ fn apply_platform_fixes(llvm_dir: &Path) -> Result<()> {
 
     // This is the first execution of the just-extracted llvm-config, so it
     // races the archive write the same way the wrapper below does.
-    if !crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
-        println!("Skipped (llvm-config could not be executed)");
+    if let Err(error) = crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+        println!("Skipped ({error})");
         return Ok(());
     }
 
@@ -866,9 +866,9 @@ printf '%s\n' "$output"
     // The caller verifies the installation by executing this wrapper straight
     // away, which would otherwise race the write and report a good install as
     // a failed one.
-    if !crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+    if let Err(error) = crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
         return Err(Error::Llvm(format!(
-            "Wrote {} but it could not be executed",
+            "Wrote {} but it could not be executed: {error}",
             llvm_config.display()
         )));
     }

--- a/crates/pecos-build/src/llvm/installer.rs
+++ b/crates/pecos-build/src/llvm/installer.rs
@@ -812,7 +812,7 @@ fn apply_platform_fixes(llvm_dir: &Path) -> Result<()> {
     // A readiness failure is not evidence that the platform fix is
     // unnecessary. Skipping here would let a broken install proceed to a
     // generic "verification failed" later, with the real cause only on stdout.
-    if let Err(error) = crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+    if let Err(error) = crate::executable::run_when_executable(&llvm_config, &["--version"]) {
         println!("FAILED");
         return Err(Error::Llvm(format!(
             "Could not execute {} after extraction: {error}",
@@ -872,7 +872,7 @@ printf '%s\n' "$output"
     // The caller verifies the installation by executing this wrapper straight
     // away, which would otherwise race the write and report a good install as
     // a failed one.
-    if let Err(error) = crate::executable::wait_until_executable(&llvm_config, &["--version"]) {
+    if let Err(error) = crate::executable::run_when_executable(&llvm_config, &["--version"]) {
         return Err(Error::Llvm(format!(
             "Wrote {} but it could not be executed: {error}",
             llvm_config.display()


### PR DESCRIPTION
Closes #718.

## Confirmed cause

`legacy_migration_reports_top_level_invalid_llvm_when_unversioned_can_migrate` writes an executable stub and immediately executes it. That races with process creation anywhere else in the test binary: a concurrent `fork` inherits the still-open write descriptor, and `execve` on that file returns `ETXTBSY` until the child completes its own `exec` and the inherited descriptor closes. `O_CLOEXEC` does not avoid it, because the descriptor is still open when the kernel performs the check. This is rust-lang/rust#39186, which remains open.

This was measured rather than inferred. A standalone probe running six threads that write-then-exec alongside six threads spawning unrelated processes:

| Configuration | `ETXTBSY` | Attempts |
|---|---:|---:|
| As the fixture behaves today | 1,475 | 9,000 |
| With the barrier added here | 0 | 9,000 |

Both figures come from consecutive runs on the same machine under the same load.

## Fix, part one: the fixture waits for the window to close

`create_fake_llvm_config` now executes the stub itself and returns only once that succeeds, with bounded backoff.

One successful execution is sufficient and the window cannot reopen. It proves every child that inherited the write descriptor has finished exec'ing, and nothing opens that file for writing again afterwards. This is a one-time barrier on a transient kernel condition, not a standing retry around a flaky operation, and it is bounded so that a genuinely unusable stub fails the test rather than hanging.

Waiting is the appropriate response because the condition cannot be prevented from inside a multi-threaded process. Writing to a temporary name and renaming does not help, since `ETXTBSY` tracks the inode rather than the path.

## Fix, part two: LLVM detection stops discarding the reason

Independent of the flake, `is_valid_llvm` collapsed three different outcomes into `false`:

1. `llvm-config` could not be executed at all
2. it executed and exited non-zero
3. it executed and reported a version that is not the required one

Only the third means "this is not a valid LLVM". Reporting the first as `false` told a user whose `llvm-config` sits on a `noexec` mount, or is not executable, that their LLVM installation was invalid, with nothing indicating why. `get_tool_llvm_version` discarded the same information through `.output().ok()?`.

Both now log the actual failure with `log::warn!`, matching the convention already used elsewhere in this crate.

The return type stays `bool` deliberately. Roughly twenty callers across six crates use `is_valid_llvm` to scan candidate paths and pick the first usable one, and a bool is the right shape for that question. Turning it into a `Result` would ripple through all of them to no benefit. This change adds diagnostics; it does not alter what any caller decides.


## Second instance, in production

The same write-then-exec pattern exists outside the test. `apply_platform_fixes` writes the `llvm-config` wrapper during LLVM installation, and the installer then immediately calls `is_valid_installation`, which executes it. When that races, a successful install reports `Installation completed but verification failed`, which is both wrong and unactionable.

The barrier is therefore a shared helper, `executable::wait_until_executable`, used by the installer and by the test fixture. The installer treats a stub that never becomes executable as an install error rather than as an invalid LLVM.

## The barrier is pinned

`newly_written_scripts_are_executable_while_other_threads_spawn` reproduces the race in-repo: four threads spawning processes alongside four threads writing and executing stubs, 600 stubs total, in about 0.3 seconds.

Removing the wait inside `wait_until_executable` fails that test and also fails `legacy_migration_reports_top_level_invalid_llvm_when_unversioned_can_migrate`, because the stress test supplies exactly the concurrent process creation that made the original test flaky in CI. The intermittent failure is now a deterministic one, so the barrier cannot be removed unnoticed.

Five consecutive runs of the crate's tests after restoring the barrier: 72 passed each time, zero failures.

## Verification

- `cargo test -p pecos-build -p pecos-cli --release`: 78 passed, zero failed.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `pre-commit` on both changed files: all hooks passed.
- Forty consecutive runs of the `home::` tests at sixteen threads: no failures, before and after.

The forty-run sweep is reported for completeness rather than as evidence. It did not reproduce the failure even before the fix, which is why the standalone probe above was built to provoke the race directly.

