### PR TITLE
Use the 2^n modulus consistently in Angle conversions

### DIFF
--- a/crates/pecos-core/src/angle.rs
+++ b/crates/pecos-core/src/angle.rs
@@ -88,6 +88,16 @@ pub struct Angle<T: Unsigned + Copy> {
     fraction: T, // Fixed-point fractional representation in [0, 2^n) turns
 }
 
+impl<T: Unsigned + Copy + ToPrimitive + Bounded> Angle<T> {
+    /// Fraction units per turn, matching the modulus of the wrapping arithmetic.
+    fn fraction_modulus() -> f64 {
+        T::max_value()
+            .to_f64()
+            .expect("Failed to convert max_value to f64")
+            + 1.0
+    }
+}
+
 impl<T> Angle<T>
 where
     T: Unsigned
@@ -119,14 +129,7 @@ where
     /// # Panics
     /// This function will panic if the conversion of `fraction` or `max_value` to `f64` fails.
     pub fn to_radians(&self) -> f64 {
-        let max_value = T::max_value()
-            .to_f64()
-            .expect("Failed to convert max_value to f64");
-        self.fraction
-            .to_f64()
-            .expect("Failed to convert fraction to f64")
-            / max_value
-            * std::f64::consts::TAU
+        self.to_turns() * std::f64::consts::TAU
     }
 
     /// Converts the angle to radians in `(-π, π]`.
@@ -192,13 +195,10 @@ where
     /// # Panics
     /// This function will panic if the conversion of `fraction` or `max_value` to `f64` fails.
     pub fn to_turns(&self) -> f64 {
-        let max_value = T::max_value()
-            .to_f64()
-            .expect("Failed to convert max_value to f64");
         self.fraction
             .to_f64()
             .expect("Failed to convert fraction to f64")
-            / max_value
+            / Self::fraction_modulus()
     }
 
     /// Converts the angle to signed turns in `(-0.5, 0.5]`.
@@ -240,16 +240,7 @@ where
     pub fn from_radians(radians: f64) -> Self {
         const TAU: f64 = std::f64::consts::TAU;
 
-        // Normalize the input to [0, 2π)
-        let fraction = ((radians.rem_euclid(TAU) / TAU)
-            * T::max_value()
-                .to_f64()
-                .expect("Conversion of max_value to f64 failed"))
-        .round();
-
-        Self {
-            fraction: T::from_f64(fraction).expect("Conversion of fraction to target type failed"),
-        }
+        Self::from_normalized_turns(radians.rem_euclid(TAU) / TAU)
     }
 
     /// Creates an angle from a value in turns.
@@ -259,14 +250,14 @@ where
     #[inline]
     #[must_use]
     pub fn from_turns(turns: f64) -> Self {
-        // Normalize the input to [0, 1) turns
-        let normalized_turns = turns.rem_euclid(1.0);
+        Self::from_normalized_turns(turns.rem_euclid(1.0))
+    }
 
-        let fraction = (normalized_turns
-            * T::max_value()
-                .to_f64()
-                .expect("Conversion of max_value to f64 failed"))
-        .round();
+    fn from_normalized_turns(turns: f64) -> Self {
+        let modulus = Self::fraction_modulus();
+        // Both rem_euclid and rounding can reach a full turn. Wrap after
+        // rounding so that it represents zero, just like integer arithmetic.
+        let fraction = (turns * modulus).round().rem_euclid(modulus);
 
         Self {
             fraction: T::from_f64(fraction).expect("Conversion of fraction to target type failed"),
@@ -405,7 +396,7 @@ where
         let max = T::max_value()
             .to_f64()
             .expect("Failed to convert max_value to f64");
-        let frac = (radians.abs() / std::f64::consts::TAU * max).round();
+        let frac = (radians.abs() / std::f64::consts::TAU * Self::fraction_modulus()).round();
         T::from_f64(frac.clamp(0.0, max)).expect("Failed to convert tolerance to fraction")
     }
 
@@ -428,7 +419,7 @@ where
         let max = T::max_value()
             .to_f64()
             .expect("Failed to convert max_value to f64");
-        let frac = (turns.abs() * max).round();
+        let frac = (turns.abs() * Self::fraction_modulus()).round();
         T::from_f64(frac.clamp(0.0, max)).expect("Failed to convert tolerance to fraction")
     }
 }
