### PR TITLE
Reduce the CRZ source angle before halving and carry the removed turn as a control Z

### DIFF
--- a/crates/pecos-core/src/controlled_rotations.rs
+++ b/crates/pecos-core/src/controlled_rotations.rs
@@ -15,39 +15,62 @@
 //! Exact lowering of controlled-rotation boundary spellings.
 
 use crate::{Angle64, Gate, PhaseGateError, QubitId};
+use smallvec::{SmallVec, smallvec};
+use std::f64::consts::{PI, TAU};
+
+/// Return half the principal value in `(-π, π]` and the parity of removed turns.
+/// Keep both reduction and parity in f64: storing the remainder in `Angle64`
+/// would quantize it before the turn count is recovered.
+fn reduced_half_and_wrap_parity(theta_radians: f64) -> (f64, bool) {
+    let reduced = theta_radians.rem_euclid(TAU);
+    let signed = if reduced > PI { reduced - TAU } else { reduced };
+    let h = signed / 2.0;
+    let wraps = ((theta_radians - signed) / TAU).round();
+    // The rounded count has exact integer parity; compare exactly, without a tolerance.
+    let needs_z = wraps.rem_euclid(2.0).total_cmp(&1.0).is_eq();
+    (h, needs_z)
+}
 
 /// Lower `CRZ(theta)` to native rotations.
 ///
 /// The identity is
 /// `CRZ(theta) = (I (x) RZ(theta/2)) . RZZ(-theta/2)`, with no global phase
-/// before angle reduction. The stored lowering is exact up to a global phase of
-/// ±1 that appears when a halved angle crosses the 2π reduction.
-/// `theta` is supplied in radians and is halved as an `f64` before either half
-/// is normalized into [`Angle64`]. This order is required because `CRZ` is
-/// 4π-periodic while a stored `Angle64` has already reduced its input modulo 2π.
+/// before angle reduction. Reduce `theta` to `(-π, π]` before halving so neither
+/// stored leg reaches the ambiguous ±π pair. Each removed 2π turn contributes
+/// a `Z` on the control; retaining its parity preserves the exact global phase
+/// and 4π periodicity without quantizing the source angle through [`Angle64`].
 #[must_use]
