### PR TITLE
Dispatch pecos-neo noise events only to channels that declare the event kind

### DIFF
--- a/exp/pecos-neo/src/lib.rs
+++ b/exp/pecos-neo/src/lib.rs
@@ -226,9 +226,9 @@ pub use extensible::{
     stabilizer_gates,
 };
 pub use noise::{
-    ComposableNoiseModel, ContextObserver, EventHandler, GeneralNoiseModelBuilder, NoiseChannel,
-    NoiseContext, NoiseEvent, NoiseModelConfig, NoisePlugin, NoiseResponse, PauliWeights,
-    TwoQubitPauliWeights,
+    ComposableNoiseModel, ContextObserver, EventHandler, EventKinds, GeneralNoiseModelBuilder,
+    NoiseChannel, NoiseContext, NoiseEvent, NoiseEventKind, NoiseModelConfig, NoisePlugin,
+    NoiseResponse, PauliWeights, TwoQubitPauliWeights,
     context::QubitState,
     correlated::{CorrelatedNoiseChannel, CorrelationStats},
     crosstalk::CrosstalkChannel,
@@ -308,9 +308,9 @@ pub mod prelude {
         stabilizer_gates,
     };
     pub use crate::noise::{
-        ComposableNoiseModel, ContextObserver, EventHandler, GeneralNoiseModelBuilder,
-        NoiseChannel, NoiseContext, NoiseEvent, NoiseModelConfig, NoisePlugin, NoiseResponse,
-        PauliWeights, TwoQubitPauliWeights,
+        ComposableNoiseModel, ContextObserver, EventHandler, EventKinds, GeneralNoiseModelBuilder,
+        NoiseChannel, NoiseContext, NoiseEvent, NoiseEventKind, NoiseModelConfig, NoisePlugin,
+        NoiseResponse, PauliWeights, TwoQubitPauliWeights,
         context::QubitState,
         correlated::{CorrelatedNoiseChannel, CorrelationStats},
         crosstalk::CrosstalkChannel,

--- a/exp/pecos-neo/src/noise.rs
+++ b/exp/pecos-neo/src/noise.rs
@@ -121,6 +121,9 @@ pub mod topology;
 pub mod two_qubit;
 pub mod validation;
 
+#[cfg(test)]
+mod event_kind_tests;
+
 pub use builder::NoiseModelBuilder;
 pub use category_channel::CategoryBasedChannel;
 pub use composer::ComposableNoiseModel;
@@ -146,6 +149,92 @@ use pecos_core::{Angle64, QubitId, Signal, TimeUnits};
 use pecos_random::PecosRng;
 use smallvec::SmallVec;
 use std::any::{Any, TypeId};
+
+macro_rules! declare_noise_event_kinds {
+    ($($variant:ident),+ $(,)?) => {
+        /// The payload-independent kind of a noise event.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum NoiseEventKind {
+            $(
+                #[doc = concat!("The kind of [`NoiseEvent::", stringify!($variant), "`].")]
+                $variant,
+            )+
+        }
+
+        impl NoiseEventKind {
+            pub(crate) const COUNT: usize = [$(Self::$variant),+].len();
+            pub(crate) const ALL: [Self; Self::COUNT] = [$(Self::$variant),+];
+
+            pub(crate) const fn index(self) -> usize {
+                // Implicit discriminants follow the declaration (and ALL) order.
+                self as usize
+            }
+        }
+
+        // Keep the list exhaustive even if the enum generation is later changed.
+        const fn noise_event_kinds_are_exhaustive(kind: NoiseEventKind) {
+            match kind {
+                $(NoiseEventKind::$variant => {}),+
+            }
+        }
+
+        const _: () = noise_event_kinds_are_exhaustive(NoiseEventKind::ALL[0]);
+    };
+}
+
+declare_noise_event_kinds!(
+    BeforeGate,
+    AfterGate,
+    BeforeMeasurement,
+    AfterMeasurement,
+    AfterPreparation,
+    IdleTime,
+    AfterReset,
+    BeforeCircuit,
+    AfterCircuit,
+    BetweenLayers,
+    Signal,
+);
+
+/// Construction-time event subscriptions for a noise channel or handler.
+///
+/// A declaration may include extra kinds, but must include every kind the
+/// implementation can handle. The composer caches this set at insertion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventKinds(u16);
+
+impl EventKinds {
+    /// Number of distinct noise event kinds.
+    pub const COUNT: usize = NoiseEventKind::COUNT;
+    /// Subscribe to every event kind (the conservative default).
+    pub const ALL: Self = Self((1 << Self::COUNT) - 1);
+    /// Subscribe to no event kinds.
+    pub const NONE: Self = Self(0);
+
+    /// Subscribe to a single event kind.
+    #[must_use]
+    pub const fn of(kind: NoiseEventKind) -> Self {
+        Self(1 << kind.index())
+    }
+
+    /// Include another kind.
+    #[must_use]
+    pub const fn with(self, kind: NoiseEventKind) -> Self {
+        self.union(Self::of(kind))
+    }
+
+    /// Check whether a kind is included.
+    #[must_use]
+    pub const fn contains(self, kind: NoiseEventKind) -> bool {
+        self.0 & Self::of(kind).0 != 0
+    }
+
+    /// Combine two declarations.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
 
 /// Events that can trigger noise in the simulation.
 ///
@@ -252,6 +341,24 @@ pub enum NoiseEvent<'a> {
 }
 
 impl<'a> NoiseEvent<'a> {
+    /// Get the payload-independent event kind.
+    #[must_use]
+    pub const fn kind(&self) -> NoiseEventKind {
+        match self {
+            Self::BeforeGate { .. } => NoiseEventKind::BeforeGate,
+            Self::AfterGate { .. } => NoiseEventKind::AfterGate,
+            Self::BeforeMeasurement { .. } => NoiseEventKind::BeforeMeasurement,
+            Self::AfterMeasurement { .. } => NoiseEventKind::AfterMeasurement,
+            Self::AfterPreparation { .. } => NoiseEventKind::AfterPreparation,
+            Self::IdleTime { .. } => NoiseEventKind::IdleTime,
+            Self::AfterReset { .. } => NoiseEventKind::AfterReset,
+            Self::BeforeCircuit { .. } => NoiseEventKind::BeforeCircuit,
+            Self::AfterCircuit { .. } => NoiseEventKind::AfterCircuit,
+            Self::BetweenLayers { .. } => NoiseEventKind::BetweenLayers,
+            Self::Signal { .. } => NoiseEventKind::Signal,
+        }
+    }
+
     /// Create a `BeforeGate` event with gate ID derived from gate type.
     ///
     /// The `gate_id` is automatically set to `gate_type.to_gate_id()`, enabling
@@ -634,6 +741,15 @@ impl NoiseResponse {
 /// measurement errors, leakage). The composer combines multiple channels to form
 /// a complete noise model.
 pub trait NoiseChannel: Send + Sync {
+    /// Declare every kind on which `try_apply` can return a response.
+    ///
+    /// This must depend only on construction-time configuration and must not
+    /// change after insertion into a model. The model caches the declaration.
+    /// Extra kinds are safe; missing a supported kind silently drops noise.
+    fn event_kinds(&self) -> EventKinds {
+        EventKinds::ALL
+    }
+
     /// Check if this channel responds to a given event.
     ///
     /// This is an optimization to avoid calling `apply` for events the channel

--- a/exp/pecos-neo/src/noise/category_channel.rs
+++ b/exp/pecos-neo/src/noise/category_channel.rs
@@ -124,6 +124,10 @@ impl CategoryBasedChannel {
 }
 
 impl NoiseChannel for CategoryBasedChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         // We respond to AfterGate events, but we need context to check category.
         // Return true here and do the check in apply().

--- a/exp/pecos-neo/src/noise/composer.rs
+++ b/exp/pecos-neo/src/noise/composer.rs
@@ -22,7 +22,9 @@
 use super::context::NoiseContext;
 use super::idle::IdleChannel;
 use super::plugin::{ContextObserver, EventHandler, NoiseModelConfig, NoisePlugin};
-use super::{NoiseChannel, NoiseEvent, NoiseGateRequirement, NoiseResponse};
+use super::{
+    EventKinds, NoiseChannel, NoiseEvent, NoiseEventKind, NoiseGateRequirement, NoiseResponse,
+};
 use crate::command::GateType;
 use pecos_core::{QubitId, TimeScale};
 use pecos_random::PecosRng;
@@ -60,6 +62,10 @@ pub struct ComposableNoiseModel {
     /// Noise channels that produce noise responses.
     channels: Vec<Box<dyn NoiseChannel>>,
 
+    /// Indices into the source vectors, preserving their dispatch order.
+    channel_buckets: [Vec<usize>; EventKinds::COUNT],
+    handler_buckets: [Vec<usize>; EventKinds::COUNT],
+
     /// Runner capabilities required by configured gate-injection mechanisms.
     gate_requirements: Vec<NoiseGateRequirement>,
 
@@ -78,25 +84,32 @@ pub struct ComposableNoiseModel {
 
 impl std::fmt::Debug for ComposableNoiseModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Buckets are derived indices, not part of the model's diagnostic view.
+        let Self {
+            event_handlers,
+            channels,
+            gate_requirements,
+            observers,
+            context,
+            time_scale,
+            channel_buckets: _,
+            handler_buckets: _,
+        } = self;
         f.debug_struct("ComposableNoiseModel")
-            .field("time_scale", &self.time_scale)
-            .field("gate_requirements", &self.gate_requirements)
-            .field("event_handler_count", &self.event_handlers.len())
+            .field("time_scale", &time_scale)
+            .field("gate_requirements", &gate_requirements)
+            .field("event_handler_count", &event_handlers.len())
             .field(
                 "event_handler_names",
-                &self
-                    .event_handlers
-                    .iter()
-                    .map(|h| h.name())
-                    .collect::<Vec<_>>(),
+                &event_handlers.iter().map(|h| h.name()).collect::<Vec<_>>(),
             )
-            .field("channel_count", &self.channels.len())
+            .field("channel_count", &channels.len())
             .field(
                 "channel_names",
-                &self.channels.iter().map(|c| c.name()).collect::<Vec<_>>(),
+                &channels.iter().map(|c| c.name()).collect::<Vec<_>>(),
             )
-            .field("observer_count", &self.observers.len())
-            .field("context", &self.context)
+            .field("observer_count", &observers.len())
+            .field("context", &context)
             .finish()
     }
 }
@@ -114,6 +127,8 @@ impl ComposableNoiseModel {
         Self {
             event_handlers: Vec::new(),
             channels: Vec::new(),
+            channel_buckets: std::array::from_fn(|_| Vec::new()),
+            handler_buckets: std::array::from_fn(|_| Vec::new()),
             gate_requirements: Vec::new(),
             observers: Vec::new(),
             context: NoiseContext::new(),
@@ -198,12 +213,15 @@ impl ComposableNoiseModel {
                 .iter()
                 .flat_map(|channel| channel.gate_requirements()),
         );
-        self.channels.extend(config.channels);
+        for channel in config.channels {
+            self.push_channel(channel);
+        }
         self.observers.extend(config.observers);
 
         // Keep handlers sorted by priority (high to low) for efficient iteration
         self.event_handlers
             .sort_by_key(|h| std::cmp::Reverse(h.priority()));
+        self.rebuild_handler_buckets();
 
         self
     }
@@ -214,7 +232,7 @@ impl ComposableNoiseModel {
     #[must_use]
     pub fn add_channel(mut self, channel: impl NoiseChannel + 'static) -> Self {
         self.gate_requirements.extend(channel.gate_requirements());
-        self.channels.push(Box::new(channel));
+        self.push_channel(Box::new(channel));
         self
     }
 
@@ -233,7 +251,7 @@ impl ComposableNoiseModel {
                     ..requirement
                 }
             }));
-        self.channels.push(Box::new(channel));
+        self.push_channel(Box::new(channel));
         self
     }
 
@@ -244,7 +262,7 @@ impl ComposableNoiseModel {
     #[must_use]
     pub fn add_boxed_channel(mut self, channel: Box<dyn NoiseChannel>) -> Self {
         self.gate_requirements.extend(channel.gate_requirements());
-        self.channels.push(channel);
+        self.push_channel(channel);
         self
     }
 
@@ -295,8 +313,31 @@ impl ComposableNoiseModel {
     /// For plugin-based configuration, use `add_plugin()` instead.
     #[must_use]
     pub fn add_event_handler(mut self, handler: impl EventHandler + 'static) -> Self {
+        index_kinds(
+            &mut self.handler_buckets,
+            self.event_handlers.len(),
+            handler.event_kinds(),
+        );
         self.event_handlers.push(Box::new(handler));
         self
+    }
+
+    fn push_channel(&mut self, channel: Box<dyn NoiseChannel>) {
+        index_kinds(
+            &mut self.channel_buckets,
+            self.channels.len(),
+            channel.event_kinds(),
+        );
+        self.channels.push(channel);
+    }
+
+    fn rebuild_handler_buckets(&mut self) {
+        for bucket in &mut self.handler_buckets {
+            bucket.clear();
+        }
+        for (index, handler) in self.event_handlers.iter().enumerate() {
+            index_kinds(&mut self.handler_buckets, index, handler.event_kinds());
+        }
     }
 
     /// Add a context observer directly to the model.
@@ -424,7 +465,8 @@ impl ComposableNoiseModel {
 
         // 2. Collect responses from noise channels using try_apply for efficiency
         let mut combined = NoiseResponse::None;
-        for channel in &self.channels {
+        for &index in &self.channel_buckets[event.kind().index()] {
+            let channel = &self.channels[index];
             // try_apply combines responds_to + apply in one call
             // filter out NoiseResponse::None to avoid unnecessary combine calls
             if let Some(response) = channel
@@ -454,12 +496,11 @@ impl ComposableNoiseModel {
         // Collect indices of handlers that respond to this event.
         // This allows us to release the borrow on self.event_handlers
         // before mutably borrowing self.context.
-        let handler_indices: smallvec::SmallVec<[usize; 4]> = self
-            .event_handlers
+        let bucket = &self.handler_buckets[event.kind().index()];
+        let handler_indices: smallvec::SmallVec<[usize; 4]> = bucket
             .iter()
-            .enumerate()
-            .filter(|(_, h)| h.handles(event))
-            .map(|(i, _)| i)
+            .copied()
+            .filter(|&i| self.event_handlers[i].handles(event))
             .collect();
 
         for i in handler_indices {
@@ -551,6 +592,14 @@ impl ComposableNoiseModel {
     }
 }
 
+fn index_kinds(buckets: &mut [Vec<usize>; EventKinds::COUNT], index: usize, kinds: EventKinds) {
+    for kind in NoiseEventKind::ALL {
+        if kinds.contains(kind) {
+            buckets[kind.index()].push(index);
+        }
+    }
+}
+
 fn supports_clifford_noise_gate(gate_type: GateType) -> bool {
     matches!(
         gate_type,
@@ -606,6 +655,8 @@ impl Clone for ComposableNoiseModel {
         Self {
             event_handlers: self.event_handlers.iter().map(|h| h.clone_box()).collect(),
             channels: self.channels.iter().map(|c| c.clone_box()).collect(),
+            channel_buckets: self.channel_buckets.clone(),
+            handler_buckets: self.handler_buckets.clone(),
             gate_requirements: self.gate_requirements.clone(),
             observers: self.observers.iter().map(|o| o.clone_box()).collect(),
             context: self.context.clone(),
@@ -643,6 +694,592 @@ impl From<super::GeneralNoiseModelBuilder> for ComposableNoiseModel {
 
 #[cfg(test)]
 mod tests {
+    use crate::noise::event_kind_tests::{representative, witnesses};
+    use std::sync::{Arc, Mutex};
+
+    type DispatchLog = Arc<Mutex<Vec<(&'static str, &'static str, NoiseEventKind)>>>;
+
+    #[derive(Clone)]
+    struct Recorder {
+        label: &'static str,
+        priority: i32,
+        selected: bool,
+        log: DispatchLog,
+    }
+
+    impl NoiseChannel for Recorder {
+        fn responds_to(&self, _event: &NoiseEvent<'_>) -> bool {
+            // Deliberately differs from try_apply to pin optimized dispatch.
+            false
+        }
+
+        fn apply(
+            &self,
+            _event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            _rng: &mut PecosRng,
+        ) -> NoiseResponse {
+            panic!("the composer must call try_apply");
+        }
+
+        fn try_apply(
+            &self,
+            event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            _rng: &mut PecosRng,
+        ) -> Option<NoiseResponse> {
+            self.log
+                .lock()
+                .unwrap()
+                .push(("try_apply", self.label, event.kind()));
+            Some(NoiseResponse::None)
+        }
+
+        fn name(&self) -> &'static str {
+            self.label
+        }
+        fn clone_box(&self) -> Box<dyn NoiseChannel> {
+            Box::new(self.clone())
+        }
+    }
+
+    impl EventHandler for Recorder {
+        fn handles(&self, event: &NoiseEvent<'_>) -> bool {
+            self.log
+                .lock()
+                .unwrap()
+                .push(("handles", self.label, event.kind()));
+            self.selected
+        }
+
+        fn handle(&self, event: &NoiseEvent<'_>, _ctx: &mut NoiseContext) {
+            self.log
+                .lock()
+                .unwrap()
+                .push(("handle", self.label, event.kind()));
+        }
+
+        fn name(&self) -> &'static str {
+            self.label
+        }
+        fn priority(&self) -> i32 {
+            self.priority
+        }
+        fn clone_box(&self) -> Box<dyn EventHandler> {
+            Box::new(self.clone())
+        }
+    }
+
+    struct RecordingPlugin {
+        handlers: Vec<Recorder>,
+        channels: Vec<Recorder>,
+    }
+
+    #[derive(Clone)]
+    struct KindRecorder {
+        inner: Recorder,
+        kinds: EventKinds,
+    }
+
+    impl NoiseChannel for KindRecorder {
+        fn event_kinds(&self) -> EventKinds {
+            self.kinds
+        }
+        fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
+            self.kinds.contains(event.kind())
+        }
+        fn apply(
+            &self,
+            _event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            _rng: &mut PecosRng,
+        ) -> NoiseResponse {
+            NoiseResponse::None
+        }
+        fn try_apply(
+            &self,
+            event: &NoiseEvent<'_>,
+            ctx: &mut NoiseContext,
+            rng: &mut PecosRng,
+        ) -> Option<NoiseResponse> {
+            let response = self.inner.try_apply(event, ctx, rng);
+            if self.responds_to(event) {
+                response
+            } else {
+                None
+            }
+        }
+        fn name(&self) -> &'static str {
+            self.inner.label
+        }
+        fn clone_box(&self) -> Box<dyn NoiseChannel> {
+            Box::new(self.clone())
+        }
+    }
+
+    impl EventHandler for KindRecorder {
+        fn event_kinds(&self) -> EventKinds {
+            self.kinds
+        }
+        fn handles(&self, event: &NoiseEvent<'_>) -> bool {
+            self.inner.handles(event) && self.kinds.contains(event.kind())
+        }
+        fn handle(&self, event: &NoiseEvent<'_>, ctx: &mut NoiseContext) {
+            self.inner.handle(event, ctx);
+        }
+        fn clone_box(&self) -> Box<dyn EventHandler> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[test]
+    fn excluded_kinds_do_not_visit_channels_or_handlers() {
+        let log: DispatchLog = Arc::default();
+        let recorder = |label, kinds| KindRecorder {
+            inner: Recorder {
+                label,
+                priority: 0,
+                selected: true,
+                log: log.clone(),
+            },
+            kinds,
+        };
+        let prep = recorder("prep", EventKinds::of(NoiseEventKind::AfterPreparation));
+        let never = recorder("never", EventKinds::NONE);
+        let mut model = ComposableNoiseModel::new()
+            .add_channel(never.clone())
+            .add_channel(prep.clone())
+            .add_event_handler(never)
+            .add_event_handler(prep);
+        let mut rng = PecosRng::seed_from_u64(42);
+        for kind in NoiseEventKind::ALL {
+            log.lock().unwrap().clear();
+            model.emit(&representative(kind), &mut rng);
+            if kind == NoiseEventKind::AfterPreparation {
+                assert_eq!(
+                    *log.lock().unwrap(),
+                    [
+                        ("handles", "prep", kind),
+                        ("handle", "prep", kind),
+                        ("try_apply", "prep", kind),
+                    ]
+                );
+            } else {
+                assert!(log.lock().unwrap().is_empty());
+            }
+        }
+    }
+
+    impl NoisePlugin for RecordingPlugin {
+        fn build(&self, config: &mut NoiseModelConfig) {
+            for handler in &self.handlers {
+                config.add_event_handler(handler.clone());
+            }
+            for channel in &self.channels {
+                config.add_channel(channel.clone());
+            }
+        }
+    }
+
+    #[test]
+    fn default_declarations_dispatch_every_kind_at_every_insertion_point() {
+        let log: DispatchLog = Arc::default();
+        let recorder = |label| Recorder {
+            label,
+            priority: 0,
+            selected: true,
+            log: log.clone(),
+        };
+        let mut model = ComposableNoiseModel::new()
+            .add_channel(recorder("direct"))
+            .add_channel_configured_by(recorder("configured"), "test", "test")
+            .add_boxed_channel(Box::new(recorder("boxed")))
+            .add_plugin(&RecordingPlugin {
+                handlers: vec![recorder("plugin_handler")],
+                channels: vec![recorder("plugin_channel")],
+            })
+            .add_event_handler(recorder("direct_handler"));
+        assert_eq!(
+            model.channel_names(),
+            ["direct", "configured", "boxed", "plugin_channel"]
+        );
+        let mut rng = PecosRng::seed_from_u64(42);
+        for kind in NoiseEventKind::ALL {
+            log.lock().unwrap().clear();
+            model.emit(&representative(kind), &mut rng);
+            assert_eq!(
+                *log.lock().unwrap(),
+                [
+                    ("handles", "plugin_handler", kind),
+                    ("handles", "direct_handler", kind),
+                    ("handle", "plugin_handler", kind),
+                    ("handle", "direct_handler", kind),
+                    ("try_apply", "direct", kind),
+                    ("try_apply", "configured", kind),
+                    ("try_apply", "boxed", kind),
+                    ("try_apply", "plugin_channel", kind),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn handler_buckets_preserve_stable_sort_append_and_two_phase_dispatch() {
+        let log: DispatchLog = Arc::default();
+        let recorder = |label, priority, selected| Recorder {
+            label,
+            priority,
+            selected,
+            log: log.clone(),
+        };
+        let mut model = ComposableNoiseModel::new()
+            .add_event_handler(recorder("direct_first", 10, true))
+            .add_plugin(&RecordingPlugin {
+                handlers: vec![
+                    recorder("low", 1, false),
+                    recorder("high_a", 20, true),
+                    recorder("high_b", 20, true),
+                ],
+                channels: vec![],
+            })
+            .add_event_handler(recorder("direct_last", 100, true));
+        let kind = NoiseEventKind::AfterGate;
+        let event = representative(kind);
+        let mut rng = PecosRng::seed_from_u64(42);
+        model.emit(&event, &mut rng);
+        assert_eq!(
+            *log.lock().unwrap(),
+            [
+                ("handles", "high_a", kind),
+                ("handles", "high_b", kind),
+                ("handles", "direct_first", kind),
+                ("handles", "low", kind),
+                ("handles", "direct_last", kind),
+                ("handle", "high_a", kind),
+                ("handle", "high_b", kind),
+                ("handle", "direct_first", kind),
+                ("handle", "direct_last", kind),
+            ]
+        );
+
+        // Another plugin sorts the entire vector, including previous direct appends.
+        model = model.add_plugin(&RecordingPlugin {
+            handlers: vec![recorder("high_c", 20, true)],
+            channels: vec![],
+        });
+        log.lock().unwrap().clear();
+        model.emit(&event, &mut rng);
+        assert_eq!(
+            *log.lock().unwrap(),
+            [
+                ("handles", "direct_last", kind),
+                ("handles", "high_a", kind),
+                ("handles", "high_b", kind),
+                ("handles", "high_c", kind),
+                ("handles", "direct_first", kind),
+                ("handles", "low", kind),
+                ("handle", "direct_last", kind),
+                ("handle", "high_a", kind),
+                ("handle", "high_b", kind),
+                ("handle", "high_c", kind),
+                ("handle", "direct_first", kind),
+            ]
+        );
+    }
+
+    // ALL adapters recreate flat-vector dispatch without changing any predicate,
+    // optimized try_apply, gate requirements, priority or response.
+    struct AllChannel(Box<dyn NoiseChannel>);
+    impl NoiseChannel for AllChannel {
+        fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
+            self.0.responds_to(event)
+        }
+        fn apply(
+            &self,
+            event: &NoiseEvent<'_>,
+            ctx: &mut NoiseContext,
+            rng: &mut PecosRng,
+        ) -> NoiseResponse {
+            self.0.apply(event, ctx, rng)
+        }
+        fn try_apply(
+            &self,
+            event: &NoiseEvent<'_>,
+            ctx: &mut NoiseContext,
+            rng: &mut PecosRng,
+        ) -> Option<NoiseResponse> {
+            self.0.try_apply(event, ctx, rng)
+        }
+        fn name(&self) -> &'static str {
+            self.0.name()
+        }
+        fn priority(&self) -> i32 {
+            self.0.priority()
+        }
+        fn gate_requirements(&self) -> smallvec::SmallVec<[NoiseGateRequirement; 2]> {
+            self.0.gate_requirements()
+        }
+        fn clone_box(&self) -> Box<dyn NoiseChannel> {
+            Box::new(Self(self.0.clone_box()))
+        }
+    }
+
+    struct AllHandler(Box<dyn EventHandler>);
+    impl EventHandler for AllHandler {
+        fn handles(&self, event: &NoiseEvent<'_>) -> bool {
+            self.0.handles(event)
+        }
+        fn handle(&self, event: &NoiseEvent<'_>, ctx: &mut NoiseContext) {
+            self.0.handle(event, ctx);
+        }
+        fn name(&self) -> &'static str {
+            self.0.name()
+        }
+        fn priority(&self) -> i32 {
+            self.0.priority()
+        }
+        fn clone_box(&self) -> Box<dyn EventHandler> {
+            Box::new(Self(self.0.clone_box()))
+        }
+    }
+
+    fn assert_same_response(actual: &NoiseResponse, expected: &NoiseResponse) {
+        use NoiseResponse::{
+            FlipOutcomes, ForceOutcomes, InjectGates, LeakedMeasurement, MarkLeaked, MarkUnleaked,
+            Multiple, None, SkipGate,
+        };
+        match (actual, expected) {
+            (None, None) | (SkipGate, SkipGate) => {}
+            (InjectGates(a), InjectGates(b)) => assert_eq!(a, b),
+            (FlipOutcomes(a), FlipOutcomes(b))
+            | (MarkLeaked(a), MarkLeaked(b))
+            | (MarkUnleaked(a), MarkUnleaked(b))
+            | (LeakedMeasurement(a), LeakedMeasurement(b)) => assert_eq!(a, b),
+            (ForceOutcomes(a), ForceOutcomes(b)) => assert_eq!(a, b),
+            (Multiple(a), Multiple(b)) => {
+                assert_eq!(a.len(), b.len());
+                for (a, b) in a.iter().zip(b) {
+                    assert_same_response(a, b);
+                }
+            }
+            _ => panic!("response variants differ: {actual:?} vs {expected:?}"),
+        }
+    }
+
+    #[derive(Clone)]
+    struct OptimizedEmptyChannel;
+
+    impl NoiseChannel for OptimizedEmptyChannel {
+        fn event_kinds(&self) -> EventKinds {
+            EventKinds::NONE
+        }
+
+        fn responds_to(&self, _event: &NoiseEvent<'_>) -> bool {
+            true
+        }
+
+        fn apply(
+            &self,
+            _event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            _rng: &mut PecosRng,
+        ) -> NoiseResponse {
+            NoiseResponse::None
+        }
+
+        fn try_apply(
+            &self,
+            _event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            _rng: &mut PecosRng,
+        ) -> Option<NoiseResponse> {
+            None
+        }
+
+        fn name(&self) -> &'static str {
+            "OptimizedEmptyChannel"
+        }
+
+        fn clone_box(&self) -> Box<dyn NoiseChannel> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct RandomProbeChannel;
+
+    impl NoiseChannel for RandomProbeChannel {
+        fn responds_to(&self, _event: &NoiseEvent<'_>) -> bool {
+            true
+        }
+
+        fn apply(
+            &self,
+            _event: &NoiseEvent<'_>,
+            _ctx: &mut NoiseContext,
+            rng: &mut PecosRng,
+        ) -> NoiseResponse {
+            if rng.next_u64() > u64::MAX / 2 {
+                NoiseResponse::SkipGate
+            } else {
+                NoiseResponse::None
+            }
+        }
+
+        fn name(&self) -> &'static str {
+            "RandomProbeChannel"
+        }
+
+        fn clone_box(&self) -> Box<dyn NoiseChannel> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[test]
+    fn importance_wrapper_preserves_rng_when_inner_optimized_dispatch_is_empty() {
+        use crate::sampling::importance::{ImportanceConfig, ImportanceSamplingChannel};
+
+        // The inner declaration covers its optimized try_apply, not responds_to.
+        // The wrapper uses responds_to and consumes a proposal draw regardless
+        // of whether the inner channel produces a response.
+        let wrapper = ImportanceSamplingChannel::new(
+            OptimizedEmptyChannel,
+            ImportanceConfig::with_boost(0.02, 10.0),
+        );
+        let mut bucketed = ComposableNoiseModel::new()
+            .add_channel(wrapper.clone())
+            .add_channel(RandomProbeChannel);
+        let mut flat = ComposableNoiseModel::new()
+            .add_channel(AllChannel(Box::new(wrapper)))
+            .add_channel(AllChannel(Box::new(RandomProbeChannel)));
+        let mut rng = PecosRng::seed_from_u64(42);
+        let mut flat_rng = PecosRng::seed_from_u64(42);
+        let mut events = vec![NoiseEvent::BeforeCircuit { num_qubits: 1 }];
+        events.extend(witnesses());
+
+        for (index, event) in events.iter().enumerate() {
+            let expected = flat.emit(event, &mut flat_rng);
+            if index == 0 {
+                // Seed 42 pins the reproducer: omitting the proposal draw makes
+                // the probe emit SkipGate instead of None on the first event.
+                assert_same_response(&expected, &NoiseResponse::None);
+            }
+            assert_same_response(&bucketed.emit(event, &mut rng), &expected);
+        }
+        assert_eq!(rng.next_u64(), flat_rng.next_u64());
+    }
+
+    fn equivalence_model(idle_family: usize) -> ComposableNoiseModel {
+        use crate::noise::composite::channel::{
+            BatchCompositeChannel, CompositeChannel, CompositeCrosstalkChannel,
+            CompositeEventFilter,
+        };
+        use crate::noise::composite::prelude::pauli;
+        use crate::noise::*;
+        use crate::sampling::importance::{ImportanceConfig, ImportanceSamplingChannel};
+        let axes = std::collections::BTreeMap::from([("Z".into(), 1.0)]);
+        let builder = GeneralNoiseModelBuilder::new()
+            .with_p1(0.2)
+            .with_p2(0.3)
+            .with_p1_emission_ratio(0.2)
+            .with_p2_emission_ratio(0.2)
+            .with_p1_seepage(0.2)
+            .with_p2_seepage(0.2)
+            .with_p_prep(0.2)
+            .with_p_prep_leak_ratio(0.2)
+            .with_p_meas(0.2, 0.3)
+            .with_p_meas_state_flip(0.2)
+            .with_p_prep_crosstalk(0.2)
+            .with_p_meas_crosstalk(0.3, 0.2)
+            .with_p_idle_linear(0.1, &axes)
+            .with_idle_after_2q(1.0);
+        let builder = match idle_family {
+            0 => builder.with_p_idle_sin_squared(0.2, &axes),
+            1 => builder.with_p_idle_quadratic(0.2),
+            2 => builder
+                .with_p_idle_quadratic(0.2)
+                .with_p_idle_coherent(true),
+            _ => unreachable!("test defines three idle configurations"),
+        };
+        builder
+            .build()
+            .add_channel(CategoryBasedChannel::new().with_default(0.2))
+            .add_channel(GateDependentChannel::new().with_gate_error(GateType::H, 0.2))
+            .add_channel(GateIdDependentChannel::new().with_gate_type_error(GateType::CX, 0.2))
+            .add_channel(CorrelatedNoiseChannel::new(0.2, 0.5))
+            .add_channel(
+                PerGatePauliChannel::new()
+                    .with_base(0.2, 0.2)
+                    .with_meas_init(0.2, 0.2),
+            )
+            .add_channel(ImportanceSamplingChannel::new(
+                SingleQubitChannel::depolarizing(0.2),
+                ImportanceConfig::with_boost(0.02, 10.0),
+            ))
+            .add_channel(
+                CompositeChannel::new("composite", pauli())
+                    .with_filter(CompositeEventFilter::BeforeGate)
+                    .with_filter(CompositeEventFilter::AfterReset)
+                    .with_filter(CompositeEventFilter::BetweenLayers),
+            )
+            .add_channel(
+                BatchCompositeChannel::new("batch", 0.2, pauli())
+                    .with_filter(CompositeEventFilter::AnyGate),
+            )
+            .add_channel(
+                CompositeCrosstalkChannel::new("crosstalk", pauli())
+                    .responds_to_gates()
+                    .responds_to_measurement()
+                    .responds_to_preparation(),
+            )
+    }
+
+    #[test]
+    fn bucketed_and_all_kind_dispatch_and_clone_emit_identically() {
+        for idle_family in 0..3 {
+            let mut bucketed = equivalence_model(idle_family);
+            let mut flat = equivalence_model(idle_family);
+            flat.channels = flat
+                .channels
+                .into_iter()
+                .map(|channel| Box::new(AllChannel(channel)) as Box<dyn NoiseChannel>)
+                .collect();
+            flat.event_handlers = flat
+                .event_handlers
+                .into_iter()
+                .map(|handler| Box::new(AllHandler(handler)) as Box<dyn EventHandler>)
+                .collect();
+            flat.channel_buckets = std::array::from_fn(|_| Vec::new());
+            for (index, channel) in flat.channels.iter().enumerate() {
+                index_kinds(&mut flat.channel_buckets, index, channel.event_kinds());
+            }
+            flat.rebuild_handler_buckets();
+            assert_eq!(bucketed.channel_names(), flat.channel_names());
+            assert_eq!(bucketed.gate_requirements, flat.gate_requirements);
+            assert_eq!(bucketed.describe(), flat.describe());
+            let mut cloned = bucketed.clone();
+            assert_eq!(bucketed.channel_buckets, cloned.channel_buckets);
+            assert_eq!(bucketed.handler_buckets, cloned.handler_buckets);
+            let mut rng = PecosRng::seed_from_u64(12345);
+            let mut flat_rng = PecosRng::seed_from_u64(12345);
+            let mut clone_rng = PecosRng::seed_from_u64(12345);
+            let mut events = vec![NoiseEvent::AfterPreparation {
+                qubits: &[QubitId(0), QubitId(1), QubitId(2), QubitId(3)],
+            }];
+            events.extend(witnesses());
+            for _ in 0..4 {
+                for event in &events {
+                    let response = bucketed.emit(event, &mut rng);
+                    assert_same_response(&response, &flat.emit(event, &mut flat_rng));
+                    assert_same_response(&response, &cloned.emit(event, &mut clone_rng));
+                }
+            }
+            let next = rng.random::<u64>();
+            assert_eq!(next, flat_rng.random::<u64>());
+            assert_eq!(next, clone_rng.random::<u64>());
+        }
+    }
+
     use super::*;
     use crate::command::{GateCommand, GateType};
     use crate::noise::plugins::CorePlugin;

--- a/exp/pecos-neo/src/noise/composite/channel.rs
+++ b/exp/pecos-neo/src/noise/composite/channel.rs
@@ -19,6 +19,7 @@
 use super::Primitive;
 use super::batch::GeometricSampler;
 use super::response::CompositeResponse;
+use crate::noise::{EventKinds, NoiseEventKind};
 use crate::noise::{NoiseChannel, NoiseContext, NoiseEvent, NoiseGateRequirement, NoiseResponse};
 use pecos_core::QubitId;
 use pecos_random::PecosRng;
@@ -54,6 +55,22 @@ pub enum CompositeEventFilter {
 }
 
 impl CompositeEventFilter {
+    /// The event kind tested by this filter; arity remains a dynamic check.
+    const fn kind(self) -> NoiseEventKind {
+        match self {
+            Self::SingleQubitGate | Self::TwoQubitGate | Self::AnyGate => NoiseEventKind::AfterGate,
+            Self::Preparation => NoiseEventKind::AfterPreparation,
+            Self::BeforeMeasurement => NoiseEventKind::BeforeMeasurement,
+            Self::AfterMeasurement => NoiseEventKind::AfterMeasurement,
+            Self::IdleTime => NoiseEventKind::IdleTime,
+            Self::BeforeGate => NoiseEventKind::BeforeGate,
+            Self::AfterReset => NoiseEventKind::AfterReset,
+            Self::BeforeCircuit => NoiseEventKind::BeforeCircuit,
+            Self::AfterCircuit => NoiseEventKind::AfterCircuit,
+            Self::BetweenLayers => NoiseEventKind::BetweenLayers,
+        }
+    }
+
     /// Check if this filter matches the given event.
     #[allow(clippy::match_same_arms)] // Arms intentionally separate for clarity
     #[must_use]
@@ -382,6 +399,12 @@ impl<P: Primitive> CompositeChannel<P> {
 }
 
 impl<P: Primitive + Clone + 'static> NoiseChannel for CompositeChannel<P> {
+    fn event_kinds(&self) -> EventKinds {
+        self.filters
+            .iter()
+            .fold(EventKinds::NONE, |kinds, filter| kinds.with(filter.kind()))
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         self.filters.iter().any(|f| f.matches(event))
     }
@@ -855,6 +878,12 @@ impl<P: Primitive> BatchCompositeChannel<P> {
 }
 
 impl<P: Primitive + Clone + 'static> NoiseChannel for BatchCompositeChannel<P> {
+    fn event_kinds(&self) -> EventKinds {
+        self.filters
+            .iter()
+            .fold(EventKinds::NONE, |kinds, filter| kinds.with(filter.kind()))
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         self.filters.iter().any(|f| f.matches(event))
     }
@@ -1127,6 +1156,12 @@ impl<P: Primitive> CompositeCrosstalkChannel<P> {
 }
 
 impl<P: Primitive + Clone + 'static> NoiseChannel for CompositeCrosstalkChannel<P> {
+    fn event_kinds(&self) -> EventKinds {
+        self.events
+            .iter()
+            .fold(EventKinds::NONE, |kinds, filter| kinds.with(filter.kind()))
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         self.events.iter().any(|f| f.matches(event))
     }
@@ -1202,6 +1237,50 @@ impl CompositeChannelBuilder {
 #[cfg(test)]
 #[allow(clippy::float_cmp, clippy::cast_precision_loss)]
 mod tests {
+    #[test]
+    fn each_composite_filter_has_a_positive_kind_witness() {
+        use crate::noise::event_kind_tests::assert_channel_kinds;
+        use CompositeEventFilter::{
+            AfterCircuit, AfterMeasurement, AfterReset, AnyGate, BeforeCircuit, BeforeGate,
+            BeforeMeasurement, BetweenLayers, IdleTime, Preparation, SingleQubitGate, TwoQubitGate,
+        };
+        for (filter, kind) in [
+            (SingleQubitGate, NoiseEventKind::AfterGate),
+            (TwoQubitGate, NoiseEventKind::AfterGate),
+            (AnyGate, NoiseEventKind::AfterGate),
+            (Preparation, NoiseEventKind::AfterPreparation),
+            (BeforeMeasurement, NoiseEventKind::BeforeMeasurement),
+            (AfterMeasurement, NoiseEventKind::AfterMeasurement),
+            (IdleTime, NoiseEventKind::IdleTime),
+            (BeforeGate, NoiseEventKind::BeforeGate),
+            (AfterReset, NoiseEventKind::AfterReset),
+            (BeforeCircuit, NoiseEventKind::BeforeCircuit),
+            (AfterCircuit, NoiseEventKind::AfterCircuit),
+            (BetweenLayers, NoiseEventKind::BetweenLayers),
+        ] {
+            let kinds = EventKinds::of(kind);
+            assert_channel_kinds(
+                &CompositeChannel::new("composite", pauli()).with_filter(filter),
+                kinds,
+            );
+            assert_channel_kinds(
+                &BatchCompositeChannel::new("batch", 0.2, pauli()).with_filter(filter),
+                kinds,
+            );
+            let mut crosstalk = CompositeCrosstalkChannel::new("crosstalk", pauli());
+            crosstalk.events.push(filter);
+            assert_channel_kinds(&crosstalk, kinds);
+        }
+
+        // Arity filters inspect qubit count, not the gate type.
+        let two_targets = NoiseEvent::after_gate(GateType::H, &[QubitId(0), QubitId(1)], &[]);
+        let one_target = NoiseEvent::after_gate(GateType::CX, &[QubitId(0)], &[]);
+        assert!(TwoQubitGate.matches(&two_targets));
+        assert!(!SingleQubitGate.matches(&two_targets));
+        assert!(SingleQubitGate.matches(&one_target));
+        assert!(!TwoQubitGate.matches(&one_target));
+    }
+
     use super::*;
     use crate::command::GateType;
     use crate::noise::composite::prelude::*;

--- a/exp/pecos-neo/src/noise/correlated.rs
+++ b/exp/pecos-neo/src/noise/correlated.rs
@@ -122,6 +122,10 @@ impl CorrelatedNoiseChannel {
 }
 
 impl NoiseChannel for CorrelatedNoiseChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.base_error_probability <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/noise/crosstalk.rs
+++ b/exp/pecos-neo/src/noise/crosstalk.rs
@@ -216,6 +216,12 @@ impl CrosstalkChannel {
 }
 
 impl NoiseChannel for CrosstalkChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterPreparation)
+            .with(super::NoiseEventKind::AfterMeasurement)
+            .with(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         // Only respond if we have non-zero crosstalk rates
         if self.local_rate <= 0.0 && self.global_rate <= 0.0 {

--- a/exp/pecos-neo/src/noise/event_kind_tests.rs
+++ b/exp/pecos-neo/src/noise/event_kind_tests.rs
@@ -1,0 +1,262 @@
+// Copyright 2026 The PECOS Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use super::*;
+use crate::sampling::importance::{ImportanceConfig, ImportanceSamplingChannel};
+
+pub(super) fn representative(kind: NoiseEventKind) -> NoiseEvent<'static> {
+    match kind {
+        NoiseEventKind::BeforeGate => NoiseEvent::before_gate(GateType::H, &[QubitId(0)], &[]),
+        NoiseEventKind::AfterGate => NoiseEvent::after_gate(GateType::H, &[QubitId(0)], &[]),
+        NoiseEventKind::BeforeMeasurement => NoiseEvent::BeforeMeasurement {
+            qubits: &[QubitId(0)],
+        },
+        NoiseEventKind::AfterMeasurement => NoiseEvent::AfterMeasurement {
+            qubits: &[QubitId(0)],
+            outcomes: &[true],
+        },
+        NoiseEventKind::AfterPreparation => NoiseEvent::AfterPreparation {
+            qubits: &[QubitId(0)],
+        },
+        NoiseEventKind::IdleTime => NoiseEvent::IdleTime {
+            qubits: &[QubitId(0)],
+            duration: TimeUnits::new(2),
+        },
+        NoiseEventKind::AfterReset => NoiseEvent::AfterReset {
+            qubits: &[QubitId(0)],
+        },
+        NoiseEventKind::BeforeCircuit => NoiseEvent::BeforeCircuit { num_qubits: 4 },
+        NoiseEventKind::AfterCircuit => NoiseEvent::AfterCircuit { num_qubits: 4 },
+        NoiseEventKind::BetweenLayers => NoiseEvent::BetweenLayers {
+            qubits: &[QubitId(0)],
+            layer_index: 1,
+        },
+        NoiseEventKind::Signal => NoiseEvent::Signal {
+            type_id: TypeId::of::<u64>(),
+            data: &7_u64,
+        },
+    }
+}
+
+pub(super) fn witnesses() -> Vec<NoiseEvent<'static>> {
+    let mut events: Vec<_> = NoiseEventKind::ALL
+        .into_iter()
+        .map(representative)
+        .collect();
+    events.push(NoiseEvent::before_gate(
+        GateType::CX,
+        &[QubitId(0), QubitId(1)],
+        &[],
+    ));
+    events.push(NoiseEvent::after_gate(
+        GateType::CX,
+        &[QubitId(0), QubitId(1)],
+        &[],
+    ));
+    events
+}
+
+#[test]
+fn kinds_round_trip_and_bitset_operations() {
+    let mut accumulated = EventKinds::NONE;
+    for (index, kind) in NoiseEventKind::ALL.into_iter().enumerate() {
+        assert_eq!(kind.index(), index);
+        assert_eq!(representative(kind).kind(), kind);
+        assert!(EventKinds::ALL.contains(kind));
+        assert!(!EventKinds::NONE.contains(kind));
+        for other in NoiseEventKind::ALL {
+            assert_eq!(EventKinds::of(kind).contains(other), kind == other);
+        }
+        accumulated = accumulated.with(kind);
+        assert_eq!(accumulated.union(EventKinds::of(kind)), accumulated);
+    }
+    assert_eq!(accumulated, EventKinds::ALL);
+    assert_eq!(NoiseEventKind::ALL.len(), EventKinds::COUNT);
+}
+
+pub(super) fn assert_channel_kinds(channel: &dyn NoiseChannel, expected: EventKinds) {
+    let events = witnesses();
+    for kind in NoiseEventKind::ALL {
+        if expected.contains(kind) {
+            let witness = events
+                .iter()
+                .find(|event| event.kind() == kind && channel.responds_to(event))
+                .unwrap_or_else(|| {
+                    panic!("{} has no positive witness for {kind:?}", channel.name())
+                });
+            assert!(channel.responds_to(witness));
+            assert!(
+                channel.event_kinds().contains(kind),
+                "{} missing {kind:?}",
+                channel.name()
+            );
+            let mut ctx = NoiseContext::new();
+            for q in 0..4 {
+                ctx.mark_prepared(QubitId(q));
+            }
+            assert!(
+                channel
+                    .try_apply(witness, &mut ctx, &mut PecosRng::seed_from_u64(42))
+                    .is_some(),
+                "{} rejected its positive {kind:?} witness in try_apply",
+                channel.name()
+            );
+        } else {
+            assert!(
+                !channel.event_kinds().contains(kind),
+                "{} unexpectedly declares {kind:?}",
+                channel.name()
+            );
+            for event in events.iter().filter(|event| event.kind() == kind) {
+                assert!(
+                    !channel.responds_to(event),
+                    "{} responds to excluded {kind:?}",
+                    channel.name()
+                );
+                assert!(
+                    channel
+                        .try_apply(
+                            event,
+                            &mut NoiseContext::new(),
+                            &mut PecosRng::seed_from_u64(42)
+                        )
+                        .is_none(),
+                    "{} try_apply responds to excluded {kind:?}",
+                    channel.name()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn builtin_channel_kind_declarations_have_positive_witnesses() {
+    use NoiseEventKind::{
+        AfterGate, AfterMeasurement, AfterPreparation, BeforeGate, BeforeMeasurement, IdleTime,
+    };
+    let gates = EventKinds::of(BeforeGate).with(AfterGate);
+    let after_gate = EventKinds::of(AfterGate);
+    let channels: Vec<(Box<dyn NoiseChannel>, EventKinds)> = vec![
+        (Box::new(SingleQubitChannel::depolarizing(0.2)), gates),
+        (Box::new(TwoQubitChannel::depolarizing(0.2)), gates),
+        (
+            Box::new(LeakageChannel::new()),
+            gates.with(BeforeMeasurement),
+        ),
+        (
+            Box::new(MeasurementChannel::symmetric(0.2)),
+            EventKinds::of(AfterMeasurement),
+        ),
+        (
+            Box::new(MeasurementStateFlipChannel::new(0.2)),
+            EventKinds::of(BeforeMeasurement),
+        ),
+        (
+            Box::new(PreparationChannel::new(0.2)),
+            EventKinds::of(AfterPreparation),
+        ),
+        (
+            Box::new(IdleChannel::linear(0.2).with_idle_after_2q(1.0)),
+            EventKinds::of(IdleTime).with(AfterGate),
+        ),
+        (
+            Box::new(CrosstalkChannel::global_only(0.2)),
+            after_gate.with(AfterPreparation).with(AfterMeasurement),
+        ),
+        (Box::new(CorrelatedNoiseChannel::new(0.2, 0.5)), after_gate),
+        (
+            Box::new(CategoryBasedChannel::new().with_default(0.2)),
+            after_gate,
+        ),
+        (
+            Box::new(GateDependentChannel::new().with_gate_error(GateType::H, 0.2)),
+            after_gate,
+        ),
+        (
+            Box::new(GateIdDependentChannel::new().with_gate_type_error(GateType::H, 0.2)),
+            after_gate,
+        ),
+        (
+            Box::new(
+                PerGatePauliChannel::new()
+                    .with_base(0.2, 0.2)
+                    .with_meas_init(0.2, 0.2),
+            ),
+            after_gate.with(BeforeMeasurement).with(AfterPreparation),
+        ),
+    ];
+    for (channel, kinds) in channels {
+        assert_channel_kinds(&*channel, kinds);
+    }
+
+    // The wrapper conservatively declares ALL: its default try_apply consults
+    // responds_to, not the inner channel's potentially optimized try_apply.
+    let inner = SingleQubitChannel::depolarizing(0.2);
+    let wrapper =
+        ImportanceSamplingChannel::new(inner.clone(), ImportanceConfig::with_boost(0.02, 10.0));
+    assert_eq!(wrapper.event_kinds(), EventKinds::ALL);
+    for event in witnesses() {
+        assert_eq!(wrapper.responds_to(&event), inner.responds_to(&event));
+        assert_eq!(
+            wrapper
+                .try_apply(
+                    &event,
+                    &mut NoiseContext::new(),
+                    &mut PecosRng::seed_from_u64(42),
+                )
+                .is_some(),
+            inner.responds_to(&event)
+        );
+    }
+}
+
+#[test]
+fn per_gate_optional_kind_declarations_follow_configuration() {
+    let base = PerGatePauliChannel::new().with_base(0.2, 0.2);
+    let after_gate = EventKinds::of(NoiseEventKind::AfterGate);
+    assert_channel_kinds(&base, after_gate);
+    assert_channel_kinds(
+        &base.clone().with_meas_rate_for_qubit(QubitId(0), 0.2),
+        after_gate.with(NoiseEventKind::BeforeMeasurement),
+    );
+    assert_channel_kinds(
+        &base.with_init_rate_for_qubit(QubitId(0), 0.2),
+        after_gate.with(NoiseEventKind::AfterPreparation),
+    );
+}
+
+#[test]
+fn core_handler_kind_declarations_have_positive_witnesses() {
+    let mut config = NoiseModelConfig::new();
+    plugins::CorePlugin.build(&mut config);
+    assert_eq!(config.event_handlers.len(), 2);
+    for (handler, expected) in config.event_handlers.iter().zip([
+        NoiseEventKind::AfterPreparation,
+        NoiseEventKind::AfterMeasurement,
+    ]) {
+        for kind in NoiseEventKind::ALL {
+            let event = representative(kind);
+            assert_eq!(
+                handler.handles(&event),
+                kind == expected,
+                "{} {kind:?}",
+                handler.name()
+            );
+            assert_eq!(
+                handler.event_kinds().contains(kind),
+                kind == expected,
+                "{} {kind:?}",
+                handler.name()
+            );
+        }
+    }
+}

--- a/exp/pecos-neo/src/noise/gate_dependent.rs
+++ b/exp/pecos-neo/src/noise/gate_dependent.rs
@@ -126,6 +126,10 @@ impl GateDependentChannel {
 }
 
 impl NoiseChannel for GateDependentChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         match event {
             NoiseEvent::AfterGate { gate_type, .. } => {

--- a/exp/pecos-neo/src/noise/gate_id_dependent.rs
+++ b/exp/pecos-neo/src/noise/gate_id_dependent.rs
@@ -162,6 +162,10 @@ impl GateIdDependentChannel {
 }
 
 impl NoiseChannel for GateIdDependentChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         match event {
             NoiseEvent::AfterGate { gate_id, .. } => {

--- a/exp/pecos-neo/src/noise/idle.rs
+++ b/exp/pecos-neo/src/noise/idle.rs
@@ -421,6 +421,11 @@ impl IdleChannel {
 }
 
 impl NoiseChannel for IdleChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::IdleTime)
+            .with(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.linear_rate <= 0.0 && self.quadratic_rate <= 0.0 && self.sin_squared_rate <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/noise/leakage.rs
+++ b/exp/pecos-neo/src/noise/leakage.rs
@@ -84,6 +84,12 @@ impl LeakageChannel {
 }
 
 impl NoiseChannel for LeakageChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::BeforeGate)
+            .with(super::NoiseEventKind::AfterGate)
+            .with(super::NoiseEventKind::BeforeMeasurement)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         // Always respond to gate and measurement events - we need to check for leakage
         matches!(

--- a/exp/pecos-neo/src/noise/measurement.rs
+++ b/exp/pecos-neo/src/noise/measurement.rs
@@ -106,6 +106,10 @@ impl MeasurementChannel {
 }
 
 impl NoiseChannel for MeasurementChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterMeasurement)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if !self.is_active() {
             return false;
@@ -244,6 +248,10 @@ impl MeasurementStateFlipChannel {
 }
 
 impl NoiseChannel for MeasurementStateFlipChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::BeforeMeasurement)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.p <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/noise/per_gate_pauli.rs
+++ b/exp/pecos-neo/src/noise/per_gate_pauli.rs
@@ -307,6 +307,17 @@ impl PerGatePauliChannel {
 }
 
 impl NoiseChannel for PerGatePauliChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        let mut kinds = super::EventKinds::of(super::NoiseEventKind::AfterGate);
+        if self.p_meas > 0.0 || !self.measurement_rates.is_empty() {
+            kinds = kinds.with(super::NoiseEventKind::BeforeMeasurement);
+        }
+        if self.p_init > 0.0 || !self.init_rates.is_empty() {
+            kinds = kinds.with(super::NoiseEventKind::AfterPreparation);
+        }
+        kinds
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         match event {
             NoiseEvent::AfterGate { gate_type, .. } => {

--- a/exp/pecos-neo/src/noise/plugin.rs
+++ b/exp/pecos-neo/src/noise/plugin.rs
@@ -102,6 +102,14 @@ impl NoiseModelConfig {
 /// - Marking qubits as prepared/active
 /// - Marking qubits as measured/inactive
 pub trait EventHandler: Send + Sync {
+    /// Declare every kind this handler can handle.
+    ///
+    /// This must depend only on construction-time configuration and remain
+    /// unchanged after insertion: the model caches it. Extra kinds are safe.
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::ALL
+    }
+
     /// Check if this handler should process the event.
     fn handles(&self, event: &NoiseEvent<'_>) -> bool;
 

--- a/exp/pecos-neo/src/noise/plugins/core.rs
+++ b/exp/pecos-neo/src/noise/plugins/core.rs
@@ -67,6 +67,10 @@ impl NoisePlugin for CorePlugin {
 struct PreparationStateHandler;
 
 impl EventHandler for PreparationStateHandler {
+    fn event_kinds(&self) -> crate::noise::EventKinds {
+        crate::noise::EventKinds::of(crate::noise::NoiseEventKind::AfterPreparation)
+    }
+
     fn handles(&self, event: &NoiseEvent<'_>) -> bool {
         matches!(event, NoiseEvent::AfterPreparation { .. })
     }
@@ -98,6 +102,10 @@ impl EventHandler for PreparationStateHandler {
 struct MeasurementStateHandler;
 
 impl EventHandler for MeasurementStateHandler {
+    fn event_kinds(&self) -> crate::noise::EventKinds {
+        crate::noise::EventKinds::of(crate::noise::NoiseEventKind::AfterMeasurement)
+    }
+
     fn handles(&self, event: &NoiseEvent<'_>) -> bool {
         matches!(event, NoiseEvent::AfterMeasurement { .. })
     }

--- a/exp/pecos-neo/src/noise/prelude.rs
+++ b/exp/pecos-neo/src/noise/prelude.rs
@@ -49,8 +49,8 @@ pub use super::composite::prelude::*;
 
 // --- Core Traits and Types ---
 
+pub use super::{EventKinds, NoiseChannel, NoiseEvent, NoiseEventKind, NoiseResponse};
 pub use super::{GateInfo, IdleInfo, NoiseContext};
-pub use super::{NoiseChannel, NoiseEvent, NoiseResponse};
 
 // --- Topology (Spatial Noise Helpers) ---
 

--- a/exp/pecos-neo/src/noise/preparation.rs
+++ b/exp/pecos-neo/src/noise/preparation.rs
@@ -68,6 +68,10 @@ impl PreparationChannel {
 }
 
 impl NoiseChannel for PreparationChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::AfterPreparation)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.error_probability <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/noise/single_qubit.rs
+++ b/exp/pecos-neo/src/noise/single_qubit.rs
@@ -214,6 +214,11 @@ impl SingleQubitChannel {
 }
 
 impl NoiseChannel for SingleQubitChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::BeforeGate)
+            .with(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.error_probability <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/noise/two_qubit.rs
+++ b/exp/pecos-neo/src/noise/two_qubit.rs
@@ -407,6 +407,11 @@ impl TwoQubitChannel {
 }
 
 impl NoiseChannel for TwoQubitChannel {
+    fn event_kinds(&self) -> super::EventKinds {
+        super::EventKinds::of(super::NoiseEventKind::BeforeGate)
+            .with(super::NoiseEventKind::AfterGate)
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         if self.error_probability <= 0.0 {
             return false;

--- a/exp/pecos-neo/src/sampling/importance.rs
+++ b/exp/pecos-neo/src/sampling/importance.rs
@@ -138,6 +138,16 @@ impl<C: NoiseChannel> ImportanceSamplingChannel<C> {
 }
 
 impl<C: NoiseChannel + Clone + 'static> NoiseChannel for ImportanceSamplingChannel<C> {
+    fn event_kinds(&self) -> crate::noise::EventKinds {
+        // This wrapper dispatches through the default `try_apply`, whose
+        // predicate is `inner.responds_to`, and `apply` draws the proposal
+        // sample before consulting the inner channel. The inner declaration
+        // only promises to cover the inner `try_apply`, so forwarding it could
+        // skip an event on which `inner.responds_to` is true and change the
+        // random stream. Stay conservative.
+        crate::noise::EventKinds::ALL
+    }
+
     fn responds_to(&self, event: &NoiseEvent<'_>) -> bool {
         self.inner.responds_to(event)
     }


### PR DESCRIPTION
## Summary

`ComposableNoiseModel::emit` visits only the channels and event handlers that can respond to an event's kind, instead of walking every channel with a virtual `try_apply` per event. Channels keep `Box<dyn NoiseChannel>` and their dynamic predicates; the model just stops asking a measurement channel about gate events. No behaviour change. Step 3 of the pecos-neo core-adoption sequence (after #711, #712, #756).

### What changed

- `NoiseEventKind` (one fieldless variant per `NoiseEvent` variant) and `NoiseEvent::kind()`, plus a small `EventKinds` bitset (`ALL`, `NONE`, `of`, `with`, `contains`, `union`, `COUNT`). The kind list is produced by one `declare_noise_event_kinds!` invocation whose exhaustive `const fn` match makes it a compile error to add a `NoiseEvent` variant without listing it, the same guard `GateType::ALL` uses.
- `NoiseChannel::event_kinds()` and `EventHandler::event_kinds()`, both defaulting to `EventKinds::ALL`, so every downstream implementor (custom channels in examples, pecos-rslib-exp's coherent idle channel, pecos-qec's `PerGatePauliChannel` use) keeps working unchanged. Every built-in channel and handler overrides it with the kinds its predicate can accept; composite channels derive theirs from their filter values. `ImportanceSamplingChannel<C>` keeps `ALL`: it dispatches through the default `try_apply`, whose predicate is the inner channel's `responds_to`, and draws its proposal sample before consulting the inner channel, so forwarding the inner declaration (which only promises to cover the inner `try_apply`) could skip an event and shift the random stream; an independent review reproduced that with a custom inner channel and the case is now a regression test. Declaring a superset is sound (the dynamic predicate still runs); declaring a subset is a bug, which the tests below pin.
- `ComposableNoiseModel` keeps its flat channel and handler vectors as the source of truth (`channel_names`, `describe`, `Debug`, `Clone`, gate-requirement collection are unchanged) and adds per-kind index lists filled at every insertion point and rebuilt after `add_plugin`'s stable priority sort. `emit` and `run_event_handlers` iterate one bucket in the old order and call `try_apply` / `handles` + `handle` exactly as before.

### Tests

- Positive-witness soundness tests per built-in channel and handler (`noise/event_kind_tests.rs`): for every declared kind, a witness event on which the predicate is known to return true, asserting both the predicate and membership; for every undeclared kind, the predicate is false. Shown red by removing `BeforeMeasurement` from `LeakageChannel`'s declaration (`LeakageChannel missing BeforeMeasurement`). Composite filters tested one value at a time.
- Composer tests: a default-declaration channel and handler are reached on every kind; excluded kinds are actually skipped; handler order with mixed `add_plugin` and `add_event_handler` registration and unequal priorities matches the flat vector; a cloned model dispatches identically.
- Old-vs-new equivalence pin: the same model built twice, the second with every channel and handler wrapped in an adapter that forwards everything but declares `ALL` (so its buckets are trivial), driven through a fixed event sequence covering every kind with identically seeded RNGs; the `NoiseResponse` sequences are compared with a recursive, variant-sensitive comparator. Separate configurations cover the idle families the builder does not allow together.
- Existing pins: `noise_comparison_test`, the facade equivalence matrix and emission tests, `simulation_reuse_test`, pecos-qec's `per_gate` tests.

### Benchmarks (criterion, `hot_path`, baseline recorded on the pre-change tree in the same worktree, quiet machine)

| case | change |
|---|---|
| `noise_emission/after_gate_1q` (3 channels) | -6.1% |
| `noise_emission/after_gate_2q` | -8.9% |
| `noise_emission/after_measurement` | -10.9% |
| `shot_execution/bell_with_noise` | -5.2% |
| `multi_shot/bell_with_noise/1000` | -3.9% |
| `monte_carlo_comparison/neo_bell_with_noise/1000` | -4.4% |
| noiseless shot and multi-shot cases | no change (within noise) |
| `composite_vs_channel/composite_noise_emission_1q` (one channel) | +3.5% |

The single-channel composite case pays the bucket lookup with nothing to skip; that is about 4 ns on a 127 ns micro-benchmark and is accepted rather than special-cased. The `50q_*` multi-shot cases showed +2 to +3% across runs on a `CircuitRunner` with no noise model, a path this change does not touch. An unrequested rewrite of `CompositeEventFilter::matches` that cost the composite cases 4 to 8% was caught by the benchmark and reverted before this was opened.

### Verification

```
cargo fmt --all -- --check
cargo clippy --locked -p pecos-neo --all-targets --all-features -- -D warnings
cargo clippy --locked -p pecos-neo --all-targets -- -D warnings
cargo clippy --locked -p pecos -p pecos-rslib-exp -p pecos-qec -p benchmarks --all-targets --all-features -- -D warnings
cargo test --locked -p pecos-neo --all-features
cargo test --locked -p pecos --features neo --test neo_routing_test --test neo_emission_test --test neo_v6_example_sweep_test --test neo_equivalence_matrix_test --test neo_hugr_routing_test
cargo test --locked -p pecos-qec --features neo per_gate
cargo check --locked --workspace --all-targets --all-features
```

All green on a cold build (changed crates cleaned first). Public API: additions only (`NoiseEventKind`, `EventKinds`, `NoiseEvent::kind`, the two defaulted trait methods, re-exported from the prelude). `noise/composite/compiled.rs` is untouched; it belongs to the composite feature step.
