### PR TITLE
Defer the upward reduction until a pair's constraint system is known consistent

### DIFF
--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -44,7 +44,7 @@ use crate::clifford_frame::{
 use crate::{
     ArbitraryRotationGateable, CliffordGateable, MeasurementResult, QuantumSimulator, StateVecSoA,
 };
-use ch_form::CHFormGeneric;
+use ch_form::{CHFormGeneric, InnerProductScratch};
 use core::fmt::Debug;
 use core::mem::size_of;
 use num_complex::Complex64;
@@ -244,6 +244,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
             Vec::new()
         };
 
+        let mut scratch = InnerProductScratch::default();
         let mut norm_sq = 0.0;
         let mut twice_prob0 = 0.0;
         for (coefficient, ch) in &self.terms {
@@ -268,6 +269,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
                         q,
                         &constraint_rows[j],
                         &constraint_rows[k],
+                        &mut scratch,
                     )
                 };
                 let coefficient_product = self.terms[j].0.conj() * self.terms[k].0;

--- a/crates/pecos-simulators/src/stab_vec/ch_form.rs
+++ b/crates/pecos-simulators/src/stab_vec/ch_form.rs
@@ -75,6 +75,115 @@ pub(crate) struct ConstraintRows {
     rows_wide: Vec<Vec<u64>>,
 }
 
