### PR TITLE
Carry the lost scalar -1 when rotation fusion wraps or a half-turn adjoint self-negates

### DIFF
--- a/crates/pecos-core/src/unitary_rep.rs
+++ b/crates/pecos-core/src/unitary_rep.rs
@@ -1349,7 +1349,7 @@ impl UnitaryRep {
     /// Returns the adjoint (Hermitian conjugate) of this expression.
     #[must_use]
     pub fn dg(&self) -> Self {
-        match self {
+        let adjoint = match self {
             // Pauli adjoint: Paulis are Hermitian, but phase conjugates
             Self::Pauli(ps) => {
                 let conj_phase = ps.phase().conjugate();
@@ -1448,6 +1448,15 @@ impl UnitaryRep {
             Self::Compose(parts) => Self::Compose(parts.iter().rev().map(UnitaryRep::dg).collect()),
             // Double adjoint: unwrap
             Self::Adjoint(inner) => (**inner).clone(),
+        };
+        // Only rotation slots have period 4pi. At pi, stored negation is pi
+        // again, so each such slot contributes a scalar -1 to the adjoint.
+        if let Self::Gate(unitary, _) = self
+            && rotation_adjoint_needs_phase(unitary)
+        {
+            adjoint.with_phase(Angle64::HALF_TURN)
+        } else {
+            adjoint
         }
     }
 
@@ -1719,7 +1728,7 @@ impl UnitaryRep {
     /// - `Tensor([Pauli(a), Pauli(b), ...])` → merges into a single `PauliString`
     /// - `Compose` → multiplies convertible parts in application order, including scalar phases
     /// - Named Pauli gates (`X`, `Y`, `Z`) → corresponding single-qubit `PauliString`
-    /// - Half-turn rotations (`RX(π)`, `RY(π)`, `RZ(π)`) → corresponding `PauliString`
+    /// - Half-turn Pauli rotations → corresponding `PauliString` with phase `-i`
     ///
     /// Returns `None` if the operator cannot be represented as a `PauliString`.
     ///
@@ -1774,19 +1783,18 @@ impl UnitaryRep {
                     return Some(PauliString::identity());
                 }
 
-                // Only half-turn rotations are Pauli operators
-                let half = Angle64::HALF_TURN;
-                let neg_half = negate_angle(half);
-                if angle != half && angle != neg_half {
+                if angle != Angle64::HALF_TURN {
                     return None;
                 }
-                let qubit = qubits.first().copied()?;
-                match rotation_type {
-                    RotationType::RX => Some(PauliString::x(qubit)),
-                    RotationType::RY => Some(PauliString::y(qubit)),
-                    RotationType::RZ => Some(PauliString::z(qubit)),
-                    _ => None,
-                }
+                let pauli = match rotation_type {
+                    RotationType::RX | RotationType::RXX => Pauli::X,
+                    RotationType::RY | RotationType::RYY => Pauli::Y,
+                    RotationType::RZ | RotationType::RZZ => Pauli::Z,
+                };
+                Some(PauliString::with_phase_and_paulis(
+                    QuarterPhase::MinusI,
+                    qubits.into_iter().map(|q| (pauli, QubitId(q))).collect(),
+                ))
             }
 
             Self::Adjoint(inner) => {
@@ -1833,7 +1841,7 @@ impl UnitaryRep {
     ///
     /// Returns true for:
     /// - `Pauli` variants (any `PauliString`)
-    /// - Zero- and half-turn single-qubit rotations
+    /// - Zero- and half-turn Pauli rotations
     /// - Named Pauli gates: `I`, `X`, `Y`, `Z`
     /// - One-qubit `Phase(0)` and `Phase(π)`
     /// - Zero-operand quarter-turn phases and compositions of convertible Paulis
@@ -1847,20 +1855,8 @@ impl UnitaryRep {
             Self::Gate(unitary @ Unitary::Phase { num_qubits, .. }, qubits) => {
                 validate_phase_operands(*num_qubits, qubits).is_ok() && unitary.is_pauli()
             }
-            Self::Gate(
-                Unitary::Rotation {
-                    rotation_type,
-                    angle,
-                },
-                _,
-            ) => {
-                let half = Angle64::HALF_TURN;
-                let neg_half = negate_angle(half);
-                (*angle == Angle64::ZERO || *angle == half || *angle == neg_half)
-                    && matches!(
-                        rotation_type,
-                        RotationType::RX | RotationType::RY | RotationType::RZ
-                    )
+            Self::Gate(Unitary::Rotation { angle, .. }, _) => {
+                matches!(*angle, Angle64::ZERO | Angle64::HALF_TURN)
             }
             Self::Gate(Unitary::Named(NamedGate(gate_type)), _) => {
                 matches!(
@@ -1876,10 +1872,8 @@ impl UnitaryRep {
     ///
     /// Converts:
     /// - `Pauli` → returns as-is
-    /// - Zero-angle single-qubit rotations → `I`
-    /// - `RX(π)` → `X`
-    /// - `RY(π)` → `Y`
-    /// - `RZ(π)` → `Z`
+    /// - Zero-angle Pauli rotations → `I`
+    /// - Half-turn Pauli rotations → `-i` times the corresponding Pauli string
     /// - Named gates `I`, `X`, `Y`, `Z` → corresponding `Pauli` variant
     /// - One-qubit `Phase(0)` → `I`, `Phase(π)` → `Z`
     /// - Zero-operand quarter-turn phases and compositions of convertible Paulis
@@ -1894,32 +1888,12 @@ impl UnitaryRep {
             Self::Pauli(_) => Some(self),
             Self::Gate(
                 Unitary::Rotation {
+                    angle: Angle64::ZERO,
                     rotation_type,
-                    angle,
                 },
-                qubits,
-            ) => {
-                let half = Angle64::HALF_TURN;
-                let neg_half = negate_angle(half);
-                if angle == Angle64::ZERO
-                    && matches!(
-                        rotation_type,
-                        RotationType::RX | RotationType::RY | RotationType::RZ
-                    )
-                {
-                    return Some(I(*qubits.first()?));
-                }
-                if angle != half && angle != neg_half {
-                    return None;
-                }
-                let qubit = *qubits.first()?;
-                match rotation_type {
-                    RotationType::RX => Some(X(qubit)),
-                    RotationType::RY => Some(Y(qubit)),
-                    RotationType::RZ => Some(Z(qubit)),
-                    _ => None,
-                }
-            }
+                ref qubits,
+            ) if rotation_type.num_qubits() == 1 => Some(I(*qubits.first()?)),
+            Self::Gate(Unitary::Rotation { .. }, _) => self.try_to_pauli_string().map(Self::Pauli),
             Self::Gate(Unitary::Named(NamedGate(gate_type)), qubits) => {
                 let qubit = *qubits.first()?;
                 match gate_type {
@@ -3044,41 +3018,40 @@ fn flatten_compose(parts: Vec<UnitaryRep>) -> Vec<UnitaryRep> {
 
 /// Merge adjacent rotations or phase-fixed named roots on the same qubits.
 fn merge_adjacent_rotations(parts: Vec<UnitaryRep>) -> Vec<UnitaryRep> {
-    if parts.len() < 2 {
-        return parts;
-    }
-
-    let mut result = Vec::with_capacity(parts.len());
-    let mut idx = 0;
-
-    while idx < parts.len() {
-        let current = &parts[idx];
-
-        // Check if next element can be merged with current
-        if idx + 1 < parts.len()
-            && let Some(merged) = try_merge_rotations(current, &parts[idx + 1])
-        {
-            // Skip the merged element
-            if merged.is_identity() {
-                // Both cancelled out, skip both
-                idx += 2;
-                continue;
+    let mut pending: Vec<_> = parts.into_iter().rev().collect();
+    let mut result = Vec::new();
+    let mut phase = Angle64::ZERO;
+    while let Some(part) = pending.pop() {
+        match part {
+            UnitaryRep::Compose(parts) => pending.extend(parts.into_iter().rev()),
+            UnitaryRep::Gate(
+                Unitary::Phase {
+                    gamma,
+                    num_qubits: 0,
+                },
+                ref qubits,
+            ) if qubits.is_empty() => {
+                // Scalars commute with every gate. Keep them outside the rotation
+                // chain so a wrap does not prevent further adjacent fusion.
+                phase += gamma;
             }
-            result.push(merged);
-            idx += 2;
-            continue;
+            part if part.is_identity() => {}
+            part => {
+                if let Some(previous) = result.last()
+                    && let Some(merged) = try_merge_rotations(previous, &part)
+                {
+                    result.pop();
+                    pending.push(merged);
+                } else {
+                    result.push(part);
+                }
+            }
         }
-
-        result.push(parts[idx].clone());
-        idx += 1;
     }
-
-    // Recurse if we made any merges (might enable more merges)
-    if result.len() < parts.len() {
-        merge_adjacent_rotations(result)
-    } else {
-        result
+    if phase != Angle64::ZERO {
+        result.insert(0, UnitaryRep::phase_gate(phase, smallvec::smallvec![]));
     }
+    result
 }
 
 /// Try to merge two rotations if they are compatible.
@@ -3104,13 +3077,18 @@ fn try_merge_rotations(a: &UnitaryRep, b: &UnitaryRep) -> Option<UnitaryRep> {
             // Can only merge if same rotation type and same qubits
             if rt_a == rt_b && qubits_a == qubits_b {
                 let combined_angle = *angle_a + *angle_b;
-                Some(UnitaryRep::Gate(
+                let rotation = UnitaryRep::Gate(
                     Unitary::Rotation {
                         rotation_type: *rt_a,
                         angle: combined_angle,
                     },
                     qubits_a.clone(),
-                ))
+                );
+                Some(if rotation_sum_wraps(*angle_a, *angle_b) {
+                    rotation.with_phase(Angle64::HALF_TURN)
+                } else {
+                    rotation
+                })
             } else {
                 None
             }
@@ -3430,6 +3408,49 @@ impl GateTypeExt for GateType {
                     | GateType::SWAP
                     | GateType::CCX
             )
+    }
+}
+
+/// Whether adding two signed rotation representatives crosses the principal boundary.
+///
+/// `Angle64` stores angles modulo 2pi, but Pauli rotations have period 4pi.
+/// A wrapped sum therefore needs an additional scalar -1. This is shared with
+/// the stabilizer-vector simulator's pending RZ fusion.
+#[must_use]
+pub fn rotation_sum_wraps(a: Angle64, b: Angle64) -> bool {
+    const HALF: i128 = 1_i128 << 63;
+    const FULL: i128 = 1_i128 << 64;
+
+    let signed_fraction = |angle: Angle64| {
+        let fraction = i128::from(angle.fraction());
+        if fraction > HALF {
+            fraction - FULL
+        } else {
+            fraction
+        }
+    };
+    signed_fraction(a) + signed_fraction(b) != signed_fraction(a + b)
+}
+
+fn rotation_adjoint_needs_phase(unitary: &Unitary) -> bool {
+    let is_half = |angle: Angle64| angle == Angle64::HALF_TURN;
+    match unitary {
+        Unitary::Rotation { angle, .. } => is_half(*angle),
+        Unitary::RXY1Q { theta, .. } | Unitary::U3 { theta, .. } => is_half(*theta),
+        Unitary::RXXRYYRZZ { alpha, beta, gamma } => {
+            is_half(*alpha) ^ is_half(*beta) ^ is_half(*gamma)
+        }
+        Unitary::U2q {
+            before,
+            interaction,
+            after,
+        } => before
+            .iter()
+            .chain(after.iter())
+            .map(|u3| u3[0])
+            .chain(interaction.iter().copied())
+            .fold(false, |parity, angle| parity ^ is_half(angle)),
+        Unitary::Named(_) | Unitary::Phase { .. } => false,
     }
 }
 
@@ -5278,7 +5299,7 @@ mod tests {
     #[test]
     #[allow(clippy::similar_names)]
     fn test_try_to_pauli_rotation() {
-        // RX(π) = X
+        // RX(π) = -i X
         let rx_pi = RX(Angle64::HALF_TURN, 0);
         let converted = rx_pi.try_to_pauli().expect("Should convert");
         if let UnitaryRep::Pauli(ps) = converted {
@@ -5287,7 +5308,7 @@ mod tests {
             panic!("Expected Pauli variant");
         }
 
-        // RY(π) = Y
+        // RY(π) = -i Y
         let ry_pi = RY(Angle64::HALF_TURN, 1);
         let converted = ry_pi.try_to_pauli().expect("Should convert");
         if let UnitaryRep::Pauli(ps) = converted {
@@ -5296,7 +5317,7 @@ mod tests {
             panic!("Expected Pauli variant");
         }
 
-        // RZ(π) = Z
+        // RZ(π) = -i Z
         let rz_pi = RZ(Angle64::HALF_TURN, 2);
         let converted = rz_pi.try_to_pauli().expect("Should convert");
         if let UnitaryRep::Pauli(ps) = converted {

--- a/crates/pecos-core/tests/clifford_rep_roundtrip_tests.rs
+++ b/crates/pecos-core/tests/clifford_rep_roundtrip_tests.rs
@@ -503,8 +503,11 @@ fn dg_involution_rotation() {
                 },
                 smallvec::smallvec![0],
             );
+            // A half-turn adjoint carries a scalar -1; the two scalar leaves
+            // cancel during simplification. Matrix equality is covered by the
+            // rotation_phase_algebra tests in pecos-quantum.
             assert_eq!(
-                ur.dg().dg(),
+                ur.dg().dg().simplify(),
                 ur,
                 "dg(dg({rot:?}({angle:?}))) should equal original"
             );

--- a/crates/pecos-quantum/tests/rotation_phase_algebra.rs
+++ b/crates/pecos-quantum/tests/rotation_phase_algebra.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations
+// under the License.
+
+//! Rotation algebra must preserve amplitudes, including global phase.
+
+use pecos_core::unitary_rep::{RotationType, rotation_sum_wraps};
+use pecos_core::{Angle64, Unitary, UnitaryRep};
+use pecos_quantum::unitary_matrix::{ToMatrix, UnitaryMatrix, to_matrix_with_size};
+use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+const AXES: [RotationType; 6] = [
+    RotationType::RX,
+    RotationType::RY,
+    RotationType::RZ,
+    RotationType::RXX,
+    RotationType::RYY,
+    RotationType::RZZ,
+];
+
+fn rotation(axis: RotationType, angle: Angle64) -> UnitaryRep {
+    Unitary::Rotation {
+        rotation_type: axis,
+        angle,
+    }
+    .on_qubits(0, 1)
+}
+
+// Compare the complex amplitudes themselves, with only floating-point roundoff
+// tolerance. No phase normalization or quotient is permitted.
+fn assert_same_matrix(actual: &UnitaryMatrix, expected: &UnitaryMatrix) {
+    assert_eq!(actual.shape(), expected.shape());
+    let error = (actual.inner() - expected.inner()).norm();
+    assert!(
+        error < 1e-12,
+        "amplitude error {error}:\nactual={actual:?}\nexpected={expected:?}"
+    );
+}
+
+fn assert_simplification(rep: &UnitaryRep, size: usize) {
+    let expected = to_matrix_with_size(rep, size);
+    let simplified = rep.simplify();
+    assert_same_matrix(&to_matrix_with_size(&simplified, size), &expected);
+    assert_same_matrix(
+        &to_matrix_with_size(&simplified.simplify(), size),
+        &expected,
+    );
+}
+
+#[test]
+fn rotation_fusion_preserves_minus_identity() {
+    for axis in AXES {
+        let u = rotation(axis, Angle64::HALF_TURN);
+        let size = u.to_matrix().num_qubits();
+        let original = u.clone() * u;
+        let expected = UnitaryMatrix::identity(1 << size) * num_complex::Complex64::new(-1.0, 0.0);
+        assert_same_matrix(&original.to_matrix(), &expected);
+        assert_simplification(&original, size);
+    }
+}
+
+#[test]
+fn rotation_adjoint_is_inverse() {
+    for axis in AXES {
+        for theta in [0.0, PI, -PI, FRAC_PI_2, TAU, 0.37] {
+            let u = rotation(axis, Angle64::from_radians(theta));
+            let matrix = u.to_matrix();
+            assert_same_matrix(&u.dg().to_matrix(), &matrix.adjoint());
+            let product = u.dg() * u;
+            assert_same_matrix(
+                &product.to_matrix(),
+                &UnitaryMatrix::identity(matrix.nrows()),
+            );
+            assert_simplification(&product, matrix.num_qubits());
+        }
+    }
+}
+
+#[test]
+fn rotation_double_adjoint_preserves_amplitudes() {
+    for axis in AXES {
+        for theta in [0.0, PI, -PI, FRAC_PI_2, TAU, 0.37] {
+            let u = rotation(axis, Angle64::from_radians(theta));
+            assert_same_matrix(&u.dg().dg().to_matrix(), &u.to_matrix());
+            assert_simplification(&u.dg().dg(), u.to_matrix().num_qubits());
+        }
+    }
+}
+
+#[test]
+fn rotation_fusion_pi_over_four_lattice() {
+    for axis in AXES {
+        for i in -8..=8 {
+            for j in -8..=8 {
+                let a = Angle64::from_turn_ratio(i, 8);
+                let b = Angle64::from_turn_ratio(j, 8);
+                let original = rotation(axis, a) * rotation(axis, b);
+                assert_simplification(&original, original.to_matrix().num_qubits());
+            }
+        }
+    }
+}
+
+#[test]
+fn rotation_fusion_fixed_point_boundaries() {
+    let half = Angle64::HALF_TURN.fraction();
+    let angles = [0, 1, half - 1, half, half + 1, u64::MAX];
+    for axis in AXES {
+        for a in angles.map(Angle64::new) {
+            for b in angles.map(Angle64::new) {
+                let original = rotation(axis, a) * rotation(axis, b);
+                assert_simplification(&original, original.to_matrix().num_qubits());
+            }
+        }
+    }
+}
+
+#[test]
+fn rotation_fusion_chains_and_nested_consumers() {
+    use pecos_core::unitary_rep::{H, X};
+    for axis in AXES {
+        let u = rotation(axis, Angle64::from_turn_ratio(3, 8));
+        for count in 2..=12 {
+            let chain = u.pow(count);
+            assert_simplification(&chain, 2);
+            let nested = (chain.simplify() * H(0)) & X(2);
+            assert_simplification(&nested, 3);
+            assert_same_matrix(&nested.dg().to_matrix(), &nested.to_matrix().adjoint());
+            let adjoint = UnitaryRep::Adjoint(Box::new(chain));
+            assert_simplification(&adjoint, 2);
+        }
+    }
+}
+
+#[test]
+fn rotation_adjoint_parameter_slots() {
+    for theta in [0.0, PI, -PI, FRAC_PI_2, TAU, 0.37] {
+        for phi in [0.0, PI, -PI, 0.23] {
+            for lambda in [0.0, PI, -PI, -0.41] {
+                for unitary in [
+                    Unitary::RXY1Q {
+                        theta: Angle64::from_radians(theta),
+                        phi: Angle64::from_radians(phi),
+                    },
+                    Unitary::U3 {
+                        theta: Angle64::from_radians(theta),
+                        phi: Angle64::from_radians(phi),
+                        lambda: Angle64::from_radians(lambda),
+                    },
+                ] {
+                    let u = unitary.on_qubit(0);
+                    let matrix = u.to_matrix();
+                    assert_same_matrix(&u.dg().to_matrix(), &matrix.adjoint());
+                    assert_same_matrix(
+                        &(u.dg() * u.clone()).to_matrix(),
+                        &UnitaryMatrix::identity(2),
+                    );
+                    assert_same_matrix(&u.dg().dg().to_matrix(), &matrix);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn rotation_adjoint_compound_slot_parity() {
+    // All subsets of the four U3 rotation slots and three interaction slots.
+    // Phase slots deliberately include pi and must not affect sign parity.
+    for mask in 0..128 {
+        let angle = |bit| {
+            if mask & (1 << bit) != 0 {
+                Angle64::HALF_TURN
+            } else {
+                Angle64::from_radians(0.37)
+            }
+        };
+        let interaction = [angle(4), angle(5), angle(6)];
+        for unitary in [
+            Unitary::RXXRYYRZZ {
+                alpha: interaction[0],
+                beta: interaction[1],
+                gamma: interaction[2],
+            },
+            Unitary::U2q {
+                before: [
+                    [angle(0), Angle64::HALF_TURN, Angle64::QUARTER_TURN],
+                    [angle(1), Angle64::ZERO, Angle64::HALF_TURN],
+                ],
+                interaction,
+                after: [
+                    [angle(2), Angle64::HALF_TURN, Angle64::ZERO],
+                    [angle(3), Angle64::QUARTER_TURN, Angle64::HALF_TURN],
+                ],
+            },
+        ] {
+            let u = unitary.on_qubits(0, 1);
+            assert_same_matrix(&u.dg().to_matrix(), &u.to_matrix().adjoint());
+            assert_same_matrix(
+                &(u.dg() * u.clone()).to_matrix(),
+                &UnitaryMatrix::identity(4),
+            );
+            assert_same_matrix(&u.dg().dg().to_matrix(), &u.to_matrix());
+        }
+    }
+}
+
+#[test]
+fn rotation_pauli_consumers_preserve_amplitudes() {
+    for axis in AXES {
+        let u = rotation(axis, Angle64::HALF_TURN);
+        for rep in [
+            u.clone(),
+            u.dg(),
+            u.dg().simplify(),
+            (u.clone() * u).simplify(),
+        ] {
+            let expected = to_matrix_with_size(&rep, 2);
+            let pauli = rep.clone().try_to_pauli().expect("Pauli conversion");
+            assert_same_matrix(&to_matrix_with_size(&pauli, 2), &expected);
+            let string =
+                UnitaryRep::Pauli(rep.try_to_pauli_string().expect("Pauli string conversion"));
+            assert_same_matrix(&to_matrix_with_size(&string, 2), &expected);
+        }
+    }
+}
+
+#[test]
+fn rotation_phase_packet_reproduction() {
+    let u = rotation(RotationType::RZ, Angle64::HALF_TURN);
+    let original = (u.clone() * u.clone()).to_matrix();
+    let naive = rotation(RotationType::RZ, Angle64::ZERO).to_matrix();
+    println!(
+        "fusion errors: corrected={:.4}, naive={:.4}",
+        (to_matrix_with_size(&(u.clone() * u.clone()).simplify(), 1).inner() - original.inner())
+            .norm(),
+        (naive.inner() - original.inner()).norm()
+    );
+    println!(
+        "adjoint errors: corrected={:.4}, naive={:.4}",
+        (u.dg().to_matrix().inner() - u.to_matrix().adjoint().inner()).norm(),
+        (u.to_matrix().inner() - u.to_matrix().adjoint().inner()).norm()
+    );
+    for i in -8..=8 {
+        for j in -8..=8 {
+            let a = Angle64::from_turn_ratio(i, 8);
+            let b = Angle64::from_turn_ratio(j, 8);
+            let fused = rotation(RotationType::RZ, a + b).with_phase(if rotation_sum_wraps(a, b) {
+                Angle64::HALF_TURN
+            } else {
+                Angle64::ZERO
+            });
+            assert_same_matrix(
+                &fused.to_matrix(),
+                &(rotation(RotationType::RZ, a) * rotation(RotationType::RZ, b)).to_matrix(),
+            );
+        }
+    }
+    println!("wrap rule: 289 pairs, 0 mismatches");
+}
+
+#[test]
+fn rotation_op_adjoint_preserves_amplitudes() {
+    for axis in AXES {
+        let u = rotation(axis, Angle64::HALF_TURN);
+        let expected = u.to_matrix().adjoint();
+        let op = pecos_core::Op::from(u);
+        assert_same_matrix(&op.dg().to_matrix(), &expected);
+        assert_same_matrix(
+            &op.try_dg().expect("unitary adjoint").to_matrix(),
+            &expected,
+        );
+    }
+}

--- a/crates/pecos-simulators/src/stab_vec.rs
+++ b/crates/pecos-simulators/src/stab_vec.rs
@@ -796,20 +796,9 @@ impl<S: IndexSet, R: SeedableRng + Rng + Debug + Clone> StabVecGeneric<S, R> {
     /// scalar -1 lost when a signed sum wraps is tracked in `global_phase`
     /// (e.g. 8T = RZ(2pi) = -I).
     fn apply_rz(&mut self, theta: Angle64, q: usize) {
-        const HALF: i128 = 1_i128 << 63;
-        const FULL: i128 = 1_i128 << 64;
-
-        let signed_fraction = |angle: Angle64| {
-            let fraction = i128::from(angle.fraction());
-            if fraction > HALF {
-                fraction - FULL
-            } else {
-                fraction
-            }
-        };
         let previous = self.pending_rz[q];
         let combined = previous + theta;
-        if signed_fraction(previous) + signed_fraction(theta) != signed_fraction(combined) {
+        if pecos_core::unitary_rep::rotation_sum_wraps(previous, theta) {
             // Replacing a signed sum that crossed the principal-value boundary
             // by its stored representative changes RZ by a scalar -1.
             self.global_phase += Angle64::HALF_TURN;


### PR DESCRIPTION
Closes #754.

`UnitaryRep` rotation fusion and rotation adjoint silently dropped the global `-1` that `Angle64`'s `2pi` storage cannot represent.

| operation | before | correct |
|---|---|---|
| `RZ(pi) . RZ(pi)` evaluated directly | `-I` | `-I` |
| the same after `.simplify()` | **`+I`** | `-I` |
| `RZ(pi).dg()` | `diag(-i, +i)`, identical to the original | `diag(+i, -i)` |
| `dg() * original` | **`-I`** | `I` |

The adjoint case is wrong under any convention, since `U.dg() * U` must be `I`. The fusion case is wrong because `simplify()` must preserve the operator, and here it changed it by `-1`.

## The fix

`Angle64` stores a `2pi`-reduced fraction while `exp(-i theta P / 2)` has period `4pi`, so the lost factor is exactly `-1`. It cannot be folded back into the stored angle: `RZ(-pi)` is not representable, because it shares a stored value with `RZ(pi)` and the convention evaluates that value to `diag(-i, +i)`. It is, however, expressible as the zero-operand `Phase` leaf added in #672, which is the scalar `-1`.

**Fusion.** Fusing `RZ(a) . RZ(b)` loses the sign exactly when the signed sum wraps the principal-value boundary. `StabVecGeneric::apply_rz` already detected that condition and compensated with a global phase, with a comment naming the cause. Rather than write a second spelling of the same rule, that logic is extracted as `rotation_sum_wraps` and both callers now share it.

**Adjoint.** Negating the stored value is correct except at exactly `HALF_TURN`, the only non-zero value whose negation is itself; there the result carries the same `-1` leaf. `ZERO` also negates to itself but is the identity and needs nothing.

Applied to `RX`, `RY`, `RZ`, `RXX`, `RYY`, `RZZ`. The audit found `RXY1Q.theta` and `U3.theta` need the same adjoint correction; their axis and phase slots are 2pi-periodic and are untouched. Compound adjoints and Pauli conversion were corrected to carry the phase through, and fusion now continues past scalar leaves instead of discarding them.

## Verification

`cargo test --workspace --no-fail-fast`: 11,979 passed, with the 12 failures exactly matching the pre-existing `dev` baseline (one GPU test, eleven fault-tolerance corpus and decoder tests). Workspace clippy with all targets and features, formatting, `just build-debug`, `just pytest-ci-core`, `just python-ci-lint`, and `pre-commit run --all-files` all pass.

Eleven new amplitude-level tests. **None of them uses `matrices_equiv_up_to_phase` or `unitaries_equiv`**: every existing comparison in this area quotients the global phase and is structurally incapable of observing this defect, which is why it survived.

Three mutations, each failing a test:

| mutation | result |
|---|---|
| suppress the phase leaf in fusion | `rotation_fusion_preserves_minus_identity` fails, exit 101 |
| suppress it in the adjoint | `rotation_adjoint_is_inverse` fails, exit 101 |
| make the correction fire unconditionally | 4 tests fail, exit 101 |

The third is the one worth noting: the first two both test under-correction, so a suite that merely checked "a phase leaf is present" would pass them. Forcing the correction to fire always catches spurious over-correction, which is equally wrong.

One existing assertion was relaxed rather than weakened. `dg_involution_rotation` compared `ur.dg().dg()` to `ur` structurally; with a phase carrier that is no longer structurally the identity, it is the original inside two cancelling leaves, so the comparison now runs after `simplify()`. Matrix-level coverage is provided by `rotation_double_adjoint_preserves_amplitudes`, which compares `u.dg().dg().to_matrix()` to `u.to_matrix()` exactly.

## Not in this change

The gate-level fusion passes in `crates/pecos-quantum/src/pass.rs` have the same wrapping `+=` and the same loss, and are reachable -- three consecutive `RZ(pi/2)` produce a wrapping sum. They are not fixed here because a `Gate` list has no way to carry a global phase: there is no `GateType` for one.

That gap has now appeared three times -- `lower_phase` returning no gates for a zero-operand phase, the QASM half of #670, and now circuit fusion. #672's design note anticipated it, observing that what a phase leaf adds over an expression-tree wrapper is that it "survives as a gate through a gate-list pipeline", and that the pipeline side needed writing down before being relied on. Whether that argues for a gate-level phase carrier is worth deciding on its own.

`Angle64` and its arithmetic are unchanged. This is a fix within current storage semantics; the separate proposal in `pecos-docs/design/half-angle-storage.md` would make the wrap impossible and render both corrections dead code, at which point they should be removed.
