### PR TITLE
Build wheels with uv build instead of fetching the build package from PyPI

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -170,7 +170,7 @@ jobs:
         run: just ci-env
 
       - name: Install Python build tooling
-        run: uv pip install --system build maturin
+        run: uv pip install --system maturin
 
       - name: Build pecos-rslib wheel
         run: |
@@ -186,7 +186,7 @@ jobs:
         run: |
           mkdir -p dist/quantum-pecos
           cd python/quantum-pecos
-          python -m build --wheel --outdir ../../dist/quantum-pecos
+          uv build --wheel --out-dir ../../dist/quantum-pecos
 
       - name: Upload PR smoke artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -396,7 +396,7 @@ jobs:
         key: ${{ steps.cache-llvm.outputs.cache-primary-key }}
 
     - name: Install Python build tooling
-      run: uv pip install --system build maturin
+      run: uv pip install --system maturin
 
     - name: Build pecos-rslib wheel
       run: |
@@ -414,7 +414,7 @@ jobs:
       run: |
         mkdir -p dist/quantum-pecos
         cd python/quantum-pecos
-        python -m build --wheel --outdir ../../dist/quantum-pecos
+        uv build --wheel --out-dir ../../dist/quantum-pecos
 
     - name: Upload Python compatibility smoke artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/selene-plugins.yml
+++ b/.github/workflows/selene-plugins.yml
@@ -246,8 +246,7 @@ jobs:
       - name: Build wheel
         run: |
           cd python/selene-plugins/${{ matrix.plugin.name }}
-          uv pip install --system build
-          python -m build --wheel --outdir dist
+          uv build --wheel --out-dir dist
 
       - name: Upload wheel
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Closes #725.

## Problem

`build-wheels` in Selene Plugins intermittently failed on macOS while fetching the `build` package from PyPI:

```
error: Request failed after 3 retries in 48.0s
  Caused by: Failed to fetch: `https://pypi.org/simple/build/`
  Caused by: operation timed out
```

Two occurrences on unrelated PRs, both on `macos-15-intel`.

## Change

The step installed a build frontend and then invoked it:

```yaml
uv pip install --system build
python -m build --wheel --outdir dist
```

`uv` is already installed in that job by `astral-sh/setup-uv`, and it has a native `uv build`. Using it removes the network fetch entirely:

```yaml
uv build --wheel --out-dir dist
```

This is a removal of a dependency rather than a retry around it, so the failure mode cannot recur rather than recurring less often. #725 listed extending the retry budget and caching the wheel as cheaper options; both leave the fetch in place.

## Equivalence

Both frontends drive the same PEP 517 backend, `hatchling.build.build_wheel`, including the plugin's `cargo build` hook. Verified rather than assumed: built `pecos-selene-general-noise` in a clean worktree both ways and compared the results.

- Same wheel name: `pecos_selene_general_noise-0.11.0.dev0-py3-none-linux_x86_64.whl`
- Identical file lists inside the wheel, all six entries

## Scope

The same pattern appears in five places. Three are converted here, all of which already run `astral-sh/setup-uv` **within the same job**:

- `selene-plugins.yml`, `build-wheels` (the job in #725)
- `python-release.yml`, `pr_smoke_build`
- `python-test.yml`, `python-compat-smoke-build`

In the latter two, `build` is dropped from the tooling install while `maturin` is kept, since `maturin` is still invoked directly.

Two are deliberately **not** converted: `build_sdist_quantum_pecos` and `build_wheels_quantum_pecos` in `python-release.yml`. Those use plain `pip install build` and have no `setup-uv` step in their own job, so converting them would mean adding `uv` to release jobs. That is a larger change to the release path and is not needed to close #725; worth doing separately if wanted.

## Verification

`pre-commit` on all three changed workflows passes. The equivalence check above is the substantive verification; the workflows themselves are exercised by CI on this PR.
