### PR TITLE
Fail loudly when a per-gate noise rate key names a Clifford action instead of the scheduled gate

### DIFF
--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -945,13 +945,16 @@ impl<'a> DemBuilder<'a> {
     }
 
     fn validate_noise_configuration(&self) -> Result<(), DemBuilderError> {
-        self.noise
-            .validate_gate_rate_keys(&self.influence_map.locations)
-            .and_then(|()| {
-                self.per_gate.as_ref().map_or(Ok(()), |noise| {
-                    noise.validate_gate_rate_keys(&self.influence_map.locations)
-                })
-            })
+        // Validate exactly what this path consumes: per-gate noise or scalar tables.
+        self.per_gate
+            .as_ref()
+            .map_or_else(
+                || {
+                    self.noise
+                        .validate_gate_rate_keys(&self.influence_map.locations)
+                },
+                |noise| noise.validate_gate_rate_keys(&self.influence_map.locations),
+            )
             .map_err(|error| DemBuilderError::ConfigurationError(error.to_string()))?;
         if let Some(weights) = &self.noise.p2_weights {
             weights

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/builder.rs
@@ -832,7 +832,7 @@ impl<'a> DemBuilder<'a> {
         self.validate_supported_gates()?;
         self.validate_measurement_count()?;
         self.validate_metadata_refs()?;
-        self.validate_replacement_branch_approximation()?;
+        self.validate_noise_configuration()?;
         self.validate_measurement_crosstalk_dem_mode()?;
         self.validate_idle_noise()?;
         self.build_inner()
@@ -868,7 +868,7 @@ impl<'a> DemBuilder<'a> {
     /// replacement-branch configuration, or failed signature conversion.
     pub fn build(&self) -> Result<DetectorErrorModel, DemBuilderError> {
         self.validate_supported_gates()?;
-        self.validate_replacement_branch_approximation()?;
+        self.validate_noise_configuration()?;
         self.validate_measurement_crosstalk_dem_mode()?;
         self.validate_idle_noise()?;
         self.build_inner()
@@ -944,7 +944,15 @@ impl<'a> DemBuilder<'a> {
         Ok(dem)
     }
 
-    fn validate_replacement_branch_approximation(&self) -> Result<(), DemBuilderError> {
+    fn validate_noise_configuration(&self) -> Result<(), DemBuilderError> {
+        self.noise
+            .validate_gate_rate_keys(&self.influence_map.locations)
+            .and_then(|()| {
+                self.per_gate.as_ref().map_or(Ok(()), |noise| {
+                    noise.validate_gate_rate_keys(&self.influence_map.locations)
+                })
+            })
+            .map_err(|error| DemBuilderError::ConfigurationError(error.to_string()))?;
         if let Some(weights) = &self.noise.p2_weights {
             weights
                 .validate_replacement_locations(

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/dem_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/dem_sampler.rs
@@ -467,6 +467,10 @@ impl SamplingEngine {
             return Err(super::DemBuilderError::UnsupportedGate(error.clone()));
         }
 
+        noise
+            .validate_gate_rate_keys(&influence_map.locations)
+            .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
+
         if let Some(weights) = &noise.p2_weights {
             weights
                 .validate_replacement_locations(
@@ -2215,6 +2219,17 @@ impl<'a> SamplingEngineBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(super::DemBuilderError::UnsupportedGate(error.clone()));
         }
+        super::types::validate_scalar_gate_rate_tables(
+            &self.p1_gate_rates,
+            &self.p2_gate_rates,
+            &self.influence_map.locations,
+        )
+        .and_then(|()| {
+            self.per_gate.as_ref().map_or(Ok(()), |noise| {
+                noise.validate_gate_rate_keys(&self.influence_map.locations)
+            })
+        })
+        .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
         if let Some(weights) = &self.p2_weights {
             weights
                 .validate_replacement_locations(

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/dem_sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/dem_sampler.rs
@@ -2219,17 +2219,20 @@ impl<'a> SamplingEngineBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(super::DemBuilderError::UnsupportedGate(error.clone()));
         }
-        super::types::validate_scalar_gate_rate_tables(
-            &self.p1_gate_rates,
-            &self.p2_gate_rates,
-            &self.influence_map.locations,
-        )
-        .and_then(|()| {
-            self.per_gate.as_ref().map_or(Ok(()), |noise| {
-                noise.validate_gate_rate_keys(&self.influence_map.locations)
-            })
-        })
-        .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
+        // Validate exactly what this path consumes: per-gate noise or scalar tables.
+        self.per_gate
+            .as_ref()
+            .map_or_else(
+                || {
+                    super::types::validate_scalar_gate_rate_tables(
+                        &self.p1_gate_rates,
+                        &self.p2_gate_rates,
+                        &self.influence_map.locations,
+                    )
+                },
+                |noise| noise.validate_gate_rate_keys(&self.influence_map.locations),
+            )
+            .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
         if let Some(weights) = &self.p2_weights {
             weights
                 .validate_replacement_locations(
@@ -3082,6 +3085,34 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gate_rate_sampling_engine_builder_scalar_tables() {
+        use crate::fault_tolerance::propagator::DagFaultAnalyzer;
+        let mut circuit = pecos_quantum::DagCircuit::new();
+        circuit.pz(&[0, 1]);
+        circuit.add_gate_auto_wire(pecos_core::Gate::rzz(
+            pecos_core::Angle64::QUARTER_TURN,
+            &[(0, 1)],
+        ));
+        circuit.mz(&[0, 1]);
+        let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+        let mut noise = NoiseConfig::uniform(0.001);
+        noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+        let error = SamplingEngineBuilder::new(&map)
+            .with_noise_config(noise.clone())
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(error, super::super::DemBuilderError::ConfigurationError(message)
+            if message.contains("p2_gate_rates key SZZ") && message.contains("RZZ"))
+        );
+        SamplingEngineBuilder::new(&map)
+            .with_noise_config(noise)
+            .with_per_gate_noise(PerGateTypeNoise::default())
+            .build()
+            .unwrap();
+    }
 
     #[test]
     fn test_dem_mechanism_ordering() {

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
@@ -80,9 +80,7 @@ impl<'a> MemBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(DemBuilderError::UnsupportedGate(error.clone()));
         }
-        self.noise
-            .validate_gate_rate_keys(&self.influence_map.locations)
-            .map_err(|error| DemBuilderError::ConfigurationError(error.to_string()))?;
+        // Validate exactly what this path consumes; gate-rate tables are unused here.
         let num_measurements = self.influence_map.measurements.len();
         let mut mem = MeasurementNoiseModel::new(num_measurements);
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
@@ -75,12 +75,25 @@ impl<'a> MemBuilder<'a> {
     ///
     /// Returns an error if the influence map contains a gate that Pauli
     /// propagation cannot faithfully represent, or a configuration error if a noise
-    /// input or signature channel is invalid.
+    /// input or signature channel is invalid. Nonzero gate-rate tables are rejected
+    /// because this builder applies scalar rates only.
     pub fn build(&self) -> Result<MeasurementNoiseModel, DemBuilderError> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(DemBuilderError::UnsupportedGate(error.clone()));
         }
-        // Validate exactly what this path consumes; gate-rate tables are unused here.
+        // build reads p_prep/p_meas directly; process_single_qubit_fault and
+        // process_two_qubit_fault read p1 / 3 and p2 / 15 without gate-rate lookups.
+        if self
+            .noise
+            .p1_gate_rates
+            .values()
+            .chain(self.noise.p2_gate_rates.values())
+            .any(|&rate| rate != 0.0)
+        {
+            return Err(DemBuilderError::ConfigurationError(
+                "MemBuilder applies scalar rates only; nonzero p1_gate_rates or p2_gate_rates are not supported".to_string(),
+            ));
+        }
         let num_measurements = self.influence_map.measurements.len();
         let mut mem = MeasurementNoiseModel::new(num_measurements);
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/mem_builder.rs
@@ -80,6 +80,9 @@ impl<'a> MemBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(DemBuilderError::UnsupportedGate(error.clone()));
         }
+        self.noise
+            .validate_gate_rate_keys(&self.influence_map.locations)
+            .map_err(|error| DemBuilderError::ConfigurationError(error.to_string()))?;
         let num_measurements = self.influence_map.measurements.len();
         let mut mem = MeasurementNoiseModel::new(num_measurements);
 

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1073,6 +1073,8 @@ impl<'a> DemSamplerBuilder<'a> {
     }
 
     /// Set per-gate-type and optional per-qubit Pauli rates.
+    ///
+    /// Supported in detector-event mode; raw-measurement mode rejects this configuration.
     #[must_use]
     pub fn with_per_gate_noise(mut self, config: PerGateTypeNoise) -> Self {
         self.noise = config.base.clone();
@@ -1098,7 +1100,8 @@ impl<'a> DemSamplerBuilder<'a> {
     /// Request raw measurement output (default).
     ///
     /// Each deterministic measurement is its own output channel. Non-deterministic
-    /// measurements get independent coin flips.
+    /// measurements get independent coin flips. Building this mode rejects
+    /// per-gate noise because it applies scalar noise only.
     #[must_use]
     pub fn raw_measurements(mut self) -> Self {
         self.output_mode = OutputMode::RawMeasurements;
@@ -1381,7 +1384,11 @@ impl<'a> DemSamplerBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(DetectorValidationError::UnsupportedGate(error.clone()));
         }
-        // Validate exactly what this path consumes: scalar noise through the sampling engine.
+        if self.per_gate.is_some() {
+            return Err(DetectorValidationError::InvalidConfiguration {
+                message: "raw-measurement mode applies scalar noise only; per-gate noise is not supported".to_string(),
+            });
+        }
         let num_measurements = self.influence_map.measurements.len();
 
         // Build per-location probabilities from gate-type noise

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1378,6 +1378,14 @@ impl<'a> DemSamplerBuilder<'a> {
     /// Mechanism table is in measurement coordinates. Non-deterministic
     /// measurements are identified and marked for coin-flip output.
     fn build_raw(self) -> Result<DemSampler, DetectorValidationError> {
+        if let Some(error) = self.influence_map.unsupported_gate() {
+            return Err(DetectorValidationError::UnsupportedGate(error.clone()));
+        }
+        if let Some(noise) = &self.per_gate {
+            noise
+                .validate_gate_rate_keys(&self.influence_map.locations)
+                .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
+        }
         let num_measurements = self.influence_map.measurements.len();
 
         // Build per-location probabilities from gate-type noise

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/sampler.rs
@@ -1381,11 +1381,7 @@ impl<'a> DemSamplerBuilder<'a> {
         if let Some(error) = self.influence_map.unsupported_gate() {
             return Err(DetectorValidationError::UnsupportedGate(error.clone()));
         }
-        if let Some(noise) = &self.per_gate {
-            noise
-                .validate_gate_rate_keys(&self.influence_map.locations)
-                .map_err(|error| super::DemBuilderError::ConfigurationError(error.to_string()))?;
-        }
+        // Validate exactly what this path consumes: scalar noise through the sampling engine.
         let num_measurements = self.influence_map.measurements.len();
 
         // Build per-location probabilities from gate-type noise

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -2221,6 +2221,67 @@ pub(crate) struct MissingOmittedGateTwirl {
     pub clifford: CliffordLowering,
 }
 
+/// A rate key that names a Clifford action instead of a scheduled gate.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(
+    "{table} key {key:?} matches no scheduled gate; node {node} schedules {scheduled:?} whose Clifford action is {clifford:?}. Per-gate rates apply to the gate as scheduled; key the rate by {scheduled:?}, or lower the circuit with lower_clifford_rotations() before building."
+)]
+pub(crate) struct GateRateKeyMismatch {
+    pub table: &'static str,
+    pub key: GateType,
+    pub node: usize,
+    pub scheduled: GateType,
+    pub clifford: CliffordLowering,
+}
+
+/// Validate the scalar per-gate rate tables shared by every builder that owns
+/// them directly instead of through a [`NoiseConfig`].
+pub(crate) fn validate_scalar_gate_rate_tables(
+    p1_gate_rates: &BTreeMap<GateType, f64>,
+    p2_gate_rates: &BTreeMap<GateType, f64>,
+    locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
+) -> Result<(), GateRateKeyMismatch> {
+    for (table, rates) in [
+        ("p1_gate_rates", p1_gate_rates),
+        ("p2_gate_rates", p2_gate_rates),
+    ] {
+        validate_active_gate_rate_keys(
+            table,
+            rates
+                .iter()
+                .filter_map(|(&key, &rate)| (rate != 0.0).then_some(key)),
+            locations,
+        )?;
+    }
+    Ok(())
+}
+
+/// Validate active keys against scheduled gates before considering Clifford actions.
+fn validate_active_gate_rate_keys(
+    table: &'static str,
+    keys: impl IntoIterator<Item = GateType>,
+    locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
+) -> Result<(), GateRateKeyMismatch> {
+    for key in keys {
+        if locations.iter().any(|location| location.gate_type == key) {
+            continue;
+        }
+        if let Some(location) = locations.iter().find(|location| {
+            matches!(location.clifford,
+                CliffordLowering::Named(gate) | CliffordLowering::PerQubit(gate) if gate == key)
+        }) {
+            return Err(GateRateKeyMismatch {
+                table,
+                key,
+                node: location.node,
+                scheduled: location.gate_type,
+                clifford: location.clifford,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// A single Pauli-projected impact term produced by a replacement branch.
 ///
 /// This is intentionally an intermediate representation rather than a final
@@ -2577,6 +2638,8 @@ pub struct NoiseConfig {
     /// When a single-qubit gate type appears here, this total rate replaces
     /// `p1` while still using `p1_weights` to distribute probability across
     /// Pauli channels.
+    /// Keys name the scheduled gate; traced rotations such as `RZZ` and `RXY1Q`
+    /// require rotation keys or lowering the circuit first.
     pub p1_gate_rates: BTreeMap<GateType, f64>,
     /// Two-qubit gate error rate.
     pub p2: f64,
@@ -2585,6 +2648,8 @@ pub struct NoiseConfig {
     /// When a two-qubit gate type appears here, this total rate replaces
     /// `p2` while still using `p2_weights` to distribute probability across
     /// Pauli-pair channels.
+    /// Keys name the scheduled gate; traced rotations such as `RZZ` and `RXY1Q`
+    /// require rotation keys or lowering the circuit first.
     pub p2_gate_rates: BTreeMap<GateType, f64>,
     /// Measurement error rate.
     pub p_meas: f64,
@@ -3277,6 +3342,14 @@ impl Default for NoiseConfig {
 }
 
 impl NoiseConfig {
+    /// Reject active rate keys that match only a location's Clifford action.
+    pub(crate) fn validate_gate_rate_keys(
+        &self,
+        locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
+    ) -> Result<(), GateRateKeyMismatch> {
+        validate_scalar_gate_rate_tables(&self.p1_gate_rates, &self.p2_gate_rates, locations)
+    }
+
     /// Creates a new noise configuration (idle defaults to `None`).
     #[must_use]
     pub fn new(p1: f64, p2: f64, p_meas: f64, p_prep: f64) -> Self {
@@ -4156,6 +4229,10 @@ pub const PAULI_2Q_ORDER: [&str; 15] = [
 ///      [`Self::with_2q_rates_for_qubits`] for heterogeneous devices, or
 ///      [`Self::with_1q_rates`] / [`Self::with_2q_rates`] for homogeneous
 ///      models.
+///
+/// Keys in all gate-rate tables name the gate as scheduled; runtime-traced
+/// circuits schedule rotations such as `RZZ` and `RXY1Q`, so key by those
+/// or lower the circuit first.
 #[derive(Debug, Clone, Default)]
 pub struct PerGateTypeNoise {
     pub rates_1q: HashMap<GateType, [f64; 3]>,
@@ -4174,6 +4251,47 @@ pub struct PerGateTypeNoise {
 }
 
 impl PerGateTypeNoise {
+    /// Validate every gate-keyed rate table, including the base configuration.
+    pub(crate) fn validate_gate_rate_keys(
+        &self,
+        locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
+    ) -> Result<(), GateRateKeyMismatch> {
+        self.base.validate_gate_rate_keys(locations)?;
+        validate_active_gate_rate_keys(
+            "rates_1q",
+            self.rates_1q
+                .iter()
+                .filter_map(|(&key, rates)| rates.iter().any(|&rate| rate != 0.0).then_some(key)),
+            locations,
+        )?;
+        validate_active_gate_rate_keys(
+            "rates_2q",
+            self.rates_2q
+                .iter()
+                .filter_map(|(&key, rates)| rates.iter().any(|&rate| rate != 0.0).then_some(key)),
+            locations,
+        )?;
+        validate_active_gate_rate_keys(
+            "rates_1q_per_qubit",
+            self.rates_1q_per_qubit
+                .iter()
+                .filter_map(|(&(key, _), rates)| {
+                    rates.iter().any(|&rate| rate != 0.0).then_some(key)
+                }),
+            locations,
+        )?;
+        validate_active_gate_rate_keys(
+            "rates_2q_per_qubits",
+            self.rates_2q_per_qubits
+                .iter()
+                .filter_map(|(&(key, _, _), rates)| {
+                    rates.iter().any(|&rate| rate != 0.0).then_some(key)
+                }),
+            locations,
+        )?;
+        Ok(())
+    }
+
     /// Construct with empty gate maps; unspecified gates use `base`.
     #[must_use]
     pub fn from_base_noise(base: NoiseConfig) -> Self {

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -2221,38 +2221,65 @@ pub(crate) struct MissingOmittedGateTwirl {
     pub clifford: CliffordLowering,
 }
 
-/// A rate key that names a Clifford action instead of a scheduled gate.
-#[derive(Debug, Clone, thiserror::Error)]
-#[error(
-    "{table} key {key:?} names the Clifford action of a different scheduled gate; node {node} schedules {scheduled:?} whose Clifford action is {clifford:?}. Per-gate rates apply to the gate as scheduled; key the rate by {scheduled:?} in {remedy_table}, or lower the circuit with lower_clifford_rotations() before building."
-)]
+/// A rate key that names the action of a differently scheduled gate, whether
+/// or not it also matches scheduled gates in its qubit scope.
+#[derive(Debug, Clone)]
 pub(crate) struct GateRateKeyMismatch {
     pub table: &'static str,
     pub key: GateType,
     pub node: usize,
     pub scheduled: GateType,
-    pub clifford: CliffordLowering,
     pub remedy_table: &'static str,
+    pub matches_scheduled: bool,
+}
+
+impl fmt::Display for GateRateKeyMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.matches_scheduled {
+            write!(
+                f,
+                "{} key {:?} matches scheduled {:?} gates but also names the Clifford action of {:?} at node {}. ",
+                self.table, self.key, self.key, self.scheduled, self.node,
+            )?;
+        } else {
+            write!(
+                f,
+                "{} key {:?} matches no scheduled gate; node {} schedules {:?} whose Clifford action is {:?}. ",
+                self.table, self.key, self.node, self.scheduled, self.key,
+            )?;
+        }
+        let remedy = if self.matches_scheduled {
+            "add a key for"
+        } else {
+            "key the rate by"
+        };
+        write!(
+            f,
+            "Per-gate rates apply to the gate as scheduled: {remedy} {:?} in {}, or lower the circuit with lower_clifford_rotations() before building.",
+            self.scheduled, self.remedy_table,
+        )
+    }
+}
+
+impl std::error::Error for GateRateKeyMismatch {}
+
+/// The rate representation shared by the one- and two-qubit tables.
+#[derive(Clone, Copy)]
+enum GateRateTableFamily {
+    Scalar,
+    Pauli,
+    PerQubit,
 }
 
 /// The corresponding rate table for the scheduled gate's arity.
-fn scheduled_gate_rate_table(table: &'static str, scheduled: GateType) -> &'static str {
-    let tables = match table {
-        "p1_gate_rates" | "p2_gate_rates" => ("p1_gate_rates", "p2_gate_rates"),
-        "rates_1q" | "rates_2q" => ("rates_1q", "rates_2q"),
-        "rates_1q_per_qubit" | "rates_2q_per_qubits" => {
-            ("rates_1q_per_qubit", "rates_2q_per_qubits")
-        }
-        _ => unreachable!("gate-rate validation uses a known rate table"),
-    };
-    if is_two_qubit_noise_gate(scheduled) {
-        tables.1
-    } else {
-        assert!(
-            scheduled.is_single_qubit(),
-            "a mismatched Clifford rotation has one or two qubits"
-        );
-        tables.0
+fn scheduled_gate_rate_table(family: GateRateTableFamily, scheduled: GateType) -> &'static str {
+    match (family, scheduled.is_two_qubit()) {
+        (GateRateTableFamily::Scalar, false) => "p1_gate_rates",
+        (GateRateTableFamily::Scalar, true) => "p2_gate_rates",
+        (GateRateTableFamily::Pauli, false) => "rates_1q",
+        (GateRateTableFamily::Pauli, true) => "rates_2q",
+        (GateRateTableFamily::PerQubit, false) => "rates_1q_per_qubit",
+        (GateRateTableFamily::PerQubit, true) => "rates_2q_per_qubits",
     }
 }
 
@@ -2305,9 +2332,9 @@ pub(crate) fn validate_scalar_gate_rate_tables(
     ] {
         validate_active_gate_rate_keys(
             table,
-            rates
-                .iter()
-                .filter_map(|(&key, &rate)| (rate != 0.0).then_some((key, GateRateQubits::Any))),
+            rates.iter().filter_map(|(&key, &rate)| {
+                (rate != 0.0).then_some((key, GateRateQubits::Any, GateRateTableFamily::Scalar))
+            }),
             locations,
         )?;
     }
@@ -2317,10 +2344,10 @@ pub(crate) fn validate_scalar_gate_rate_tables(
 /// Reject active keys that name the Clifford action of a different scheduled gate.
 fn validate_active_gate_rate_keys(
     table: &'static str,
-    keys: impl IntoIterator<Item = (GateType, GateRateQubits)>,
+    keys: impl IntoIterator<Item = (GateType, GateRateQubits, GateRateTableFamily)>,
     locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
 ) -> Result<(), GateRateKeyMismatch> {
-    for (key, qubits) in keys {
+    for (key, qubits, family) in keys {
         if let Some(location) = locations.iter().find(|location| {
             location.gate_type != key
                 && matches!(location.clifford,
@@ -2332,8 +2359,10 @@ fn validate_active_gate_rate_keys(
                 key,
                 node: location.node,
                 scheduled: location.gate_type,
-                clifford: location.clifford,
-                remedy_table: scheduled_gate_rate_table(table, location.gate_type),
+                remedy_table: scheduled_gate_rate_table(family, location.gate_type),
+                matches_scheduled: locations
+                    .iter()
+                    .any(|other| other.gate_type == key && qubits.matches(other, locations)),
             });
         }
     }
@@ -4324,20 +4353,22 @@ impl PerGateTypeNoise {
         validate_active_gate_rate_keys(
             "rates_1q",
             self.rates_1q.iter().filter_map(|(&key, rates)| {
-                rates
-                    .iter()
-                    .any(|&rate| rate != 0.0)
-                    .then_some((key, GateRateQubits::Any))
+                rates.iter().any(|&rate| rate != 0.0).then_some((
+                    key,
+                    GateRateQubits::Any,
+                    GateRateTableFamily::Pauli,
+                ))
             }),
             locations,
         )?;
         validate_active_gate_rate_keys(
             "rates_2q",
             self.rates_2q.iter().filter_map(|(&key, rates)| {
-                rates
-                    .iter()
-                    .any(|&rate| rate != 0.0)
-                    .then_some((key, GateRateQubits::Any))
+                rates.iter().any(|&rate| rate != 0.0).then_some((
+                    key,
+                    GateRateQubits::Any,
+                    GateRateTableFamily::Pauli,
+                ))
             }),
             locations,
         )?;
@@ -4346,10 +4377,11 @@ impl PerGateTypeNoise {
             self.rates_1q_per_qubit
                 .iter()
                 .filter_map(|(&(key, qubit), rates)| {
-                    rates
-                        .iter()
-                        .any(|&rate| rate != 0.0)
-                        .then_some((key, GateRateQubits::One(qubit)))
+                    rates.iter().any(|&rate| rate != 0.0).then_some((
+                        key,
+                        GateRateQubits::One(qubit),
+                        GateRateTableFamily::PerQubit,
+                    ))
                 }),
             locations,
         )?;
@@ -4358,10 +4390,11 @@ impl PerGateTypeNoise {
             self.rates_2q_per_qubits
                 .iter()
                 .filter_map(|(&(key, control, target), rates)| {
-                    rates
-                        .iter()
-                        .any(|&rate| rate != 0.0)
-                        .then_some((key, GateRateQubits::Pair(control, target)))
+                    rates.iter().any(|&rate| rate != 0.0).then_some((
+                        key,
+                        GateRateQubits::Pair(control, target),
+                        GateRateTableFamily::PerQubit,
+                    ))
                 }),
             locations,
         )?;

--- a/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
+++ b/crates/pecos-qec/src/fault_tolerance/dem_builder/types.rs
@@ -2224,7 +2224,7 @@ pub(crate) struct MissingOmittedGateTwirl {
 /// A rate key that names a Clifford action instead of a scheduled gate.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
-    "{table} key {key:?} matches no scheduled gate; node {node} schedules {scheduled:?} whose Clifford action is {clifford:?}. Per-gate rates apply to the gate as scheduled; key the rate by {scheduled:?}, or lower the circuit with lower_clifford_rotations() before building."
+    "{table} key {key:?} names the Clifford action of a different scheduled gate; node {node} schedules {scheduled:?} whose Clifford action is {clifford:?}. Per-gate rates apply to the gate as scheduled; key the rate by {scheduled:?} in {remedy_table}, or lower the circuit with lower_clifford_rotations() before building."
 )]
 pub(crate) struct GateRateKeyMismatch {
     pub table: &'static str,
@@ -2232,6 +2232,64 @@ pub(crate) struct GateRateKeyMismatch {
     pub node: usize,
     pub scheduled: GateType,
     pub clifford: CliffordLowering,
+    pub remedy_table: &'static str,
+}
+
+/// The corresponding rate table for the scheduled gate's arity.
+fn scheduled_gate_rate_table(table: &'static str, scheduled: GateType) -> &'static str {
+    let tables = match table {
+        "p1_gate_rates" | "p2_gate_rates" => ("p1_gate_rates", "p2_gate_rates"),
+        "rates_1q" | "rates_2q" => ("rates_1q", "rates_2q"),
+        "rates_1q_per_qubit" | "rates_2q_per_qubits" => {
+            ("rates_1q_per_qubit", "rates_2q_per_qubits")
+        }
+        _ => unreachable!("gate-rate validation uses a known rate table"),
+    };
+    if is_two_qubit_noise_gate(scheduled) {
+        tables.1
+    } else {
+        assert!(
+            scheduled.is_single_qubit(),
+            "a mismatched Clifford rotation has one or two qubits"
+        );
+        tables.0
+    }
+}
+
+/// The qubit scope of a gate-rate key.
+enum GateRateQubits {
+    Any,
+    One(QubitId),
+    Pair(QubitId, QubitId),
+}
+
+impl GateRateQubits {
+    fn matches(
+        &self,
+        location: &crate::fault_tolerance::propagator::DagSpacetimeLocation,
+        locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
+    ) -> bool {
+        match self {
+            Self::Any => true,
+            Self::One(qubit) => location.qubits.contains(qubit),
+            Self::Pair(control, target) => {
+                if !location.qubits.contains(control) {
+                    return false;
+                }
+                // Builders pair successive fault locations at a node in gate order.
+                let mut qubits = locations
+                    .iter()
+                    .filter(|other| other.node == location.node && other.before == location.before)
+                    .flat_map(|other| &other.qubits);
+                while let (Some(qc), Some(qt)) = (qubits.next(), qubits.next()) {
+                    if (qc, qt) == (control, target) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
 }
 
 /// Validate the scalar per-gate rate tables shared by every builder that owns
@@ -2249,26 +2307,25 @@ pub(crate) fn validate_scalar_gate_rate_tables(
             table,
             rates
                 .iter()
-                .filter_map(|(&key, &rate)| (rate != 0.0).then_some(key)),
+                .filter_map(|(&key, &rate)| (rate != 0.0).then_some((key, GateRateQubits::Any))),
             locations,
         )?;
     }
     Ok(())
 }
 
-/// Validate active keys against scheduled gates before considering Clifford actions.
+/// Reject active keys that name the Clifford action of a different scheduled gate.
 fn validate_active_gate_rate_keys(
     table: &'static str,
-    keys: impl IntoIterator<Item = GateType>,
+    keys: impl IntoIterator<Item = (GateType, GateRateQubits)>,
     locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
 ) -> Result<(), GateRateKeyMismatch> {
-    for key in keys {
-        if locations.iter().any(|location| location.gate_type == key) {
-            continue;
-        }
+    for (key, qubits) in keys {
         if let Some(location) = locations.iter().find(|location| {
-            matches!(location.clifford,
-                CliffordLowering::Named(gate) | CliffordLowering::PerQubit(gate) if gate == key)
+            location.gate_type != key
+                && matches!(location.clifford,
+                    CliffordLowering::Named(gate) | CliffordLowering::PerQubit(gate) if gate == key)
+                && qubits.matches(location, locations)
         }) {
             return Err(GateRateKeyMismatch {
                 table,
@@ -2276,6 +2333,7 @@ fn validate_active_gate_rate_keys(
                 node: location.node,
                 scheduled: location.gate_type,
                 clifford: location.clifford,
+                remedy_table: scheduled_gate_rate_table(table, location.gate_type),
             });
         }
     }
@@ -2639,7 +2697,9 @@ pub struct NoiseConfig {
     /// `p1` while still using `p1_weights` to distribute probability across
     /// Pauli channels.
     /// Keys name the scheduled gate; traced rotations such as `RZZ` and `RXY1Q`
-    /// require rotation keys or lowering the circuit first.
+    /// require rotation keys or lowering the circuit first. Nonzero keys naming
+    /// the action of a different scheduled gate are rejected, even if another
+    /// scheduled gate matches the key.
     pub p1_gate_rates: BTreeMap<GateType, f64>,
     /// Two-qubit gate error rate.
     pub p2: f64,
@@ -2649,7 +2709,9 @@ pub struct NoiseConfig {
     /// `p2` while still using `p2_weights` to distribute probability across
     /// Pauli-pair channels.
     /// Keys name the scheduled gate; traced rotations such as `RZZ` and `RXY1Q`
-    /// require rotation keys or lowering the circuit first.
+    /// require rotation keys or lowering the circuit first. Nonzero keys naming
+    /// the action of a different scheduled gate are rejected, even if another
+    /// scheduled gate matches the key.
     pub p2_gate_rates: BTreeMap<GateType, f64>,
     /// Measurement error rate.
     pub p_meas: f64,
@@ -3342,7 +3404,7 @@ impl Default for NoiseConfig {
 }
 
 impl NoiseConfig {
-    /// Reject active rate keys that match only a location's Clifford action.
+    /// Reject active rate keys that name an action of a different scheduled gate.
     pub(crate) fn validate_gate_rate_keys(
         &self,
         locations: &[crate::fault_tolerance::propagator::DagSpacetimeLocation],
@@ -4232,7 +4294,9 @@ pub const PAULI_2Q_ORDER: [&str; 15] = [
 ///
 /// Keys in all gate-rate tables name the gate as scheduled; runtime-traced
 /// circuits schedule rotations such as `RZZ` and `RXY1Q`, so key by those
-/// or lower the circuit first.
+/// or lower the circuit first. Nonzero keys naming the action of a different
+/// scheduled gate in the key's qubit scope are rejected, even if another
+/// scheduled gate matches the key.
 #[derive(Debug, Clone, Default)]
 pub struct PerGateTypeNoise {
     pub rates_1q: HashMap<GateType, [f64; 3]>,
@@ -4259,24 +4323,33 @@ impl PerGateTypeNoise {
         self.base.validate_gate_rate_keys(locations)?;
         validate_active_gate_rate_keys(
             "rates_1q",
-            self.rates_1q
-                .iter()
-                .filter_map(|(&key, rates)| rates.iter().any(|&rate| rate != 0.0).then_some(key)),
+            self.rates_1q.iter().filter_map(|(&key, rates)| {
+                rates
+                    .iter()
+                    .any(|&rate| rate != 0.0)
+                    .then_some((key, GateRateQubits::Any))
+            }),
             locations,
         )?;
         validate_active_gate_rate_keys(
             "rates_2q",
-            self.rates_2q
-                .iter()
-                .filter_map(|(&key, rates)| rates.iter().any(|&rate| rate != 0.0).then_some(key)),
+            self.rates_2q.iter().filter_map(|(&key, rates)| {
+                rates
+                    .iter()
+                    .any(|&rate| rate != 0.0)
+                    .then_some((key, GateRateQubits::Any))
+            }),
             locations,
         )?;
         validate_active_gate_rate_keys(
             "rates_1q_per_qubit",
             self.rates_1q_per_qubit
                 .iter()
-                .filter_map(|(&(key, _), rates)| {
-                    rates.iter().any(|&rate| rate != 0.0).then_some(key)
+                .filter_map(|(&(key, qubit), rates)| {
+                    rates
+                        .iter()
+                        .any(|&rate| rate != 0.0)
+                        .then_some((key, GateRateQubits::One(qubit)))
                 }),
             locations,
         )?;
@@ -4284,8 +4357,11 @@ impl PerGateTypeNoise {
             "rates_2q_per_qubits",
             self.rates_2q_per_qubits
                 .iter()
-                .filter_map(|(&(key, _, _), rates)| {
-                    rates.iter().any(|&rate| rate != 0.0).then_some(key)
+                .filter_map(|(&(key, control, target), rates)| {
+                    rates
+                        .iter()
+                        .any(|&rate| rate != 0.0)
+                        .then_some((key, GateRateQubits::Pair(control, target)))
                 }),
             locations,
         )?;

--- a/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
+++ b/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
@@ -1133,3 +1133,267 @@ fn symbolic_history_unsupported_rotation_diagnostic_preserves_angles() {
     let error = symbolic_measurement_history(&circuit).unwrap_err();
     assert!(error.to_string().contains("RZ(0.125000 turns)"));
 }
+
+fn assert_gate_rate_configuration_error(
+    error: DemBuilderError,
+    table: &str,
+    key: &str,
+    scheduled: &str,
+) {
+    let DemBuilderError::ConfigurationError(message) = error else {
+        panic!("expected configuration error, got {error:?}");
+    };
+    for expected in [
+        table,
+        key,
+        "node 3",
+        scheduled,
+        "lower_clifford_rotations()",
+        "gate as scheduled",
+    ] {
+        assert!(message.contains(expected), "missing {expected}: {message}");
+    }
+}
+
+#[test]
+fn gate_rate_key_mismatch_rejected_by_every_builder() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    let check = |error| assert_gate_rate_configuration_error(error, "p2_gate_rates", "SZZ", "RZZ");
+    check(DemBuilder::try_from_circuit_with_noise_config(&circuit, noise.clone()).unwrap_err());
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    check(
+        DemBuilder::new(&map)
+            .with_noise_config(noise.clone())
+            .build()
+            .unwrap_err(),
+    );
+    check(
+        SamplingEngine::from_influence_map(&map, &vec![0.001; map.locations.len()], &noise)
+            .unwrap_err(),
+    );
+    check(sampler_gate_rate_error(
+        DemSamplerBuilder::new(&map)
+            .with_noise_config(noise.clone())
+            .with_detectors(Vec::new(), Vec::new())
+            .build()
+            .unwrap_err(),
+    ));
+    check(
+        MemBuilder::new(&map)
+            .with_noise_config(noise.clone())
+            .build()
+            .unwrap_err(),
+    );
+    let error = DemSampler::from_circuit(&circuit, &noise).unwrap_err();
+    let DetectorValidationError::InvalidConfiguration { message } = error else {
+        panic!("expected invalid configuration, got {error:?}");
+    };
+    check(DemBuilderError::ConfigurationError(message));
+}
+
+#[test]
+fn gate_rate_scheduled_rotation_key_applies() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    let scalar = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise.clone())
+        .unwrap()
+        .to_string();
+    noise.p2_gate_rates.insert(GateType::RZZ, 0.05);
+    let keyed = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise)
+        .unwrap()
+        .to_string();
+    assert!(keyed.contains("error("));
+    assert_ne!(scalar, keyed);
+}
+
+#[test]
+fn gate_rate_key_matching_scheduled_and_clifford_gates_is_allowed() {
+    let mut circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    circuit.szz(&[(0, 1)]);
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap();
+}
+
+#[test]
+fn gate_rate_key_absent_from_circuit_is_allowed() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::CX, 0.05);
+    DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap();
+}
+
+#[test]
+fn gate_rate_zero_key_is_ignored() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.0);
+    DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap();
+}
+
+#[test]
+fn gate_rate_named_single_qubit_action_is_rejected() {
+    let circuit = replacement_circuit(Gate::rxy1q(Angle64::QUARTER_TURN, Angle64::ZERO, &[0]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p1_gate_rates.insert(GateType::SX, 0.01);
+    assert_gate_rate_configuration_error(
+        DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err(),
+        "p1_gate_rates",
+        "SX",
+        "RXY1Q",
+    );
+}
+
+#[test]
+fn gate_rate_per_qubit_clifford_action_is_rejected() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::HALF_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p1_gate_rates.insert(GateType::Z, 0.01);
+    assert_gate_rate_configuration_error(
+        DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err(),
+        "p1_gate_rates",
+        "Z",
+        "RZZ",
+    );
+}
+
+fn assert_per_gate_rate_mismatch(
+    noise: &pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise,
+    table: &str,
+    gate: Gate,
+    key: &str,
+    scheduled: &str,
+) {
+    let circuit = replacement_circuit(gate);
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    assert_gate_rate_configuration_error(
+        DemBuilder::new(&map)
+            .with_per_gate_noise(noise.clone())
+            .try_build()
+            .unwrap_err(),
+        table,
+        key,
+        scheduled,
+    );
+    for builder in [
+        DemSamplerBuilder::new(&map),
+        DemSamplerBuilder::new(&map).with_detectors(Vec::new(), Vec::new()),
+    ] {
+        assert_gate_rate_configuration_error(
+            sampler_gate_rate_error(
+                builder
+                    .with_per_gate_noise(noise.clone())
+                    .build()
+                    .unwrap_err(),
+            ),
+            table,
+            key,
+            scheduled,
+        );
+    }
+}
+
+#[test]
+fn gate_rate_rates_1q_mismatch() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    assert_per_gate_rate_mismatch(
+        &PerGateTypeNoise::default().with_1q_rates(GateType::SX, [0.0, 0.0, 0.01]),
+        "rates_1q",
+        Gate::rxy1q(Angle64::QUARTER_TURN, Angle64::ZERO, &[0]),
+        "SX",
+        "RXY1Q",
+    );
+}
+
+#[test]
+fn gate_rate_rates_2q_mismatch() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    assert_per_gate_rate_mismatch(
+        &PerGateTypeNoise::default().with_2q_rates(GateType::SZZ, [0.001; 15]),
+        "rates_2q",
+        Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]),
+        "SZZ",
+        "RZZ",
+    );
+}
+
+#[test]
+fn gate_rate_rates_1q_per_qubit_mismatch() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    assert_per_gate_rate_mismatch(
+        &PerGateTypeNoise::default().with_1q_rates_for_qubit(
+            GateType::SX,
+            pecos_core::QubitId(99),
+            [0.01; 3],
+        ),
+        "rates_1q_per_qubit",
+        Gate::rxy1q(Angle64::QUARTER_TURN, Angle64::ZERO, &[0]),
+        "SX",
+        "RXY1Q",
+    );
+}
+
+#[test]
+fn gate_rate_rates_2q_per_qubits_mismatch() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    assert_per_gate_rate_mismatch(
+        &PerGateTypeNoise::default().with_2q_rates_for_qubits(
+            GateType::SZZ,
+            pecos_core::QubitId(98),
+            pecos_core::QubitId(99),
+            [0.001; 15],
+        ),
+        "rates_2q_per_qubits",
+        Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]),
+        "SZZ",
+        "RZZ",
+    );
+}
+
+fn sampler_gate_rate_error(error: DetectorValidationError) -> DemBuilderError {
+    let DetectorValidationError::InvalidConfiguration { message } = error else {
+        panic!("expected invalid configuration, got {error:?}");
+    };
+    DemBuilderError::ConfigurationError(message)
+}
+
+#[test]
+fn gate_rate_per_gate_base_mismatch() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    let mut base = NoiseConfig::uniform(0.001);
+    base.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    assert_per_gate_rate_mismatch(
+        &PerGateTypeNoise::from_base_noise(base),
+        "p2_gate_rates",
+        Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]),
+        "SZZ",
+        "RZZ",
+    );
+}
+
+#[test]
+fn gate_rate_zero_pauli_tables_are_ignored() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    let noise = PerGateTypeNoise::default()
+        .with_1q_rates(GateType::SZZ, [0.0; 3])
+        .with_2q_rates(GateType::SZZ, [0.0; 15])
+        .with_1q_rates_for_qubit(GateType::SZZ, pecos_core::QubitId(0), [0.0; 3])
+        .with_2q_rates_for_qubits(
+            GateType::SZZ,
+            pecos_core::QubitId(0),
+            pecos_core::QubitId(1),
+            [0.0; 15],
+        );
+    DemBuilder::new(&map)
+        .with_per_gate_noise(noise.clone())
+        .try_build()
+        .unwrap();
+    DemSamplerBuilder::new(&map)
+        .with_per_gate_noise(noise)
+        .build()
+        .unwrap();
+}

--- a/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
+++ b/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
@@ -1156,7 +1156,7 @@ fn assert_gate_rate_configuration_error(
 }
 
 #[test]
-fn gate_rate_key_mismatch_rejected_by_every_builder() {
+fn gate_rate_key_mismatch_rejected_by_consuming_builders() {
     let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     let mut noise = NoiseConfig::uniform(0.001);
     noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
@@ -1176,16 +1176,17 @@ fn gate_rate_key_mismatch_rejected_by_every_builder() {
     check(sampler_gate_rate_error(
         DemSamplerBuilder::new(&map)
             .with_noise_config(noise.clone())
+            .raw_measurements()
+            .build()
+            .unwrap_err(),
+    ));
+    check(sampler_gate_rate_error(
+        DemSamplerBuilder::new(&map)
+            .with_noise_config(noise.clone())
             .with_detectors(Vec::new(), Vec::new())
             .build()
             .unwrap_err(),
     ));
-    check(
-        MemBuilder::new(&map)
-            .with_noise_config(noise.clone())
-            .build()
-            .unwrap_err(),
-    );
     let error = DemSampler::from_circuit(&circuit, &noise).unwrap_err();
     let DetectorValidationError::InvalidConfiguration { message } = error else {
         panic!("expected invalid configuration, got {error:?}");
@@ -1209,12 +1210,17 @@ fn gate_rate_scheduled_rotation_key_applies() {
 }
 
 #[test]
-fn gate_rate_key_matching_scheduled_and_clifford_gates_is_allowed() {
+fn gate_rate_key_matching_scheduled_and_clifford_gates_is_rejected() {
     let mut circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     circuit.szz(&[(0, 1)]);
     let mut noise = NoiseConfig::uniform(0.001);
     noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
-    DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap();
+    assert_gate_rate_configuration_error(
+        DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err(),
+        "p2_gate_rates",
+        "SZZ",
+        "RZZ",
+    );
 }
 
 #[test]
@@ -1277,22 +1283,18 @@ fn assert_per_gate_rate_mismatch(
         key,
         scheduled,
     );
-    for builder in [
-        DemSamplerBuilder::new(&map),
-        DemSamplerBuilder::new(&map).with_detectors(Vec::new(), Vec::new()),
-    ] {
-        assert_gate_rate_configuration_error(
-            sampler_gate_rate_error(
-                builder
-                    .with_per_gate_noise(noise.clone())
-                    .build()
-                    .unwrap_err(),
-            ),
-            table,
-            key,
-            scheduled,
-        );
-    }
+    let builder = DemSamplerBuilder::new(&map).with_detectors(Vec::new(), Vec::new());
+    assert_gate_rate_configuration_error(
+        sampler_gate_rate_error(
+            builder
+                .with_per_gate_noise(noise.clone())
+                .build()
+                .unwrap_err(),
+        ),
+        table,
+        key,
+        scheduled,
+    );
 }
 
 #[test]
@@ -1325,7 +1327,7 @@ fn gate_rate_rates_1q_per_qubit_mismatch() {
     assert_per_gate_rate_mismatch(
         &PerGateTypeNoise::default().with_1q_rates_for_qubit(
             GateType::SX,
-            pecos_core::QubitId(99),
+            pecos_core::QubitId(0),
             [0.01; 3],
         ),
         "rates_1q_per_qubit",
@@ -1341,8 +1343,8 @@ fn gate_rate_rates_2q_per_qubits_mismatch() {
     assert_per_gate_rate_mismatch(
         &PerGateTypeNoise::default().with_2q_rates_for_qubits(
             GateType::SZZ,
-            pecos_core::QubitId(98),
-            pecos_core::QubitId(99),
+            pecos_core::QubitId(0),
+            pecos_core::QubitId(1),
             [0.001; 15],
         ),
         "rates_2q_per_qubits",
@@ -1394,6 +1396,121 @@ fn gate_rate_zero_pauli_tables_are_ignored() {
         .unwrap();
     DemSamplerBuilder::new(&map)
         .with_per_gate_noise(noise)
+        .build()
+        .unwrap();
+}
+
+#[test]
+fn gate_rate_per_qubit_remedy_uses_scheduled_arity() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::HALF_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p1_gate_rates.insert(GateType::Z, 0.01);
+    let error = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("key the rate by RZZ in p2_gate_rates")
+    );
+    assert_gate_rate_configuration_error(error, "p1_gate_rates", "Z", "RZZ");
+}
+
+#[test]
+fn gate_rate_named_remedy_uses_scheduled_arity() {
+    let circuit = replacement_circuit(Gate::rxy1q(Angle64::QUARTER_TURN, Angle64::ZERO, &[0]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SX, 0.01);
+    let error = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("key the rate by RXY1Q in p1_gate_rates")
+    );
+    assert_gate_rate_configuration_error(error, "p2_gate_rates", "SX", "RXY1Q");
+}
+
+#[test]
+fn gate_rate_shadowed_scalar_tables_are_not_validated() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    DemBuilder::new(&map)
+        .with_noise_config(noise.clone())
+        .with_per_gate_noise(PerGateTypeNoise::default())
+        .try_build()
+        .unwrap();
+    DemSamplerBuilder::new(&map)
+        .with_noise_config(noise)
+        .with_per_gate_noise(PerGateTypeNoise::default())
+        .with_detectors(Vec::new(), Vec::new())
+        .build()
+        .unwrap();
+}
+
+#[test]
+fn gate_rate_raw_mode_does_not_validate_unused_per_gate_tables() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    DemSamplerBuilder::new(&map)
+        .with_per_gate_noise(PerGateTypeNoise::default().with_2q_rates(GateType::SZZ, [0.001; 15]))
+        .raw_measurements()
+        .build()
+        .unwrap();
+}
+
+#[test]
+fn gate_rate_absent_qubit_keys_are_allowed() {
+    use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
+    let mut circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    circuit.add_gate_auto_wire(Gate::rxy1q(Angle64::QUARTER_TURN, Angle64::ZERO, &[0]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    for noise in [
+        PerGateTypeNoise::default().with_1q_rates_for_qubit(
+            GateType::SX,
+            pecos_core::QubitId(99),
+            [0.01; 3],
+        ),
+        PerGateTypeNoise::default().with_2q_rates_for_qubits(
+            GateType::SZZ,
+            pecos_core::QubitId(98),
+            pecos_core::QubitId(99),
+            [0.001; 15],
+        ),
+        PerGateTypeNoise::default().with_2q_rates_for_qubits(
+            GateType::SZZ,
+            pecos_core::QubitId(0),
+            pecos_core::QubitId(99),
+            [0.001; 15],
+        ),
+        PerGateTypeNoise::default().with_2q_rates_for_qubits(
+            GateType::SZZ,
+            pecos_core::QubitId(1),
+            pecos_core::QubitId(0),
+            [0.001; 15],
+        ),
+    ] {
+        DemBuilder::new(&map)
+            .with_per_gate_noise(noise.clone())
+            .try_build()
+            .unwrap();
+        DemSamplerBuilder::new(&map)
+            .with_per_gate_noise(noise)
+            .with_detectors(Vec::new(), Vec::new())
+            .build()
+            .unwrap();
+    }
+}
+
+#[test]
+fn gate_rate_mem_builder_does_not_validate_unused_tables() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    MemBuilder::new(&map)
+        .with_noise_config(noise)
         .build()
         .unwrap();
 }

--- a/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
+++ b/crates/pecos-qec/tests/unsupported_dem_gates_tests.rs
@@ -1211,16 +1211,47 @@ fn gate_rate_scheduled_rotation_key_applies() {
 
 #[test]
 fn gate_rate_key_matching_scheduled_and_clifford_gates_is_rejected() {
-    let mut circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut circuit = DagCircuit::new();
+    circuit.pz(&[0, 1]);
+    circuit.h(&[0]);
+    circuit.add_gate_auto_wire(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     circuit.szz(&[(0, 1)]);
+    circuit.h(&[0]);
+    circuit.mz(&[0]);
+    circuit.mz(&[1]);
+    circuit.set_attr(
+        "detectors",
+        pecos_quantum::Attribute::String(
+            r#"[{"id":0,"records":[-2]},{"id":1,"records":[-1]}]"#.to_string(),
+        ),
+    );
     let mut noise = NoiseConfig::uniform(0.001);
     noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
-    assert_gate_rate_configuration_error(
-        DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err(),
-        "p2_gate_rates",
-        "SZZ",
-        "RZZ",
+    let error = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err();
+    let DemBuilderError::ConfigurationError(message) = &error else {
+        panic!("expected configuration error, got {error:?}");
+    };
+    assert_eq!(
+        message,
+        "p2_gate_rates key SZZ matches scheduled SZZ gates but also names the Clifford action of RZZ at node 3. Per-gate rates apply to the gate as scheduled: add a key for RZZ in p2_gate_rates, or lower the circuit with lower_clifford_rotations() before building."
     );
+    assert_gate_rate_configuration_error(error, "p2_gate_rates", "SZZ", "RZZ");
+}
+
+#[test]
+fn gate_rate_key_matching_no_scheduled_gate_message() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let mut noise = NoiseConfig::uniform(0.001);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    let error = DemBuilder::try_from_circuit_with_noise_config(&circuit, noise).unwrap_err();
+    let DemBuilderError::ConfigurationError(message) = &error else {
+        panic!("expected configuration error, got {error:?}");
+    };
+    assert_eq!(
+        message,
+        "p2_gate_rates key SZZ matches no scheduled gate; node 3 schedules RZZ whose Clifford action is SZZ. Per-gate rates apply to the gate as scheduled: key the rate by RZZ in p2_gate_rates, or lower the circuit with lower_clifford_rotations() before building."
+    );
+    assert_gate_rate_configuration_error(error, "p2_gate_rates", "SZZ", "RZZ");
 }
 
 #[test]
@@ -1396,6 +1427,7 @@ fn gate_rate_zero_pauli_tables_are_ignored() {
         .unwrap();
     DemSamplerBuilder::new(&map)
         .with_per_gate_noise(noise)
+        .with_detectors(Vec::new(), Vec::new())
         .build()
         .unwrap();
 }
@@ -1429,7 +1461,7 @@ fn gate_rate_named_remedy_uses_scheduled_arity() {
 }
 
 #[test]
-fn gate_rate_shadowed_scalar_tables_are_not_validated() {
+fn gate_rate_per_gate_noise_supersedes_scalar_config_on_dem_builder() {
     use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
     let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
@@ -1449,15 +1481,25 @@ fn gate_rate_shadowed_scalar_tables_are_not_validated() {
 }
 
 #[test]
-fn gate_rate_raw_mode_does_not_validate_unused_per_gate_tables() {
+fn gate_rate_raw_mode_rejects_per_gate_noise() {
     use pecos_qec::fault_tolerance::dem_builder::PerGateTypeNoise;
     let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
-    DemSamplerBuilder::new(&map)
-        .with_per_gate_noise(PerGateTypeNoise::default().with_2q_rates(GateType::SZZ, [0.001; 15]))
-        .raw_measurements()
-        .build()
-        .unwrap();
+    for noise in [
+        PerGateTypeNoise::default(),
+        PerGateTypeNoise::default().with_2q_rates(GateType::SZZ, [0.001; 15]),
+        PerGateTypeNoise::default().with_2q_rates(GateType::RZZ, [0.0; 15]),
+    ] {
+        let error = DemSamplerBuilder::new(&map)
+            .with_per_gate_noise(noise)
+            .raw_measurements()
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(error, DetectorValidationError::InvalidConfiguration { message }
+            if message.contains("raw-measurement mode applies scalar noise only"))
+        );
+    }
 }
 
 #[test]
@@ -1504,11 +1546,36 @@ fn gate_rate_absent_qubit_keys_are_allowed() {
 }
 
 #[test]
-fn gate_rate_mem_builder_does_not_validate_unused_tables() {
+fn gate_rate_mem_builder_rejects_nonzero_tables() {
+    let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
+    let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
+    for (key, two_qubit) in [
+        (GateType::X, false),
+        (GateType::SZZ, true),
+        (GateType::CX, true),
+    ] {
+        let mut noise = NoiseConfig::uniform(0.001);
+        if two_qubit {
+            noise.p2_gate_rates.insert(key, 0.05);
+        } else {
+            noise.p1_gate_rates.insert(key, 0.05);
+        }
+        let error = MemBuilder::new(&map)
+            .with_noise_config(noise)
+            .build()
+            .unwrap_err();
+        assert!(matches!(error, DemBuilderError::ConfigurationError(message)
+            if message.contains("MemBuilder applies scalar rates only")));
+    }
+}
+
+#[test]
+fn gate_rate_mem_builder_allows_zero_tables() {
     let circuit = replacement_circuit(Gate::rzz(Angle64::QUARTER_TURN, &[(0, 1)]));
     let map = DagFaultAnalyzer::new(&circuit).build_influence_map();
     let mut noise = NoiseConfig::uniform(0.001);
-    noise.p2_gate_rates.insert(GateType::SZZ, 0.05);
+    noise.p1_gate_rates.insert(GateType::X, 0.0);
+    noise.p2_gate_rates.insert(GateType::SZZ, 0.0);
     MemBuilder::new(&map)
         .with_noise_config(noise)
         .build()

--- a/python/pecos-rslib/src/fault_tolerance_bindings.rs
+++ b/python/pecos-rslib/src/fault_tolerance_bindings.rs
@@ -1891,6 +1891,10 @@ impl PyDetectorErrorModel {
     ///     >>> dem = DetectorErrorModel.from_circuit(tc, p2=0.01)
     ///     >>> print(dem.to_string())
     ///     >>> sampler = dem.to_sampler()
+    ///
+    /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
+    /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
+    /// so key by those or lower the circuit first.
     #[staticmethod]
     #[pyo3(signature = (circuit, p1=0.001, p2=0.01, p_meas=0.001, p_prep=0.001, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -2390,6 +2394,10 @@ impl PyDemBuilder {
     ///
     /// Returns:
     ///     Self for method chaining.
+    ///
+    /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
+    /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
+    /// so key by those or lower the circuit first.
     #[pyo3(signature = (p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
     fn with_noise(
@@ -3390,6 +3398,10 @@ impl PyDemSampler {
     /// Example:
     ///     >>> sampler = DemSampler.from_circuit(dag, p1=0.001, p2=0.01)
     ///     >>> sampler = DemSampler.from_circuit(tc, p2=0.01)  # TickCircuit also works
+    ///
+    /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
+    /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
+    /// so key by those or lower the circuit first.
     #[staticmethod]
     #[pyo3(signature = (circuit, p1=0.001, p2=0.01, p_meas=0.001, p_prep=0.001, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -3567,6 +3579,10 @@ impl PyDemSampler {
     /// Create a sampler in detector-event mode.
     ///
     /// The `observables` argument defines observables.
+    ///
+    /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
+    /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
+    /// so key by those or lower the circuit first.
     #[staticmethod]
     #[pyo3(signature = (influence_map, detectors, observables, p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -4137,6 +4153,10 @@ impl PyDemSamplerBuilder {
     }
 
     /// Set noise parameters.
+    ///
+    /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
+    /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
+    /// so key by those or lower the circuit first.
     #[pyo3(signature = (p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
     fn with_noise(

--- a/python/pecos-rslib/src/fault_tolerance_bindings.rs
+++ b/python/pecos-rslib/src/fault_tolerance_bindings.rs
@@ -1894,7 +1894,9 @@ impl PyDetectorErrorModel {
     ///
     /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
     /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
-    /// so key by those or lower the circuit first.
+    /// so key by those or lower the circuit first. Nonzero keys naming the
+    /// Clifford action of a different scheduled gate are rejected, even if
+    /// another scheduled gate matches the key.
     #[staticmethod]
     #[pyo3(signature = (circuit, p1=0.001, p2=0.01, p_meas=0.001, p_prep=0.001, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -2397,7 +2399,9 @@ impl PyDemBuilder {
     ///
     /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
     /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
-    /// so key by those or lower the circuit first.
+    /// so key by those or lower the circuit first. Nonzero keys naming the
+    /// Clifford action of a different scheduled gate are rejected, even if
+    /// another scheduled gate matches the key.
     #[pyo3(signature = (p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
     fn with_noise(
@@ -3401,7 +3405,9 @@ impl PyDemSampler {
     ///
     /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
     /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
-    /// so key by those or lower the circuit first.
+    /// so key by those or lower the circuit first. Nonzero keys naming the
+    /// Clifford action of a different scheduled gate are rejected, even if
+    /// another scheduled gate matches the key.
     #[staticmethod]
     #[pyo3(signature = (circuit, p1=0.001, p2=0.01, p_meas=0.001, p_prep=0.001, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -3582,7 +3588,9 @@ impl PyDemSampler {
     ///
     /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
     /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
-    /// so key by those or lower the circuit first.
+    /// so key by those or lower the circuit first. Nonzero keys naming the
+    /// Clifford action of a different scheduled gate are rejected, even if
+    /// another scheduled gate matches the key.
     #[staticmethod]
     #[pyo3(signature = (influence_map, detectors, observables, p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
@@ -4156,7 +4164,9 @@ impl PyDemSamplerBuilder {
     ///
     /// `p1_gate_rates` and `p2_gate_rates` keys name the gate as scheduled;
     /// runtime-traced circuits schedule rotations such as `RZZ` and `RXY1Q`,
-    /// so key by those or lower the circuit first.
+    /// so key by those or lower the circuit first. Nonzero keys naming the
+    /// Clifford action of a different scheduled gate are rejected, even if
+    /// another scheduled gate matches the key.
     #[pyo3(signature = (p1, p2, p_meas, p_prep, p_idle=None, t1=None, t2=None, idle_rz=None, p_idle_linear_rate=None, p_idle_quadratic_rate=None, p_idle_x_linear_rate=None, p_idle_y_linear_rate=None, p_idle_z_linear_rate=None, p_idle_x_quadratic_rate=None, p_idle_y_quadratic_rate=None, p_idle_z_quadratic_rate=None, p_idle_quadratic_sine_rate=None, p_idle_x_quadratic_sine_rate=None, p_idle_y_quadratic_sine_rate=None, p_idle_z_quadratic_sine_rate=None, p1_weights=None, p2_weights=None, p2_replacement_approximation=None, p_meas_crosstalk_local=None, p_meas_crosstalk_global=None, p_meas_crosstalk_model=None, measurement_crosstalk_dem_mode=None, p2_gate_rates=None, p1_gate_rates=None))]
     #[allow(clippy::too_many_arguments)]
     fn with_noise(

--- a/python/quantum-pecos/src/pecos/qec/dem.py
+++ b/python/quantum-pecos/src/pecos/qec/dem.py
@@ -10,6 +10,10 @@ module attaches a Python :meth:`from_guppy` classmethod to the Rust-backed
 ``pecos_rslib.qec.DetectorErrorModel`` and re-exports that class as the public
 ``pecos.qec.DetectorErrorModel``.
 
+``p1_gate_rates`` and ``p2_gate_rates`` keys name the gate as scheduled;
+runtime-traced circuits schedule rotations such as ``RZZ`` and ``RXY1Q``,
+so key by those or lower the circuit first.
+
 This wrapper is intentionally thin: it traces the Guppy program into a
 ``TickCircuit``, compiles Guppy inputs to a HUGR to reject unverified control
 flow and, when requested, recover the sound tag -> measurement binding via

--- a/python/quantum-pecos/src/pecos/qec/dem.py
+++ b/python/quantum-pecos/src/pecos/qec/dem.py
@@ -10,9 +10,13 @@ module attaches a Python :meth:`from_guppy` classmethod to the Rust-backed
 ``pecos_rslib.qec.DetectorErrorModel`` and re-exports that class as the public
 ``pecos.qec.DetectorErrorModel``.
 
-``p1_gate_rates`` and ``p2_gate_rates`` keys name the gate as scheduled;
-runtime-traced circuits schedule rotations such as ``RZZ`` and ``RXY1Q``,
-so key by those or lower the circuit first.
+``GuppyDemBuilder.build`` and ``DetectorErrorModel.from_guppy`` lower Clifford
+rotations first, so gate-rate keys name the lowered gates, such as ``SZZ``;
+an ``RZZ`` key matches nothing after lowering. ``DetectorErrorModel.from_circuit``
+and ``DemSampler.from_circuit`` do not lower raw traces, so key by the scheduled
+rotations, such as ``RZZ`` and ``RXY1Q``, or lower the circuit first. A nonzero
+key naming the Clifford action of a different scheduled gate is rejected,
+even when the key also matches another scheduled gate.
 
 This wrapper is intentionally thin: it traces the Guppy program into a
 ``TickCircuit``, compiles Guppy inputs to a HUGR to reject unverified control

--- a/python/quantum-pecos/src/pecos/qec/surface/circuit_builder.py
+++ b/python/quantum-pecos/src/pecos/qec/surface/circuit_builder.py
@@ -3134,6 +3134,9 @@ def tick_circuit_to_stim(
             ``"SZ"``, and ``"SZdg"``. The surface SZZ reference path uses
             this to mirror the staged PECOS device model where Z/SZ/SZdg frame
             updates are virtual and p1-free.
+            Keys name the gate as scheduled; runtime-traced circuits schedule
+            rotations such as ``RZZ`` and ``RXY1Q``, so key by those or lower
+            the circuit first.
         p2: Two-qubit error rate
         p_meas: Measurement error rate
         p_prep: Initialization error rate
@@ -3672,6 +3675,9 @@ def generate_dem_from_tick_circuit_via_stim(
             depolarizing rates. Gate names are PECOS ``GateType`` names. The
             surface SZZ reference path uses this to mirror the staged PECOS
             device model where Z/SZ/SZdg frame updates are virtual and p1-free.
+            Keys name the gate as scheduled; runtime-traced circuits schedule
+            rotations such as ``RZZ`` and ``RXY1Q``, so key by those or lower
+            the circuit first.
         p2: Two-qubit depolarizing error rate
         p_meas: Measurement error rate
         p_prep: Initialization (prep) error rate

--- a/python/quantum-pecos/src/pecos/qec/surface/decode.py
+++ b/python/quantum-pecos/src/pecos/qec/surface/decode.py
@@ -160,6 +160,10 @@ class NoiseParameters:
     Matches the Rust ``NoiseConfig`` type. All parameters are optional
     beyond the four base rates.
 
+    Per-gate rate keys name the gate as scheduled; runtime-traced circuits
+    schedule rotations such as ``RZZ`` and ``RXY1Q``, so key by those or
+    lower the circuit first.
+
     Attributes:
         p1: Single-qubit gate error rate.
         p1_weights: Optional relative probabilities over single-qubit Pauli

--- a/python/quantum-pecos/src/pecos/qec/surface/decode.py
+++ b/python/quantum-pecos/src/pecos/qec/surface/decode.py
@@ -160,9 +160,9 @@ class NoiseParameters:
     Matches the Rust ``NoiseConfig`` type. All parameters are optional
     beyond the four base rates.
 
-    Per-gate rate keys name the gate as scheduled; runtime-traced circuits
-    schedule rotations such as ``RZZ`` and ``RXY1Q``, so key by those or
-    lower the circuit first.
+    Per-gate two-qubit overrides emit ``SZZ`` and ``SZZdg`` keys. The surface
+    path lowers Clifford rotations before building, so these keys name the
+    lowered scheduled gates.
 
     Attributes:
         p1: Single-qubit gate error rate.

--- a/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
+++ b/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
@@ -2682,9 +2682,9 @@ def test_raw_surface_trace_gate_rate_keys_name_scheduled_gates() -> None:
         circuit_source="traced_qis",
     )
     noise = {"p1": 0.005, "p2": 0.005, "p_meas": 0.005, "p_prep": 0.005}
-    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ.*lower_clifford_rotations"):
+    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ in p2_gate_rates.*lower_clifford_rotations"):
         DemSampler.from_circuit(raw_tc, p2_gate_rates={"SZZ": 0.05}, **noise)
-    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ.*lower_clifford_rotations"):
+    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ in p2_gate_rates.*lower_clifford_rotations"):
         DetectorErrorModel.from_circuit(raw_tc, p2_gate_rates={"SZZ": 0.05}, **noise)
     scalar = DemSampler.from_circuit(raw_tc, **noise).to_detector_error_model().to_string()
     keyed = DemSampler.from_circuit(raw_tc, p2_gate_rates={"RZZ": 0.05}, **noise).to_detector_error_model().to_string()

--- a/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
+++ b/python/quantum-pecos/tests/qec/test_from_guppy_dem.py
@@ -2668,3 +2668,27 @@ def test_raw_surface_trace_sampler_matches_lowered_dem(p2_weights: dict[str, flo
     )
     lowered_dem = DemSampler.from_circuit(raw_tc, p2_weights=p2_weights, **noise).to_detector_error_model().to_string()
     assert raw_dem == lowered_dem
+
+
+def test_raw_surface_trace_gate_rate_keys_name_scheduled_gates() -> None:
+    """Per-gate rates reject action names until the traced rotations are lowered."""
+    from pecos_rslib.qec import DemSampler
+
+    raw_tc = _build_surface_tick_circuit_for_native_model(
+        SurfacePatch.create(distance=3),
+        num_rounds=2,
+        basis="Z",
+        ancilla_budget=2,
+        circuit_source="traced_qis",
+    )
+    noise = {"p1": 0.005, "p2": 0.005, "p_meas": 0.005, "p_prep": 0.005}
+    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ.*lower_clifford_rotations"):
+        DemSampler.from_circuit(raw_tc, p2_gate_rates={"SZZ": 0.05}, **noise)
+    with pytest.raises(ValueError, match=r"p2_gate_rates key SZZ.*RZZ.*lower_clifford_rotations"):
+        DetectorErrorModel.from_circuit(raw_tc, p2_gate_rates={"SZZ": 0.05}, **noise)
+    scalar = DemSampler.from_circuit(raw_tc, **noise).to_detector_error_model().to_string()
+    keyed = DemSampler.from_circuit(raw_tc, p2_gate_rates={"RZZ": 0.05}, **noise).to_detector_error_model().to_string()
+    assert "error(" in keyed
+    assert scalar != keyed
+    raw_tc.lower_clifford_rotations()
+    DemSampler.from_circuit(raw_tc, p2_gate_rates={"SZZ": 0.05}, **noise)


### PR DESCRIPTION
Closes #746.

## Problem

Per-gate noise rates are keyed by `GateType` and looked up by each noise location's scheduled gate type, with the scalar rate as the default. Nothing checked that a key matched any location. Since #742 noise locations follow the gate as scheduled, so on a Selene-traced circuit, which schedules `RZZ(pi/2)`, `RXY1Q(pi/2, 0)`, and `RZ(pi)`, a rate keyed `"SZZ"`, `"SX"`, or `"Z"` applied to nothing and raised nothing. The surface-code path never hit this because it lowers traced rotations to named gates before building; the raw-trace entry points did.

## Change

Keys keep meaning the scheduled gate. One validator in `dem_builder/types.rs` checks every gate-keyed table in the noise configuration (`p1_gate_rates`, `p2_gate_rates`, and the `PerGateTypeNoise` tables `rates_1q`, `rates_2q`, `rates_1q_per_qubit`, `rates_2q_per_qubits`): a key with a non-zero rate that matches no scheduled gate but names the Clifford action of one (`Named` or `PerQubit` on the location) is a `ConfigurationError` that states the table, the key, the node, the scheduled gate, and the remedy (key by the scheduled gate, or lower the circuit with `lower_clifford_rotations()` first). A key that matches nothing at all stays allowed so a noise configuration can be shared across circuits with different gate sets. Zero rates are ignored. Applying rates by Clifford action was considered and rejected as a second key namespace for one table.

Every builder runs the check in its preflight next to the existing replacement-branch validation: `DemBuilder`, `DemSampler` (including its raw-measurement builder), `SamplingEngine`, `SamplingEngineBuilder`, and `MemBuilder`. Python callers see `ValueError` through the existing mappings. Docstrings for the rate parameters in `dem.py`, `surface/decode.py`, `surface/circuit_builder.py`, and the bindings state the contract.

## Tests

Thirteen Rust tests in `unsupported_dem_gates_tests.rs` cover the mismatch through each builder, the applied rate (`{"RZZ": r}` changes the DEM), scheduled-gate precedence when both `SZZ` and `RZZ(pi/2)` are present, unrelated keys staying allowed, zero rates ignored, the per-qubit case (`RZZ(pi)` with a `Z` key), and every `PerGateTypeNoise` table. Gutting the validator fails eight of them. Python tests on the raw d=3 surface trace: `{"SZZ": r}` raises with a message naming `SZZ` and `RZZ`, `{"RZZ": r}` builds and differs from the scalar model, and `{"SZZ": r}` builds after `lower_clifford_rotations()`.

## Verification

`cargo test -p pecos-qec --no-fail-fast`: 1044 passed. `cargo clippy --workspace --all-targets -- -D warnings` on the touched files: clean. Python `tests/qec` and `pecos-rslib/tests`: 3954 passed. `pre-commit run --all-files`: 17 hooks passed.

## Second commit, after review

An independent review of the first commit found four edge cases in the validator, none a wrong DEM, all fixed here.

- **Mixed gate sets.** A circuit scheduling both `SZZ` and `RZZ(pi/2)` with `{"SZZ": r}` was accepted and silently applied `r` to one pair and the scalar to the other, which is the silent miss this change exists to remove. The rule is now: a non-zero key naming the Clifford action of a location whose scheduled gate differs is an error even when the key also matches other scheduled gates. Keys matching nothing at all stay allowed.
- **Remedy names the right table.** `RZZ(pi)` with `p1_gate_rates={"Z": r}` advised keying by `RZZ`, a two-qubit gate that the Python boundary rejects in `p1_gate_rates`. The message now names the table the scheduled gate belongs in, derived from its arity.
- **Only consumed tables are validated.** When per-gate noise is set, the scalar tables are never read and are no longer validated; the raw-measurement sampler path never applies per-gate noise and no longer validates it; `MemBuilder` reads no gate-rate table and validates none. Each site carries a one-line comment stating the rule.
- **Per-qubit keys carry their qubit scope.** A `rates_1q_per_qubit` or `rates_2q_per_qubits` key for a qubit or pair absent from the circuit matches nothing and is allowed; a key matches a location only when gate and qubits both match, in the pair order the lookup uses.
- Docstrings corrected: `from_guppy` and `GuppyDemBuilder` lower before building, so their keys name the lowered gates; only the raw-circuit entry points see scheduled rotations. `NoiseParameters` in `surface/decode.py` emits `SZZ`/`SZZdg` keys and the surface path lowers first.

Six new Rust tests cover the tightened rule, both remedy messages, absent-qubit keys, and the consume-only rule in each builder; restoring the old first-match exemption fails the mixed-circuit test. Pre-existing and out of scope: `MemStabSim` and `DemStabSim` without per-gate noise forward only the four scalar rates and never carried gate-rate tables. The validator costs under one percent of build time on a d=7, seven-round surface DEM, so it has no index.

Verification after the second commit: `cargo test -p pecos-qec --no-fail-fast` 1051 passed, clippy clean on the touched files, Python `tests/qec` and `pecos-rslib/tests` 3954 passed, pre-commit 17 hooks passed.

## Third commit, after a second review

The second review found that "validate only what the path consumes" had enshrined two silent drops. Raw-measurement mode in `DemSamplerBuilder` never applies per-gate noise, and `MemBuilder` never reads a gate-rate table; both now reject those configurations with a configuration error instead of validating nothing. The mismatch message now distinguishes a key that matches no scheduled gate from one that also matches scheduled gates elsewhere, and the remedy names the table the scheduled gate belongs in, selected by arity through a total function rather than string matching with an assertion. The mixed-circuit test schedules its matching `SZZ` before the measurements so the key genuinely contributes on that pair, and the Python assertions require the remedy table in the message.

Left as pre-existing and tracked separately: per-gate noise supersedes the scalar configuration on `DemBuilder` and `SamplingEngineBuilder` (the sampler builder relies on that by syncing the scalar config to the per-gate base), and the pairing between "reads table X" and "validates table X" is enforced by comments; #752 proposes a validated-noise type that makes it structural.

Verification after the third commit: `cargo test -p pecos-qec --no-fail-fast` 1053 passed, clippy clean on the touched files, Python `tests/qec` and `pecos-rslib/tests` 3954 passed, pre-commit 17 hooks passed.