@@ -737,9 +728,7 @@ impl<T: Unsigned + ToPrimitive + Bounded + Copy> fmt::Display for Angle<T> {
             .fraction
             .to_f64()
             .expect("Failed to convert fraction to f64")
-            / T::max_value()
-                .to_f64()
-                .expect("Failed to convert max_value to f64");
+            / Self::fraction_modulus();
         write!(f, "{fraction:.6} turns")
     }
 }

--- a/crates/pecos-core/src/angle.rs
+++ b/crates/pecos-core/src/angle.rs
@@ -378,6 +378,7 @@ where
     }
 
     /// Convert a radians tolerance to the equivalent fraction-unit epsilon.
+    /// Finite tolerances saturate at the largest representable fraction magnitude.
     ///
     /// Useful when you want to precompute the epsilon once and reuse it
     /// across many comparisons, or when passing to the `approx` macros:
@@ -393,14 +394,11 @@ where
     /// Panics if the conversion between `f64` and `T` fails.
     #[must_use]
     pub fn epsilon_from_radians(radians: f64) -> T {
-        let max = T::max_value()
-            .to_f64()
-            .expect("Failed to convert max_value to f64");
-        let frac = (radians.abs() / std::f64::consts::TAU * Self::fraction_modulus()).round();
-        T::from_f64(frac.clamp(0.0, max)).expect("Failed to convert tolerance to fraction")
+        Self::epsilon_from_turns(radians.abs() / std::f64::consts::TAU)
     }
 
     /// Convert a turns tolerance to the equivalent fraction-unit epsilon.
+    /// Finite tolerances saturate at the largest representable fraction magnitude.
     ///
     /// Useful when you want to precompute the epsilon once and reuse it
     /// across many comparisons, or when passing to the `approx` macros:
@@ -420,6 +418,14 @@ where
             .to_f64()
             .expect("Failed to convert max_value to f64");
         let frac = (turns.abs() * Self::fraction_modulus()).round();
+        // MAX rounds up to the modulus in f64 for wide integers. Saturate
+        // directly in T instead of converting that unrepresentable bound.
+        // An infinite tolerance saturates for the same reason a full turn
+        // does: every angle is within it. NaN has no ordering, so it falls
+        // through and still fails the conversion.
+        if frac >= max {
+            return T::max_value();
+        }
         T::from_f64(frac.clamp(0.0, max)).expect("Failed to convert tolerance to fraction")
     }
 }

