### PR TITLE
Remove the unreachable two-qubit source-frame pull-back path superseded by the exclusive-signature fit

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -29,7 +29,6 @@ use crate::fault_tolerance::propagator::{
     is_supported_noop_or_metadata_gate, is_supported_prep_gate,
 };
 use pecos_core::BitSet;
-use pecos_core::CliffordLowering;
 use pecos_core::gate_type::GateType;
 use pecos_simulators::{
     PauliProp, SymbolicMeasurementResult, SymbolicSparseStab,
@@ -1708,7 +1707,7 @@ impl<'a> DemBuilder<'a> {
                 loc1_meta,
                 loc2_meta,
                 dem,
-                Some(DirectSourceFamily::TwoLocationReplacementBranchImpact),
+                DirectSourceFamily::TwoLocationReplacementBranchImpact,
             );
         }
     }
@@ -2252,7 +2251,7 @@ impl<'a> DemBuilder<'a> {
         loc1_meta: &DagSpacetimeLocation,
         loc2_meta: &DagSpacetimeLocation,
         dem: &mut DetectorErrorModel,
-        direct_source_family: Option<DirectSourceFamily>,
+        direct_source_family: DirectSourceFamily,
     ) {
         let effect = &effects[p1 as usize][p2 as usize];
         if effect.is_empty() {
@@ -2277,51 +2276,26 @@ impl<'a> DemBuilder<'a> {
         let source_gate_types = [loc1_meta.gate_type, loc2_meta.gate_type];
         let source_before_flags = [loc1_meta.before, loc2_meta.before];
 
-        let source_frame_components = if direct_source_family.is_none() {
-            Self::two_qubit_clifford_source_frame_components(loc1_meta.clifford, p1, p2, effects)
-        } else {
-            None
-        };
-        if let Some(parts) = source_frame_components.as_ref() {
-            dem.add_direct_contribution_with_source_components(
-                effect.clone(),
-                prob,
-                SourceMetadata::new(
-                    &source_locations,
-                    &source_paulis,
-                    &source_gate_types,
-                    &source_before_flags,
-                ),
-                &DirectSourceComponents::from_slice(parts.as_slice()),
-            );
-            return;
-        }
-
         if let Some((a1, a2, b1, b2)) = get_y_decomposition(p1, p2) {
             let e_a = &effects[a1 as usize][a2 as usize];
             let e_b = &effects[b1 as usize][b2 as usize];
-            let mut source = SourceMetadata::new(
+            let source = SourceMetadata::new(
                 &source_locations,
                 &source_paulis,
                 &source_gate_types,
                 &source_before_flags,
-            );
-            if direct_source_family.is_some() {
-                source = source.with_replacement_branch();
-            }
+            )
+            .with_replacement_branch();
             dem.add_y_decomposed_contribution_with_source(e_a, e_b, prob, source);
         } else {
-            let mut source = SourceMetadata::new(
+            let source = SourceMetadata::new(
                 &source_locations,
                 &source_paulis,
                 &source_gate_types,
                 &source_before_flags,
-            );
-            if let Some(family) = direct_source_family {
-                source = source
-                    .with_direct_source_family(family)
-                    .with_replacement_branch();
-            }
+            )
+            .with_direct_source_family(direct_source_family)
+            .with_replacement_branch();
 
             dem.add_direct_contribution_with_source_components(
                 effect.clone(),
@@ -2330,47 +2304,6 @@ impl<'a> DemBuilder<'a> {
                 &DirectSourceComponents::new(e1, e2),
             );
         }
-    }
-
-    /// Builds exact source-frame components for ordinary post-gate Pauli noise
-    /// on supported two-qubit Clifford gates.
-    ///
-    /// A post-gate Pauli can be pulled back through the Clifford into a pre-gate
-    /// Pauli. Decomposing that pre-gate Pauli into X/Z generators often exposes
-    /// the graphlike source pieces that were hidden by the native gate frame.
-    /// Each generator is then pushed forward again and looked up in the existing
-    /// post-gate effect table, so the XOR of returned components is exactly the
-    /// original post-gate effect.
-    fn two_qubit_clifford_source_frame_components(
-        clifford: CliffordLowering,
-        post_p1: u8,
-        post_p2: u8,
-        effects: &[[FaultMechanism; 4]; 4],
-    ) -> Option<SmallVec<[FaultMechanism; 4]>> {
-        let images = two_qubit_pre_generator_post_images(clifford)?;
-        let (pre_p1, pre_p2) = invert_two_qubit_clifford_post_pauli(images, (post_p1, post_p2))?;
-
-        let mut components = SmallVec::new();
-        for image in two_qubit_pre_pauli_generator_images(images, pre_p1, pre_p2) {
-            toggle_source_component(
-                &mut components,
-                effects[image.0 as usize][image.1 as usize].clone(),
-            );
-        }
-
-        if components.is_empty() {
-            return None;
-        }
-
-        #[cfg(debug_assertions)]
-        {
-            let combined = components
-                .iter()
-                .fold(FaultMechanism::new(), |acc, part| acc.xor(part));
-            debug_assert_eq!(combined, effects[post_p1 as usize][post_p2 as usize]);
-        }
-
-        Some(components)
     }
 
     /// Builds mappings from measurement indices to detector/DEM-output IDs.
@@ -2663,139 +2596,6 @@ fn pauli_label_to_index(label: char) -> Option<u8> {
 // ============================================================================
 // Intra-Channel Decomposition
 // ============================================================================
-
-type TwoQubitPauli = (u8, u8);
-type TwoQubitGeneratorImages = [TwoQubitPauli; 4];
-
-/// Returns post-gate images of the pre-gate generators
-/// `[X1, Z1, X2, Z2]`, ignoring phase.
-#[inline]
-fn two_qubit_pre_generator_post_images(
-    clifford: CliffordLowering,
-) -> Option<TwoQubitGeneratorImages> {
-    match clifford {
-        CliffordLowering::Named(GateType::CX) => Some([
-            (1, 1), // X1 -> XX
-            (3, 0), // Z1 -> ZI
-            (0, 1), // X2 -> IX
-            (3, 3), // Z2 -> ZZ
-        ]),
-        CliffordLowering::Named(GateType::CZ) => Some([
-            (1, 3), // X1 -> XZ
-            (3, 0), // Z1 -> ZI
-            (3, 1), // X2 -> ZX
-            (0, 3), // Z2 -> IZ
-        ]),
-        CliffordLowering::Named(GateType::SZZ | GateType::SZZdg) => {
-            Some([
-                (2, 3), // X1 -> YZ
-                (3, 0), // Z1 -> ZI
-                (3, 2), // X2 -> ZY
-                (0, 3), // Z2 -> IZ
-            ])
-        }
-        // Pauli conjugation changes only phases, which these images ignore.
-        CliffordLowering::PerQubit(_) => Some([(1, 0), (3, 0), (0, 1), (0, 3)]),
-        CliffordLowering::Named(_) => None,
-    }
-}
-
-#[inline]
-fn invert_two_qubit_clifford_post_pauli(
-    images: TwoQubitGeneratorImages,
-    post: TwoQubitPauli,
-) -> Option<TwoQubitPauli> {
-    for pre_p1 in 0..4 {
-        for pre_p2 in 0..4 {
-            if forward_two_qubit_pauli(images, pre_p1, pre_p2) == post {
-                return Some((pre_p1, pre_p2));
-            }
-        }
-    }
-    None
-}
-
-fn two_qubit_pre_pauli_generator_images(
-    images: TwoQubitGeneratorImages,
-    pre_p1: u8,
-    pre_p2: u8,
-) -> SmallVec<[TwoQubitPauli; 4]> {
-    let mut out = SmallVec::new();
-    if pauli_has_x(pre_p1) {
-        out.push(images[0]);
-    }
-    if pauli_has_z(pre_p1) {
-        out.push(images[1]);
-    }
-    if pauli_has_x(pre_p2) {
-        out.push(images[2]);
-    }
-    if pauli_has_z(pre_p2) {
-        out.push(images[3]);
-    }
-    out
-}
-
-#[inline]
-fn forward_two_qubit_pauli(
-    images: TwoQubitGeneratorImages,
-    pre_p1: u8,
-    pre_p2: u8,
-) -> TwoQubitPauli {
-    two_qubit_pre_pauli_generator_images(images, pre_p1, pre_p2)
-        .into_iter()
-        .fold((0, 0), xor_two_qubit_pauli)
-}
-
-#[inline]
-fn xor_two_qubit_pauli(a: TwoQubitPauli, b: TwoQubitPauli) -> TwoQubitPauli {
-    (xor_pauli(a.0, b.0), xor_pauli(a.1, b.1))
-}
-
-#[inline]
-fn xor_pauli(a: u8, b: u8) -> u8 {
-    pauli_from_bits(
-        pauli_has_x(a) ^ pauli_has_x(b),
-        pauli_has_z(a) ^ pauli_has_z(b),
-    )
-}
-
-#[inline]
-fn pauli_has_x(pauli: u8) -> bool {
-    matches!(pauli, 1 | 2)
-}
-
-#[inline]
-fn pauli_has_z(pauli: u8) -> bool {
-    matches!(pauli, 2 | 3)
-}
-
-#[inline]
-fn pauli_from_bits(has_x: bool, has_z: bool) -> u8 {
-    match (has_x, has_z) {
-        (false, false) => 0,
-        (true, false) => 1,
-        (true, true) => 2,
-        (false, true) => 3,
-    }
-}
-
-fn toggle_source_component(
-    components: &mut SmallVec<[FaultMechanism; 4]>,
-    component: FaultMechanism,
-) {
-    if component.is_empty() {
-        return;
-    }
-    if let Some(index) = components
-        .iter()
-        .position(|existing| existing == &component)
-    {
-        components.remove(index);
-    } else {
-        components.push(component);
-    }
-}
 
 /// Returns the intra-channel decomposition for Y-containing Pauli cases.
 ///
@@ -3847,16 +3647,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn per_qubit_source_frame_preserves_generators() {
-        for pauli in [GateType::X, GateType::Y, GateType::Z] {
-            assert_eq!(
-                two_qubit_pre_generator_post_images(CliffordLowering::PerQubit(pauli)),
-                Some([(1, 0), (3, 0), (0, 1), (0, 3)])
-            );
-        }
-    }
-
-    #[test]
     fn z_error_before_mx_produces_a_detector_mechanism() {
         use pecos_num::graph::Attribute;
 
@@ -3879,86 +3669,6 @@ mod tests {
         assert_eq!(mechanisms.len(), 1);
         assert_eq!(mechanisms[0].1, vec![0]);
         assert!(mechanisms[0].2.is_empty());
-    }
-
-    #[test]
-    fn rotated_location_uses_exact_source_frame_components() {
-        use pecos_core::{Angle64, Gate, QubitId};
-        let a = FaultMechanism::from_unsorted([0, 1], []);
-        let b = FaultMechanism::from_unsorted([2], []);
-        let c = FaultMechanism::from_unsorted([3, 4], []);
-        let mut effects: [[FaultMechanism; 4]; 4] = Default::default();
-        effects[2][3] = a.clone();
-        effects[3][0] = b.clone();
-        effects[0][3] = c.clone();
-        effects[1][0] = a.xor(&b).xor(&c);
-        for gate in [
-            Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]),
-            Gate::szz(&[(0, 1)]),
-        ] {
-            let first = DagSpacetimeLocation::new(0, vec![QubitId(0)], false, &gate);
-            let second = DagSpacetimeLocation::new(0, vec![QubitId(1)], false, &gate);
-            let mut dem = DetectorErrorModel::new();
-            DemBuilder::add_two_qubit_pauli_contribution(
-                0, 1, 1, 0, 0.01, &effects, &first, &second, &mut dem, None,
-            );
-            let contributions = dem.contributions_for_effect(&[0, 1, 2, 3, 4], &[]);
-            assert_eq!(contributions.len(), 1);
-            let parts = contributions[0].source_component_effects().unwrap();
-            assert_eq!(parts.len(), 3);
-            for expected in [&a, &b, &c] {
-                assert!(parts.contains(expected));
-            }
-        }
-    }
-
-    #[test]
-    fn test_szz_source_frame_components_pull_post_error_to_pre_generators() {
-        fn dets(indices: &[u32]) -> FaultMechanism {
-            FaultMechanism::from_unsorted(indices.iter().copied(), std::iter::empty())
-        }
-
-        let a = dets(&[0, 1]);
-        let b = dets(&[2]);
-        let c = dets(&[3, 4]);
-
-        let mut effects: [[FaultMechanism; 4]; 4] = Default::default();
-        effects[2][3] = a.clone(); // SZZ maps pre X1 to post YZ.
-        effects[3][0] = b.clone(); // SZZ maps pre Z1 to post ZI.
-        effects[0][3] = c.clone(); // SZZ maps pre Z2 to post IZ.
-        effects[1][0] = a.xor(&b).xor(&c);
-
-        let parts = DemBuilder::two_qubit_clifford_source_frame_components(
-            CliffordLowering::Named(GateType::SZZ),
-            1,
-            0,
-            &effects,
-        )
-        .expect("post XI should pull back through SZZ to pre YZ");
-
-        assert_eq!(parts.len(), 3);
-        assert!(parts.contains(&a));
-        assert!(parts.contains(&b));
-        assert!(parts.contains(&c));
-        assert_eq!(
-            parts
-                .iter()
-                .fold(FaultMechanism::new(), |acc, part| acc.xor(part)),
-            effects[1][0]
-        );
-
-        effects[3][0] = a.clone();
-        effects[1][0] = c.clone();
-
-        let parts = DemBuilder::two_qubit_clifford_source_frame_components(
-            CliffordLowering::Named(GateType::SZZ),
-            1,
-            0,
-            &effects,
-        )
-        .expect("duplicate source components should cancel by XOR");
-
-        assert_eq!(parts.as_slice(), &[c]);
     }
 
     #[test]

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -269,12 +269,6 @@ impl<'a> DirectSourceComponents<'a> {
         }
     }
 
-    pub(crate) fn from_slice(components: &'a [FaultMechanism]) -> Self {
-        Self {
-            components: components.iter().collect(),
-        }
-    }
-
     fn as_slice(&self) -> &[&'a FaultMechanism] {
         &self.components
     }
@@ -7294,6 +7288,12 @@ mod tests {
     }
     use super::*;
 
+    fn source_components_from_slice(components: &[FaultMechanism]) -> DirectSourceComponents<'_> {
+        DirectSourceComponents {
+            components: components.iter().collect(),
+        }
+    }
+
     #[test]
     fn test_error_mechanism_xor() {
         let m1 = FaultMechanism::from_unsorted([0, 1, 2], [0]);
@@ -9066,7 +9066,7 @@ mod tests {
                 &[GateType::SZZ, GateType::SZZ],
                 &[false, false],
             ),
-            &DirectSourceComponents::from_slice(&components),
+            &source_components_from_slice(&components),
         );
 
         let source_graphlike = dem.to_string_source_graphlike_decomposed();
@@ -9342,7 +9342,7 @@ mod tests {
                 &[GateType::SZZ, GateType::SZZ, GateType::SZZ],
                 &[false, false, false],
             ),
-            &DirectSourceComponents::from_slice(&[repeated.clone(), repeated, survivor]),
+            &source_components_from_slice(&[repeated.clone(), repeated, survivor]),
         );
 
         let source_decomposed = dem.to_string_source_decomposed();


