### PR TITLE
Define qelib crz through the 2pi-periodic phase gate so controlled rotations stay exact at the wrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ dependencies = [
  "pecos-phir",
  "pecos-phir-json",
  "pecos-programs",
+ "pecos-qec",
  "pecos-quantum",
  "pecos-random",
  "pecos-simulators",

--- a/crates/pecos-qasm/Cargo.toml
+++ b/crates/pecos-qasm/Cargo.toml
@@ -49,6 +49,8 @@ wat = { workspace = true, optional = true }
 
 [dev-dependencies]
 pecos-phir-json.workspace = true
+pecos-qec.workspace = true
+pecos-quantum = { workspace = true, features = ["hugr"] }
 
 # Testing
 tempfile.workspace = true

--- a/crates/pecos-qasm/includes/qelib1.inc
+++ b/crates/pecos-qasm/includes/qelib1.inc
@@ -85,10 +85,12 @@ gate szz a,b { SZZ a,b; }
 gate szzdg a,b { SZZDG a,b; }
 
 // Controlled RZ
+// Phase gates are 2*pi-periodic, so opposite half angles cancel exactly even
+// when Angle64 identifies +pi and -pi. Symmetric RZ halves would leave -I there.
 gate crz(theta) a,b {
-  rz(theta/2) b;
+  p(theta/2) b;
   cx a,b;
-  rz(-theta/2) b;
+  p(-theta/2) b;
   cx a,b;
 }
 
@@ -101,11 +103,11 @@ gate crx(theta) a,b {
 }
 
 // Controlled RY
+// SXdg · RZ(theta) · SX = RY(theta) on the target
 gate cry(theta) a,b {
-  ry(theta/2) b;
-  cx a,b;
-  ry(-theta/2) b;
-  cx a,b;
+  sx b;
+  crz(theta) a,b;
+  sxdg b;
 }
 
 // Controlled phase

--- a/crates/pecos-qasm/tests/controlled_rotation_downstream.rs
+++ b/crates/pecos-qasm/tests/controlled_rotation_downstream.rs
@@ -1,0 +1,184 @@
+//! Exercise consumers of the phase-shaped U emitted by qelib1 controlled rotations.
+
+use pecos_core::gate_type::GateType;
+use pecos_core::{Angle64, Gate};
+use pecos_engines::noise::GeneralNoiseModel;
+use pecos_engines::prelude::state_vector;
+use pecos_engines::{ClassicalEngine, sim_builder};
+use pecos_phir_json::phir_json_engine;
+use pecos_qasm::{QASMEngine, qasm_engine, qasm_to_phir_json};
+use pecos_qec::fault_tolerance::dem_builder::{DemSampler, NoiseConfig};
+use pecos_quantum::DagCircuit;
+use pecos_quantum::hugr_convert::dag_circuit_to_hugr;
+use pecos_quantum::pass::{CancelInverses, CircuitPass, StripIdentities};
+use std::str::FromStr;
+
+fn qasm(body: &str) -> String {
+    format!("OPENQASM 2.0; include \"qelib1.inc\"; qreg q[2]; creg c[2]; {body}")
+}
+
+fn emitted_gates(body: &str) -> Vec<Gate> {
+    let mut engine = QASMEngine::from_str(&qasm(body)).expect("QASM must parse");
+    let mut gates = Vec::new();
+    loop {
+        let batch = engine
+            .generate_commands()
+            .expect("QASM must emit commands")
+            .quantum_ops()
+            .expect("commands must contain valid gates");
+        if batch.is_empty() {
+            break;
+        }
+        gates.extend(batch);
+    }
+    gates
+}
+
+fn controlled_rotation_dag(name: &str, angle: &str) -> DagCircuit {
+    let gates = emitted_gates(&format!("{name}({angle}) q[0],q[1];"));
+    // Guard the integration boundary: these tests must actually reach consumers with U.
+    let phases: Vec<_> = gates
+        .iter()
+        .filter(|gate| gate.gate_type == GateType::U)
+        .collect();
+    assert_eq!(phases.len(), 2, "{name} must emit two U gates");
+    for gate in phases {
+        assert_eq!(gate.angles.len(), 3);
+        assert_eq!(gate.angles[0], Angle64::ZERO);
+        assert_eq!(gate.angles[1], Angle64::ZERO);
+    }
+    let mut dag = DagCircuit::new();
+    for gate in gates {
+        dag.add_gate_auto_wire(gate);
+    }
+    assert!(dag.wire_count() > 0, "the emitted circuit must be wired");
+    dag
+}
+
+fn noisy_qasm_outcomes(body: &str, p1: f64) -> Vec<u64> {
+    let results = sim_builder()
+        .classical(qasm_engine().qasm(qasm(body)))
+        .quantum(state_vector())
+        .noise(
+            GeneralNoiseModel::builder()
+                .with_p1(p1)
+                .with_noiseless_gate(GateType::RZ),
+        )
+        .seed(42)
+        .workers(1)
+        .run(1000)
+        .expect("QASM simulation must execute");
+    results
+        .try_as_shot_map()
+        .unwrap()
+        .try_bits_as_u64("c")
+        .unwrap()
+}
+
+#[test]
+fn qasm_crz_inherits_noiseless_rz() {
+    controlled_rotation_dag("crz", "0.7");
+    let outcomes = noisy_qasm_outcomes("crz(0.7) q[0],q[1]; measure q -> c;", 0.2);
+    assert_eq!(outcomes, vec![0; 1000]);
+}
+
+#[test]
+fn qasm_general_u_remains_noisy_with_noiseless_rz() {
+    let body = "U(pi,0,0.7) q[1]; measure q -> c;";
+    let gates = emitted_gates("U(pi,0,0.7) q[1];");
+    assert_eq!(gates.len(), 1);
+    assert_eq!(gates[0].gate_type, GateType::U);
+    assert_ne!(gates[0].angles[0], Angle64::ZERO);
+    // p1 must be NON-ZERO here: with no noise configured the outcome is
+    // deterministic whatever the classification, so a zero rate cannot
+    // distinguish "general U is exempt" from "general U is noisy". The
+    // exemption keys on the phase-shaped form, so this U(theta=pi) must still
+    // pick up faults and therefore must NOT be deterministic.
+    let outcomes = noisy_qasm_outcomes(body, 0.2);
+    assert_eq!(outcomes.len(), 1000);
+    assert!(
+        outcomes.iter().any(|outcome| *outcome != 2),
+        "a general U must remain noisy when only RZ is noiseless, but every shot gave 2"
+    );
+    let noisy = noisy_qasm_outcomes(body, 0.2);
+    assert_eq!(noisy.len(), 1000);
+    assert!(
+        noisy.contains(&0),
+        "general U must still receive bit-flip noise"
+    );
+    assert!(
+        noisy.contains(&2),
+        "some shots must retain the ideal outcome"
+    );
+    assert!(noisy.iter().all(|&value| value == 0 || value == 2));
+}
+
+#[test]
+fn qasm_crz_pi_builds_dem_sampler() {
+    let dag = controlled_rotation_dag("crz", "pi");
+    DemSampler::from_circuit(&dag, &NoiseConfig::uniform(0.01))
+        .expect("DEM sampler must accept the gates emitted by QASM crz(pi)");
+}
+
+fn assert_json_execution(name: &str) {
+    // Check both control states so the controlled operation actually takes effect.
+    for (preparation, expected) in [("", 0), ("x q[0];", if name == "crz" { 1 } else { 3 })] {
+        let source = qasm(&format!(
+            "{preparation} {name}(pi) q[0],q[1]; measure q -> c;"
+        ));
+        let json = qasm_to_phir_json(&source).expect("QASM to PHIR/JSON conversion must succeed");
+        let ops = json["ops"].as_array().unwrap();
+        assert_eq!(ops.iter().filter(|op| op["qop"] == "U").count(), 2);
+        if name == "cry" {
+            assert!(ops.iter().any(|op| op["qop"] == "SX"));
+            assert!(ops.iter().any(|op| op["qop"] == "SXdg"));
+        }
+        let results = sim_builder()
+            .classical(phir_json_engine().json(&json.to_string()).unwrap())
+            .quantum(state_vector())
+            .seed(42)
+            .workers(1)
+            .run(32)
+            .unwrap_or_else(|error| panic!("QASM {name}(pi) JSON execution failed: {error}"));
+        assert_eq!(results.len(), 32);
+        for shot in &results.shots {
+            assert_eq!(shot.data["c"].as_u32(), Some(expected), "{name}: {shot:?}");
+        }
+    }
+}
+
+#[test]
+fn qasm_crz_pi_json_executes() {
+    assert_json_execution("crz");
+}
+
+#[test]
+fn qasm_crx_pi_json_executes() {
+    assert_json_execution("crx");
+}
+
+#[test]
+fn qasm_cry_pi_json_executes() {
+    assert_json_execution("cry");
+}
+
+#[test]
+fn qasm_controlled_rotations_export_to_hugr() {
+    for name in ["crz", "crx", "cry"] {
+        for angle in ["pi", "0.7"] {
+            let dag = controlled_rotation_dag(name, angle);
+            dag_circuit_to_hugr(&dag)
+                .unwrap_or_else(|error| panic!("QASM {name}({angle}) HUGR export failed: {error}"));
+        }
+    }
+}
+
+#[test]
+fn qasm_crz_zero_optimizes_away() {
+    let mut dag = controlled_rotation_dag("crz", "0");
+    assert_eq!(dag.gate_count(), 4);
+    StripIdentities.apply_dag(&mut dag);
+    assert_eq!(dag.gate_count(), 2, "only the CX pair should remain");
+    CancelInverses.apply_dag(&mut dag);
+    assert_eq!(dag.gate_count(), 0);
+}

--- a/crates/pecos-qasm/tests/gates/rotation_gates.rs
+++ b/crates/pecos-qasm/tests/gates/rotation_gates.rs
@@ -55,10 +55,10 @@ fn test_controlled_rotation_gates() {
                 .filter(|op| is_gate_with_name(op, "CX"))
                 .count();
 
-            let rz_count = program
+            let u_count = program
                 .operations
                 .iter()
-                .filter(|op| is_gate_with_name(op, "RZ"))
+                .filter(|op| is_gate_with_name(op, "U"))
                 .count();
 
             let h_count = program
@@ -67,7 +67,7 @@ fn test_controlled_rotation_gates() {
                 .filter(|op| is_gate_with_name(op, "H"))
                 .count();
 
-            println!("Gate counts - CX: {cx_count}, RZ: {rz_count}, H: {h_count}");
+            println!("Gate counts - CX: {cx_count}, U: {u_count}, H: {h_count}");
 
             // Verify the operations expanded correctly
             // Each controlled rotation requires 2 CX gates (3 gates total * 2 = 6)
@@ -76,8 +76,8 @@ fn test_controlled_rotation_gates() {
                 "Expected 6 CX gates from 3 controlled rotations"
             );
 
-            // crz and crx each contribute two RZ gates.
-            assert_eq!(rz_count, 4, "Expected 4 RZ gates from crz and crx");
+            // Each controlled rotation contributes two phase gates lowered to U.
+            assert_eq!(u_count, 6, "Expected 6 U gates from crz, crx, and cry");
 
             // crx conjugates crz by H on the target.
             assert_eq!(h_count, 2, "Expected 2 H gates from crx");
@@ -107,7 +107,8 @@ fn test_crz_expansion() {
                 program.operations.len()
             );
 
-            // crz(theta) expands to: rz(theta/2) b; cx a,b; rz(-theta/2) b; cx a,b;
+            // crz(theta) expands to: p(theta/2) b; cx a,b; p(-theta/2) b; cx a,b;
+            // Each p(lambda) is native U(0, 0, lambda).
             assert_eq!(
                 program.operations.len(),
                 4,
@@ -121,24 +122,27 @@ fn test_crz_expansion() {
                     parameters,
                     qubits,
                 } => {
-                    assert_eq!(name, "RZ");
+                    assert_eq!(name, "U");
+                    assert_eq!(parameters.len(), 3);
+                    assert_eq!(&parameters[..2], &[0.0, 0.0]);
                     assert_eq!(qubits, &[1]); // Target qubit
                     assert!(
-                        (parameters[0] - std::f64::consts::PI / 4.0).abs() < 1e-10,
-                        "First RZ should have angle pi/4"
+                        (parameters[2] - std::f64::consts::PI / 4.0).abs() < 1e-10,
+                        "First U lambda should have angle pi/4"
                     );
                 }
-                Operation::NativeGate(gate) if matches!(gate.gate_type, GateType::RZ) => {
+                Operation::NativeGate(gate) if matches!(gate.gate_type, GateType::U) => {
                     assert_eq!(gate.qubits.len(), 1);
                     assert_eq!(gate.qubits[0].0, 1); // Target qubit
                     // For native gates, the angle is in the angles field as Angle64
-                    assert_eq!(gate.angles.len(), 1);
+                    assert_eq!(gate.angles.len(), 3);
+                    assert_eq!(&gate.angles[..2], &[pecos_core::Angle64::ZERO; 2]);
                     assert!(
-                        (gate.angles[0].to_radians() - std::f64::consts::PI / 4.0).abs() < 1e-10,
-                        "First RZ should have angle pi/4"
+                        (gate.angles[2].to_radians() - std::f64::consts::PI / 4.0).abs() < 1e-10,
+                        "First U lambda should have angle pi/4"
                     );
                 }
-                _ => panic!("Expected RZ gate at position 0"),
+                _ => panic!("Expected U gate at position 0"),
             }
 
             match &program.operations[1] {
@@ -160,27 +164,30 @@ fn test_crz_expansion() {
                     parameters,
                     qubits,
                 } => {
-                    assert_eq!(name, "RZ");
+                    assert_eq!(name, "U");
+                    assert_eq!(parameters.len(), 3);
+                    assert_eq!(&parameters[..2], &[0.0, 0.0]);
                     assert_eq!(qubits, &[1]); // Target qubit
                     assert!(
-                        (parameters[0] + std::f64::consts::PI / 4.0).abs() < 1e-10,
-                        "Second RZ should have angle -pi/4"
+                        (parameters[2] + std::f64::consts::PI / 4.0).abs() < 1e-10,
+                        "Second U lambda should have angle -pi/4"
                     );
                 }
-                Operation::NativeGate(gate) if matches!(gate.gate_type, GateType::RZ) => {
+                Operation::NativeGate(gate) if matches!(gate.gate_type, GateType::U) => {
                     assert_eq!(gate.qubits.len(), 1);
                     assert_eq!(gate.qubits[0].0, 1); // Target qubit
                     // For native gates, the angle is in the angles field as Angle64
                     // Note: Angle64 normalizes to [0, 2π), so -π/4 becomes 7π/4
-                    assert_eq!(gate.angles.len(), 1);
-                    let angle = gate.angles[0].to_radians();
+                    assert_eq!(gate.angles.len(), 3);
+                    assert_eq!(&gate.angles[..2], &[pecos_core::Angle64::ZERO; 2]);
+                    let angle = gate.angles[2].to_radians();
                     let expected = 7.0 * std::f64::consts::PI / 4.0; // -pi/4 normalized to 7pi/4
                     assert!(
                         (angle - expected).abs() < 1e-10,
-                        "Second RZ should have angle 7pi/4 (normalized from -pi/4), got {angle}"
+                        "Second U lambda should have angle 7pi/4 (normalized from -pi/4), got {angle}"
                     );
                 }
-                _ => panic!("Expected RZ gate at position 2"),
+                _ => panic!("Expected U gate at position 2"),
             }
 
             match &program.operations[3] {
@@ -245,8 +252,8 @@ fn test_crx_expansion() {
                 "CRX should contain H gates from H-RZ-H conjugation"
             );
             assert!(
-                gate_types.iter().any(|name| name.to_uppercase() == "RZ"),
-                "CRX should contain RZ gates from crz"
+                gate_types.iter().any(|name| name.to_uppercase() == "U"),
+                "CRX should contain U phase gates from crz"
             );
             assert!(
                 gate_types
@@ -280,11 +287,11 @@ fn test_cry_expansion() {
                 program.operations.len()
             );
 
-            // cry contains two native RXY1Q rotations and two CX gates.
+            // cry conjugates the four-gate crz expansion by native SX and SXDG.
             assert_eq!(
                 program.operations.len(),
-                4,
-                "CRY should expand to 4 operations"
+                6,
+                "CRY should expand to 6 operations"
             );
 
             // Count gate types
@@ -293,18 +300,20 @@ fn test_cry_expansion() {
                 .iter()
                 .filter(|op| is_gate_with_name(op, "CX"))
                 .count();
-            let rxy_count = program
+            let u_count = program
                 .operations
                 .iter()
-                .filter(|op| is_gate_with_name(op, "RXY1Q"))
+                .filter(|op| is_gate_with_name(op, "U"))
                 .count();
 
-            println!("CRY gate counts - CX: {cx_count}, RXY1Q: {rxy_count}");
+            println!("CRY gate counts - CX: {cx_count}, U: {u_count}");
 
-            // Should have 2 CX gates from the original cry structure
+            // The inner crz contributes two CX gates and two U phase gates.
             assert_eq!(cx_count, 2, "CRY should have 2 CX gates");
 
-            assert_eq!(rxy_count, 2, "CRY should have 2 RXY1Q gates from ry");
+            assert_eq!(u_count, 2, "CRY should have 2 U phase gates from crz");
+            assert!(is_gate_with_name(&program.operations[0], "SX"));
+            assert!(is_gate_with_name(&program.operations[5], "SXDG"));
         }
         Err(e) => {
             panic!("Failed to parse cry gate: {e}");

--- a/crates/pecos-qasm/tests/integration/include_gate_conformance_test.rs
+++ b/crates/pecos-qasm/tests/integration/include_gate_conformance_test.rs
@@ -10,12 +10,10 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-//! This is a PROJECTIVE check: each gate is compared to its reference up to one
-//! shared global phase, because a boundary conversion is only required to be exact
-//! up to an unobservable global phase. It therefore does NOT pin phase exactness --
-//! `phase_exactness_test.rs` is the test that does. Every RELATIVE phase, including
-//! the control-side phase that distinguishes a controlled rotation from a controlled
-//! phase, is compared exactly.
+//! Controlled rotations (`crz`, `crx`, `cry`) are compared phase-exactly, including
+//! at the half-angle wrap boundary. Other gates are compared up to one shared
+//! global phase; every relative phase is still compared exactly. Additional exact
+//! amplitude checks live in `phase_exactness_test.rs`.
 
 use num_complex::Complex64;
 use pecos_engines::{ClassicalEngine, DenseStateVecEngine, Engine};
@@ -397,6 +395,14 @@ fn parameter_cases(definition: &GateDefinition) -> Vec<Vec<f64>> {
             cases.push(parameters);
         }
     }
+    if matches!(definition.name.as_str(), "crz" | "crx" | "cry") {
+        // Check both sides of each half-angle wrap as well as the boundary.
+        for boundary in [-TAU, TAU, 3.0 * TAU] {
+            for offset in [-1e-7, 0.0, 1e-7] {
+                cases.push(vec![boundary + offset]);
+            }
+        }
+    }
     cases
 }
 
@@ -522,7 +528,11 @@ fn assert_matrix_matches(
         .max_by(|left, right| left.2.total_cmp(&right.2))
         .expect("a unitary matrix is nonempty");
     let phase_ratio = actual[pivot_row][pivot_column] / expected[pivot_row][pivot_column];
-    let phase = phase_ratio / phase_ratio.norm();
+    let phase = if matches!(gate_name, "crz" | "crx" | "cry") {
+        complex(1.0, 0.0)
+    } else {
+        phase_ratio / phase_ratio.norm()
+    };
 
     for (row_index, (actual_row, expected_row)) in actual.iter().zip(expected).enumerate() {
         for (column_index, (&actual_entry, &expected_entry)) in

--- a/crates/pecos-qasm/tests/integration/phase_exactness_test.rs
+++ b/crates/pecos-qasm/tests/integration/phase_exactness_test.rs
@@ -110,6 +110,12 @@ fn apply_expanded_operation(sim: &mut StateVecSoA32, operation: &Operation) {
         Operation::Gate { name, qubits, .. } if name == "H" => {
             sim.h(&[QubitId(qubits[0])]);
         }
+        Operation::Gate { name, qubits, .. } if name == "SX" => {
+            sim.sx(&[QubitId(qubits[0])]);
+        }
+        Operation::Gate { name, qubits, .. } if name == "SXDG" => {
+            sim.sxdg(&[QubitId(qubits[0])]);
+        }
         Operation::Gate {
             name,
             parameters,
@@ -143,6 +149,12 @@ fn apply_expanded_operation(sim: &mut StateVecSoA32, operation: &Operation) {
         }
         Operation::NativeGate(gate) if gate.gate_type == GateType::H => {
             sim.h(&gate.qubits);
+        }
+        Operation::NativeGate(gate) if gate.gate_type == GateType::SX => {
+            sim.sx(&gate.qubits);
+        }
+        Operation::NativeGate(gate) if gate.gate_type == GateType::SXdg => {
+            sim.sxdg(&gate.qubits);
         }
         Operation::NativeGate(gate) if gate.gate_type == GateType::RX => {
             sim.rx(gate.angles[0], &gate.qubits);
@@ -246,6 +258,67 @@ fn controlled_phase_family_remains_exact() {
     assert_controlled_phase("hqslib1.inc", "cp");
     assert_controlled_phase("qelib1.inc", "cu1");
     assert_controlled_phase("qelib1.inc", "cphase");
+}
+
+// At odd multiples of 2*pi, each controlled rotation is exactly Z on the
+// control, independently of the target axis. Compare amplitudes directly so a
+// global -1 cannot be hidden. Exercise each shipped include body by name.
+fn assert_controlled_rotation_wrap_phase_exact(spelling: &str) {
+    for theta in ["2*pi", "-2*pi", "6*pi"] {
+        let qasm = format!(
+            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\n{spelling}({theta}) q[0],q[1];"
+        );
+        let program = QASMParser::parse_str(&qasm).expect("controlled rotation must parse");
+
+        for basis in 0..4 {
+            for superposed_control in [false, true] {
+                let mut sim = StateVecSoA32::new(2);
+                for qubit in 0..2 {
+                    if basis & (1 << qubit) != 0 {
+                        sim.x(&[QubitId(qubit)]);
+                    }
+                }
+                if superposed_control {
+                    sim.h(&[QubitId(0)]);
+                }
+                let expected: [Complex64; 4] = std::array::from_fn(|index| {
+                    let amplitude = complex64(sim.get_amplitude(index));
+                    if index & 1 == 0 {
+                        amplitude
+                    } else {
+                        -amplitude
+                    }
+                });
+
+                for operation in &program.operations {
+                    apply_expanded_operation(&mut sim, operation);
+                }
+                for (index, expected) in expected.iter().enumerate() {
+                    let actual = complex64(sim.get_amplitude(index));
+                    assert!(
+                        (actual - expected).norm() < TOLERANCE,
+                        "{spelling}({theta}), input {basis}, superposed control={superposed_control}, \
+                         amplitude {index}: actual={actual}, expected={expected}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn qelib1_crz_wrap_phase_exact() {
+    assert_controlled_rotation_wrap_phase_exact("crz");
+}
+
+#[test]
+fn qelib1_crx_wrap_phase_exact() {
+    assert_controlled_rotation_wrap_phase_exact("crx");
+}
+
+#[test]
+fn qelib1_cry_wrap_phase_exact() {
+    assert_controlled_rotation_wrap_phase_exact("cry");
 }
 
 #[test]


### PR DESCRIPTION
Closes the QASM half of #670.

`crates/pecos-qasm/includes/qelib1.inc` defined `crz` and `cry` with bodies that are off by a global `-1` at `theta = 2pi (mod 4pi)`, and `crx` inherited it. This is a separate instance from the Rust-side defect #743 fixed: QASM `crz` never reaches `lower_crz`, it expands its own textual body.

```
gate crz(theta) a,b { rz(theta/2) b; cx a,b; rz(-theta/2) b; cx a,b; }
gate cry(theta) a,b { ry(theta/2) b; cx a,b; ry(-theta/2) b; cx a,b; }
```

At `theta = 2pi` the two legs are `+pi` and `-pi`, which collapse to the same `Angle64`, and `rz(-pi) = -rz(pi)`.

`cry` is a **separate instance, not an inheritance** -- its body never mentions `crz`. #670 described the QASM case as `crz` plus whatever derives from it; that was incomplete.

## The fix

Use the `2pi`-periodic phase gate, which `qelib1.inc` already defines as `U(0, 0, lambda)`:

```
gate crz(theta) a,b { p(theta/2) b; cx a,b; p(-theta/2) b; cx a,b; }
gate crx(theta) a,b { h b; crz(theta) a,b; h b; }        // unchanged
gate cry(theta) a,b { sx b; crz(theta) a,b; sxdg b; }    // now routes through crz
```

For control `0` the two phases cancel. For control `1` the target operator is exactly `diag(exp(-i theta/2), exp(i theta/2))`. `p(-pi)` and `p(pi)` are both `diag(1, -1)`, so the `Angle64` collapse that breaks `rz` is harmless here, and no conditional correction is needed.

The dividing line is periodicity, which also explains why `cphase` and `cu1` were always fine: `rz` and `ry` are `4pi`-periodic so their `+-pi` halves are distinct operators, while `p` and `u1` are `2pi`-periodic.

## The defect was demonstrated before it was fixed

`every_include_gate_matches_its_textbook_unitary` already probed `TAU` and `3*PI` for exactly these three gates, and could not fail because it divided out a fitted global phase before comparing. Removing that quotient for `crz`, `crx`, and `cry` only -- other gates in that sweep are genuinely correct only up to phase -- made it fail on the shipped bodies:

```
crx(2*pi): actual = -1.0000000000000002, expected = 1, error = 2
```

After the qelib change the same test passes. The quotient removal is retained, so these three gates are now compared phase-exactly, and the sweep gained cases on both sides of each wrap (`+-TAU`, `3*TAU`, each at `-1e-7`, `0`, `+1e-7`) so continuity is checked rather than just the boundary point.

## Verification

`just rstest debug` -- the recipe the PR gate runs, rather than a `cargo test --workspace` approximation that silently skips optional-feature tests: 12,809 passed across 382 suites, with one failure, the known GPU tolerance test already failing on `dev`. Workspace clippy with all targets and features, formatting, `just build-debug`, `just pytest-ci-core` (8,110 tests), `just python-ci-lint`, and `pre-commit run --all-files` all pass.

New tests `qelib1_crz_wrap_phase_exact`, `qelib1_crx_wrap_phase_exact`, and `qelib1_cry_wrap_phase_exact` exercise each shipped body independently at `2pi`, `-2pi`, and `6pi` with a superposed control and no phase normalisation. `cry` is tested through its own body rather than through `crz`, since it was an independent instance.

Three mutations, each failing a test:

| mutation | result |
|---|---|
| restore `crz`'s `rz`-based body | all three new tests fail, exit 101 |
| restore only `cry`'s original body | only `cry`'s test fails, exit 101 |
| swap the half-angle signs, giving `CRZ(-theta)` | `test_crz_expansion` and the conformance sweep fail, exit 101 |

The third is included because the first two restore a body that fails loudly at `2pi`; the sign swap is correct at `2pi`, where the operator is symmetric, and wrong elsewhere, so it catches a suite that only probes the boundary.

## The downstream regressions, and the tests that pin them closed

An adversarial review of the first version of this branch reproduced four downstream
regressions. Swapping `rz` for `p` changes the emitted native gate from `RZ` to `U`, and four
subsystems did not recognise a phase-shaped `U`:

| regression | measured then |
|---|---|
| noise classification | with `RZ` noiseless, `crz(0.7)` went from `c = 0` in all 1000 shots to 792/208 |
| DEM construction | `DemSampler::from_circuit` failed with "unsupported gate U(...)" |
| PHIR/JSON execution | "Gate type 'U' is not implemented"; `cry` failed first on `SX` |
| HUGR and ZX export | "Unsupported gate type: U" |

Those gaps were **pre-existing, not caused by this branch**: `lower_cphase` already emits
`Gate::u(ZERO, ZERO, half_angle, ..)` and is called from the PHIR executor, so executing any
`CPhase` reached the same paths. They are fixed in #760, which is merged; this branch is
rebased on top of it.

`crates/pecos-qasm/tests/controlled_rotation_downstream.rs` adds eight tests that exercise the
combination through the QASM surface, because #760's tests build a `U` by hand while this
branch is what makes QASM emit one -- the combination is what regressed:

| assertion | result |
|---|---|
| `crz(0.7)` with `RZ` noiseless is deterministic | `c = 0` in all 1000 shots |
| a general `U` with non-zero `theta` remains noisy | noise still fires |
| `DemSampler::from_circuit` accepts the `crz(pi)` expansion | passes |
| PHIR/JSON executes `crz`, `crx`, `cry` at `pi`, both control states | passes |
| HUGR export succeeds for all three at `pi` and `0.7` | passes |
| `crz(0)` optimises away again | four gates to two CX to zero |

The second row was initially written with a noise rate of `0.0`, which made it vacuous: with
no noise configured the outcome is deterministic whatever the classification, so it could not
distinguish "general `U` is exempt" from "general `U` is noisy". It now uses a non-zero rate
and asserts noise fires, and was confirmed non-vacuous by broadening the exemption to accept
any `U`, which the strengthened test catches and the original passed.

## Expected structural changes

`cry` goes from four gates to six now that it routes through `crz`, and `crz`'s legs are `U` rather than `RZ`. Four structural tests were updated to match: `test_controlled_rotation_gates`, `test_crz_expansion`, `test_crx_expansion`, and `test_cry_expansion`. These assert gate counts and types, not physics.

## Scope

Only `qelib1.inc` and tests. `controlled_rotations.rs`, `Angle64`, the parser, and the native gate table are untouched. A repo-wide search for a `+-theta/2` half applied to a `4pi`-periodic rotation returns exactly four lines, all in `qelib1.inc`, covering only `crz` and `cry`; `hqslib1.inc` and `pecos.inc` do not define these gates.

`rxx` was checked and is unaffected: its body passes `rz(theta)` unhalved. `rzz` maps directly to the native gate. Whether PECOS's native rotations should be `4pi`-periodic at all is a separate question tracked in `pecos-docs/design/phase-exactness-program.md`.