--- a/crates/pecos-core/tests/angle_cyclic_conversions.rs
+++ b/crates/pecos-core/tests/angle_cyclic_conversions.rs
@@ -1,0 +1,238 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::ToPrimitive;
+use pecos_core::controlled_rotations::{lower_cphase, lower_crz};
+use pecos_core::{Angle8, Angle16, Angle32, Angle64, Angle128, QubitId};
+use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+#[test]
+fn tiny_negative_radians_wrap_after_rounding() {
+    for (input, distance) in [
+        (-1e-15, 2048),
+        (-1e-16, 0),
+        (-1e-17, 0),
+        (-1e-18, 0),
+        (-f64::MIN_POSITIVE, 0),
+    ] {
+        assert_eq!(
+            Angle64::from_radians(input),
+            -Angle64::new(distance),
+            "input={input}"
+        );
+    }
+}
+
+#[test]
+fn tiny_negative_turns_wrap_after_rounding() {
+    for (input, distance) in [
+        (-1e-15, 18_432),
+        (-1e-16, 2048),
+        (-1e-17, 0),
+        (-1e-18, 0),
+        (-f64::MIN_POSITIVE, 0),
+    ] {
+        assert_eq!(
+            Angle64::from_turns(input),
+            -Angle64::new(distance),
+            "input={input}"
+        );
+    }
+}
+
+#[test]
+fn rounding_to_full_turn_wraps_even_when_ratio_is_below_one() {
+    // This ratio is strictly below one, but rounds to 256 fraction units.
+    let turns = 1.0 - 1.0 / 1024.0;
+    assert_eq!(Angle8::from_turns(turns), Angle8::ZERO);
+    assert_eq!(Angle8::from_radians(turns * TAU), Angle8::ZERO);
+    assert_eq!(Angle8::from_turns(1.0 - 1.0 / 512.0), Angle8::ZERO);
+    assert_eq!(Angle8::from_turns(1.0 - 1.0 / 256.0), Angle8::new(255));
+}
+
+#[test]
+fn conversions_agree_with_constants_at_every_width() {
+    macro_rules! check {
+        ($($angle:ty),+) => {$(
+            assert_eq!(<$angle>::from_radians(PI), <$angle>::HALF_TURN);
+            assert_eq!(<$angle>::from_radians(FRAC_PI_2), <$angle>::QUARTER_TURN);
+            assert_eq!(<$angle>::from_turns(0.75), <$angle>::THREE_QUARTERS_TURN);
+            assert_eq!(<$angle>::from_radians(TAU), <$angle>::ZERO);
+            assert_eq!(<$angle>::from_turns(1.0), <$angle>::ZERO);
+            assert_eq!(<$angle>::HALF_TURN.to_radians().to_bits(), PI.to_bits());
+            assert_eq!(<$angle>::THREE_QUARTERS_TURN.to_turns().to_bits(), 0.75_f64.to_bits());
+            assert_eq!(format!("{}", <$angle>::THREE_QUARTERS_TURN), "0.750000 turns");
+            assert_eq!(<$angle>::from_radians(-1e-18), <$angle>::ZERO);
+            assert_eq!(<$angle>::from_turns(-1e-18), <$angle>::ZERO);
+        )+};
+    }
+    check!(Angle8, Angle16, Angle32, Angle64, Angle128);
+}
+
+#[test]
+fn narrow_angles_round_trip_every_fraction() {
+    for fraction in 0..=u16::MAX {
+        let angle = Angle16::new(fraction);
+        assert_eq!(Angle16::from_turns(angle.to_turns()), angle);
+        assert_eq!(Angle16::from_radians(angle.to_radians()), angle);
+    }
+    for fraction in 0..=u8::MAX {
+        let angle = Angle8::new(fraction);
+        assert_eq!(Angle8::from_turns(angle.to_turns()), angle);
+        assert_eq!(Angle8::from_radians(angle.to_radians()), angle);
+    }
+}
+
+#[test]
+fn radians_round_trip_across_wrap_point() {
+    for input in [
+        -100.0,
+        -TAU,
+        -TAU.next_up(),
+        -TAU.next_down(),
+        -PI,
+        -0.7,
+        -1e-15,
+        -1e-16,
+        -1e-17,
+        -1e-18,
+        -f64::MIN_POSITIVE,
+        0.0,
+        f64::MIN_POSITIVE,
+        1e-18,
+        1e-17,
+        1e-16,
+        1e-15,
+        0.7,
+        FRAC_PI_2,
+        PI,
+        TAU.next_down(),
+        TAU,
+        TAU.next_up(),
+        100.0,
+    ] {
+        let actual = Angle64::from_radians(input).to_radians();
+        let expected = input.rem_euclid(TAU);
+        // Compare on the circle: a rounded full turn is zero.
+        let difference = (actual - expected).abs();
+        assert!(
+            difference.min((TAU - difference).abs()) <= 2.0 * f64::EPSILON * TAU,
+            "input={input}, actual={actual}, expected={expected}"
+        );
+    }
+}
+
+#[test]
+fn wide_angle_outputs_are_bit_identical_to_previous_scale() {
+    macro_rules! check {
+        ($angle:ty, $integer:ty, $fraction:expr) => {{
+            let fraction: $integer = $fraction;
+            let old_scale = <$integer>::MAX.to_f64().unwrap();
+            assert_eq!(old_scale.to_bits(), (old_scale + 1.0).to_bits());
+            let old_turns = fraction.to_f64().unwrap() / old_scale;
+            let angle = <$angle>::new(fraction);
+            assert_eq!(angle.to_turns().to_bits(), old_turns.to_bits());
+            assert_eq!(angle.to_radians().to_bits(), (old_turns * TAU).to_bits());
+        }};
+    }
+    for fraction in [
+        0,
+        1,
+        (1 << 62) - 1,
+        1 << 62,
+        1 << 63,
+        u64::MAX - 1,
+        u64::MAX,
+    ] {
+        check!(Angle64, u64, fraction);
+        check!(Angle128, u128, u128::from(fraction) << 64);
+    }
+    check!(Angle128, u128, u128::MAX);
+    let mut fraction = 1_u64;
+    for _ in 0..100_000 {
+        fraction = fraction
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        check!(Angle64, u64, fraction);
+        check!(
+            Angle128,
+            u128,
+            (u128::from(fraction) << 64) | u128::from(!fraction)
+        );
+    }
+}
+
+#[test]
+fn tolerance_uses_fraction_units_but_clamps_full_turns() {
+    assert_eq!(Angle8::epsilon_from_turns(0.75), 192);
+    assert_eq!(Angle8::epsilon_from_radians(0.75 * TAU), 192);
+    for turns in [1.0, 2.0, -2.0] {
+        assert_eq!(Angle8::epsilon_from_turns(turns), u8::MAX);
+        assert_eq!(Angle8::epsilon_from_radians(turns * TAU), u8::MAX);
+        assert_eq!(Angle32::epsilon_from_turns(turns), u32::MAX);
+    }
+}
+
+#[test]
+fn nonfinite_conversions_still_panic() {
+    for input in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert!(std::panic::catch_unwind(|| Angle64::from_radians(input)).is_err());
+        assert!(std::panic::catch_unwind(|| Angle64::from_turns(input)).is_err());
+    }
+}
+
+#[test]
+fn tiny_controlled_rotations_have_expected_angles() {
+    for (input, negative_half, positive_half) in [
+        (1e-15, -Angle64::new(2048), Angle64::new(1468)),
+        (1e-16, Angle64::ZERO, Angle64::new(147)),
+        (1e-17, Angle64::ZERO, Angle64::new(15)),
+        (1e-18, Angle64::ZERO, Angle64::new(1)),
+        (f64::MIN_POSITIVE, Angle64::ZERO, Angle64::ZERO),
+    ] {
+        for (theta, rzz_angle, rz_angle) in [
+            (input, negative_half, positive_half),
+            (-input, positive_half, negative_half),
+        ] {
+            let [rzz, rz] = lower_crz(theta, QubitId(0), QubitId(1));
+            assert_eq!(rzz.angles.as_slice(), &[rzz_angle], "theta={theta}");
+            assert_eq!(rz.angles.as_slice(), &[rz_angle], "theta={theta}");
+        }
+    }
+}
+
+#[test]
+fn tiny_controlled_phases_have_expected_angles() {
+    for (input, rzz_angle, half_angle) in [
+        (1e-15, -Angle64::new(2048), Angle64::new(1468)),
+        (-1e-15, Angle64::new(1304), Angle64::ZERO),
+        (1e-16, Angle64::ZERO, Angle64::new(147)),
+        (-1e-16, Angle64::ZERO, Angle64::ZERO),
+        (1e-17, Angle64::ZERO, Angle64::new(15)),
+        (-1e-17, Angle64::ZERO, Angle64::ZERO),
+        (1e-18, Angle64::ZERO, Angle64::new(2)),
+        (-1e-18, Angle64::ZERO, Angle64::ZERO),
+        (f64::MIN_POSITIVE, Angle64::ZERO, Angle64::ZERO),
+        (-f64::MIN_POSITIVE, Angle64::ZERO, Angle64::ZERO),
+    ] {
+        let [rzz, u, rz] = lower_cphase(input, QubitId(0), QubitId(1));
+        assert_eq!(rzz.angles.as_slice(), &[rzz_angle], "input={input}");
+        assert_eq!(
+            u.angles.as_slice(),
+            &[Angle64::ZERO, Angle64::ZERO, half_angle],
+            "input={input}"
+        );
+        assert_eq!(rz.angles.as_slice(), &[half_angle], "input={input}");
+    }
+}