### PR DESCRIPTION
Closes #744.

## Problem

`two_qubit_clifford_source_frame_components` in `crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs` pulled a post-gate Pauli back through a two-qubit Clifford using a hand table of generator images (`two_qubit_pre_generator_post_images`) that covered `CX`, `CZ`, and `SZZ`, and since #742 the per-qubit Pauli action of a half-turn rotation. The gap for `CY`, `SWAP`, `SXX`, and `SYY` looked like a decomposition-quality defect, and #742's third review flagged it as one.

Tracing the callers shows the path is unreachable in production. It runs only when `add_two_qubit_pauli_contribution` is called with no `DirectSourceFamily`. The sole production caller, the replacement-branch impact path, always passes `TwoLocationReplacementBranchImpact`. Ordinary two-qubit gate noise has gone through `fit_exclusive_signatures` with `DirectSourceFamily::ExclusiveSignature` since #420, which superseded the pull-back introduced in #322. Only a unit test still called it without a family.

## Change

The pull-back path is deleted together with everything only it used: the generator-image table, the inverse search, the generator decomposition, the two-qubit Pauli XOR helpers, `toggle_source_component`, and three tests (including the two #742 added for the per-qubit rows). `add_two_qubit_pauli_contribution` now takes a required `DirectSourceFamily`. `DirectSourceComponents::from_slice`, which had no production user left, is gone; the two tests that used it construct components through a helper inside the test module.

## Evidence

DEM output is unchanged by construction, and that was checked rather than assumed: a d=3, three-round Z-memory surface DEM built through the public `generate_circuit_level_dem_from_builder` path with non-zero `p1`, `p2`, `p_meas`, `p_prep`, once with plain gate noise and once with `p2_weights={"XX": 0.5, "~XX": 0.5}`, is byte-identical before and after this change in all four serializations (`to_string`, `to_string_decomposed`, `to_string_source_decomposed`, `to_string_source_graphlike_decomposed`), eight strings between 4383 and 8772 bytes each.

`cargo test -p pecos-qec --no-fail-fast`: 1031 passed. `cargo clippy --workspace --all-targets -- -D warnings` on the touched files: clean. Python `tests/qec`: 1657 passed. `pre-commit run --all-files`: 17 hooks passed.

## Not in scope

`p1_gate_rates` / `p2_gate_rates` key on the scheduled gate name, consistent with #742's rule that noise locations follow the gate as scheduled.