-pub fn lower_crz(theta_radians: f64, control: QubitId, target: QubitId) -> [Gate; 2] {
-    let half_theta = theta_radians / 2.0;
-    [
+pub fn lower_crz(theta_radians: f64, control: QubitId, target: QubitId) -> SmallVec<[Gate; 3]> {
+    let (half_theta, needs_z) = reduced_half_and_wrap_parity(theta_radians);
+    let mut gates = SmallVec::new();
+    if needs_z {
+        gates.push(Gate::z(&[control]));
+    }
+    gates.extend([
         Gate::rzz(Angle64::from_radians(-half_theta), &[(control, target)]),
         Gate::rz(Angle64::from_radians(half_theta), &[target]),
-    ]
+    ]);
+    gates
 }
 
 /// Lower `CRX(theta) = (I (x) H) . CRZ(theta) . (I (x) H)`.
 #[must_use]
-pub fn lower_crx(theta_radians: f64, control: QubitId, target: QubitId) -> [Gate; 4] {
-    let [rzz, rz] = lower_crz(theta_radians, control, target);
-    [Gate::h(&[target]), rzz, rz, Gate::h(&[target])]
+pub fn lower_crx(theta_radians: f64, control: QubitId, target: QubitId) -> SmallVec<[Gate; 5]> {
+    let mut gates = smallvec![Gate::h(&[target])];
+    gates.extend(lower_crz(theta_radians, control, target));
+    gates.push(Gate::h(&[target]));
+    gates
 }
 
 /// Lower `CRY(theta) = (I (x) SXdg) . CRZ(theta) . (I (x) SX)`.
 ///
 /// Circuit emission order is `SX`, the `CRZ` lowering, then `SXdg`.
 #[must_use]
-pub fn lower_cry(theta_radians: f64, control: QubitId, target: QubitId) -> [Gate; 4] {
-    let [rzz, rz] = lower_crz(theta_radians, control, target);
-    [Gate::sx(&[target]), rzz, rz, Gate::sxdg(&[target])]
+pub fn lower_cry(theta_radians: f64, control: QubitId, target: QubitId) -> SmallVec<[Gate; 5]> {
+    let mut gates = smallvec![Gate::sx(&[target])];
+    gates.extend(lower_crz(theta_radians, control, target));
+    gates.push(Gate::sxdg(&[target]));
+    gates
 }
 
 /// Lower controlled phase while retaining its relative phase.
@@ -144,6 +167,13 @@ mod tests {
     fn apply_gate(state: &mut [Complex64; 4], gate: &Gate) {
         let i = Complex64::new(0.0, 1.0);
         match gate.gate_type {
+            GateType::Z => {
+                for (basis, amplitude) in state.iter_mut().enumerate() {
+                    if basis & (1 << (1 - gate.qubits[0].index())) != 0 {
+                        *amplitude = -*amplitude;
+                    }
+                }
+            }
             GateType::H => {
                 let s = std::f64::consts::FRAC_1_SQRT_2;
                 apply_single(
@@ -217,7 +247,6 @@ mod tests {
     fn assert_matrix_eq_up_to_one_global_phase(
         actual: [[Complex64; 4]; 4],
         expected: [[Complex64; 4]; 4],
-        angle: f64,
     ) {
         let (phase_column, phase_row, reference) = (0..4)
             .flat_map(|column| (0..4).map(move |row| (column, row)))
@@ -226,26 +255,12 @@ mod tests {
             .expect("matrix has entries");
         let phase = actual[phase_column][phase_row] / reference;
         assert!((phase.norm() - 1.0).abs() < TOLERANCE);
-        let crosses_reduction = ![
-            -std::f64::consts::PI,
-            std::f64::consts::PI / 3.0,
-            std::f64::consts::PI,
-        ]
-        .iter()
-        .any(|expected| (angle - expected).abs() < f64::EPSILON);
-        if crosses_reduction {
-            assert!(
-                (phase - Complex64::new(1.0, 0.0)).norm() < TOLERANCE
-                    || (phase + Complex64::new(1.0, 0.0)).norm() < TOLERANCE
-            );
-        } else {
-            assert!((phase - Complex64::new(1.0, 0.0)).norm() < TOLERANCE);
-        }
+        assert!((phase - Complex64::new(1.0, 0.0)).norm() < TOLERANCE);
         for column in 0..4 {
             for row in 0..4 {
                 assert!(
-                    (actual[column][row] / phase - expected[column][row]).norm() < TOLERANCE,
-                    "angle {angle}, column {column}, row {row}: actual={}, expected={}",
+                    (actual[column][row] - expected[column][row]).norm() < TOLERANCE,
+                    "column {column}, row {row}: actual={}, expected={}",
                     actual[column][row],
                     expected[column][row]
                 );
@@ -288,22 +303,111 @@ mod tests {
             std::f64::consts::PI / 3.0,
             std::f64::consts::PI,
             std::f64::consts::TAU,
+            -std::f64::consts::TAU,
+            3.0 * std::f64::consts::TAU,
+            -3.0 * std::f64::consts::TAU,
             3.0 * std::f64::consts::PI,
         ] {
             assert_matrix_eq_up_to_one_global_phase(
                 matrix_from_lowering(&lower_crz(theta, QubitId(0), QubitId(1))),
                 controlled_reference('Z', theta),
-                theta,
             );
             assert_matrix_eq_up_to_one_global_phase(
                 matrix_from_lowering(&lower_crx(theta, QubitId(0), QubitId(1))),
                 controlled_reference('X', theta),
-                theta,
             );
             assert_matrix_eq_up_to_one_global_phase(
                 matrix_from_lowering(&lower_cry(theta, QubitId(0), QubitId(1))),
                 controlled_reference('Y', theta),
-                theta,
+            );
+        }
+    }
+
+    fn axis_lowering(axis: char, theta: f64) -> SmallVec<[Gate; 5]> {
+        match axis {
+            'X' => lower_crx(theta, QubitId(0), QubitId(1)),
+            'Y' => lower_cry(theta, QubitId(0), QubitId(1)),
+            'Z' => lower_crz(theta, QubitId(0), QubitId(1))
+                .into_iter()
+                .collect(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn matrix_distance(left: [[Complex64; 4]; 4], right: [[Complex64; 4]; 4]) -> f64 {
+        left.iter()
+            .flatten()
+            .zip(right.iter().flatten())
+            .map(|(l, r)| (l - r).norm_sqr())
+            .sum::<f64>()
+            .sqrt()
+    }
+
+    #[test]
+    fn crz_two_pi_is_z_on_control() {
+        let expected = matrix_from_lowering(&[Gate::z(&[QubitId(0)])]);
+        assert_matrix_eq_up_to_one_global_phase(
+            matrix_from_lowering(&lower_crz(TAU, QubitId(0), QubitId(1))),
+            expected,
+        );
+    }
+
+    #[test]
+    fn controlled_rotations_are_continuous_at_odd_turns() {
+        for axis in ['X', 'Y', 'Z'] {
+            for theta in [TAU, -TAU, 3.0 * TAU, -3.0 * TAU] {
+                let at = matrix_from_lowering(&axis_lowering(axis, theta));
+                for offset in [-1e-7, 1e-7] {
+                    let near = matrix_from_lowering(&axis_lowering(axis, theta + offset));
+                    assert!(
+                        matrix_distance(at, near) < 1e-7,
+                        "axis={axis}, theta={theta}, offset={offset}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn controlled_rotations_preserve_four_pi_periodicity() {
+        for axis in ['X', 'Y', 'Z'] {
+            for theta in [-200.0, -66.0, -3.0 * TAU, -PI, 0.37, TAU, 3.0 * TAU, 200.0] {
+                assert_matrix_eq_up_to_one_global_phase(
+                    matrix_from_lowering(&axis_lowering(axis, theta)),
+                    matrix_from_lowering(&axis_lowering(axis, theta + 2.0 * TAU)),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reduced_half_parity_matches_trigonometric_sheet_over_wide_ranges() {
+        // Independent oracle: cos(theta/2) changes sign once per removed turn.
+        // Midpoint sampling avoids the ambiguous zero at odd multiples of pi.
+        for limit in [200.0, 10_000.0] {
+            for sample in 0..300_000 {
+                let theta = -limit + 2.0 * limit * (f64::from(sample) + 0.5) / 300_000.0;
+                let (half, needs_z) = reduced_half_and_wrap_parity(theta);
+                assert!(half > -PI / 2.0 && half <= PI / 2.0);
+                assert_eq!(needs_z, (theta / 2.0).cos() < 0.0, "theta={theta}");
+            }
+        }
+    }
+
+    #[test]
+    fn reduced_lowering_agrees_with_raw_half_away_from_odd_turns() {
+        for sample in 0..800 {
+            let theta = -200.0 + 400.0 * (f64::from(sample) + 0.5) / 800.0;
+            let old = [
+                Gate::rzz(
+                    Angle64::from_radians(-theta / 2.0),
+                    &[(QubitId(0), QubitId(1))],
+                ),
+                Gate::rz(Angle64::from_radians(theta / 2.0), &[QubitId(1)]),
+            ];
+            assert_matrix_eq_up_to_one_global_phase(
+                matrix_from_lowering(&lower_crz(theta, QubitId(0), QubitId(1))),
+                matrix_from_lowering(&old),
             );
         }
     }
@@ -325,7 +429,6 @@ mod tests {
             assert_matrix_eq_up_to_one_global_phase(
                 matrix_from_lowering(&lower_cphase(lambda, QubitId(0), QubitId(1))),
                 expected,
-                lambda,
             );
         }
     }

--- a/crates/pecos-core/src/controlled_rotations.rs
+++ b/crates/pecos-core/src/controlled_rotations.rs
@@ -22,12 +22,13 @@ use std::f64::consts::{PI, TAU};
 /// Keep both reduction and parity in f64: storing the remainder in `Angle64`
 /// would quantize it before the turn count is recovered.
 fn reduced_half_and_wrap_parity(theta_radians: f64) -> (f64, bool) {
-    // Bound the source to one 4π period before deriving either component.
-    // The removed-turn count is then only 0, 1, or 2, even for huge inputs.
-    let bounded = theta_radians.rem_euclid(2.0 * TAU);
-    let reduced = bounded.rem_euclid(TAU);
+    // Reduce directly to preserve the principal branch near -π and tiny angles.
+    let reduced = theta_radians.rem_euclid(TAU);
     let signed = if reduced > PI { reduced - TAU } else { reduced };
     let h = signed / 2.0;
+    // Use the 4π reduction only for parity. Subtracting an even number of 2π
+    // turns preserves parity while keeping the rounded count in 0, 1, or 2.
+    let bounded = theta_radians.rem_euclid(2.0 * TAU);
     let wraps = ((bounded - signed) / TAU).round();
     // The rounded count has exact integer parity; compare exactly, without a tolerance.
     let needs_z = wraps.rem_euclid(2.0).total_cmp(&1.0).is_eq();
@@ -42,9 +43,10 @@ fn reduced_half_and_wrap_parity(theta_radians: f64) -> (f64, bool) {
 /// stored leg reaches the ambiguous ±π pair. Each removed 2π turn contributes
 /// a `Z` on the control; retaining its parity preserves the exact global phase
 /// and 4π periodicity without quantizing the source angle through [`Angle64`].
-/// The source is first reduced modulo 4π to keep the turn count bounded. This
-/// prevents loss of integer parity in an enormous quotient; it does not improve
-/// the accuracy of floating-point argument reduction.
+/// A separate reduction modulo 4π keeps the turn count bounded without changing
+/// the directly reduced signed representative. This prevents loss of integer
+/// parity in an enormous quotient; it does not improve the accuracy of
+/// floating-point argument reduction.
 ///
 /// # Numerical validation
 ///
@@ -409,6 +411,67 @@ mod tests {
                 assert_eq!(needs_z, (theta / 2.0).cos() < 0.0, "theta={theta}");
             }
         }
+    }
+
+    #[test]
+    fn crz_just_above_negative_pi_keeps_two_gates() {
+        let theta = (-PI).next_up();
+        let (half, needs_z) = reduced_half_and_wrap_parity(theta);
+        assert_eq!(half.to_bits(), (theta / 2.0).to_bits());
+        assert!(!needs_z);
+        let gates = lower_crz(theta, QubitId(0), QubitId(1));
+        assert_eq!(gates.len(), 2);
+        assert_eq!(
+            gates.as_slice(),
+            &[
+                Gate::rzz(
+                    Angle64::from_radians(-theta / 2.0),
+                    &[(QubitId(0), QubitId(1))]
+                ),
+                Gate::rz(Angle64::from_radians(theta / 2.0), &[QubitId(1)]),
+            ]
+        );
+    }
+
+    /// The principal representative is half-open at `+π`, so `π` itself keeps the
+    /// positive branch and emits no correction. Choosing `-π` instead denotes the
+    /// same operator, because the extra control `Z` cancels the sign it introduces,
+    /// but it emits three gates where two suffice and so changes tick scheduling.
+    #[test]
+    fn crz_at_positive_pi_keeps_the_upper_branch_and_two_gates() {
+        let (half, needs_z) = reduced_half_and_wrap_parity(PI);
+        assert_eq!(half.to_bits(), (PI / 2.0).to_bits());
+        assert!(!needs_z);
+
+        let gates = lower_crz(PI, QubitId(0), QubitId(1));
+        assert_eq!(gates.len(), 2);
+        assert_eq!(
+            gates.as_slice(),
+            &[
+                Gate::rzz(
+                    Angle64::from_radians(-PI / 2.0),
+                    &[(QubitId(0), QubitId(1))]
+                ),
+                Gate::rz(Angle64::from_radians(PI / 2.0), &[QubitId(1)]),
+            ]
+        );
+
+        // `-π` is the other end of the same half-open interval: it reduces onto the
+        // upper branch and pays for it with the correction.
+        let (negated_half, negated_needs_z) = reduced_half_and_wrap_parity(-PI);
+        assert_eq!(negated_half.to_bits(), (PI / 2.0).to_bits());
+        assert!(negated_needs_z);
+        assert_eq!(lower_crz(-PI, QubitId(0), QubitId(1)).len(), 3);
+    }
+
+    #[test]
+    fn tiny_negative_crz_preserves_directly_reduced_half() {
+        let (half, needs_z) = reduced_half_and_wrap_parity(-1e-15);
+        assert_eq!(
+            (2.0 * half).to_bits(),
+            (-8.881_784_197_001_252e-16_f64).to_bits()
+        );
+        assert!(!needs_z);
     }
 
     #[test]

--- a/crates/pecos-core/src/controlled_rotations.rs
+++ b/crates/pecos-core/src/controlled_rotations.rs
@@ -22,10 +22,13 @@ use std::f64::consts::{PI, TAU};
 /// Keep both reduction and parity in f64: storing the remainder in `Angle64`
 /// would quantize it before the turn count is recovered.
 fn reduced_half_and_wrap_parity(theta_radians: f64) -> (f64, bool) {
-    let reduced = theta_radians.rem_euclid(TAU);
+    // Bound the source to one 4π period before deriving either component.
+    // The removed-turn count is then only 0, 1, or 2, even for huge inputs.
+    let bounded = theta_radians.rem_euclid(2.0 * TAU);
+    let reduced = bounded.rem_euclid(TAU);
     let signed = if reduced > PI { reduced - TAU } else { reduced };
     let h = signed / 2.0;
-    let wraps = ((theta_radians - signed) / TAU).round();
+    let wraps = ((bounded - signed) / TAU).round();
     // The rounded count has exact integer parity; compare exactly, without a tolerance.
     let needs_z = wraps.rem_euclid(2.0).total_cmp(&1.0).is_eq();
     (h, needs_z)
@@ -39,6 +42,20 @@ fn reduced_half_and_wrap_parity(theta_radians: f64) -> (f64, bool) {
 /// stored leg reaches the ambiguous ±π pair. Each removed 2π turn contributes
 /// a `Z` on the control; retaining its parity preserves the exact global phase
 /// and 4π periodicity without quantizing the source angle through [`Angle64`].
+/// The source is first reduced modulo 4π to keep the turn count bounded. This
+/// prevents loss of integer parity in an enormous quotient; it does not improve
+/// the accuracy of floating-point argument reduction.
+///
+/// # Numerical validation
+///
+/// An 80-digit reference comparison of 10,000 random f64 inputs per magnitude
+/// found no sheet errors through `|theta| <= 1e13`. The review measured about
+/// 1 error per 10,000 at `1e14`; an independent sweep (seed 670) found 6. Errors
+/// increase as floating-point input rounding and reduction lose angular detail.
+/// These are sampled results, not a uniform bound: an evenly spaced sweep
+/// already finds the wrong sheet at `theta = 156_700_000_000.0`. The regression
+/// tests pin high-precision samples through `1e13` and the bounded outputs of
+/// known counterexamples. No exact argument reduction is performed here.
 #[must_use]
 pub fn lower_crz(theta_radians: f64, control: QubitId, target: QubitId) -> SmallVec<[Gate; 3]> {
     let (half_theta, needs_z) = reduced_half_and_wrap_parity(theta_radians);
@@ -392,6 +409,62 @@ mod tests {
                 assert_eq!(needs_z, (theta / 2.0).cos() < 0.0, "theta={theta}");
             }
         }
+    }
+
+    #[test]
+    fn bounded_parity_matches_high_precision_samples_through_1e13() {
+        // Reference: ceil((exact_f64(theta) - pi) / (2*pi)) modulo 2,
+        // evaluated with 80-digit Decimal arithmetic. Factors are applied in f64
+        // before conversion to Decimal. These samples establish no uniform bound.
+        for (magnitude, expected) in [
+            (1e0, [false, false, false, false]),
+            (1e1, [false, true, true, false]),
+            (1e2, [false, false, false, false]),
+            (1e3, [false, true, true, true]),
+            (1e4, [true, true, false, false]),
+            (1e5, [true, true, true, true]),
+            (1e6, [false, true, false, true]),
+            (1e7, [false, true, false, true]),
+            (1e8, [true, true, true, false]),
+            (1e9, [false, true, true, true]),
+            (1e10, [true, true, true, true]),
+            (1e11, [true, false, false, true]),
+            (1e12, [false, false, true, false]),
+            (1e13, [true, false, true, true]),
+        ] {
+            for (factor, parity) in [0.125, 0.37, 0.75, 1.0].into_iter().zip(expected) {
+                for sign in [-1.0, 1.0] {
+                    let theta = sign * magnitude * factor;
+                    let (half, needs_z) = reduced_half_and_wrap_parity(theta);
+                    assert_eq!(needs_z, parity, "theta={theta}");
+                    assert!(half > -PI / 2.0 && half <= PI / 2.0);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_reduction_pins_large_inputs_and_a_sheet_counterexample() {
+        // Pin outputs of the bounded f64 implementation, not ideal real-angle
+        // answers. These two inputs have odd reference parity, but their reduced
+        // f64 angles still lose accuracy.
+        for (theta, rzz, rz) in [
+            (1e20, 15_664_121_865_801_654_272, 2_782_622_207_907_898_368),
+            (
+                18_014_398_509_482_004.0,
+                3_526_899_157_453_711_360,
+                14_919_844_916_255_840_256,
+            ),
+        ] {
+            let gates = lower_crz(theta, QubitId(0), QubitId(1));
+            assert_eq!(gates.len(), 3);
+            assert_eq!(gates[0], Gate::z(&[QubitId(0)]));
+            assert_eq!(gates[1].angles[0], Angle64::new(rzz));
+            assert_eq!(gates[2].angles[0], Angle64::new(rz));
+        }
+        // Even a value below 1e13 can lie close enough to a sheet boundary for
+        // f64 reduction to choose the wrong parity. Do not promise a uniform bound.
+        assert!(reduced_half_and_wrap_parity(156_700_000_000.0).1);
     }
 
     #[test]

--- a/crates/pecos-core/tests/angle_cyclic_conversions.rs
+++ b/crates/pecos-core/tests/angle_cyclic_conversions.rs
@@ -324,21 +324,27 @@ fn nonfinite_conversions_panic_and_infinite_tolerances_saturate() {
 
 #[test]
 fn tiny_controlled_rotations_have_expected_angles() {
-    for (input, negative_half, positive_half) in [
+    // Reduction before halving leaves positive inputs unchanged. For negative
+    // inputs, adding TAU rounds -1e-15 to -8.881784197001252e-16 and smaller
+    // magnitudes to zero; the stored half therefore need not be symmetric.
+    for (theta, rzz_angle, rz_angle) in [
         (1e-15, -Angle64::new(2048), Angle64::new(1468)),
+        (-1e-15, Angle64::new(1304), Angle64::ZERO),
         (1e-16, Angle64::ZERO, Angle64::new(147)),
+        (-1e-16, Angle64::ZERO, Angle64::ZERO),
         (1e-17, Angle64::ZERO, Angle64::new(15)),
+        (-1e-17, Angle64::ZERO, Angle64::ZERO),
         (1e-18, Angle64::ZERO, Angle64::new(1)),
+        (-1e-18, Angle64::ZERO, Angle64::ZERO),
         (f64::MIN_POSITIVE, Angle64::ZERO, Angle64::ZERO),
+        (-f64::MIN_POSITIVE, Angle64::ZERO, Angle64::ZERO),
     ] {
-        for (theta, rzz_angle, rz_angle) in [
-            (input, negative_half, positive_half),
-            (-input, positive_half, negative_half),
-        ] {
-            let [rzz, rz] = lower_crz(theta, QubitId(0), QubitId(1));
-            assert_eq!(rzz.angles.as_slice(), &[rzz_angle], "theta={theta}");
-            assert_eq!(rz.angles.as_slice(), &[rz_angle], "theta={theta}");
-        }
+        let gates = lower_crz(theta, QubitId(0), QubitId(1));
+        let [rzz, rz] = gates.as_slice() else {
+            panic!("tiny angles must not need a control Z");
+        };
+        assert_eq!(rzz.angles.as_slice(), &[rzz_angle], "theta={theta}");
+        assert_eq!(rz.angles.as_slice(), &[rz_angle], "theta={theta}");
     }
 }
 

--- a/crates/pecos-core/tests/angle_cyclic_conversions.rs
+++ b/crates/pecos-core/tests/angle_cyclic_conversions.rs
@@ -325,11 +325,11 @@ fn nonfinite_conversions_panic_and_infinite_tolerances_saturate() {
 #[test]
 fn tiny_controlled_rotations_have_expected_angles() {
     // Reduction before halving leaves positive inputs unchanged. For negative
-    // inputs, adding 2*TAU rounds -1e-15 to -1.7763568394002505e-15 and smaller
+    // inputs, adding TAU rounds -1e-15 to -8.881784197001252e-16 and smaller
     // magnitudes to zero; the stored half therefore need not be symmetric.
     for (theta, rzz_angle, rz_angle) in [
         (1e-15, -Angle64::new(2048), Angle64::new(1468)),
-        (-1e-15, Angle64::new(2608), -Angle64::new(2048)),
+        (-1e-15, Angle64::new(1304), Angle64::ZERO),
         (1e-16, Angle64::ZERO, Angle64::new(147)),
         (-1e-16, Angle64::ZERO, Angle64::ZERO),
         (1e-17, Angle64::ZERO, Angle64::new(15)),

--- a/crates/pecos-core/tests/angle_cyclic_conversions.rs
+++ b/crates/pecos-core/tests/angle_cyclic_conversions.rs
@@ -325,11 +325,11 @@ fn nonfinite_conversions_panic_and_infinite_tolerances_saturate() {
 #[test]
 fn tiny_controlled_rotations_have_expected_angles() {
     // Reduction before halving leaves positive inputs unchanged. For negative
-    // inputs, adding TAU rounds -1e-15 to -8.881784197001252e-16 and smaller
+    // inputs, adding 2*TAU rounds -1e-15 to -1.7763568394002505e-15 and smaller
     // magnitudes to zero; the stored half therefore need not be symmetric.
     for (theta, rzz_angle, rz_angle) in [
         (1e-15, -Angle64::new(2048), Angle64::new(1468)),
-        (-1e-15, Angle64::new(1304), Angle64::ZERO),
+        (-1e-15, Angle64::new(2608), -Angle64::new(2048)),
         (1e-16, Angle64::ZERO, Angle64::new(147)),
         (-1e-16, Angle64::ZERO, Angle64::ZERO),
         (1e-17, Angle64::ZERO, Angle64::new(15)),

--- a/crates/pecos-phir/src/hugr_parser.rs
+++ b/crates/pecos-phir/src/hugr_parser.rs
@@ -526,23 +526,35 @@ impl HugrToPhirConverter {
                         })?;
                         // PHIR carries qubit identity in SSA operands, so only the lowered gate
                         // kinds and angles are retained from these placeholder qubit IDs.
-                        let [rzz, rz] = pecos_core::controlled_rotations::lower_crz(
+                        for gate in pecos_core::controlled_rotations::lower_crz(
                             angle.expect("rotation angle checked above"),
                             QubitId(0),
                             QubitId(1),
-                        );
-                        block.add_instruction(Instruction::new(
-                            Operation::Quantum(QuantumOp::RZZ(rzz.angles[0])),
-                            vec![control, target],
-                            vec![self.fresh_ssa(), self.fresh_ssa()],
-                            vec![Type::Qubit; 2],
-                        ));
-                        block.add_instruction(Instruction::new(
-                            Operation::Quantum(QuantumOp::RZ(rz.angles[0])),
-                            vec![target],
-                            vec![self.fresh_ssa()],
-                            vec![Type::Qubit],
-                        ));
+                        ) {
+                            let op = match gate.gate_type {
+                                pecos_core::gate_type::GateType::Z => QuantumOp::Z,
+                                pecos_core::gate_type::GateType::RZZ => {
+                                    QuantumOp::RZZ(gate.angles[0])
+                                }
+                                pecos_core::gate_type::GateType::RZ => {
+                                    QuantumOp::RZ(gate.angles[0])
+                                }
+                                _ => unreachable!("unexpected CRZ lowering gate"),
+                            };
+                            let operands: Vec<_> = gate
+                                .qubits
+                                .iter()
+                                .map(|qubit| if qubit.index() == 0 { control } else { target })
+                                .collect();
+                            let results = (0..operands.len()).map(|_| self.fresh_ssa()).collect();
+                            let types = vec![Type::Qubit; operands.len()];
+                            block.add_instruction(Instruction::new(
+                                Operation::Quantum(op),
+                                operands,
+                                results,
+                                types,
+                            ));
+                        }
                         self.map_wire(node, 0, control);
                         self.map_wire(node, 1, target);
                         continue;

--- a/crates/pecos-phir/tests/hugr_parser_tests.rs
+++ b/crates/pecos-phir/tests/hugr_parser_tests.rs
@@ -195,11 +195,7 @@ fn assert_crz_matrix(execute: impl Fn(f64, usize) -> Vec<(f64, f64)>) {
             (phase_norm - 1.0).abs() < 1e-12,
             "theta={theta}, phase={phase:?}"
         );
-        if theta.abs() <= std::f64::consts::PI {
-            assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-        } else {
-            assert!((phase.0.abs() - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-        }
+        assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
 
         for (row, row_values) in actual.iter().enumerate() {
             for (column, &value) in row_values.iter().enumerate() {

--- a/crates/pecos-qis/src/ccengine.rs
+++ b/crates/pecos-qis/src/ccengine.rs
@@ -747,7 +747,7 @@ impl QisEngine {
                             );
                             builder.add_gate_commands(&gates);
                             let metadata = std::mem::take(&mut pending_metadata);
-                            gate_metadata.extend([metadata.clone(), metadata]);
+                            gate_metadata.extend(std::iter::repeat_n(metadata, gates.len()));
                         }
                         QuantumOp::Reset(qubit) => {
                             builder.pz(&[self.mapped_qubit(*qubit, qop)?]);
@@ -899,7 +899,7 @@ impl QisEngine {
                             target.into(),
                         );
                         builder.add_gate_commands(&gates);
-                        gate_metadata.extend([metadata.clone(), metadata]);
+                        gate_metadata.extend(std::iter::repeat_n(metadata, gates.len()));
                     }
                     QuantumOp::Reset(qubit) => {
                         builder.pz(&[qubit]);
@@ -2167,11 +2167,46 @@ mod tests {
             ])
             .expect("lower QIS CRZ");
         let gates = lowered.commands.quantum_ops().unwrap();
-        assert_eq!(gates.len(), 2);
-        assert_eq!(gates[0].gate_type, pecos_core::gate_type::GateType::RZZ);
-        assert_eq!(gates[1].gate_type, pecos_core::gate_type::GateType::RZ);
-        assert_eq!(gates[1].qubits.as_slice(), [1.into()]);
-        assert_eq!(lowered.gate_metadata.len(), 2);
+        assert_eq!(gates.len(), 3);
+        assert_eq!(gates[0].gate_type, pecos_core::gate_type::GateType::Z);
+        assert_eq!(gates[0].qubits.as_slice(), [0.into()]);
+        assert_eq!(gates[1].gate_type, pecos_core::gate_type::GateType::RZZ);
+        assert_eq!(gates[2].gate_type, pecos_core::gate_type::GateType::RZ);
+        assert_eq!(gates[2].qubits.as_slice(), [1.into()]);
+        assert_eq!(lowered.gate_metadata.len(), 3);
+    }
+
+    #[test]
+    fn corrected_crz_copies_metadata_to_every_emitted_gate() {
+        let mut engine = QisEngine::with_runtime(Box::new(DummyRuntime::default()));
+        let metadata = TraceMetadata::from([("source_label".to_string(), "crz".to_string())]);
+        let ops = vec![
+            Operation::AllocateQubit { id: 0 },
+            Operation::AllocateQubit { id: 1 },
+            Operation::TraceMetadata {
+                metadata: metadata.clone(),
+                qubit: None,
+            },
+            QuantumOp::CRZ(std::f64::consts::TAU, 0, 1).into(),
+            QuantumOp::H(1).into(),
+        ];
+        let lowered = engine
+            .operations_to_lowered_commands(&ops)
+            .expect("lower annotated CRZ");
+        let gates = lowered.commands.quantum_ops().unwrap();
+        // Allocations emit two PZ commands before the three CRZ legs and H.
+        assert_eq!(gates.len(), 6);
+        assert_eq!(gates[2].gate_type, pecos_core::gate_type::GateType::Z);
+        assert!(
+            lowered.gate_metadata[..2]
+                .iter()
+                .all(TraceMetadata::is_empty)
+        );
+        assert_eq!(
+            &lowered.gate_metadata[2..5],
+            &[metadata.clone(), metadata.clone(), metadata]
+        );
+        assert!(lowered.gate_metadata[5].is_empty());
     }
 
     fn qis_crz_state(theta: f64, basis: usize) -> Vec<(f64, f64)> {
@@ -2231,11 +2266,7 @@ mod tests {
             let phase = actual[0][0];
             let phase_norm = phase.0 * phase.0 + phase.1 * phase.1;
             assert!((phase_norm - 1.0).abs() < 1e-12);
-            if theta.abs() <= std::f64::consts::PI {
-                assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-            } else {
-                assert!((phase.0.abs() - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-            }
+            assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
             for (row, row_values) in actual.iter().enumerate() {
                 for (column, &value) in row_values.iter().enumerate() {
                     let normalized = (

--- a/crates/pecos-quantum/src/dag_circuit.rs
+++ b/crates/pecos-quantum/src/dag_circuit.rs
@@ -2899,6 +2899,7 @@ mod tests {
             let gate = circuit.gate(node).expect("DAG node contains a gate");
             match gate.gate_type {
                 GateType::X => simulator.x(&gate.qubits),
+                GateType::Z => simulator.z(&gate.qubits),
                 GateType::RZ => simulator.rz(gate.angles[0], &gate.qubits),
                 GateType::RZZ => simulator.rzz(gate.angles[0], &[(gate.qubits[0], gate.qubits[1])]),
                 other => panic!("unexpected DAG builder gate {other}"),
@@ -3010,11 +3011,7 @@ mod tests {
             let phase = actual[0][0];
             let phase_norm = phase.0 * phase.0 + phase.1 * phase.1;
             assert!((phase_norm - 1.0).abs() < 1e-12);
-            if theta.abs() <= std::f64::consts::PI {
-                assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-            } else {
-                assert!((phase.0.abs() - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-            }
+            assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
             for (row, row_values) in actual.iter().enumerate() {
                 for (column, &value) in row_values.iter().enumerate() {
                     let normalized = (

--- a/crates/pecos-quantum/src/hugr_convert.rs
+++ b/crates/pecos-quantum/src/hugr_convert.rs
@@ -846,7 +846,7 @@ pub fn hugr_to_dag_circuit(hugr: &Hugr) -> Result<DagCircuit, HugrConvertError> 
                 qubits[0],
                 qubits[1],
             )
-            .into()
+            .into_vec()
         } else {
             let angles: Vec<Angle64> = op.params.iter().map(|&p| Angle64::from_turns(p)).collect();
             vec![
@@ -1505,7 +1505,7 @@ impl SimpleHugr {
                     qubits[0],
                     qubits[1],
                 )
-                .into()
+                .into_vec()
             } else {
                 let angles: Vec<Angle64> =
                     op.params.iter().map(|&p| Angle64::from_turns(p)).collect();
@@ -1607,22 +1607,23 @@ impl SimpleHugr {
         // Calculate depth
         let depth = Self::calculate_depth(&gates, &roots);
 
-        // Create gate attributes
-        let gate_attrs: Vec<BTreeMap<String, Attribute>> = quantum_ops
-            .iter()
-            .flat_map(|op| {
-                let mut attrs = BTreeMap::new();
-                attrs.insert(
+        // Use the emitted indices so every lowered gate retains its source attributes.
+        let mut gate_attrs = vec![BTreeMap::new(); gates.len()];
+        for (op, indices) in quantum_ops.iter().zip(&op_to_gate_indices) {
+            let attrs = BTreeMap::from([
+                (
                     "hugr_node".to_string(),
                     Attribute::Int(i64::try_from(op.node.index()).unwrap_or(i64::MAX)),
-                );
-                attrs.insert(
+                ),
+                (
                     "hugr_op".to_string(),
                     Attribute::String(op.hugr_op_name.clone()),
-                );
-                std::iter::repeat_n(attrs, if op.is_crz { 2 } else { 1 })
-            })
-            .collect();
+                ),
+            ]);
+            for &index in indices {
+                gate_attrs[index] = attrs.clone();
+            }
+        }
 
         // Circuit-level attributes
         let mut circuit_attrs = BTreeMap::new();
@@ -1854,7 +1855,7 @@ mod tests {
             .expect("finish HUGR")
     }
 
-    fn crz_hugr() -> Hugr {
+    fn crz_hugr(rotation_half_turns: f64) -> Hugr {
         let mut builder = DFGBuilder::new(Signature::new(vec![], vec![])).expect("create HUGR");
         let control = builder
             .add_dataflow_op(TketOp::QAlloc, vec![])
@@ -1869,7 +1870,7 @@ mod tests {
             .next()
             .expect("target output");
         let rotation = builder.add_load_value(
-            ConstRotation::new(1.0 / 3.0).expect("create finite rotation constant"),
+            ConstRotation::new(rotation_half_turns).expect("create finite rotation constant"),
         );
         let mut outputs = builder
             .add_dataflow_op(TketOp::CRz, vec![control, target, rotation])
@@ -2048,7 +2049,7 @@ mod tests {
 
     #[test]
     fn hugr_crz_lowering_preserves_source_attributes_and_target_wire() {
-        let dag = hugr_to_dag_circuit(&crz_hugr()).expect("convert HUGR");
+        let dag = hugr_to_dag_circuit(&crz_hugr(1.0 / 3.0)).expect("convert HUGR");
         let (rzz_node, rzz) = dag
             .iter_gates()
             .find(|(_, gate)| gate.gate_type == GateType::RZZ)
@@ -2084,7 +2085,7 @@ mod tests {
 
     #[test]
     fn simple_hugr_crz_control_successor_depends_on_rzz_not_target_rz() {
-        let simple = SimpleHugr::new_relaxed(crz_hugr()).expect("convert CRz HUGR");
+        let simple = SimpleHugr::new_relaxed(crz_hugr(1.0 / 3.0)).expect("convert CRz HUGR");
         let find_gate = |gate_type| {
             simple
                 .nodes()
@@ -2103,6 +2104,44 @@ mod tests {
         assert!(simple.predecessors(control_z).contains(&rzz));
         assert!(!simple.predecessors(control_z).contains(&rz));
         assert_eq!(simple.depth(), 4);
+    }
+
+    #[test]
+    fn corrected_crz_retains_attributes_and_wire_dependencies() {
+        let simple = SimpleHugr::new_relaxed(crz_hugr(2.0)).expect("convert CRz(2pi)");
+        let lowered: Vec<_> = simple
+            .nodes()
+            .into_iter()
+            .filter(|&idx| {
+                simple.gate_attrs(idx).unwrap().get("hugr_op")
+                    == Some(&Attribute::String("CRz".to_string()))
+            })
+            .collect();
+        assert_eq!(lowered.len(), 3);
+        let kinds: Vec<_> = lowered
+            .iter()
+            .map(|&idx| simple.gate(idx).unwrap().gate_type)
+            .collect();
+        assert_eq!(kinds, [GateType::Z, GateType::RZZ, GateType::RZ]);
+        assert!(simple.predecessors(lowered[1]).contains(&lowered[0]));
+        assert!(simple.predecessors(lowered[2]).contains(&lowered[1]));
+        let source_node = simple.gate_attrs(lowered[0]).unwrap().get("hugr_node");
+        for &idx in &lowered {
+            assert_eq!(
+                simple.gate_attrs(idx).unwrap().get("hugr_node"),
+                source_node
+            );
+        }
+        let successor = simple
+            .nodes()
+            .into_iter()
+            .find(|&idx| {
+                simple.gate_attrs(idx).unwrap().get("hugr_op")
+                    == Some(&Attribute::String("Z".to_string()))
+            })
+            .expect("control successor");
+        assert!(simple.predecessors(successor).contains(&lowered[1]));
+        assert!(!simple.predecessors(successor).contains(&lowered[2]));
     }
 
     #[test]

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3919,6 +3919,30 @@ mod tests {
     }
 
     #[test]
+    fn crz_just_above_negative_pi_fits_before_occupied_third_tick() {
+        let mut circuit = TickCircuit::new();
+        circuit.reserve_ticks(3);
+        circuit.tick_at(2).h(&[1]);
+        circuit
+            .tick_at(0)
+            .try_crz((-std::f64::consts::PI).next_up(), &[(0, 1)])
+            .unwrap();
+
+        assert_eq!(circuit.num_ticks(), 3);
+        assert_eq!(circuit.gate_count(), 3);
+        for (stage, kind, qubits) in [
+            (0, GateType::RZZ, vec![QubitId(0), QubitId(1)]),
+            (1, GateType::RZ, vec![QubitId(1)]),
+            (2, GateType::H, vec![QubitId(1)]),
+        ] {
+            let gates = circuit.get_tick(stage).unwrap().gate_batches();
+            assert_eq!(gates.len(), 1);
+            assert_eq!(gates[0].gate_type, kind);
+            assert_eq!(gates[0].qubits.as_slice(), qubits);
+        }
+    }
+
+    #[test]
     fn corrected_crz_preflights_all_three_ticks() {
         for conflict_tick in 0..3 {
             let mut circuit = TickCircuit::new();

--- a/crates/pecos-quantum/src/tick_circuit.rs
+++ b/crates/pecos-quantum/src/tick_circuit.rs
@@ -3111,7 +3111,7 @@ impl<'a> TickHandle<'a> {
     ///
     /// # Panics
     ///
-    /// Panics if either native gate conflicts with an operation already present
+    /// Panics if any lowered gate conflicts with an operation already present
     /// in its destination tick. Use [`Self::try_crz`] for fallible insertion.
     pub fn crz(
         &mut self,
@@ -3128,8 +3128,8 @@ impl<'a> TickHandle<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`TickGateError`] if either native gate is invalid or conflicts
-    /// with an operation already present in its destination tick. Neither gate
+    /// Returns [`TickGateError`] if any lowered gate is invalid or conflicts
+    /// with an operation already present in its destination tick. No gate
     /// is inserted when preflight validation fails.
     pub fn try_crz(
         &mut self,
@@ -3140,53 +3140,52 @@ impl<'a> TickHandle<'a> {
             return Ok(self);
         }
 
-        let mut rzz_batch: Option<Gate> = None;
-        let mut rz_batch: Option<Gate> = None;
+        let mut batches: smallvec::SmallVec<[Gate; 3]> = smallvec::SmallVec::new();
         for &(control, target) in pairs {
-            let [rzz, rz] = pecos_core::controlled_rotations::lower_crz(
+            for (stage, gate) in pecos_core::controlled_rotations::lower_crz(
                 theta_radians,
                 control.into(),
                 target.into(),
-            );
-            if let Some(batch) = &mut rzz_batch {
-                batch.append_batch(rzz);
-            } else {
-                rzz_batch = Some(rzz);
+            )
+            .into_iter()
+            .enumerate()
+            {
+                if let Some(batch) = batches.get_mut(stage) {
+                    batch.append_batch(gate);
+                } else {
+                    batches.push(gate);
+                }
             }
-            if let Some(batch) = &mut rz_batch {
-                batch.append_batch(rz);
-            } else {
-                rz_batch = Some(rz);
+        }
+
+        // Preflight every destination before inserting any part of the lowering.
+        for (stage, gate) in batches.iter().enumerate() {
+            let tick_idx = self.tick_idx + stage;
+            let mut preview = self
+                .circuit
+                .ticks
+                .get(tick_idx)
+                .cloned()
+                .unwrap_or_default();
+            if let Err(mut err) = preview.try_add_gate(gate.clone()) {
+                err.set_tick_idx(tick_idx);
+                return Err(err);
             }
         }
-
-        let Some(rzz_batch) = rzz_batch else {
-            return Ok(self);
-        };
-        let Some(rz_batch) = rz_batch else {
-            return Ok(self);
-        };
-        let rz_tick = self.tick_idx + 1;
-
-        let mut rzz_preview = self.circuit.ticks[self.tick_idx].clone();
-        if let Err(mut err) = rzz_preview.try_add_gate(rzz_batch.clone()) {
-            err.set_tick_idx(self.tick_idx);
-            return Err(err);
-        }
-        let mut rz_preview = self.circuit.ticks.get(rz_tick).cloned().unwrap_or_default();
-        if let Err(mut err) = rz_preview.try_add_gate(rz_batch.clone()) {
-            err.set_tick_idx(rz_tick);
-            return Err(err);
-        }
-
-        self.try_add_gate(rzz_batch)?;
-        while rz_tick >= self.circuit.ticks.len() {
-            self.circuit.ticks.push(Tick::new());
-        }
-        self.circuit.next_tick = self.circuit.next_tick.max(rz_tick + 1);
-        if let Err(mut err) = self.circuit.ticks[rz_tick].try_add_gate(rz_batch) {
-            err.set_tick_idx(rz_tick);
-            return Err(err);
+        for (stage, gate) in batches.into_iter().enumerate() {
+            if stage == 0 {
+                self.try_add_gate(gate)?;
+                continue;
+            }
+            let tick_idx = self.tick_idx + stage;
+            while tick_idx >= self.circuit.ticks.len() {
+                self.circuit.ticks.push(Tick::new());
+            }
+            self.circuit.next_tick = self.circuit.next_tick.max(tick_idx + 1);
+            if let Err(mut err) = self.circuit.ticks[tick_idx].try_add_gate(gate) {
+                err.set_tick_idx(tick_idx);
+                return Err(err);
+            }
         }
         Ok(self)
     }
@@ -3906,22 +3905,41 @@ mod tests {
         let mut circuit = TickCircuit::new();
         circuit.tick().crz(std::f64::consts::TAU, &[(0, 1)]);
 
-        assert_eq!(circuit.num_ticks(), 2);
-        assert_eq!(circuit.gate_count(), 2);
-        assert_eq!(
-            circuit.get_tick(0).unwrap().gate_batches()[0].gate_type,
-            GateType::RZZ
-        );
-        assert_eq!(
-            circuit.get_tick(1).unwrap().gate_batches()[0].gate_type,
-            GateType::RZ
-        );
-        assert_eq!(
-            circuit.get_tick(1).unwrap().gate_batches()[0]
-                .qubits
-                .as_slice(),
-            &[QubitId(1)]
-        );
+        assert_eq!(circuit.num_ticks(), 3);
+        assert_eq!(circuit.gate_count(), 3);
+        for (stage, kind, qubits) in [
+            (0, GateType::Z, vec![QubitId(0)]),
+            (1, GateType::RZZ, vec![QubitId(0), QubitId(1)]),
+            (2, GateType::RZ, vec![QubitId(1)]),
+        ] {
+            let gate = &circuit.get_tick(stage).unwrap().gate_batches()[0];
+            assert_eq!(gate.gate_type, kind);
+            assert_eq!(gate.qubits.as_slice(), qubits);
+        }
+    }
+
+    #[test]
+    fn corrected_crz_preflights_all_three_ticks() {
+        for conflict_tick in 0..3 {
+            let mut circuit = TickCircuit::new();
+            circuit.reserve_ticks(3);
+            let qubit = usize::from(conflict_tick == 2);
+            circuit.tick_at(conflict_tick).h(&[qubit]);
+            let before = circuit.clone();
+            assert!(
+                circuit
+                    .tick_at(0)
+                    .try_crz(std::f64::consts::TAU, &[(0, 1)])
+                    .is_err()
+            );
+            assert_eq!(circuit.num_ticks(), before.num_ticks());
+            for tick in 0..3 {
+                assert_eq!(
+                    circuit.get_tick(tick).unwrap().gate_batches(),
+                    before.get_tick(tick).unwrap().gate_batches()
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/pecos-quantum/tests/controlled_rotation_dense.rs
+++ b/crates/pecos-quantum/tests/controlled_rotation_dense.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 The PECOS Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//! Raw dense-matrix regressions for controlled-rotation lowering, including global phase.
+
+use pecos_core::controlled_rotations::{lower_crx, lower_cry, lower_crz};
+use pecos_core::gate_type::GateType;
+use pecos_core::unitary_rep::RotationType;
+use pecos_core::{Angle64, Gate, QubitId, UnitaryRep};
+use pecos_quantum::unitary_matrix::{UnitaryMatrix, to_matrix_with_size};
+use std::f64::consts::TAU;
+
+fn dense(gates: &[Gate]) -> UnitaryMatrix {
+    gates
+        .iter()
+        .fold(UnitaryMatrix::identity(4), |matrix, gate| {
+            let qubits: Vec<_> = gate.qubits.iter().map(QubitId::index).collect();
+            let op = match gate.gate_type {
+                GateType::RZ => {
+                    UnitaryRep::rotation(RotationType::RZ, gate.angles[0], qubits.as_slice())
+                }
+                GateType::RZZ => {
+                    UnitaryRep::rotation(RotationType::RZZ, gate.angles[0], qubits.as_slice())
+                }
+                kind => UnitaryRep::gate(kind, qubits.as_slice()),
+            };
+            to_matrix_with_size(&op, 2) * matrix
+        })
+}
+
+fn old_lowering(theta: f64) -> [Gate; 2] {
+    [
+        Gate::rzz(
+            Angle64::from_radians(-theta / 2.0),
+            &[(QubitId(1), QubitId(0))],
+        ),
+        Gate::rz(Angle64::from_radians(theta / 2.0), &[QubitId(0)]),
+    ]
+}
+
+#[test]
+fn dense_controlled_rotations_are_continuous_and_exact_at_odd_turns() {
+    let control_z = dense(&[Gate::z(&[QubitId(1)])]);
+    for theta in [TAU, -TAU, 3.0 * TAU, -3.0 * TAU] {
+        let fixed = dense(&lower_crz(theta, QubitId(1), QubitId(0)));
+        let old = dense(&old_lowering(theta));
+        let error = (&fixed - &control_z).norm();
+        let old_error = (&old - &control_z).norm();
+        assert!(error < 1e-12);
+        assert!((old_error - 4.0).abs() < 1e-12);
+        for offset in [-1e-7, 1e-7] {
+            let near = dense(&lower_crz(theta + offset, QubitId(1), QubitId(0)));
+            let jump = (&fixed - &near).norm();
+            let old_jump = (&old - dense(&old_lowering(theta + offset))).norm();
+            println!(
+                "theta={theta}, offset={offset}: fixed jump={jump:.4}, old jump={old_jump:.4}"
+            );
+            assert!(jump < 1e-7);
+            assert!((old_jump - 4.0).abs() < 1e-7);
+        }
+        for lowering in [lower_crx, lower_cry] {
+            let matrix = dense(&lowering(theta, QubitId(1), QubitId(0)));
+            assert!((&matrix - &control_z).norm() < 1e-12);
+        }
+        println!("theta={theta}: fixed Z error={error:.6}, old Z error={old_error:.6}");
+    }
+}
+
+#[test]
+fn dense_reduced_lowering_matches_raw_half_at_800_angles() {
+    let mut worst = 0.0_f64;
+    for sample in 0..800 {
+        let theta = -200.0 + 400.0 * (f64::from(sample) + 0.5) / 800.0;
+        let fixed = dense(&lower_crz(theta, QubitId(1), QubitId(0)));
+        worst = worst.max((&fixed - dense(&old_lowering(theta))).norm());
+        let shifted = dense(&lower_crz(theta + 2.0 * TAU, QubitId(1), QubitId(0)));
+        assert!((&fixed - shifted).norm() < 1e-12);
+    }
+    println!("800-angle worst raw-half disagreement={worst:.3e}");
+    assert!(worst < 1e-12);
+}

--- a/crates/pecos-quantum/tests/crz_boundary.rs
+++ b/crates/pecos-quantum/tests/crz_boundary.rs
@@ -121,11 +121,7 @@ fn rust_hugr_crz_boundary_preserves_full_matrix() {
             (phase_norm - 1.0).abs() < 1e-12,
             "theta={theta}, phase={phase:?}"
         );
-        if theta.abs() <= std::f64::consts::PI {
-            assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-        } else {
-            assert!((phase.0.abs() - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
-        }
+        assert!((phase.0 - 1.0).abs() < 1e-12 && phase.1.abs() < 1e-12);
         for (row, row_values) in actual.iter().enumerate() {
             for (column, &value) in row_values.iter().enumerate() {
                 let normalized = (

--- a/crates/pecos-simulators/src/clifford_rotation.rs
+++ b/crates/pecos-simulators/src/clifford_rotation.rs
@@ -569,12 +569,23 @@ mod tests {
 
     #[test]
     fn lower_crz_pi_matches_sz_then_szzdg_tableau() {
-        let [rzz, rz] = lower_crz(std::f64::consts::PI, QubitId(0), QubitId(1));
         let mut lowered = SparseStab::new(2);
-        lowered
-            .try_rzz(rzz.angles[0], &[(rzz.qubits[0], rzz.qubits[1])])
-            .unwrap();
-        lowered.try_rz(rz.angles[0], &rz.qubits).unwrap();
+        for gate in lower_crz(std::f64::consts::PI, QubitId(0), QubitId(1)) {
+            match gate.gate_type {
+                pecos_core::gate_type::GateType::Z => {
+                    lowered.z(&gate.qubits);
+                }
+                pecos_core::gate_type::GateType::RZZ => {
+                    lowered
+                        .try_rzz(gate.angles[0], &[(gate.qubits[0], gate.qubits[1])])
+                        .unwrap();
+                }
+                pecos_core::gate_type::GateType::RZ => {
+                    lowered.try_rz(gate.angles[0], &gate.qubits).unwrap();
+                }
+                other => panic!("unexpected lowered gate {other:?}"),
+            }
+        }
 
         let mut expected = SparseStab::new(2);
         expected.sz(&qid(1)).szzdg(&[(QubitId(0), QubitId(1))]);

--- a/python/pecos-rslib-cuda/src/lib.rs
+++ b/python/pecos-rslib-cuda/src/lib.rs
@@ -81,6 +81,9 @@ impl PyCuStateVec {
     fn apply_lowered_controlled_rotation(&mut self, gates: impl IntoIterator<Item = Gate>) {
         for gate in gates {
             match gate.gate_type {
+                GateType::Z => {
+                    self.inner.z(&gate.qubits);
+                }
                 GateType::H => {
                     self.inner.h(&gate.qubits);
                 }

--- a/python/pecos-rslib-exp/src/sim_neo_bindings.rs
+++ b/python/pecos-rslib-exp/src/sim_neo_bindings.rs
@@ -1633,18 +1633,17 @@ fn build_rust_tick_circuit_from_gates(
                         )));
                     }
                     for pair in pairs {
-                        let lowered: Vec<Gate> = match gate_name.as_str() {
+                        let lowered = match gate_name.as_str() {
                             "CRX" => {
                                 pecos_core::controlled_rotations::lower_crx(angle, pair[0], pair[1])
-                                    .into()
                             }
                             "CRY" => {
                                 pecos_core::controlled_rotations::lower_cry(angle, pair[0], pair[1])
-                                    .into()
                             }
                             "CRZ" => {
                                 pecos_core::controlled_rotations::lower_crz(angle, pair[0], pair[1])
-                                    .into()
+                                    .into_iter()
+                                    .collect()
                             }
                             _ => unreachable!(),
                         };
@@ -1973,6 +1972,7 @@ fn append_lowered_command(mut builder: CommandBuilder, gate: &Gate) -> PyResult<
 
     let qubits: Vec<usize> = gate.qubits.iter().map(pecos_core::QubitId::index).collect();
     builder = match gate.gate_type {
+        GateType::Z => builder.z(&qubits),
         GateType::H => builder.h(&qubits),
         GateType::SX => builder.sx(&qubits),
         GateType::SXdg => builder.sxdg(&qubits),
@@ -2158,25 +2158,24 @@ fn extract_commands(py_tc: &Bound<'_, PyAny>) -> PyResult<pecos_neo::command::Co
                         )));
                     }
                     for pair in pairs {
-                        let lowered: Vec<Gate> = match name.as_str() {
+                        let lowered = match name.as_str() {
                             "CRX" => pecos_core::controlled_rotations::lower_crx(
                                 angle,
                                 QubitId(pair[0]),
                                 QubitId(pair[1]),
-                            )
-                            .into(),
+                            ),
                             "CRY" => pecos_core::controlled_rotations::lower_cry(
                                 angle,
                                 QubitId(pair[0]),
                                 QubitId(pair[1]),
-                            )
-                            .into(),
+                            ),
                             "CRZ" => pecos_core::controlled_rotations::lower_crz(
                                 angle,
                                 QubitId(pair[0]),
                                 QubitId(pair[1]),
                             )
-                            .into(),
+                            .into_iter()
+                            .collect(),
                             _ => unreachable!(),
                         };
                         for lowered_gate in &lowered {

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -188,6 +188,25 @@ def test_sim_neo_extract_commands_control_interference(symbol, operands, theta):
     assert [list(row) for row in result] == [[1, 0]] * 4
 
 
+@pytest.mark.parametrize("symbol", ["CRX", "CRY", "CRZ"])
+@pytest.mark.parametrize("operands", [(0, 1), (1, 0)])
+@pytest.mark.parametrize("theta", [math.tau, -math.tau, 3 * math.tau, -3 * math.tau])
+def test_sim_neo_extract_commands_control_and_target_interference(symbol, operands, theta):
+    control, target = operands
+    circuit = _boundary_circuit(
+        [
+            [("PZ", [0, 1])],
+            [("H", [control, target])],
+            [(symbol, [control, target], [theta])],
+            [("H", [control, target])],
+            [("MZ", [control, target])],
+        ],
+    )
+    # Superpose the target too: an extra target Z must change its final bit.
+    result = exp.sim_neo(circuit).quantum(exp.statevec()).sampling(exp.monte_carlo(4)).seed(670).run()
+    assert [list(row) for row in result] == [[1, 0]] * 4
+
+
 def test_stab_mps_measurement_selection_precedence_and_reset_retention():
     assert exp.StabMps(1).measurement == "exact"
     assert exp.StabMps(1, measurement="pragmatic").measurement == "pragmatic"

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -92,7 +92,9 @@ def test_sim_neo_rejects_rotation_with_wrong_angle_arity():
         exp.sim_neo(Circuit())
 
 
-def test_sim_neo_python_fallback_crz_preserves_full_matrix():
+def _boundary_circuit(ticks):
+    """Keep boundary rotations in Python so sim_neo must call extract_commands."""
+
     class GateType:
         def __init__(self, name):
             self.name = name
@@ -108,19 +110,14 @@ def test_sim_neo_python_fallback_crz_preserves_full_matrix():
 
     class Tick:
         def __init__(self, gates):
-            self.gates = gates
+            self.gates = [Gate(*gate) for gate in gates]
 
         def gate_batches(self):
             return self.gates
 
     class Circuit:
-        def __init__(self, basis, theta):
-            prep = []
-            if basis & 1:
-                prep.append(Gate("X", [0]))
-            if basis & 2:
-                prep.append(Gate("X", [1]))
-            self.ticks = [Tick(prep), Tick([Gate("CRZ", [1, 0], [theta])])]
+        def __init__(self):
+            self.ticks = [Tick(gates) for gates in ticks]
 
         def num_ticks(self):
             return len(self.ticks)
@@ -131,13 +128,19 @@ def test_sim_neo_python_fallback_crz_preserves_full_matrix():
         def annotations(self):
             return []
 
-    for theta in (-math.pi, math.pi / 3, math.pi, math.tau, 3 * math.pi):
+    return Circuit()
+
+
+def test_sim_neo_python_fallback_crz_preserves_full_matrix():
+    for theta in (-math.pi, math.pi / 3, math.pi, math.tau, -math.tau, 3 * math.pi, 3 * math.tau, -3 * math.tau):
         columns = []
         for basis in range(4):
-            native = exp.neo_fallback_native_gates(Circuit(basis, theta))
+            prep = [("X", [qubit]) for qubit in range(2) if basis & (1 << qubit)]
+            circuit = _boundary_circuit([prep, [("CRZ", [1, 0], [theta])]])
+            native = exp.neo_fallback_native_gates(circuit)
             simulator = StateVec(2)
             for _, name, qubits, angles in native:
-                if name in {"X", "RZ"}:
+                if name in {"X", "Z", "RZ"}:
                     params = {"angle": angles[0]} if name == "RZ" else None
                     for qubit in qubits:
                         simulator.backend.run_1q_gate(name, qubit, params)
@@ -160,15 +163,29 @@ def test_sim_neo_python_fallback_crz_preserves_full_matrix():
             [0, 0, complex(math.cos(half), -math.sin(half)), 0],
             [0, 0, 0, complex(math.cos(half), math.sin(half))],
         ]
-        phase = columns[0][0] / reference[0][0]
-        assert abs(abs(phase) - 1) < 1e-12
-        if theta in {-math.pi, math.pi / 3, math.pi}:
-            assert abs(phase - 1) < 1e-12
-        else:
-            assert min(abs(phase - 1), abs(phase + 1)) < 1e-12
         for column in range(4):
             for row in range(4):
-                assert abs(columns[column][row] / phase - reference[row][column]) < 1e-12
+                assert abs(columns[column][row] - reference[row][column]) < 1e-12
+
+
+@pytest.mark.parametrize("symbol", ["CRX", "CRY", "CRZ"])
+@pytest.mark.parametrize("operands", [(0, 1), (1, 0)])
+@pytest.mark.parametrize("theta", [math.tau, -math.tau, 3 * math.tau, -3 * math.tau])
+def test_sim_neo_extract_commands_control_interference(symbol, operands, theta):
+    control, target = operands
+    circuit = _boundary_circuit(
+        [
+            [("PZ", [0, 1])],
+            [("H", [control])],
+            [(symbol, [control, target], [theta])],
+            [("H", [control])],
+            [("MZ", [control, target])],
+        ]
+    )
+    # Every controlled rotation at an odd full turn is Z on its control.
+    # The final H turns the relative sign into a deterministic measurement.
+    result = exp.sim_neo(circuit).quantum(exp.statevec()).sampling(exp.monte_carlo(4)).seed(670).run()
+    assert [list(row) for row in result] == [[1, 0]] * 4
 
 
 def test_stab_mps_measurement_selection_precedence_and_reset_retention():

--- a/python/pecos-rslib-exp/tests/test_exposure.py
+++ b/python/pecos-rslib-exp/tests/test_exposure.py
@@ -180,7 +180,7 @@ def test_sim_neo_extract_commands_control_interference(symbol, operands, theta):
             [(symbol, [control, target], [theta])],
             [("H", [control])],
             [("MZ", [control, target])],
-        ]
+        ],
     )
     # Every controlled rotation at an odd full turn is Z on its control.
     # The final H turns the relative sign into a deterministic measurement.

--- a/python/pecos-rslib/src/state_vec_bindings.rs
+++ b/python/pecos-rslib/src/state_vec_bindings.rs
@@ -435,23 +435,25 @@ impl PyStateVec {
                     }
                     Err(err) => return Err(err),
                 };
-                let gates: Vec<Gate> = match symbol {
+                let gates = match symbol {
                     "CRX" => {
                         pecos_core::controlled_rotations::lower_crx(angle, pair[0].0, pair[0].1)
-                            .into()
                     }
                     "CRY" => {
                         pecos_core::controlled_rotations::lower_cry(angle, pair[0].0, pair[0].1)
-                            .into()
                     }
                     "CRZ" => {
                         pecos_core::controlled_rotations::lower_crz(angle, pair[0].0, pair[0].1)
-                            .into()
+                            .into_iter()
+                            .collect()
                     }
                     _ => unreachable!(),
                 };
                 for gate in gates {
                     match gate.gate_type {
+                        GateType::Z => {
+                            self.inner.z(&gate.qubits);
+                        }
                         GateType::H => {
                             self.inner.h(&gate.qubits);
                         }

--- a/python/pecos-rslib/tests/test_crz_circuit_builders.py
+++ b/python/pecos-rslib/tests/test_crz_circuit_builders.py
@@ -76,6 +76,21 @@ def test_py_tick_handle_crz_preserves_full_matrix() -> None:
                 assert abs(columns[column][row] - reference[row][column]) < 1e-12
 
 
+def test_py_tick_handle_crz_just_above_negative_pi_fits_before_h() -> None:
+    circuit = TickCircuit()
+    for _ in range(3):
+        circuit.tick()
+    circuit.tick_at(2).h([1])
+    circuit.tick_at(0).crz(math.nextafter(-math.pi, 0.0), [(0, 1)])
+
+    assert circuit.num_ticks() == 3
+    for index, (name, qubits) in enumerate([("RZZ", [0, 1]), ("RZ", [1]), ("H", [1])]):
+        gates = circuit.get_tick(index).gate_batches()
+        assert len(gates) == 1
+        assert gates[0].gate_type.name == name
+        assert list(gates[0].qubits) == qubits
+
+
 def test_py_tick_handle_crz_conflict_is_atomic() -> None:
     circuit = TickCircuit()
     circuit.tick()

--- a/python/pecos-rslib/tests/test_crz_circuit_builders.py
+++ b/python/pecos-rslib/tests/test_crz_circuit_builders.py
@@ -26,7 +26,7 @@ def _execute(circuit: TickCircuit) -> list[complex]:
             name = gate.gate_type.name
             qubits = list(gate.qubits)
             angles = list(gate.angles)
-            if name in {"X", "RZ"}:
+            if name in {"X", "Z", "RZ"}:
                 params = {"angle": angles[0]} if name == "RZ" else None
                 for qubit in qubits:
                     simulator.backend.run_1q_gate(name, qubit, params)
@@ -44,7 +44,16 @@ def _execute(circuit: TickCircuit) -> list[complex]:
 
 
 def test_py_tick_handle_crz_preserves_full_matrix() -> None:
-    for theta in (-math.pi, math.pi / 3, math.pi, math.tau, 3 * math.pi):
+    for theta in (
+        -math.pi,
+        math.pi / 3,
+        math.pi,
+        math.tau,
+        -math.tau,
+        3 * math.pi,
+        3 * math.tau,
+        -3 * math.tau,
+    ):
         columns: list[list[complex]] = []
         for basis in range(4):
             circuit = TickCircuit()
@@ -62,15 +71,9 @@ def test_py_tick_handle_crz_preserves_full_matrix() -> None:
             [0, 0, complex(math.cos(half), -math.sin(half)), 0],
             [0, 0, 0, complex(math.cos(half), math.sin(half))],
         ]
-        phase = columns[0][0] / reference[0][0]
-        assert abs(abs(phase) - 1) < 1e-12
-        if theta in {-math.pi, math.pi / 3, math.pi}:
-            assert abs(phase - 1) < 1e-12
-        else:
-            assert min(abs(phase - 1), abs(phase + 1)) < 1e-12
         for column in range(4):
             for row in range(4):
-                assert abs(columns[column][row] / phase - reference[row][column]) < 1e-12
+                assert abs(columns[column][row] - reference[row][column]) < 1e-12
 
 
 def test_py_tick_handle_crz_conflict_is_atomic() -> None:
@@ -110,3 +113,17 @@ def test_py_tick_handle_crz_metadata_targets_rzz() -> None:
     assert rzz_tick.get_attr("tag") is None
     assert rz_tick.get_gate_attr(0, "tag") is None
     assert rz_tick.get_attr("tag") is None
+
+
+@pytest.mark.parametrize("theta", [-math.pi, math.tau, -math.tau, 3 * math.tau])
+def test_py_tick_handle_crz_odd_parity_metadata_targets_z(theta: float) -> None:
+    circuit = TickCircuit()
+    circuit.tick().crz(theta, [(0, 1)]).meta("tag", "lowered-crz")
+
+    assert circuit.num_ticks() == 3
+    for index, name in enumerate(["Z", "RZZ", "RZ"]):
+        tick = circuit.get_tick(index)
+        assert [gate.gate_type.name for gate in tick.gate_batches()] == [name]
+        assert tick.get_gate_attr(0, "tag") == ("lowered-crz" if index == 0 else None)
+        assert tick.get_attr("tag") is None
+    assert list(circuit.get_tick(0).gate_batches()[0].qubits) == [0]

--- a/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
+++ b/python/quantum-pecos/tests/pecos/integration/state_sim_tests/test_statevec.py
@@ -426,7 +426,7 @@ def _assert_three_pi_differs_by_control_z(pi_state: list[complex], three_pi_stat
 
 
 def test_quantum_circuit_angle_preserves_controlled_rotation_sheet() -> None:
-    """The Python StateVec route must halve CRZ's unreduced source angle."""
+    """The Python StateVec route must retain CRZ's source rotation sheet."""
     pi_state = _run_crz_angle_circuit(StateVec(2), pc.f64.pi)
     three_pi_state = _run_crz_angle_circuit(StateVec(2), 3 * pc.f64.pi)
 
@@ -439,6 +439,15 @@ def test_statevecrs_run_circuit_preserves_controlled_rotation_sheet() -> None:
     three_pi_state = _run_crz_angle_circuit(StateVecRs(2), 3 * pc.f64.pi)
 
     _assert_three_pi_differs_by_control_z(pi_state, three_pi_state)
+
+
+@pytest.mark.parametrize("simulator_type", [StateVec, StateVecRs])
+def test_crz_two_pi_is_z_on_superposed_control(simulator_type: type[StateVec | StateVecRs]) -> None:
+    """Compare raw amplitudes so the control Z and global sign are observable."""
+    actual = _run_crz_angle_circuit(simulator_type(2), pc.f64.tau)
+    amplitude = 2**-0.5
+    expected = [amplitude, 0, -amplitude, 0]
+    assert all(abs(value - wanted) < 1e-12 for value, wanted in zip(actual, expected, strict=True))
 
 
 @pytest.mark.parametrize(

--- a/python/quantum-pecos/tests/pecos/test_tracing.py
+++ b/python/quantum-pecos/tests/pecos/test_tracing.py
@@ -79,7 +79,7 @@ def _execute_tick_circuit(circuit: TickCircuit) -> list[complex]:
             name = gate.gate_type.name
             qubits = list(gate.qubits)
             angles = list(gate.angles)
-            if name in {"PZ", "X", "RZ"}:
+            if name in {"PZ", "X", "Z", "RZ"}:
                 params = {"angle": angles[0]} if name == "RZ" else None
                 for qubit in qubits:
                     simulator.backend.run_1q_gate(name, qubit, params)
@@ -97,7 +97,7 @@ def _execute_tick_circuit(circuit: TickCircuit) -> list[complex]:
 
 
 def test_qis_trace_crz_preserves_full_matrix() -> None:
-    for theta in (-math.pi, math.pi / 3, math.pi, math.tau, 3 * math.pi):
+    for theta in (-math.pi, math.pi / 3, math.pi, math.tau, -math.tau, 3 * math.pi, 3 * math.tau, -3 * math.tau):
         columns: list[list[complex]] = []
         for basis in range(4):
             operations = [
@@ -137,15 +137,9 @@ def test_qis_trace_crz_preserves_full_matrix() -> None:
             [0, 0, complex(math.cos(half), -math.sin(half)), 0],
             [0, 0, 0, complex(math.cos(half), math.sin(half))],
         ]
-        phase = columns[0][0] / reference[0][0]
-        assert abs(abs(phase) - 1) < 1e-12
-        if theta in {-math.pi, math.pi / 3, math.pi}:
-            assert abs(phase - 1) < 1e-12
-        else:
-            assert min(abs(phase - 1), abs(phase + 1)) < 1e-12
         for column in range(4):
             for row in range(4):
-                assert abs(columns[column][row] / phase - reference[row][column]) < 1e-12
+                assert abs(columns[column][row] - reference[row][column]) < 1e-12
 
 
 def test_tracing_apis_are_exported_at_top_level() -> None:


### PR DESCRIPTION
Closes #670.

`lower_crz` emitted `RZZ(-theta/2)` then `RZ(theta/2)`. At `theta = 2pi` those legs are `-pi` and `+pi`, which a stored `Angle64` cannot distinguish, and `RZZ(-pi) = -RZZ(pi)`. The lowering was therefore off by a global `-1` at `theta = 2pi (mod 4pi)`. `CRZ(2pi)` should be `Z` on the control, `diag(1, 1, -1, -1)`; it executed as `-Z` on the control. `CRX` and `CRY` inherited the defect through `lower_crz`.

A global `-1` is unobservable on a full state and becomes observable when the operation is applied on one branch of a superposition or is itself controlled, which is the phase-exact regime adopted in #601/#616/#620.

## The fix

Reduce the source angle to `(-pi, pi]` **before** halving, which is the discipline that already makes `lower_cphase` exact, and emit the removed turns as a `Z` on the control:

```
reduced = theta.rem_euclid(TAU)
signed  = if reduced > PI { reduced - TAU } else { reduced }   // (-pi, pi]
h       = signed / 2.0                                          // (-pi/2, pi/2]
wraps   = ((theta - signed) / TAU).round()
needs_z = wraps.rem_euclid(2.0) == 1.0

gates = [ Z(control) if needs_z ] ++ [ RZZ(-h), RZ(h) ]
```

Because the reduction happens before the halving, `h` always lies in `(-pi/2, pi/2]` and no stored leg can reach the ambiguous `+-pi` pair.

The correction is derived from `CRZ(theta) = Phase(-theta/2) on {control} . CPhase(theta)`: both factors are diagonal and commute, and the two control-side phases merge to `Phase(-pi*k)`, which is `Z^k` on the control. The emitted gate is a plain `Z`, so the correction is always Clifford and at most one gate. No global-phase carrier is needed, and this does not depend on `Phase` reaching the ingress layer.

Parity is computed in `f64` and never round-trips through `Angle64`. An earlier attempt derived it from `Angle64::from_radians(...).to_radians_signed()`, whose quantization made the leftover not an exact multiple of `pi` and gave wrong parities from about `|theta| >= 66`.

The source is reduced modulo `4pi` before either component is derived, so the removed-turn count is only ever 0, 1, or 2. This is **structural, not an accuracy improvement**, and the doc comment says so. Against an 80-digit reference over 10,000 random inputs per magnitude, the bounded and unbounded forms are statistically identical (0 vs 0 through `1e13`, 34 vs 34 at `1e15`, 326 vs 326 at `1e16`); the error is dominated by floating-point argument reduction, not by the integer cliff. The bound is worth having because rounding a quotient of about `1.59e19` is fragile by construction even where it happens to be right, whereas a count in `{0, 1, 2}` is auditable.

Accuracy at large angles is documented rather than claimed. There is no uniform magnitude bound: the sheet is wrong whenever the reduced angle lands within the reduction error of the boundary at `pi`, which an evenly spaced sweep finds as low as `theta = 156_700_000_000.0` (its exact reduced angle is `5.56e-6` below `pi`, and the f64 reduction places it above). A first draft of this PR asserted exact parity through `|theta| <= 1e13` on the strength of random sampling; that claim was false and was withdrawn. No exact argument reduction is attempted, because beyond roughly `1e13` radians an f64 cannot represent the angle to sub-`2pi` precision at all -- a property of the input type, not of this code.

`lower_crz` now returns `SmallVec<[Gate; 3]>` and `lower_crx` / `lower_cry` return `SmallVec<[Gate; 5]>`, since the correction is conditional. All 13 production call sites carry it through. The three sites that destructured a fixed-size `[rzz, rz]` failed to compile and were each rewritten to iterate and apply every gate, with an explicit panic on an unexpected gate type.

## Verification

Workspace with `--no-fail-fast`: 11,930 passed, and the 12 failures are exactly the pre-existing baseline set on `dev` (one GPU test, eleven fault-tolerance corpus and decoder tests), with no additions or removals. Clippy with all targets and features, and formatting, are clean.

The correctness argument does not rest on a hand-built oracle. `CRZ(theta)` is continuous in `theta`, so the lowering is checked against itself across the boundary, which needs no rotation-convention assumption and cannot rot if a convention is later revised:

| probe | before | after |
|---|---|---|
| `\|M(2pi) - M(2pi-eps)\|` | 4.000000 | 0.000000 |
| `\|M(2pi) - (-M(2pi-eps))\|` | 0.000000 | -- |
| `\|M(2pi) - Z_control\|` | 4.000000 | 0.000000 |
| agreement away from the boundary | -- | <= 1.5e-15 over 800 angles |

A two-qubit unitary has norm 2, so a distance of 4 between `M` and `M'` means `M' = -M`.

Four mutations confirm the tests can actually observe a regression:

| mutation | result |
|---|---|
| force `needs_z = false` | `crz_two_pi_is_z_on_control` fails |
| invert the parity | 4 tests fail |
| keep the `Z` but skip the reduction | 5 tests fail |
| make the Python state-vector binding drop the `Z` | all 4 Python CRZ tests fail |
| revert the `4pi` bound to the unbounded quotient | `bounded_reduction_pins_large_inputs_and_a_sheet_counterexample` fails |

The last one matters most: it leaves the core correct and removes the correction only at a call site, which is the way this fix could regress while the Rust suite stayed green.

## Tests

`assert_matrix_eq_up_to_one_global_phase` contained a `crosses_reduction` branch accepting a phase of `+1` **or** `-1`. That branch was this defect written as an assertion; it is removed and the check is now unconditionally `+1`, with `2pi`, `-2pi`, and `6pi` added to the swept angles.

`python/quantum-pecos/tests/.../test_statevec.py` gains a `theta = 2pi` case. It reuses the existing harness, which puts `H` on the control and compares raw amplitudes with no global-phase normalisation. The superposed control is load-bearing: a definite `|1>` control cannot see this defect. Every other pre-existing test in this area normalises by a fitted global phase and is structurally incapable of observing it.

Python is verified with `just pytest-ci-core`, the recipe the PR core gate runs, rather than an ad-hoc invocation: 2300 + 106 + 5639 + 35 passed, 17 skipped, 23 xfailed, zero failures. Review found that three Python matrix helpers rejected the new gate outright (`unexpected builder gate Z`, `unexpected neo fallback gate Z`, `unexpected replay gate Z`) from `theta = -pi` onward. They now execute the `Z` on its emitted qubits, and their remaining allowance for a global `-1` has been removed so they compare raw matrices, matching the change to `assert_matrix_eq_up_to_one_global_phase`.

New Rust coverage: continuity at odd turns, `CRZ(2pi) == Z_control`, agreement with the raw half away from odd turns, parity against the trigonometric sheet over wide ranges, and `CRX` / `CRY` checked directly rather than assumed to follow `CRZ`. Added on review: large-angle parity against a high-precision reference, 24 Neo `extract_commands` control-interference cases across all three axes and both operand orders, and the odd-parity tick-metadata case (metadata annotates the first emitted gate, which with odd parity is now the `Z`).

## Stored angles

The legs now store the reduced half rather than the raw half, so `Angle64` values change for angles outside the reduced range even though the matrix does not.

## Not in this change

QASM `crz` never reaches `lower_crz`: `crates/pecos-qasm/includes/qelib1.inc` defines its own decomposition, which carries the same defect by its own `rz(-theta/2)` route. That is a separate PR, and it needs a different remedy, because the correction is conditional on the turn count and qelib gate definitions are static parameterised decompositions with no conditionals. The QASM parser will need to route `crz` / `crx` / `cry` through `controlled_rotations` instead of expanding them.

`lower_cphase` performs the same reduction via an `Angle64` round-trip that quantizes needlessly. It could adopt the shared helper introduced here, but that would shift its stored angles and deserves its own verification, so it is left unchanged.