--- a/crates/pecos-core/tests/angle_cyclic_conversions.rs
+++ b/crates/pecos-core/tests/angle_cyclic_conversions.rs
@@ -92,36 +92,45 @@ fn narrow_angles_round_trip_every_fraction() {
         assert_eq!(Angle8::from_turns(angle.to_turns()), angle);
         assert_eq!(Angle8::from_radians(angle.to_radians()), angle);
     }
+
+    macro_rules! check_last_interval {
+        ($angle:ty, $integer:ty, $modulus:expr) => {
+            for (offset, expected) in [
+                (0.75, <$angle>::new(<$integer>::MAX)),
+                (0.25, <$angle>::ZERO),
+                (0.125, <$angle>::ZERO),
+            ] {
+                let turns = 1.0 - offset / $modulus;
+                assert!(turns > <$angle>::new(<$integer>::MAX).to_turns());
+                assert!(turns < 1.0);
+                let from_turns = <$angle>::from_turns(turns);
+                let from_radians = <$angle>::from_radians(turns * TAU);
+                assert_eq!(from_turns.fraction(), expected.fraction());
+                assert_eq!(from_radians.fraction(), expected.fraction());
+                assert_eq!(<$angle>::from_turns(from_turns.to_turns()), expected);
+                assert_eq!(<$angle>::from_radians(from_radians.to_radians()), expected);
+            }
+        };
+    }
+    check_last_interval!(Angle8, u8, 256.0);
+    check_last_interval!(Angle16, u16, 65_536.0);
 }
 
 #[test]
 fn radians_round_trip_across_wrap_point() {
-    for input in [
-        -100.0,
-        -TAU,
-        -TAU.next_up(),
-        -TAU.next_down(),
-        -PI,
-        -0.7,
-        -1e-15,
-        -1e-16,
-        -1e-17,
-        -1e-18,
-        -f64::MIN_POSITIVE,
-        0.0,
-        f64::MIN_POSITIVE,
-        1e-18,
-        1e-17,
-        1e-16,
-        1e-15,
-        0.7,
-        FRAC_PI_2,
-        PI,
-        TAU.next_down(),
-        TAU,
-        TAU.next_up(),
-        100.0,
+    // Close to the wrap, a broad radians tolerance would also accept zero.
+    for (input, expected) in [
+        (-TAU.next_up(), -Angle64::new(2048)),
+        (-TAU, Angle64::ZERO),
+        (-TAU.next_down(), Angle64::new(2608)),
+        (0.0, Angle64::ZERO),
+        (TAU.next_down(), -Angle64::new(2048)),
+        (TAU, Angle64::ZERO),
+        (TAU.next_up(), Angle64::new(2608)),
     ] {
+        assert_eq!(Angle64::from_radians(input).fraction(), expected.fraction());
+    }
+    for input in [-100.0, -PI, -0.7, 0.7, FRAC_PI_2, PI, 100.0] {
         let actual = Angle64::from_radians(input).to_radians();
         let expected = input.rem_euclid(TAU);
         // Compare on the circle: a rounded full turn is zero.
@@ -131,6 +140,59 @@ fn radians_round_trip_across_wrap_point() {
             "input={input}, actual={actual}, expected={expected}"
         );
     }
+}
+
+#[test]
+fn tiny_positive_constructors_have_exact_fractions() {
+    for (input, radians_fraction, turns_fraction) in [
+        (1e-15, 2936, 18_447),
+        (1e-16, 294, 1845),
+        (1e-17, 29, 184),
+        (1e-18, 3, 18),
+        (f64::MIN_POSITIVE, 0, 0),
+    ] {
+        assert_eq!(Angle64::from_radians(input).fraction(), radians_fraction);
+        assert_eq!(Angle64::from_turns(input).fraction(), turns_fraction);
+    }
+}
+
+#[test]
+fn constructors_handle_subnormals_negative_zero_and_largest_finite_inputs() {
+    let smallest_subnormal = f64::from_bits(1);
+    let largest_subnormal = f64::MIN_POSITIVE.next_down();
+    assert!(smallest_subnormal.is_subnormal());
+    assert!(largest_subnormal.is_subnormal());
+    macro_rules! check {
+        ($angle:ty, $positive_max:expr, $negative_max:expr) => {
+            for input in [
+                smallest_subnormal,
+                -smallest_subnormal,
+                largest_subnormal,
+                -largest_subnormal,
+                -0.0,
+            ] {
+                assert_eq!(<$angle>::from_radians(input).fraction(), 0);
+                assert_eq!(<$angle>::from_turns(input).fraction(), 0);
+            }
+            assert_eq!(<$angle>::from_radians(f64::MAX).fraction(), $positive_max);
+            assert_eq!(<$angle>::from_radians(-f64::MAX).fraction(), $negative_max);
+            assert_eq!(<$angle>::from_turns(f64::MAX).fraction(), 0);
+            assert_eq!(<$angle>::from_turns(-f64::MAX).fraction(), 0);
+        };
+    }
+    check!(Angle8, 24, 232);
+    check!(Angle16, 6056, 59_480);
+    check!(Angle32, 396_914_332, 3_898_052_964);
+    check!(
+        Angle64,
+        1_704_734_075_010_201_088,
+        16_742_009_998_699_350_016
+    );
+    check!(
+        Angle128,
+        31_446_793_195_445_161_152_375_904_822_475_358_208,
+        308_835_573_725_493_292_866_265_736_870_002_425_856
+    );
 }
 
 #[test]
@@ -177,19 +239,87 @@ fn wide_angle_outputs_are_bit_identical_to_previous_scale() {
 fn tolerance_uses_fraction_units_but_clamps_full_turns() {
     assert_eq!(Angle8::epsilon_from_turns(0.75), 192);
     assert_eq!(Angle8::epsilon_from_radians(0.75 * TAU), 192);
-    for turns in [1.0, 2.0, -2.0] {
-        assert_eq!(Angle8::epsilon_from_turns(turns), u8::MAX);
-        assert_eq!(Angle8::epsilon_from_radians(turns * TAU), u8::MAX);
-        assert_eq!(Angle32::epsilon_from_turns(turns), u32::MAX);
+    macro_rules! check {
+        ($angle:ty, $integer:ty) => {
+            for turns in [1.0, 2.0, -1.0, -2.0] {
+                assert_eq!(<$angle>::epsilon_from_turns(turns), <$integer>::MAX);
+                assert_eq!(<$angle>::epsilon_from_radians(turns * TAU), <$integer>::MAX);
+            }
+            for input in [f64::MAX, -f64::MAX] {
+                assert_eq!(<$angle>::epsilon_from_turns(input), <$integer>::MAX);
+                assert_eq!(<$angle>::epsilon_from_radians(input), <$integer>::MAX);
+            }
+            for input in [0.0, -0.0, f64::from_bits(1), -f64::from_bits(1)] {
+                assert_eq!(<$angle>::epsilon_from_turns(input), 0);
+                assert_eq!(<$angle>::epsilon_from_radians(input), 0);
+            }
+            assert_eq!(
+                <$angle>::epsilon_from_turns(0.5),
+                <$angle>::HALF_TURN.fraction()
+            );
+            assert_eq!(
+                <$angle>::epsilon_from_radians(PI),
+                <$angle>::HALF_TURN.fraction()
+            );
+            assert!(<$angle>::ZERO.abs_diff_eq_turns(&<$angle>::HALF_TURN, 1.0));
+            assert!(<$angle>::ZERO.abs_diff_eq_radians(&<$angle>::HALF_TURN, TAU));
+        };
     }
+    check!(Angle8, u8);
+    check!(Angle16, u16);
+    check!(Angle32, u32);
+    check!(Angle64, u64);
+    check!(Angle128, u128);
 }
 
 #[test]
-fn nonfinite_conversions_still_panic() {
-    for input in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-        assert!(std::panic::catch_unwind(|| Angle64::from_radians(input)).is_err());
-        assert!(std::panic::catch_unwind(|| Angle64::from_turns(input)).is_err());
+fn tolerance_preserves_values_just_below_saturation() {
+    macro_rules! check {
+        ($angle:ty, $expected:expr) => {
+            assert_eq!(<$angle>::epsilon_from_turns(1.0_f64.next_down()), $expected);
+            assert_eq!(<$angle>::epsilon_from_radians(TAU.next_down()), $expected);
+        };
     }
+    check!(Angle8, u8::MAX);
+    check!(Angle16, u16::MAX);
+    check!(Angle32, u32::MAX);
+    check!(Angle64, u64::MAX - 2047);
+    check!(Angle128, u128::MAX - ((1_u128 << 75) - 1));
+}
+
+#[test]
+fn nonfinite_conversions_panic_and_infinite_tolerances_saturate() {
+    macro_rules! check {
+        ($($angle:ty),+) => {$(
+            for input in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                assert!(std::panic::catch_unwind(|| <$angle>::from_radians(input)).is_err());
+                assert!(std::panic::catch_unwind(|| <$angle>::from_turns(input)).is_err());
+            }
+            assert!(std::panic::catch_unwind(|| <$angle>::epsilon_from_radians(f64::NAN)).is_err());
+            assert!(std::panic::catch_unwind(|| <$angle>::epsilon_from_turns(f64::NAN)).is_err());
+        )+};
+    }
+    check!(Angle8, Angle16, Angle32, Angle64, Angle128);
+
+    // An infinite tolerance saturates at every width, for the same reason a
+    // full turn does: every angle lies within it. This was previously
+    // width-dependent, saturating only where `max_value` was exactly
+    // representable in f64 and panicking at `u64` and `u128`.
+    macro_rules! saturates {
+        ($($angle:ty => $integer:ty),+ $(,)?) => {$(
+            for input in [f64::INFINITY, f64::NEG_INFINITY] {
+                assert_eq!(<$angle>::epsilon_from_radians(input), <$integer>::MAX);
+                assert_eq!(<$angle>::epsilon_from_turns(input), <$integer>::MAX);
+            }
+        )+};
+    }
+    saturates!(
+        Angle8 => u8,
+        Angle16 => u16,
+        Angle32 => u32,
+        Angle64 => u64,
+        Angle128 => u128,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #740.

`Angle<T>` was inconsistent about its own modulus. The type documents itself as `[0, 2^n)` turns (`angle.rs:88`), its constants use `2^n` (`HALF_TURN = 1 << (BITS - 1)`, `FULL_TURN = 0` commented "Wraps to 0"), and all of its arithmetic is `wrapping_add` / `wrapping_sub` / `wrapping_mul` / `wrapping_neg`. But every conversion between the fraction and radians or turns scaled by `T::max_value()`, which is `2^n - 1`.

## The visible consequence

A constant named `HALF_TURN` did not convert to half a turn:

| | `HALF_TURN.to_turns()` before | after |
|---|---|---|
| `Angle8` | 0.5019607843137255 | 0.5 |
| `Angle16` | 0.5000076295109483 | 0.5 |
| `Angle32` | 0.5000000001164153 | 0.5 |
| `Angle64` | 0.5 | 0.5 |

`QUARTER_TURN` and `THREE_QUARTERS_TURN` were wrong in the same way.

`Angle64` escaped because of a detail worth stating precisely: `T::max_value().to_f64()` is exact for `u8`, `u16`, and `u32` (255, 65535, 4294967295), so those widths really did scale by `2^n - 1`. For `u64` and `u128` the maximum is not representable in f64 and rounds **up** to `2^n`, so those widths were already scaling by `2^n`. That is why the wide types were correct and why their `to_*` output is bit-identical after this change.

This change therefore does two separable things:

1. **The scale becomes exactly `2^n` at every width**, which is what repairs the narrow-width constants above.
2. **A modular wrap is added**, which is what fixes the panic below -- including for `Angle64`, where the scale was already `2^n` but `2^n` exceeds the largest storable fraction and nothing wrapped it back to zero.

## The panic

The same off-by-one made two public functions abort. `radians.rem_euclid(TAU)` rounds up to exactly `TAU` for inputs within about one ulp of zero from below; the ratio becomes `1.0`; the scaled product lands one past the representable maximum, and `T::from_f64` returns `None`.

This reached shipped code. Before this change:

| call | result |
|---|---|
| `Angle64::from_radians(-1e-17)` | panic |
| `Angle64::from_turns(-1e-17)` | panic |
| `lower_crz(1e-17, ..)` | panic |
| `lower_crz(1e-16, ..)` | panic |
| `lower_cphase(1e-18, ..)` | panic |
| `lower_crz(1e-15, ..)` | ok |

So `lower_crz` and `lower_cphase` crashed the process for any angle of magnitude below roughly `1e-16`, positive included. An angle that small is what subtracting two nearly-equal floats produces.

## The change

A single `fraction_modulus()` (`max_value + 1`, i.e. `2^n`) replaces six duplicated scale computations. `to_radians` now delegates to `to_turns`, and `from_radians` and `from_turns` both delegate to a shared `from_normalized_turns` which applies the modular wrap **after** rounding:

```rust
let fraction = (turns * modulus).round().rem_euclid(modulus);
```

The wrap has to be after the rounding, not on the ratio: a ratio strictly below 1.0 can still round up to exactly `2^n`. That case has its own test.

`epsilon_from_radians` and `epsilon_from_turns` produce a tolerance magnitude rather than a cyclic angle, so they saturate rather than wrap. Their saturation now happens in integer space.

That change came out of review. Clamping a scaled `f64` against `T::max_value().to_f64()` is inert at `u64` and `u128`, because that bound *is* `2^n` at those widths, so the clamp left a value `from_f64` rejects:

| width | `epsilon_from_turns(1.0)` before | after |
|---|---|---|
| Angle8 / 16 / 32 | `MAX` | `MAX` |
| Angle64 | panic | `MAX` |
| Angle128 | panic | `MAX` |

This panic predates this branch and is present on `origin/dev`. It is the same root pattern as the defect above -- `max_value().to_f64()` rounding up to `2^n` defeats a bound expressed in f64 -- and it lives in two functions this change already touches, so it is fixed here rather than deferred.

An infinite tolerance now saturates at every width as well. Previously it saturated only where `max_value` was exactly representable in f64 and panicked at `u64` and `u128`. Saturation is the right answer for the same reason a full turn saturates: every angle lies within an infinite tolerance. `NaN` has no ordering, falls through, and still panics at every width.

Net effect is 23 insertions and 34 deletions in one file.

## Verification

Both the branch and `origin/dev` were run with `cargo test --workspace --no-fail-fast` and their failure sets compared by name:

| | failures | passed |
|---|---|---|
| this branch | 12 | 11,918 |
| `origin/dev` | 12 | 11,904 |

The failure sets are identical: no regressions, nothing newly fixed. All 12 are pre-existing and unrelated to angles (one GPU test and eleven `fault_tolerance_bindings::sample_corpus` and decoder tests). The 14 extra passes are the new regression tests. Workspace clippy with all targets and features, and formatting, are clean.

No committed reference datum changed, and no existing test with a hard-coded expected fraction changed. `wide_angle_outputs_are_bit_identical_to_previous_scale` pins that the `Angle64` and `Angle128` `to_*` direction is bit-identical to the previous scale.

Two mutations, both independent of the ones used during development, confirm the tests are capable of catching a regression:

- Moving the wrap before the rounding fails `rounding_to_full_turn_wraps_even_when_ratio_is_below_one` (exit 101). This pins the wrap's position, not merely its presence.
- Reverting the scale to `max_value()` fails the exact-constant assertions (exit 101).
- Removing the wrap entirely fails eight tests, including `narrow_angles_round_trip_every_fraction`. Review established that this test previously fed only exact lattice points and so would have passed with the wrap removed; it now covers the rounding interval above the last representable point.

## Not in this change

`NaN` still panics at every width and in every conversion, and the infinities still panic in the cyclic constructors. `nonfinite_conversions_panic_and_infinite_tolerances_saturate` pins that behaviour. A checked-conversion API is a reasonable follow-up but is a public API change and does not belong here.

The CRZ boundary-sign defect (#670) is a separate issue with a separate fix, and is not addressed here. This change unblocks it: the correction it needs computes a half-angle that can be tiny, which would previously have panicked.