+/// Mutable pair-local system, reusable across a batch of overlaps.
+#[derive(Default)]
+pub(crate) struct InnerProductScratch {
+    rows_u64: Vec<u64>,
+    rows_wide: Vec<Vec<u64>>,
+    // Keep unused wide rows allocated when the next pair has fewer constraints.
+    num_rows: usize,
+    pivot_cols: Vec<usize>,
+}
+
+impl InnerProductScratch {
+    fn load(&mut self, left: &ConstraintRows, right: &ConstraintRows) {
+        self.rows_u64.clear();
+        self.rows_u64.extend_from_slice(&left.rows_u64);
+        self.rows_u64.extend_from_slice(&right.rows_u64);
+        self.num_rows = left.rows_wide.len() + right.rows_wide.len();
+        if self.rows_wide.len() < self.num_rows {
+            self.rows_wide.resize_with(self.num_rows, Vec::new);
+        }
+        for (target, source) in self
+            .rows_wide
+            .iter_mut()
+            .zip(left.rows_wide.iter().chain(&right.rows_wide))
+        {
+            target.clone_from(source);
+        }
+    }
+
+    /// Leave consistent systems in RREF; inconsistent systems need only echelon form.
+    fn reduce(&mut self, n: usize) -> bool {
+        self.pivot_cols.clear();
+        let mut pivot_row = 0;
+        if n <= 62 {
+            let rows = &mut self.rows_u64;
+            for col in 0..n {
+                let col_bit = 1u64 << col;
+                let found = rows
+                    .iter()
+                    .enumerate()
+                    .skip(pivot_row)
+                    .find(|(_, row)| **row & col_bit != 0)
+                    .map(|(r, _)| r);
+                if let Some(r) = found {
+                    rows.swap(pivot_row, r);
+                    self.pivot_cols.push(col);
+                    let pivot = rows[pivot_row];
+                    for row in &mut rows[pivot_row + 1..] {
+                        if *row & col_bit != 0 {
+                            *row ^= pivot;
+                        }
+                    }
+                    pivot_row += 1;
+                }
+            }
+            let rhs_mask = 1u64 << n;
+            if rows[pivot_row..].iter().any(|row| row & rhs_mask != 0) {
+                return false;
+            }
+            // Only surviving pairs need the reduction above each pivot. Pivot
+            // order is unchanged, so x0 and the ordered basis are unchanged too.
+            for (r, &col) in self.pivot_cols.iter().enumerate().rev() {
+                let pivot = rows[r];
+                let col_bit = 1u64 << col;
+                for row in &mut rows[..r] {
+                    if *row & col_bit != 0 {
+                        *row ^= pivot;
+                    }
+                }
+            }
+        } else {
+            use super::quadratic_form::{get_bit, xor_words};
+            let rows = &mut self.rows_wide[..self.num_rows];
+            for col in 0..n {
+                let found = rows
+                    .iter()
+                    .enumerate()
+                    .skip(pivot_row)
+                    .find(|(_, row)| get_bit(row, col))
+                    .map(|(r, _)| r);
+                if let Some(r) = found {
+                    rows.swap(pivot_row, r);
+                    self.pivot_cols.push(col);
+                    let (above, below) = rows.split_at_mut(pivot_row + 1);
+                    let pivot = &above[pivot_row];
+                    for row in below {
+                        if get_bit(row, col) {
+                            xor_words(row, pivot);
+                        }
+                    }
+                    pivot_row += 1;
+                }
+            }
+            if rows[pivot_row..].iter().any(|row| get_bit(row, n)) {
+                return false;
+            }
+            for (r, &col) in self.pivot_cols.iter().enumerate().rev() {
+                let (above, below) = rows.split_at_mut(r);
+                let pivot = &below[0];
+                for row in above {
+                    if get_bit(row, col) {
+                        xor_words(row, pivot);
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
 /// Precomputed constraint solution for shared-structure inner products.
 /// When all terms share v, F, s, the GF(2) constraint system is identical
 /// for all pairs. Solve once, reuse for all T^2/2 inner products.
@@ -825,7 +934,13 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
         other: &Self,
         z_qubit: usize,
     ) -> (num_complex::Complex64, num_complex::Complex64) {
-        self.inner_product_fast(other, Some(z_qubit), false, None)
+        self.inner_product_fast(
+            other,
+            Some(z_qubit),
+            false,
+            None,
+            &mut InnerProductScratch::default(),
+        )
     }
 
     /// Like `inner_product_pair`, with rows precomputed from these two states.
@@ -836,8 +951,15 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
         z_qubit: usize,
         self_rows: &ConstraintRows,
         other_rows: &ConstraintRows,
+        scratch: &mut InnerProductScratch,
     ) -> (num_complex::Complex64, num_complex::Complex64) {
-        self.inner_product_fast(other, Some(z_qubit), false, Some((self_rows, other_rows)))
+        self.inner_product_fast(
+            other,
+            Some(z_qubit),
+            false,
+            Some((self_rows, other_rows)),
+            scratch,
+        )
     }
 
     /// Like `inner_product_pair` but for states sharing F, M, v, s (only gamma/omega differ).
@@ -848,19 +970,33 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
         other: &Self,
         z_qubit: usize,
     ) -> (num_complex::Complex64, num_complex::Complex64) {
-        self.inner_product_fast(other, Some(z_qubit), true, None)
+        self.inner_product_fast(
+            other,
+            Some(z_qubit),
+            true,
+            None,
+            &mut InnerProductScratch::default(),
+        )
     }
 
     /// Compute the inner product `<self|other>`.
     #[must_use]
     pub fn inner_product(&self, other: &Self) -> num_complex::Complex64 {
-        self.inner_product_fast(other, None, false, None).0
+        self.inner_product_fast(
+            other,
+            None,
+            false,
+            None,
+            &mut InnerProductScratch::default(),
+        )
+        .0
     }
 
     /// Like `inner_product` but for states sharing F, M, v, s.
     #[must_use]
     pub fn inner_product_shared(&self, other: &Self) -> num_complex::Complex64 {
-        self.inner_product_fast(other, None, true, None).0
+        self.inner_product_fast(other, None, true, None, &mut InnerProductScratch::default())
+            .0
     }
 
     /// Build this term's rows once for a batch of divergent inner products.
@@ -962,6 +1098,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
         z_qubit: Option<usize>,
         shared_structure: bool,
         constraint_rows: Option<(&ConstraintRows, &ConstraintRows)>,
+        scratch: &mut InnerProductScratch,
     ) -> (num_complex::Complex64, num_complex::Complex64) {
         use super::quadratic_form::QuadraticForm;
         let n = self.num_qubits;
@@ -1125,84 +1262,24 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
         let rhs_bit_pos = n;
 
         let use_u64 = n <= 62;
-        let mut rows_u64: Vec<u64> = Vec::with_capacity(if use_u64 { 2 * n } else { 0 });
-        let mut rows_wide: Vec<Vec<u64>> = Vec::new();
-
-        // Stack self's rows before other's, just as in the uncached path.
-        // Elimination mutates only these copies, leaving the cached rows intact.
+        // Stack self's rows before other's. Only scratch is mutated, and its
+        // buffers survive even when an inconsistent pair returns immediately.
         if let Some((self_rows, other_rows)) = constraint_rows {
-            rows_u64.extend_from_slice(&self_rows.rows_u64);
-            rows_u64.extend_from_slice(&other_rows.rows_u64);
-            rows_wide.extend_from_slice(&self_rows.rows_wide);
-            rows_wide.extend_from_slice(&other_rows.rows_wide);
+            scratch.load(self_rows, other_rows);
         } else {
-            self.append_constraint_rows(&mut rows_u64, &mut rows_wide);
-            other.append_constraint_rows(&mut rows_u64, &mut rows_wide);
+            scratch.rows_u64.clear();
+            scratch.rows_wide.clear();
+            self.append_constraint_rows(&mut scratch.rows_u64, &mut scratch.rows_wide);
+            other.append_constraint_rows(&mut scratch.rows_u64, &mut scratch.rows_wide);
+            scratch.num_rows = scratch.rows_wide.len();
         }
-
-        // Gaussian elimination (u64 fast path)
-        let mut pivot_cols = Vec::with_capacity(n);
-        let mut pivot_row = 0;
-
-        if use_u64 {
-            for col in 0..n {
-                let col_bit = 1u64 << col;
-                let mut found = None;
-                for (r, &row) in rows_u64.iter().enumerate().skip(pivot_row) {
-                    if row & col_bit != 0 {
-                        found = Some(r);
-                        break;
-                    }
-                }
-                if let Some(r) = found {
-                    rows_u64.swap(pivot_row, r);
-                    pivot_cols.push(col);
-                    let pivot = rows_u64[pivot_row];
-                    for (r, row) in rows_u64.iter_mut().enumerate() {
-                        if r != pivot_row && *row & col_bit != 0 {
-                            *row ^= pivot;
-                        }
-                    }
-                    pivot_row += 1;
-                }
-            }
-            // Check consistency
-            let rhs_mask = 1u64 << rhs_bit_pos;
-            for &row in rows_u64.iter().skip(pivot_row) {
-                if row & rhs_mask != 0 {
-                    let z = num_complex::Complex64::new(0.0, 0.0);
-                    return (z, z);
-                }
-            }
-        } else {
-            use super::quadratic_form::{get_bit as qf_get, xor_words};
-            for col in 0..n {
-                let mut found = None;
-                for (r, row) in rows_wide.iter().enumerate().skip(pivot_row) {
-                    if qf_get(row, col) {
-                        found = Some(r);
-                        break;
-                    }
-                }
-                if let Some(r) = found {
-                    rows_wide.swap(pivot_row, r);
-                    pivot_cols.push(col);
-                    let pivot = rows_wide[pivot_row].clone();
-                    for (r, row) in rows_wide.iter_mut().enumerate() {
-                        if r != pivot_row && qf_get(row, col) {
-                            xor_words(row, &pivot);
-                        }
-                    }
-                    pivot_row += 1;
-                }
-            }
-            for row in rows_wide.iter().skip(pivot_row) {
-                if qf_get(row, n) {
-                    let z = num_complex::Complex64::new(0.0, 0.0);
-                    return (z, z);
-                }
-            }
+        if !scratch.reduce(n) {
+            let z = num_complex::Complex64::new(0.0, 0.0);
+            return (z, z);
         }
+        let rows_u64 = &scratch.rows_u64;
+        let rows_wide = &scratch.rows_wide[..scratch.num_rows];
+        let pivot_cols = &scratch.pivot_cols;
 
         let rank = pivot_cols.len();
         let free_dim = n - rank;
@@ -1217,7 +1294,7 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug> CHFormGeneric<S, R> {
             pf_heap = vec![false; n];
             &mut pf_heap
         };
-        for &pc in &pivot_cols {
+        for &pc in pivot_cols {
             pivot_flags[pc] = true;
         }
 
@@ -3662,18 +3739,293 @@ mod tests {
                 .iter()
                 .map(CHFormGeneric::precompute_constraint_rows)
                 .collect();
+            let mut scratch = InnerProductScratch::default();
             // Inconsistent systems, empty rows, enumeration, and quadratic
             // sums; reverse pairs also exercise self-before-other stacking.
             for (i, left) in states.iter().enumerate() {
                 for (j, right) in states.iter().enumerate() {
                     for zq in [0, n / 2, n - 1] {
                         let expected = left.inner_product_pair(right, zq);
-                        let actual =
-                            left.inner_product_pair_with_rows(right, zq, &rows[i], &rows[j]);
+                        let actual = left.inner_product_pair_with_rows(
+                            right,
+                            zq,
+                            &rows[i],
+                            &rows[j],
+                            &mut scratch,
+                        );
                         assert_eq!(bits(actual.0), bits(expected.0), "n={n}, i={i}, j={j}");
                         assert_eq!(bits(actual.1), bits(expected.1), "n={n}, zq={zq}");
                     }
                 }
+            }
+        }
+    }
+
+    /// Independent eager Gauss-Jordan reference using unpacked bits. Preserve
+    /// the old first-pivot selection and eliminate both above and below it.
+    fn eager_constraint_system(
+        n: usize,
+        left: &ConstraintRows,
+        right: &ConstraintRows,
+    ) -> (ConstraintRows, Vec<usize>, bool) {
+        let mut rows: Vec<Vec<bool>> = if n <= 62 {
+            left.rows_u64
+                .iter()
+                .chain(&right.rows_u64)
+                .map(|row| (0..=n).map(|c| row & (1 << c) != 0).collect())
+                .collect()
+        } else {
+            left.rows_wide
+                .iter()
+                .chain(&right.rows_wide)
+                .map(|row| {
+                    (0..=n)
+                        .map(|c| row[c / 64] & (1 << (c % 64)) != 0)
+                        .collect()
+                })
+                .collect()
+        };
+        let mut pivots = Vec::new();
+        for c in 0..n {
+            let pr = pivots.len();
+            if let Some(r) = (pr..rows.len()).find(|&r| rows[r][c]) {
+                rows.swap(pr, r);
+                pivots.push(c);
+                let pivot = rows[pr].clone();
+                for (r, row) in rows.iter_mut().enumerate() {
+                    if r != pr && row[c] {
+                        for (bit, pivot_bit) in row.iter_mut().zip(&pivot) {
+                            *bit ^= pivot_bit;
+                        }
+                    }
+                }
+            }
+        }
+        let consistent = rows[pivots.len()..].iter().all(|row| !row[n]);
+        (pack_constraint_system(n, &rows), pivots, consistent)
+    }
+
+    fn pack_constraint_system(n: usize, rows: &[Vec<bool>]) -> ConstraintRows {
+        let mut packed = ConstraintRows {
+            rows_u64: Vec::new(),
+            rows_wide: Vec::new(),
+        };
+        for row in rows {
+            let mut words = vec![0; (n + 1).div_ceil(64)];
+            for (c, &bit) in row.iter().enumerate() {
+                if bit {
+                    words[c / 64] |= 1 << (c % 64);
+                }
+            }
+            if n <= 62 {
+                packed.rows_u64.push(words[0]);
+            } else {
+                packed.rows_wide.push(words);
+            }
+        }
+        packed
+    }
+
+    #[test]
+    fn test_deferred_constraint_reduction_matches_eager() {
+        use pecos_random::RngExt;
+        let mut rng = PecosRng::seed_from_u64(704);
+        let empty = pack_constraint_system(0, &[]);
+        let mut scratch = InnerProductScratch::default();
+        for n in [0usize, 1, 5, 62, 63, 64, 65, 127, 128, 150] {
+            for rank in [n, n.saturating_sub(3), n.saturating_sub(4), n / 2, 0] {
+                let witness: Vec<bool> = (0..n).map(|_| rng.random()).collect();
+                let mut rows = Vec::new();
+                for r in 0..rank {
+                    let pivot = r * n / rank;
+                    let mut row = vec![false; n + 1];
+                    row[pivot] = true;
+                    for bit in &mut row[pivot + 1..n] {
+                        *bit = rng.random();
+                    }
+                    row[n] = row[..n]
+                        .iter()
+                        .zip(&witness)
+                        .fold(false, |b, (a, x)| b ^ (a & x));
+                    rows.push(row);
+                }
+                // Dependent rows, row swaps, nonzero RHS, and gaps in pivot columns.
+                if rank > 0 {
+                    let dependent = rows[0]
+                        .iter()
+                        .zip(&rows[rank - 1])
+                        .map(|(a, b)| a ^ b)
+                        .collect();
+                    rows.push(dependent);
+                }
+                rows.push(vec![false; n + 1]);
+                rows.reverse();
+                for consistent in [true, false] {
+                    if !consistent {
+                        let mut contradictory = rows.last().unwrap().clone();
+                        contradictory[n] ^= true;
+                        rows.push(contradictory);
+                    }
+                    let input = pack_constraint_system(n, &rows);
+                    let (eager, pivots, expected) = eager_constraint_system(n, &input, &empty);
+                    assert_eq!(expected, consistent, "n={n}, rank={rank}");
+                    scratch.load(&input, &empty);
+                    assert_eq!(scratch.reduce(n), expected, "n={n}, rank={rank}");
+                    assert_eq!(scratch.pivot_cols, pivots);
+                    if consistent {
+                        assert_eq!(scratch.rows_u64, eager.rows_u64);
+                        assert_eq!(scratch.rows_wide[..scratch.num_rows], eager.rows_wide);
+                    }
+                }
+            }
+        }
+        // An inconsistent triangular system must return before clearing the
+        // entry above the second pivot, in both representations.
+        for n in [5, 62, 63, 64, 65, 127, 128, 150] {
+            let mut rows = vec![vec![false; n + 1]; 3];
+            rows[0][0] = true;
+            rows[0][1] = true;
+            rows[1][1] = true;
+            rows[2][n] = true;
+            scratch.load(&pack_constraint_system(n, &rows), &empty);
+            assert!(!scratch.reduce(n));
+            let first = if n <= 62 {
+                scratch.rows_u64[0]
+            } else {
+                scratch.rows_wide[0][0]
+            };
+            assert_eq!(first & 3, 3);
+        }
+    }
+
+    #[test]
+    fn test_deferred_inner_products_match_eager_bits() {
+        fn bits(pair: (num_complex::Complex64, num_complex::Complex64)) -> [u64; 4] {
+            [
+                pair.0.re.to_bits(),
+                pair.0.im.to_bits(),
+                pair.1.re.to_bits(),
+                pair.1.im.to_bits(),
+            ]
+        }
+        let empty = pack_constraint_system(0, &[]);
+        let mut scratch = InnerProductScratch::default();
+        for n in [0, 1, 5, 62, 63, 64, 65, 127, 128, 150] {
+            let mut saw_consistent = false;
+            let mut saw_inconsistent = false;
+            // Include empty constraints, full rank, and both sides of the
+            // enumeration threshold. Common CX gates mix the constraint rows.
+            for free in [0, n.min(3), n.min(4), n] {
+                let mut left = CHForm::new_with_seed(n, 42);
+                for q in 0..free {
+                    left.h(&[QubitId(q)]);
+                    left.sz(&[QubitId(q)]);
+                }
+                for q in (free..n).step_by(3) {
+                    left.x(&[QubitId(q)]);
+                }
+                for inconsistent in [false, true] {
+                    if inconsistent && free == n {
+                        continue;
+                    }
+                    let mut right = left.clone();
+                    if inconsistent {
+                        right.x(&[QubitId(n - 1)]);
+                    } else if n > 0 {
+                        right.sz(&[QubitId(0)]);
+                        if free > 0 && n > 1 {
+                            right.cx(&[(QubitId(0), QubitId(n - 1))]);
+                        }
+                    }
+                    let mut left = left.clone();
+                    for q in 1..n {
+                        left.cx(&[(QubitId(q - 1), QubitId(q))]);
+                        right.cx(&[(QubitId(q - 1), QubitId(q))]);
+                    }
+                    for (left, right) in [(&left, &right), (&right, &left)] {
+                        let left_rows = left.precompute_constraint_rows();
+                        let right_rows = right.precompute_constraint_rows();
+                        let (eager, _, consistent) =
+                            eager_constraint_system(n, &left_rows, &right_rows);
+                        assert_eq!(consistent, !inconsistent, "n={n}, free={free}");
+                        saw_consistent |= consistent;
+                        saw_inconsistent |= !consistent;
+                        let z_qubits = if n == 0 {
+                            vec![None]
+                        } else {
+                            vec![None, Some(0), Some(n / 2), Some(n - 1)]
+                        };
+                        for zq in z_qubits {
+                            // Eager RREF is a fixed point of the production
+                            // solver. Feed it through the unchanged numerical
+                            // evaluation, preserving x0 and basis order exactly.
+                            let expected = if consistent {
+                                left.inner_product_fast(
+                                    right,
+                                    zq,
+                                    false,
+                                    Some((&eager, &empty)),
+                                    &mut InnerProductScratch::default(),
+                                )
+                            } else {
+                                let zero = num_complex::Complex64::new(0.0, 0.0);
+                                (zero, zero)
+                            };
+                            let actual = left.inner_product_fast(
+                                right,
+                                zq,
+                                false,
+                                Some((&left_rows, &right_rows)),
+                                &mut scratch,
+                            );
+                            assert_eq!(
+                                bits(actual),
+                                bits(expected),
+                                "n={n}, free={free}, zq={zq:?}, consistent={consistent}"
+                            );
+                            if let Some(q) = zq {
+                                assert_eq!(bits(left.inner_product_pair(right, q)), bits(expected));
+                            } else {
+                                let actual = left.inner_product(right);
+                                assert_eq!(
+                                    [actual.re.to_bits(), actual.im.to_bits()],
+                                    bits(expected)[..2]
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            assert!(saw_consistent);
+            assert!(n == 0 || saw_inconsistent);
+        }
+    }
+
+    #[test]
+    fn test_inner_product_scratch_retains_row_storage() {
+        let empty = pack_constraint_system(0, &[]);
+        for n in [5, 62, 63, 64, 65, 127, 128, 150] {
+            let ch = CHForm::new_with_seed(n, 42);
+            let rows = ch.precompute_constraint_rows();
+            let mut scratch = InnerProductScratch::default();
+            scratch.load(&rows, &rows);
+            assert!(scratch.reduce(n));
+            let narrow_ptr = scratch.rows_u64.as_ptr();
+            let wide_ptrs: Vec<_> = scratch.rows_wide.iter().map(Vec::as_ptr).collect();
+            let pivot_ptr = scratch.pivot_cols.as_ptr();
+            for (left, right) in [(&rows, &empty), (&empty, &empty), (&rows, &rows)] {
+                scratch.load(left, right);
+                assert_eq!(scratch.rows_u64.as_ptr(), narrow_ptr);
+                assert_eq!(
+                    scratch
+                        .rows_wide
+                        .iter()
+                        .map(Vec::as_ptr)
+                        .collect::<Vec<_>>(),
+                    wide_ptrs
+                );
+                assert!(scratch.reduce(n));
+                assert_eq!(scratch.pivot_cols.as_ptr(), pivot_ptr);
             }
         }
     }


### PR DESCRIPTION
Addresses part of #704. Follows #737.

## Motivation, measured

Profiling `dev` with the repository's `profiling` profile, `perf -e cpu-clock`, pinned to one performance core, running `examples/profile_stab_vec_rows`:

```
84.06%  <StabVecGeneric>::exact_norm_and_prob0   (the overlap path inlines into it)
 4.48%  _int_free
 3.65%  <CHFormGeneric>::amplitude
 2.52%  cfree
 1.72%  malloc
```

Source-line attribution puts the hottest line at `ch_form.rs:1162`, at 21.7%: the elimination inner loop. Its guard was `r != pivot_row`, so it eliminated above the pivot as well as below, producing reduced row echelon form for every pair.

RREF is only needed to extract `x0`, the pivot columns and the null-space basis, and only the enumeration paths use those. Consistency of a GF(2) system is settled by row echelon form alone. Separately instrumented, between 98.5% and 100% of pairs return at the consistency check and never enumerate: at 12 qubits and 10 T gates, 523,776 of 523,776 pairs on a first measurement and 516,096 of 523,776 on a third.

The upward reduction was therefore being performed for every pair to serve roughly 1.5% of them.

## Change

Forward-eliminate, test consistency, and perform the upward reduction only for pairs that pass. Both width paths are handled: `u64` per row for `n <= 62` and `Vec<u64>` above it. The supported range is unchanged.

The profile also showed roughly 9% in the allocator, which turned out to be real per-pair allocation. One scratch buffer is now reused across pairs, and wide pivots borrow slices rather than cloning.

This defers work; it does not approximate. Every returned value is bit-for-bit identical on both the consistent and inconsistent branches.

## Measurements

Median `mz` wall-clock, three interleaved rounds per side, both `profiling` binaries pinned to the same performance core. This machine has heterogeneous cores, so unpinned numbers are not comparable between builds.

| qubits / T | measurement | before | after | speedup |
|---|---|---:|---:|---:|
| 8 / 6 | first | 212 us | 141 us | 1.51x |
| 8 / 6 | third | 1,476 us | 1,160 us | 1.27x |
| 10 / 8 | first | 4,415 us | 2,721 us | 1.62x |
| 10 / 8 | third | 18,583 us | 13,772 us | 1.35x |
| 12 / 10 | first | 85,283 us | 57,070 us | 1.49x |
| 12 / 10 | third | 325,988 us | 224,882 us | 1.45x |

**This does not change the complexity.** Measurement remains `O(N^2)` in the term count. Together with #737 this is roughly 1.9x on the larger shapes, from two constant-factor reductions. #704 stays open for the algorithmic work.

## Verification

- `cargo test -p pecos-simulators`: 1,261 release, 1,265 debug, zero failures.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- The committed exact bit patterns in `tests/data/` are byte-for-byte unchanged, which is the strongest available statement that no numeric result moved.

New tests build an independent **eager** reference implementation and compare the deferred path against it, over a qubit sweep crossing the width boundary up to 150 qubits, for both consistent and inconsistent systems, checking the full RREF rows, the pivot order and the returned floating-point bits. The phase-zero corpus only reaches 10 qubits, so the wide path has no other guard.

Those tests are load-bearing: removing the deferred back-substitution fails `test_deferred_constraint_reduction_matches_eager` and `test_deferred_inner_products_match_eager_bits`, and restoring it returns 801 passing.
